### PR TITLE
fix(cli-adapters): separate an adapter's executable from its routing identity (#4346)

### DIFF
--- a/.changeset/olive-buses-run.md
+++ b/.changeset/olive-buses-run.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': patch
+---
+
+fix(cli-adapters): separate an adapter's executable from its routing identity (#4346)
+
+Fixes a regression the agy repoint introduced: `isCliAvailable('gemini')` returned
+**false** on a machine where the adapter worked perfectly.
+
+`BaseCliAdapter.getVersion()` ran ``execAsync(`${this.name} --version`)`` — the
+`CliName` doubled as the binary name. That is fine while the two coincide and
+silently wrong when they diverge. After the gemini arm was repointed to spawn
+`agy`, task execution went to `agy` while the health check still shelled
+`gemini --version`, reporting the retired binary's `0.51.0` against agy's `1.0.0`
+floor. The arm failed its own availability gate while returning correct results
+to any caller that bypassed the gate.
+
+`BaseCliAdapter` now exposes `binaryName`, defaulting to `name` so every other
+adapter is unaffected, overridden to `agy` for the gemini arm. `getVersion()`, the
+version-failure message, and `SubprocessCliAdapter`'s NOT_FOUND message all use
+it, and `GeminiCliAdapter.getCommand()` derives its command from the same property
+rather than a separate literal — so the execution path and the version probe
+cannot drift apart again.
+
+Verified live: `healthCheck()` now returns `{healthy: true, version: "1.1.11"}`
+where it previously returned `{healthy: false, version: "0.51.0"}`.
+
+Note this restores the health half only. `isCliAvailable` is
+`health.healthy && auth.state === 'authenticated'`, and the auth probe still reads
+the retired CLI's OAuth cache — tracked separately.

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
@@ -90,6 +90,16 @@ const DEFAULT_CONFIG: Required<Omit<GeminiConfig, 'logger' | 'circuitBreakerConf
  */
 export class GeminiCliAdapter extends SubprocessCliAdapter {
   readonly name: CliName = 'gemini';
+
+  /**
+   * #4346: the arm is still called `gemini` (it serves Google's Gemini models
+   * and keeps the routing/LinUCB identity), but the executable is `agy`. The
+   * standalone gemini CLI is EOL — it exits 55 with IneligibleTierError on
+   * every invocation.
+   */
+  override get binaryName(): string {
+    return 'agy';
+  }
   protected readonly parser: ICliResponseParser;
 
   private readonly model: string;
@@ -248,7 +258,7 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
     // always passed as its argument rather than positionally.
     args.push('--print', content);
 
-    return { command: 'agy', args };
+    return { command: this.binaryName, args };
   }
 
   private checkCircuitBreaker(): CliError | null {

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.ts
@@ -67,6 +67,21 @@ export abstract class BaseCliAdapter implements ICliAdapter {
   abstract readonly name: CliName;
   abstract readonly transport: CliTransport;
 
+  /**
+   * The executable this adapter actually runs.
+   *
+   * Defaults to {@link name} because for most arms the routing identity and the
+   * binary are the same word. They are NOT always the same: the `gemini` arm
+   * runs `agy` (Antigravity) after Google retired the standalone gemini CLI
+   * (#4346). Conflating the two is how that arm ended up executing `agy` for
+   * work while shelling `gemini --version` for its health check — reporting the
+   * dead binary's version against the live one's floor, and failing its own
+   * availability gate while working perfectly.
+   */
+  get binaryName(): string {
+    return this.name;
+  }
+
   protected readonly logger: ILogger;
   protected capacityTracker: CapacityTracker | null = null;
   protected initialized = false;
@@ -252,7 +267,7 @@ export abstract class BaseCliAdapter implements ICliAdapter {
     }
 
     try {
-      const { stdout } = await execAsync(`${this.name} --version`, {
+      const { stdout } = await execAsync(`${this.binaryName} --version`, {
         timeout: CLI_SUBPROCESS_TIMEOUTS.spawnMs,
       });
 
@@ -261,7 +276,7 @@ export abstract class BaseCliAdapter implements ICliAdapter {
       this.cachedVersion = version;
       return version;
     } catch (cause: unknown) {
-      throw new Error(`Failed to get ${this.name} version`, { cause });
+      throw new Error(`Failed to get ${this.binaryName} version`, { cause });
     }
   }
 

--- a/packages/nexus-agents/src/cli-adapters/binary-name.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/binary-name.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the adapter's executable name being distinct from its routing
+ * identity (#4346).
+ *
+ * `BaseCliAdapter` used the `CliName` as the binary name — `getVersion()` ran
+ * ``execAsync(`${this.name} --version`)``. That is fine while the two coincide,
+ * and silently wrong when they do not: after the gemini arm was repointed to
+ * spawn `agy`, task execution went to `agy` while the health check still shelled
+ * `gemini --version`. It reported the retired binary's `0.51.0` against agy's
+ * `1.0.0` floor, so `isCliAvailable('gemini')` returned false for an adapter
+ * that worked perfectly.
+ *
+ * @module cli-adapters/binary-name.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CliName, CliTransport, CliTask, ModelInfo } from './types.js';
+import type { CliResponse, CliError, ResolvedExecutionOptions } from './types.js';
+import type { Result } from '../core/index.js';
+import { ok } from '../core/index.js';
+import { BaseCliAdapter } from './base-adapter.js';
+import { GeminiCliAdapter } from './adapters/gemini-adapter.js';
+import { ClaudeCliAdapter } from './adapters/claude-adapter.js';
+
+/** An adapter that does not override `binaryName`. */
+class PlainAdapter extends BaseCliAdapter {
+  readonly name: CliName = 'codex';
+  readonly transport: CliTransport = 'subprocess';
+
+  executeTask(
+    _task: CliTask,
+    _options: ResolvedExecutionOptions
+  ): Promise<Result<CliResponse, CliError>> {
+    return Promise.resolve(ok({ text: 'ok' }));
+  }
+
+  getModelInfo(): ModelInfo {
+    return {
+      id: 'x',
+      name: 'X',
+      contextWindow: 1,
+      maxOutput: 1,
+      costPerMillionInput: 0,
+      costPerMillionOutput: 0,
+    };
+  }
+
+  initialize(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe('adapter binary name (#4346)', () => {
+  it('defaults to the CliName when the arm and the executable coincide', () => {
+    expect(new PlainAdapter().binaryName).toBe('codex');
+    expect(new ClaudeCliAdapter().binaryName).toBe('claude');
+  });
+
+  it('reports agy for the gemini arm', () => {
+    // The arm keeps its routing identity (and its LinUCB history); only the
+    // executable moved.
+    const adapter = new GeminiCliAdapter();
+
+    expect(adapter.name).toBe('gemini');
+    expect(adapter.binaryName).toBe('agy');
+  });
+
+  it('spawns the binary name, not the arm name', () => {
+    const adapter = new GeminiCliAdapter();
+    const cmd = (
+      adapter as unknown as { getCommand: (t: unknown) => { command: string } }
+    ).getCommand({ content: 'hi' });
+
+    expect(cmd.command).toBe('agy');
+    expect(cmd.command).not.toBe('gemini');
+  });
+
+  it('derives the spawned command from binaryName, so the two cannot drift', () => {
+    // Regression guard: the command was previously a separate literal, which is
+    // exactly how the version probe and the execution path came to disagree.
+    const adapter = new GeminiCliAdapter();
+    const cmd = (
+      adapter as unknown as { getCommand: (t: unknown) => { command: string } }
+    ).getCommand({ content: 'hi' });
+
+    expect(cmd.command).toBe(adapter.binaryName);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -748,7 +748,7 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
     }
 
     if (error.message.includes('ENOENT')) {
-      return err(this.createError('NOT_FOUND', `${this.name} CLI not found`, error));
+      return err(this.createError('NOT_FOUND', `${this.binaryName} CLI not found`, error));
     }
 
     return err(this.createError('EXECUTION_ERROR', sanitizeOutput(error.message), error));


### PR DESCRIPTION
Increment 1 of the #4346 follow-through. Fixes a regression **I introduced** in #4385.

## The arm was working and unavailable at the same time

```
isCliAvailable('gemini')  ->  false
healthCheck()          ->  {"healthy":false,"version":"0.51.0",
                            "message":"Version 0.51.0 is not supported. Minimum: 1.0.0"}
```

`0.51.0` is the **retired** gemini CLI. `BaseCliAdapter.getVersion()` (`base-adapter.ts:255`) ran:

```ts
const { stdout } = await execAsync(`${this.name} --version`, { ... });
```

`this.name` is the **CliName** — so the health check shelled `gemini --version` while `getCommand()` spawned `agy`. #4385 raised the version floor to agy's `1.0.0` and left the probe on the dead binary, so the arm failed its own gate. Meanwhile a direct `execute()` returned `PONG` with real token usage the whole time. Working, and unselectable.

## The bug generalizes past this one arm

The `CliName` doubling as the binary name is the actual defect — `subprocess-adapter.ts:751` builds its NOT_FOUND message the same way. Any adapter whose routing identity differs from its executable hits this, and repointing `getCommand()` can never be sufficient on its own.

`BaseCliAdapter` now exposes `binaryName`, defaulting to `name` so **every other adapter is untouched**, overridden to `agy` for the gemini arm. `getVersion()`, the version-failure message, and the NOT_FOUND message all read it.

Crucially, `GeminiCliAdapter.getCommand()` now derives its command from `this.binaryName` rather than a second literal — a test pins `cmd.command === adapter.binaryName`, so the execution path and the version probe **cannot drift apart again**. Two literals in two places is precisely how they disagreed.

## Verified live, not just in fixtures

```
before:  healthCheck: {"healthy":false,"version":"0.51.0","message":"... not supported. Minimum: 1.0.0"}
after:   healthCheck: {"healthy":true,"version":"1.1.11"}
```

## What this does NOT fix, stated plainly

`isCliAvailable` is `health.healthy && auth.state === 'authenticated'`. **It still returns false**, because the auth probe reads the retired CLI's OAuth cache. I checked that experimentally rather than assuming:

```
BEFORE mtime: 2026-08-09T08:58:53
(agy --print ... -> SUCCESS)
AFTER  mtime: 2026-08-09T08:58:53     # unchanged
expiry_date -> 2026-08-09T09:58:52    # expired ~5.5h before the run
```

agy succeeded while `~/.gemini/oauth_creds.json` sat expired and untouched. It does not use that file. Replacing the probe is increment 2 — I am not claiming this PR restores availability.

## Decision

`consensus_vote` (`higher_order`, **7/0**) approved the four-increment sequencing, with the regression fix first so every later removal is verified against a healthy adapter rather than a broken probe. The Contrarian attached a DRY condition for increment 3 that this PR sets up for: the remaining hardcoded `gemini` binary strings in `status-command.ts`, `doctor.ts` and `scripts/review-pr.ts` should read from this single authority rather than being replaced with a second hardcoded string.

## Verification

- 4 new tests: default-equals-CliName for unmodified adapters, `agy` for the gemini arm, the spawned command is `agy`, and the drift guard tying command to `binaryName`
- Full package suite **27788 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)