### PR TITLE
feat(cli-adapters): run the gemini arm on agy (Antigravity) (#4346)

### DIFF
--- a/.changeset/rare-lions-move.md
+++ b/.changeset/rare-lions-move.md
@@ -1,0 +1,42 @@
+---
+'nexus-agents': minor
+---
+
+feat(cli-adapters): run the `gemini` arm on `agy` (Antigravity), replacing the retired gemini CLI (#4346)
+
+Google retired the standalone `gemini` CLI for individual tiers. It now fails
+**every** invocation with `IneligibleTierError: This client is no longer supported
+for Gemini Code Assist for individuals`, exit code 55 — verified live against
+`gemini` v0.51.0. The routing arm was dead, not degraded.
+
+The `gemini` CliName is kept and its binary repointed to `agy` (verified against
+v1.1.9). Decided by `consensus_vote` (`higher_order`, 7/0): adding or renaming a
+CliName would touch ~30 exhaustive maps, two exhaustive switches, a duplicated
+union in `packages/nexus-memory`, and persisted LinUCB/outcome history — to buy
+routability of agy's Claude/GPT-OSS models, which are already reachable through
+their own adapters.
+
+**The load-bearing detail: `agy` exits 0 even when the run failed.** A bad model
+returns `{"status":"ERROR","response":"","error":"…"}` with exit code 0. The new
+`AgyResponseParser` is fail-closed by construction — unparseable output, truncated
+JSON, a missing `status`, an unrecognized `status`, and a non-string `response` all
+yield `null`, and `status` is pinned to the literal `SUCCESS` via Zod so a future
+status cannot be waved through. Reintroducing exit-code-based classification here
+would have undone #4350/#4354/#4362/#4363.
+
+Other changes:
+
+- Flag spellings updated (`-o json` → `--output-format json`, `-m` → `--model`,
+  `--resume` → `--conversation`).
+- `--policy <file>` has no agy equivalent, so the system prompt is prepended to
+  the content — a deliberate downgrade in framing fidelity, which also removes the
+  per-call tempdir the old path created.
+- Token usage maps onto `TokenUsage` with `thinking_tokens` folded into
+  `outputTokens` (generated, billable, and previously would have been dropped);
+  `cache_read_tokens` deliberately not added, being a subset of input already
+  counted.
+- Model slugs live in a new `config/agy-model-map.ts` rather than in
+  `cliModelName` — that field is also read by the API-based `GeminiAdapter`, which
+  calls Google directly and needs real API ids. One field cannot serve both.
+- `CLI_VERSION_REQUIREMENTS.gemini` now describes agy versions, so an installed
+  gemini 0.5x correctly fails the minimum.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,9 @@ You need at least one of these CLI tools installed and authenticated:
 ```bash
 # Verify CLI authentication
 claude --version    # Claude CLI
-gemini --version    # Gemini CLI
+agy --version       # Antigravity CLI — the `gemini` routing arm runs this now (#4346).
+                    # The standalone `gemini` CLI is retired and fails every
+                    # invocation with IneligibleTierError.
 codex --version     # Codex CLI
 ```
 
@@ -341,9 +343,7 @@ describe('ModuleName', () => {
   describe('functionName', () => {
     it('should handle expected input correctly', () => {
       // Arrange
-      const input = {
-        /* ... */
-      };
+      const input = {/* ... */};
 
       // Act
       const result = functionName(input);
@@ -354,18 +354,14 @@ describe('ModuleName', () => {
 
     it('should return error for invalid input', () => {
       // Arrange
-      const invalidInput = {
-        /* ... */
-      };
+      const invalidInput = {/* ... */};
 
       // Act
       const result = functionName(invalidInput);
 
       // Assert
       expect(result.ok).toBe(false);
-      expect(result.error).toMatchObject({
-        /* ... */
-      });
+      expect(result.error).toMatchObject({/* ... */});
     });
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.test.ts
@@ -223,51 +223,88 @@ describe('GeminiCliAdapter', () => {
   });
 });
 
-describe('GeminiCliAdapter systemPrompt (#1886)', () => {
-  it('passes --policy <tempfile> when systemPrompt is set', () => {
+describe('GeminiCliAdapter systemPrompt (#1886, reworked in #4346)', () => {
+  function getCommand(task: unknown): { command: string; args: string[]; cleanup?: () => void } {
     const adapter = new GeminiCliAdapter();
-    // Access protected getCommand via type assertion (test-only)
-    const cmd = (
-      adapter as unknown as { getCommand: (t: unknown) => { args: string[]; cleanup?: () => void } }
-    ).getCommand({ content: 'test prompt', systemPrompt: 'You are strict.' });
-    const policyIdx = cmd.args.indexOf('--policy');
-    expect(policyIdx).toBeGreaterThanOrEqual(0);
-    expect(cmd.args[policyIdx + 1]).toMatch(/policy\.md$/);
-    expect(cmd.cleanup).toBeDefined();
-    // Clean up the temp file
-    if (cmd.cleanup !== undefined) cmd.cleanup();
+    return (
+      adapter as unknown as {
+        getCommand: (t: unknown) => { command: string; args: string[]; cleanup?: () => void };
+      }
+    ).getCommand(task);
+  }
+
+  it('prepends the system prompt to the content', () => {
+    // agy has no system-prompt flag — the retired gemini CLI's `--policy <file>`
+    // has no equivalent, and `--agent` selects a preconfigured agent rather than
+    // accepting inline instructions. Prepending is a deliberate downgrade in
+    // framing fidelity, pinned here so it is not mistaken for an oversight.
+    const cmd = getCommand({ content: 'test prompt', systemPrompt: 'You are strict.' });
+
+    const printIdx = cmd.args.indexOf('--print');
+    expect(cmd.args[printIdx + 1]).toBe('You are strict.\n\ntest prompt');
   });
 
-  it('omits --policy when systemPrompt is empty', () => {
-    const adapter = new GeminiCliAdapter();
-    const cmd = (
-      adapter as unknown as { getCommand: (t: unknown) => { args: string[]; cleanup?: () => void } }
-    ).getCommand({ content: 'test prompt' });
-    expect(cmd.args).not.toContain('--policy');
+  it('passes the content unchanged when no system prompt is set', () => {
+    const cmd = getCommand({ content: 'test prompt' });
+
+    const printIdx = cmd.args.indexOf('--print');
+    expect(cmd.args[printIdx + 1]).toBe('test prompt');
+  });
+
+  it('writes no temp file, so there is nothing to clean up', () => {
+    // The old --policy path wrote a tempdir per call and needed a cleanup
+    // callback to avoid leaking it (#2824). That surface is gone entirely.
+    const cmd = getCommand({ content: 'test prompt', systemPrompt: 'You are strict.' });
+
     expect(cmd.cleanup).toBeUndefined();
+    expect(cmd.args).not.toContain('--policy');
+  });
+});
+
+describe('GeminiCliAdapter runs agy, not the retired gemini CLI (#4346)', () => {
+  function getCommand(task: unknown): { command: string; args: string[] } {
+    const adapter = new GeminiCliAdapter();
+    return (
+      adapter as unknown as { getCommand: (t: unknown) => { command: string; args: string[] } }
+    ).getCommand(task);
+  }
+
+  it('spawns agy', () => {
+    // The standalone gemini CLI fails every invocation with IneligibleTierError
+    // (exit 55) since Google retired it for individual tiers.
+    expect(getCommand({ content: 'hi' }).command).toBe('agy');
   });
 
-  it('cleanup removes parent tempdir, not just file (#2824)', async () => {
-    const adapter = new GeminiCliAdapter();
-    const cmd = (
-      adapter as unknown as { getCommand: (t: unknown) => { args: string[]; cleanup?: () => void } }
-    ).getCommand({ content: 'test prompt', systemPrompt: 'You are strict.' });
-    const policyIdx = cmd.args.indexOf('--policy');
-    const file = cmd.args[policyIdx + 1] as string;
-    const dir = file.replace(/\/policy\.md$/, '');
+  it('uses agy flag spellings', () => {
+    const { args } = getCommand({ content: 'hi' });
 
-    // Sanity check pre-cleanup
-    const { existsSync } = await import('node:fs');
-    expect(existsSync(file)).toBe(true);
-    expect(existsSync(dir)).toBe(true);
+    expect(args).toContain('--output-format');
+    expect(args).toContain('--model');
+    expect(args).toContain('--print');
+    // The retired CLI's short forms.
+    expect(args).not.toContain('-o');
+    expect(args).not.toContain('-m');
+  });
 
-    if (cmd.cleanup !== undefined) cmd.cleanup();
+  it('requests JSON output — the only place agy reports success or failure', () => {
+    const { args } = getCommand({ content: 'hi' });
 
-    // Post-cleanup: both file AND parent tempdir gone. Pre-fix only the
-    // file was unlinked, leaking an empty `nexus-gemini-sysprompt-XXXXXX`
-    // dir on every call.
-    expect(existsSync(file)).toBe(false);
-    expect(existsSync(dir)).toBe(false);
+    expect(args[args.indexOf('--output-format') + 1]).toBe('json');
+  });
+
+  it('resumes a session with --conversation, not --resume', () => {
+    const { args } = getCommand({ content: 'hi', sessionId: 'conv-123' });
+
+    expect(args[args.indexOf('--conversation') + 1]).toBe('conv-123');
+    expect(args).not.toContain('--resume');
+  });
+
+  it('passes the prompt as the value of --print, never positionally', () => {
+    // A valueless --print consumes whatever token follows it.
+    const { args } = getCommand({ content: 'hi' });
+
+    expect(args[args.indexOf('--print') + 1]).toBe('hi');
+    expect(args[0]).not.toBe('hi');
   });
 });
 

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
@@ -12,9 +12,6 @@
  * (Source: Issue #389 - Merged enhanced adapter back to canonical)
  */
 
-import { writeFileSync, rmSync, mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import type { Result, ILogger } from '../../core/index.js';
 import { ok, err, createLogger, getTimeProvider } from '../../core/index.js';
 import type {
@@ -29,7 +26,8 @@ import type {
   BaseAdapterOptions,
 } from '../types.js';
 import { SubprocessCliAdapter, type CommandConfig } from '../subprocess-adapter.js';
-import { ResilientGeminiParser } from '../parsers/gemini-parser-resilient.js';
+import { AgyResponseParser } from '../parsers/agy-parser.js';
+import { toAgyModelSlug } from '../../config/agy-model-map.js';
 import type { CliModelInfo } from '../types-capability.js';
 import { listModelsForCli } from '../../config/models-dev-by-vendor.js';
 import {
@@ -109,7 +107,7 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
     this.maxRetries = mergedConfig.maxRetries;
     this.baseDelayMs = mergedConfig.baseDelayMs;
     this.maxDelayMs = mergedConfig.maxDelayMs;
-    this.parser = new ResilientGeminiParser();
+    this.parser = new AgyResponseParser();
     this.adapterLogger = options?.logger ?? createLogger({ component: 'gemini-adapter' });
 
     // Initialize circuit breaker if enabled
@@ -209,49 +207,48 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
   protected override getCommand(task: CliTask): CommandConfig {
     const args: string[] = [];
 
-    // Add the task content as positional argument
-    args.push(task.content);
+    // #4346: the standalone `gemini` CLI is retired — it fails every invocation
+    // with IneligibleTierError (exit 55). `agy` (Antigravity) is Google's own
+    // replacement. Flag spellings differ entirely from the old CLI:
+    //   -o json      -> --output-format json
+    //   -m <model>   -> --model <slug>
+    //   --resume     -> --conversation
+    //   --policy     -> (no equivalent; see systemPrompt handling below)
+    args.push('--output-format', 'json');
 
-    // Add output format
-    args.push('-o', 'json');
+    // Registry model ids and agy slugs are different namespaces — see
+    // config/agy-model-map.ts for why `cliModelName` cannot carry the agy slug.
+    // An unmapped id would make agy return status:ERROR with exit code 0, so the
+    // resolver substitutes a valid slug rather than letting that happen.
+    const requested = task.model ?? this.model;
+    const model = toAgyModelSlug(requested);
+    if (model !== requested) {
+      this.adapterLogger.debug('Substituted an agy model slug', { requested, model });
+    }
+    args.push('--model', model);
 
-    // Add model (always present due to default)
-    const model = task.model ?? this.model;
-    args.push('-m', model);
-
-    // Add session for continuation
     if (task.sessionId !== undefined && task.sessionId !== '') {
-      args.push('--resume', task.sessionId);
+      args.push('--conversation', task.sessionId);
     }
 
-    // Note: Sandbox mode (-s) removed - causes npm permission issues
-    // and "rebuilt dependencies successfully" contamination
+    // agy has no system-prompt flag. The old CLI's `--policy <file>` preserved
+    // system-role framing (#1886); agy offers only `--agent`, which selects a
+    // preconfigured agent rather than accepting inline instructions. So the
+    // system prompt is prepended to the user content — a deliberate downgrade
+    // in framing fidelity, recorded here so it is not mistaken for an
+    // oversight. No temp file is written, which also removes the tempdir-leak
+    // surface the old path had.
+    const content =
+      task.systemPrompt !== undefined && task.systemPrompt !== ''
+        ? `${task.systemPrompt}\n\n${task.content}`
+        : task.content;
 
-    // Honor systemPrompt via gemini's --policy flag (#1886).
-    // Gemini treats policy files as system-level instructions, preserving
-    // the system-role framing (unlike prepending to user content).
-    let cleanup: (() => void) | undefined;
-    if (task.systemPrompt !== undefined && task.systemPrompt !== '') {
-      const dir = mkdtempSync(join(tmpdir(), 'nexus-gemini-sysprompt-'));
-      const file = join(dir, 'policy.md');
-      writeFileSync(file, task.systemPrompt, { encoding: 'utf8', mode: 0o600 });
-      args.push('--policy', file);
-      cleanup = (): void => {
-        // Recursive rm so we drop the parent tempdir, not just the file
-        // inside it. Pre-fix every gemini call with a systemPrompt leaked
-        // one empty `/tmp/nexus-gemini-sysprompt-XXXXXX` dir until the OS
-        // reaper ran.
-        try {
-          rmSync(dir, { recursive: true, force: true });
-        } catch {
-          // best-effort; tempdir auto-cleanup will eventually reap it
-        }
-      };
-    }
+    // --print LAST with an explicit value. agy accepts flags in any order, but
+    // a valueless --print consumes whatever token follows it, so the prompt is
+    // always passed as its argument rather than positionally.
+    args.push('--print', content);
 
-    return cleanup === undefined
-      ? { command: 'gemini', args }
-      : { command: 'gemini', args, cleanup };
+    return { command: 'agy', args };
   }
 
   private checkCircuitBreaker(): CliError | null {

--- a/packages/nexus-agents/src/cli-adapters/parsers/agy-parser.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/parsers/agy-parser.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the Antigravity (`agy`) CLI response parser (#4346).
+ *
+ * The load-bearing property is fail-closed classification. `agy` **exits 0 even
+ * on failure** — a bad model returns
+ * `{"status":"ERROR","response":"","error":"invalid model selection ..."}` with
+ * exit code 0 — so an adapter that classifies on exit status would read every
+ * agy failure as a success. That is the fail-open class #4350/#4354/#4362/#4363
+ * just removed from this repo, and reintroducing it through a new adapter would
+ * undo that work.
+ *
+ * Fixtures are verbatim captures from `agy` v1.1.9 on 2026-08-09.
+ *
+ * @module cli-adapters/parsers/agy-parser.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AgyResponseParser } from './agy-parser.js';
+
+const parser = new AgyResponseParser();
+
+/** Verbatim capture: `agy --print "Reply with exactly: OK" --output-format json`. */
+const SUCCESS_RAW = JSON.stringify({
+  conversation_id: 'f1f8db42-c436-42ef-a568-148385671f86',
+  status: 'SUCCESS',
+  response: 'OK\n',
+  duration_seconds: 1.199020029,
+  num_turns: 1,
+  usage: {
+    input_tokens: 16397,
+    output_tokens: 5,
+    thinking_tokens: 0,
+    cache_read_tokens: 0,
+    total_tokens: 16402,
+  },
+});
+
+/** Verbatim capture: `agy --print "hi" --model no-such-model` — EXIT CODE 0. */
+const ERROR_RAW = JSON.stringify({
+  conversation_id: '',
+  status: 'ERROR',
+  response: '',
+  error:
+    'invalid model selection (--model "no-such-model" --effort ""): model no-such-model is not recognized',
+  duration_seconds: 0,
+  num_turns: 0,
+  usage: {
+    input_tokens: 0,
+    output_tokens: 0,
+    thinking_tokens: 0,
+    cache_read_tokens: 0,
+    total_tokens: 0,
+  },
+});
+
+describe('AgyResponseParser', () => {
+  describe('successful responses', () => {
+    it('extracts the response text', () => {
+      expect(parser.extractResponse(SUCCESS_RAW)).toBe('OK\n');
+    });
+
+    it('parses the envelope', () => {
+      const parsed = parser.parse(SUCCESS_RAW);
+
+      expect(parsed?.status).toBe('SUCCESS');
+      expect(parsed?.conversation_id).toBe('f1f8db42-c436-42ef-a568-148385671f86');
+    });
+
+    it('reports no error message', () => {
+      expect(parser.extractErrorMessage(SUCCESS_RAW)).toBeNull();
+    });
+  });
+
+  describe('fail closed — agy exits 0 on failure', () => {
+    it('does NOT return response text for an ERROR envelope', () => {
+      // The whole point: exit code 0 plus this payload must not read as success.
+      expect(parser.extractResponse(ERROR_RAW)).toBeNull();
+    });
+
+    it('surfaces the error message so the adapter can classify it', () => {
+      expect(parser.extractErrorMessage(ERROR_RAW)).toContain('invalid model selection');
+    });
+
+    it('treats an absent status field as failure, not success', () => {
+      const raw = JSON.stringify({ response: 'looks fine', conversation_id: 'x' });
+
+      expect(parser.extractResponse(raw)).toBeNull();
+    });
+
+    it('treats an unrecognized status as failure', () => {
+      const raw = JSON.stringify({ status: 'PARTIAL', response: 'half an answer' });
+
+      expect(parser.extractResponse(raw)).toBeNull();
+    });
+
+    it('treats unparseable output as failure', () => {
+      expect(parser.parse('not json at all')).toBeNull();
+      expect(parser.extractResponse('not json at all')).toBeNull();
+    });
+
+    it('treats truncated JSON as failure', () => {
+      const truncated = SUCCESS_RAW.slice(0, SUCCESS_RAW.length / 2);
+
+      expect(parser.extractResponse(truncated)).toBeNull();
+    });
+
+    it('treats empty output as failure', () => {
+      expect(parser.extractResponse('')).toBeNull();
+    });
+
+    it('rejects a SUCCESS envelope whose response is not a string', () => {
+      const raw = JSON.stringify({ status: 'SUCCESS', response: { text: 'nested' } });
+
+      expect(parser.extractResponse(raw)).toBeNull();
+    });
+  });
+
+  describe('token usage', () => {
+    it('maps agy usage onto TokenUsage', () => {
+      expect(parser.extractUsage(SUCCESS_RAW)).toEqual({
+        inputTokens: 16397,
+        outputTokens: 5,
+        totalTokens: 16402,
+      });
+    });
+
+    it('folds thinking tokens into output rather than dropping them', () => {
+      // agy reports `thinking_tokens` separately. TokenUsage has no field for
+      // them, and silently discarding billable tokens would understate cost in
+      // the outcome data the routing loop learns from.
+      const raw = JSON.stringify({
+        status: 'SUCCESS',
+        response: 'x',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 10,
+          thinking_tokens: 40,
+          cache_read_tokens: 7,
+          total_tokens: 150,
+        },
+      });
+
+      expect(parser.extractUsage(raw)).toEqual({
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      });
+    });
+
+    it('returns null when usage is absent', () => {
+      expect(parser.extractUsage(JSON.stringify({ status: 'SUCCESS', response: 'x' }))).toBeNull();
+    });
+
+    it('returns null for unparseable output', () => {
+      expect(parser.extractUsage('garbage')).toBeNull();
+    });
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/parsers/agy-parser.ts
+++ b/packages/nexus-agents/src/cli-adapters/parsers/agy-parser.ts
@@ -1,0 +1,137 @@
+/**
+ * nexus-agents/cli-adapters - Antigravity (`agy`) CLI Response Parser
+ *
+ * Parses `agy --output-format json`, the replacement for the retired standalone
+ * `gemini` CLI (#4346).
+ *
+ * FAIL-CLOSED BY CONSTRUCTION. `agy` exits 0 even when the run failed — a bad
+ * model returns `{"status":"ERROR","response":"","error":"…"}` with exit code 0.
+ * The verdict lives in the `status` field, so this parser treats anything that
+ * is not an explicit `SUCCESS` envelope with a string `response` as a failure:
+ * unparseable output, truncated JSON, a missing `status`, an unrecognized
+ * `status`, and a non-string `response` all yield `null`. Callers must not
+ * infer success from the process exit code.
+ *
+ * Verified against `agy` v1.1.9 (2026-08-09).
+ *
+ * @module cli-adapters/parsers/agy-parser
+ */
+
+import { z } from 'zod';
+import type { ICliResponseParser, TokenUsage } from '../types.js';
+
+/**
+ * The usage block agy reports. `thinking_tokens` and `cache_read_tokens` have no
+ * home in {@link TokenUsage}; see {@link AgyResponseParser.extractUsage} for how
+ * they are handled rather than dropped.
+ */
+const AgyUsageSchema = z.object({
+  input_tokens: z.number(),
+  output_tokens: z.number(),
+  thinking_tokens: z.number().optional(),
+  cache_read_tokens: z.number().optional(),
+  total_tokens: z.number(),
+});
+
+/**
+ * A successful agy envelope. `status` is pinned to the literal `SUCCESS` so an
+ * unrecognized future status (e.g. a `PARTIAL`) fails the parse instead of being
+ * waved through as a success.
+ */
+const AgySuccessSchema = z.object({
+  status: z.literal('SUCCESS'),
+  response: z.string(),
+  conversation_id: z.string().optional(),
+  duration_seconds: z.number().optional(),
+  num_turns: z.number().optional(),
+  usage: AgyUsageSchema.optional(),
+});
+
+/** A failed agy envelope — still delivered with exit code 0. */
+const AgyErrorSchema = z.object({
+  status: z.string(),
+  error: z.string().optional(),
+  response: z.string().optional(),
+  conversation_id: z.string().optional(),
+});
+
+/** A parsed, validated agy success envelope. */
+export type AgyCliResponse = z.infer<typeof AgySuccessSchema>;
+
+/** Parse raw stdout as JSON, or undefined when it is not JSON at all. */
+function asJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Parser for `agy --output-format json`.
+ *
+ * `parse` returns a value ONLY for a well-formed success envelope. Failure
+ * detail is available separately via {@link AgyResponseParser.extractErrorMessage}.
+ */
+export class AgyResponseParser implements ICliResponseParser<AgyCliResponse> {
+  readonly name = 'agy-parser';
+  readonly supportedVersionRange = '>=1.0.0 <2.0.0';
+
+  parse(raw: string): AgyCliResponse | null {
+    const json = asJson(raw);
+    if (json === undefined) return null;
+    const parsed = AgySuccessSchema.safeParse(json);
+    return parsed.success ? parsed.data : null;
+  }
+
+  extractResponse(raw: string): string | null {
+    return this.parse(raw)?.response ?? null;
+  }
+
+  /**
+   * The error text from a non-SUCCESS envelope, or null when the run succeeded
+   * or the output was not a recognizable agy envelope at all.
+   *
+   * Returning the message lets the adapter classify it (rate limit, auth,
+   * bad model) through the shared taxonomy rather than reporting a bare
+   * PARSE_ERROR — the same reason `opencode-parser` grew this method.
+   */
+  extractErrorMessage(raw: string): string | null {
+    const json = asJson(raw);
+    if (json === undefined) return null;
+    // A valid success envelope has no error to report.
+    if (AgySuccessSchema.safeParse(json).success) return null;
+    const parsed = AgyErrorSchema.safeParse(json);
+    if (!parsed.success) return null;
+    return parsed.data.error ?? `agy reported status '${parsed.data.status}'`;
+  }
+
+  /**
+   * Maps agy's usage block onto {@link TokenUsage}.
+   *
+   * `thinking_tokens` are **folded into `outputTokens`** rather than dropped:
+   * they are generated, billable tokens, and discarding them would understate
+   * cost in exactly the outcome data the routing loop learns from.
+   * `cache_read_tokens` are deliberately NOT added — they are a subset of input
+   * already counted in `input_tokens`, so adding them would double-count.
+   */
+  /**
+   * agy's `conversation_id` is the session handle — it is what `--conversation`
+   * accepts to resume a run, so it maps directly onto the session-id contract.
+   */
+  extractSessionId(raw: string): string | null {
+    const id = this.parse(raw)?.conversation_id;
+    return id === undefined || id === '' ? null : id;
+  }
+
+  extractUsage(raw: string): TokenUsage | null {
+    const parsed = this.parse(raw);
+    if (parsed?.usage === undefined) return null;
+    const { input_tokens, output_tokens, thinking_tokens, total_tokens } = parsed.usage;
+    return {
+      inputTokens: input_tokens,
+      outputTokens: output_tokens + (thinking_tokens ?? 0),
+      totalTokens: total_tokens,
+    };
+  }
+}

--- a/packages/nexus-agents/src/cli-adapters/types-capability.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-capability.ts
@@ -306,9 +306,13 @@ export const CLI_VERSION_REQUIREMENTS: Record<CliName, VersionRequirements> = {
     recommended: '2.0.76',
     breaking: [],
   },
+  // #4346: the `gemini` arm now runs the Antigravity CLI (`agy`), which
+  // replaced the retired standalone gemini CLI. Versions are agy's, not
+  // gemini's — an installed gemini 0.5x would fail the minimum, which is
+  // correct: it cannot serve.
   gemini: {
-    minimum: '0.20.0',
-    recommended: '0.22.5',
+    minimum: '1.0.0',
+    recommended: '1.1.9',
     breaking: [],
   },
   codex: {

--- a/packages/nexus-agents/src/config/agy-model-map.test.ts
+++ b/packages/nexus-agents/src/config/agy-model-map.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the Antigravity (`agy`) model-slug mapping (#4346).
+ *
+ * @module config/agy-model-map.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  toAgyModelSlug,
+  isAgyModelSlug,
+  AGY_MODEL_SLUGS,
+  DEFAULT_AGY_MODEL,
+} from './agy-model-map.js';
+import { DEFAULT_MODEL_CAPABILITIES } from './in-tree-data.js';
+
+describe('agy model slugs', () => {
+  it('accepts an already-valid agy slug unchanged', () => {
+    for (const slug of AGY_MODEL_SLUGS) {
+      expect(toAgyModelSlug(slug)).toBe(slug);
+    }
+  });
+
+  it('maps every canonical gemini model to a slug agy accepts', () => {
+    // The mapping must be total over the registry: an unmapped id would reach
+    // agy and come back as status:ERROR with exit code 0.
+    const geminiIds = DEFAULT_MODEL_CAPABILITIES.models
+      .filter((m) => m.cliName === 'gemini')
+      .map((m) => m.id);
+
+    expect(geminiIds.length).toBeGreaterThan(0);
+    for (const id of geminiIds) {
+      expect(isAgyModelSlug(toAgyModelSlug(id))).toBe(true);
+    }
+  });
+
+  it('maps the strongest registry entry to the strongest pro tier', () => {
+    expect(toAgyModelSlug('gemini-3-pro')).toBe('gemini-3.1-pro-high');
+  });
+
+  it('maps a 2.5-generation entry agy does not serve to a surviving tier', () => {
+    // agy serves no 2.5 models at all. Dropping these would break routing that
+    // already selects them.
+    expect(isAgyModelSlug(toAgyModelSlug('gemini-pro'))).toBe(true);
+    expect(isAgyModelSlug(toAgyModelSlug('gemini-flash'))).toBe(true);
+  });
+
+  it('falls back to a valid slug for an unknown model', () => {
+    expect(toAgyModelSlug('some-model-that-does-not-exist')).toBe(DEFAULT_AGY_MODEL);
+    expect(isAgyModelSlug(DEFAULT_AGY_MODEL)).toBe(true);
+  });
+
+  it('never returns a Google API model id', () => {
+    // The API-side `cliModelName` values (gemini-2.5-flash, …) are a different
+    // namespace; returning one would make agy reject the call.
+    expect(toAgyModelSlug('gemini-2.5-flash')).not.toBe('gemini-2.5-flash');
+    expect(isAgyModelSlug(toAgyModelSlug('gemini-2.5-flash'))).toBe(true);
+  });
+
+  it('does not map agy’s non-Gemini models', () => {
+    // agy also fronts Claude and GPT-OSS. The `gemini` arm means Gemini-family
+    // models; those are routed through their own adapters (#4346, 7/0 vote).
+    expect(AGY_MODEL_SLUGS.every((s) => s.startsWith('gemini-'))).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/config/agy-model-map.ts
+++ b/packages/nexus-agents/src/config/agy-model-map.ts
@@ -1,0 +1,101 @@
+/**
+ * nexus-agents/config - Antigravity (`agy`) model-slug mapping
+ *
+ * Maps canonical registry model ids onto the model slugs the `agy` CLI accepts
+ * (#4346).
+ *
+ * WHY THIS IS SEPARATE FROM `cliModelName`. The obvious move — repointing the
+ * gemini entries' `cliModelName` at agy slugs — is wrong: that field is ALSO
+ * read by the API-based `GeminiAdapter` via `GEMINI_MODELS`
+ * (`adapters/gemini-types.ts:21-23`), which calls the Google API directly and
+ * needs real API ids like `gemini-2.5-flash`. agy's slugs (`gemini-3.6-flash-low`)
+ * are meaningless to that API. One field cannot serve both surfaces, so the
+ * CLI-transport naming lives here.
+ *
+ * Lives under `config/` because `scripts/check-model-string-drift.ts` blocks
+ * version-bearing model-id literals outside this directory, and enforces it in
+ * CI and pre-push.
+ *
+ * Verified against `agy models` on v1.1.9 (2026-08-09).
+ *
+ * @module config/agy-model-map
+ */
+
+/**
+ * The model slugs `agy` accepts, as reported by `agy models`.
+ *
+ * agy bakes reasoning effort into the slug (`-high`/`-medium`/`-low`) rather
+ * than taking it as a separate axis. A `--effort` flag also exists; the slug
+ * suffix is used here because it is what `agy models` enumerates, making it the
+ * machine-readable contract.
+ *
+ * agy is multi-model — it also fronts `claude-sonnet-4-6`,
+ * `claude-opus-4-6-thinking` and `gpt-oss-120b-medium`. Those are deliberately
+ * NOT mapped: the `gemini` routing arm means "Gemini-family models", and this
+ * repo already routes Claude through the claude adapter and GPT-OSS through
+ * openrouter arms. Adding duplicate routes here would give the router redundant
+ * arms to disambiguate with no consumer asking for them (#4346, 7/0 vote).
+ */
+export const AGY_MODEL_SLUGS = [
+  'gemini-3.6-flash-high',
+  'gemini-3.6-flash-medium',
+  'gemini-3.6-flash-low',
+  'gemini-3.5-flash-high',
+  'gemini-3.5-flash-medium',
+  'gemini-3.5-flash-low',
+  'gemini-3.1-pro-high',
+  'gemini-3.1-pro-low',
+] as const;
+
+export type AgyModelSlug = (typeof AGY_MODEL_SLUGS)[number];
+
+/**
+ * Canonical registry model id → agy slug.
+ *
+ * Mapped by TIER SEMANTICS, not by version-string similarity, because agy's
+ * generations do not line up with the registry's. The registry's quality
+ * profile is the guide: the two `pro` entries take the pro slugs (higher
+ * reasoning gets `-high`), and the three flash entries take flash slugs
+ * descending by the cost/quality trade-off each entry records.
+ *
+ * `gemini-pro` and `gemini-flash` are registry entries for the 2.5 generation,
+ * which agy does not serve at all; they map to the nearest surviving tier rather
+ * than being dropped, so routing that already selects them keeps working.
+ */
+const CANONICAL_TO_AGY: Readonly<Record<string, AgyModelSlug>> = {
+  // reasoning 10 — the strongest entry takes the strongest pro tier
+  'gemini-3-pro': 'gemini-3.1-pro-high',
+  // reasoning 9, 2.5-generation — nearest surviving pro tier
+  'gemini-pro': 'gemini-3.1-pro-low',
+  // speed 10 / quality 8
+  'gemini-3.5-flash': 'gemini-3.5-flash-medium',
+  // speed 10 / quality 8, cheaper than the above
+  'gemini-3-flash': 'gemini-3.5-flash-low',
+  // cheapest entry, quality 7, 2.5-generation
+  'gemini-flash': 'gemini-3.6-flash-low',
+};
+
+/** The slug used when a caller names a model agy cannot serve. */
+export const DEFAULT_AGY_MODEL: AgyModelSlug = 'gemini-3.1-pro-high';
+
+/** Whether a string is a slug `agy` will accept. */
+export function isAgyModelSlug(value: string): value is AgyModelSlug {
+  return (AGY_MODEL_SLUGS as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve a model identifier to a slug `agy` accepts.
+ *
+ * Accepts an already-valid agy slug unchanged (so callers can pin one
+ * directly), then a canonical registry id, and otherwise falls back to
+ * {@link DEFAULT_AGY_MODEL}.
+ *
+ * The fallback is deliberate rather than an error: an unmapped id reaching agy
+ * produces `{"status":"ERROR","error":"invalid model selection ..."}` **with
+ * exit code 0**, which is a far worse failure than quietly running a valid
+ * model. The substitution is logged by the caller.
+ */
+export function toAgyModelSlug(model: string): AgyModelSlug {
+  if (isAgyModelSlug(model)) return model;
+  return CANONICAL_TO_AGY[model] ?? DEFAULT_AGY_MODEL;
+}


### PR DESCRIPTION
Closes #4346. Also closes the agy half of #4318.

## The gemini CLI is dead, not degraded

Verified live on this machine, not inferred:

```
$ gemini --prompt "say OK"
Error authenticating: IneligibleTierError: This client is no longer supported for
Gemini Code Assist for individuals... migrate to the Antigravity suite
$ echo $?
55
```

Every invocation, `gemini` v0.51.0. `agy` v1.1.9 works.

## The load-bearing detail: agy exits 0 on failure

```
$ agy --print "hi" --model no-such-model --output-format json
{"conversation_id":"","status":"ERROR","response":"","error":"invalid model selection ..."}
$ echo $?
0
```

An adapter that classifies on exit status would read **every agy failure as a success** — the exact fail-open class #4350/#4354/#4362/#4363 just removed from this repo. So `AgyResponseParser` is fail-closed by construction: unparseable output, truncated JSON, a missing `status`, an unrecognized `status`, and a non-string `response` all yield `null`. `status` is pinned to the literal `SUCCESS` via Zod, so a future `PARTIAL` fails the parse rather than being waved through.

## Decision

`consensus_vote` (`higher_order`, live 7-voter panel, **7/0**) chose keeping the `gemini` CliName and repointing the binary. Adding or renaming a CliName would touch ~30 exhaustive maps, two exhaustive switches, a **duplicated union in `packages/nexus-memory`**, and persisted LinUCB/outcome history — to buy routability of agy's Claude/GPT-OSS models, which are already reachable through their own adapters. The panel judged that doing nothing would beat that trade.

Worth recording: the Contrarian corrected my own framing. "Preserves LinUCB history" is weaker than I claimed — that history's recent window is a stretch of 100% failures from the dead-adapter period, which could actively *suppress* the arm post-migration. The real argument for this option is avoiding churn, not preserving priors. Filing the arm-reset question separately.

## The trap the test suite caught

The obvious implementation — repoint the gemini entries' `cliModelName` at agy slugs — is **wrong**, and I wrote it before the tests told me so. That field is also read by the API-based `GeminiAdapter` via `GEMINI_MODELS` (`adapters/gemini-types.ts:21-23`), which calls the Google API directly and needs real ids like `gemini-2.5-flash`. agy's `gemini-3.6-flash-low` is meaningless to that API. One field cannot serve both surfaces.

Slugs now live in a new `config/agy-model-map.ts`, mapped by **tier semantics** rather than version-string similarity (agy's generations do not line up with the registry's), with a totality test over every registry gemini entry. It lives under `config/` because `check-model-string-drift.ts` blocks version-bearing model literals elsewhere and gates CI and pre-push.

## Other changes

- Flags: `-o json` → `--output-format json`, `-m` → `--model`, `--resume` → `--conversation`
- `--policy <file>` has no agy equivalent (`--agent` selects a preconfigured agent, not inline instructions), so the system prompt is **prepended to the content** — a deliberate downgrade in framing fidelity, commented as such so it is not read as an oversight. It also removes the per-call tempdir the old path created (#2824).
- `thinking_tokens` folded into `outputTokens` rather than dropped: generated, billable, and silent loss would understate cost in the outcome data the routing loop learns from. `cache_read_tokens` deliberately **not** added — a subset of input already counted, so adding would double-count.
- `CLI_VERSION_REQUIREMENTS.gemini` now describes agy versions, so an installed gemini 0.5x correctly fails the minimum.
- `CONTRIBUTING.md` version-check block updated.

## A cost finding for follow-up

agy reports **16,397 input tokens for a two-word prompt** — a ~16k system-prompt/tool-manifest overhead per call (its `stream-json` `init` event enumerates ~50 tools). Under `NEXUS_BILLING_MODE=api`, cost-aware TOPSIS scoring will see this arm as far more expensive than the old CLI, for reasons unrelated to value. Flagged on the issue; not silently inherited.

## Verification

- 15 new parser tests, fixtures captured verbatim from the live CLI, with the exit-0-ERROR case as the load-bearing assertion
- 7 new slug-map tests including totality over the registry
- 5 new adapter tests pinning `command === 'agy'`, the flag spellings, `--conversation`, and that the prompt is never passed positionally
- Old `--policy` tests replaced with prepend-behaviour tests
- Full package suite **27784 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓

## Not in this PR

Registering agy in `list_available_models` quota/retry classification, the readiness probe that would have caught this failure automatically (#4376), and image-generation capability (#4318). Called out on the issues rather than bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)