### PR TITLE
fix(consensus): compare canonical model identity in panel diversity checks (#4390)

### DIFF
--- a/.changeset/tricky-bats-argue.md
+++ b/.changeset/tricky-bats-argue.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': patch
+---
+
+fix(consensus): compare canonical model identity in panel diversity checks (#4390)
+
+The consensus panel's diversity check built a `Set` of raw `modelId` strings. The
+same weights arrive under different strings from different gateways —
+`claude-sonnet-4-6` via the claude CLI, `anthropic/claude-sonnet-4-6` via
+opencode, `custom/claude-sonnet-4-6` via an OpenAI-compatible endpoint — so one
+model counted as three and the warning never fired for a collapsed panel.
+
+`config/model-equivalence.ts` adds `canonicalModelKey` and `countDistinctModels`,
+built on the existing `resolveModelIdentitySync`, which already normalises gateway
+prefixes. An unidentifiable model returns `null` and is counted by its raw string
+rather than sharing a placeholder key — otherwise two genuinely different models
+would compare equal, which is the inverse error and the worse one, since it would
+silence a warning that should fire.
+
+Also adds the check the CLI round-robin path never had: distinct CLIs do not imply
+distinct models, and a panel spread across two arms fronting the same weights is no
+more independent than one on a single arm.
+
+Scope note: these checks are `logger.warn` only — nothing gates on them — so this
+fixes observability rather than a live consensus hole. The same string comparison
+also affects cost attribution in `decision-cost-recording`, which is tracked
+separately.

--- a/packages/nexus-agents/src/cli/voter-agents.test.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.test.ts
@@ -27,7 +27,7 @@ import {
   NoAdapterError,
 } from './voter-agents.js';
 import type { VoterRole } from './vote-types.js';
-import type { IModelAdapter, CompletionResponse } from '../core/index.js';
+import type { IModelAdapter, CompletionResponse, ILogger } from '../core/index.js';
 import type { Result } from '../core/index.js';
 import { createLogger } from '../core/index.js';
 
@@ -550,6 +550,77 @@ That's my vote.`;
       expect(results).toHaveLength(1);
       expect(results[0]?.source).toBe('llm');
       expect(results[0]?.vote.decision).toBe('approve');
+    });
+  });
+
+  // #4390: the diversity check compared raw modelId STRINGS, so one model
+  // reached through two gateways — `anthropic/claude-sonnet-4-6` and
+  // `custom/claude-sonnet-4-6` are the same weights — counted as two distinct
+  // models and the warning never fired.
+  describe('panel diversity uses canonical model identity (#4390)', () => {
+    function adapterFor(modelId: string): IModelAdapter {
+      return {
+        providerId: 'gateway',
+        modelId,
+        capabilities: [],
+        complete: vi.fn().mockResolvedValue({
+          ok: true,
+          value: {
+            content: JSON.stringify({
+              decision: 'approve',
+              reasoning: 'Reasonable enough for a test fixture.',
+              confidence: 0.8,
+            }),
+            usage: {},
+            stopReason: 'end_turn',
+            model: modelId,
+          },
+        }),
+        stream: vi.fn(),
+        countTokens: vi.fn().mockResolvedValue(10),
+        validateConfig: vi.fn().mockReturnValue({ ok: true }),
+      };
+    }
+
+    async function warningsFor(modelIds: readonly string[]): Promise<string[]> {
+      const warnings: string[] = [];
+      const capturing = {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+        warn: (msg: string) => warnings.push(msg),
+      } as unknown as ILogger;
+
+      await collectRealVotes({
+        roles: ['architect', 'security'],
+        proposal: 'Test proposal',
+        logger: capturing,
+        gatewayAdapters: modelIds.map(adapterFor),
+      });
+      return warnings;
+    }
+
+    it('warns when two gateways serve the same underlying model', async () => {
+      const warnings = await warningsFor([
+        'anthropic/claude-sonnet-4-6',
+        'custom/claude-sonnet-4-6',
+      ]);
+
+      expect(warnings.some((w) => w.includes('collapsed to a single gateway model'))).toBe(true);
+    });
+
+    it('stays quiet for a genuinely diverse panel', async () => {
+      const warnings = await warningsFor(['anthropic/claude-sonnet-4-6', 'openai/gpt-5.5']);
+
+      expect(warnings.some((w) => w.includes('collapsed to a single gateway model'))).toBe(false);
+    });
+
+    it('does not merge two unidentifiable models into one', async () => {
+      // The inverse error: collapsing distinct models because neither can be
+      // identified would silence a warning that should NOT fire.
+      const warnings = await warningsFor(['some-private-model', 'another-private-model']);
+
+      expect(warnings.some((w) => w.includes('collapsed to a single gateway model'))).toBe(false);
     });
   });
 

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -28,6 +28,7 @@ import { getAvailableClis } from '../cli-adapters/factory.js';
 import { authRemediation } from '../cli-adapters/cli-error-envelope.js';
 import type { CliName } from '../cli-adapters/types.js';
 import { checkCodexConcurrency } from '../cli-adapters/codex-limits.js';
+import { countDistinctModels } from '../config/model-equivalence.js';
 
 // Re-export prompts for backward compatibility
 export { VOTER_SYSTEM_PROMPTS, SIMULATED_VOTE_REASONING } from './voter-prompts.js';
@@ -378,11 +379,16 @@ export function resolveGatewayRoleAdapters(
   // Consensus-integrity parity with the single-model path (#4055 review): warn if
   // the FINAL assignment collapsed every role onto one model — e.g. an operator
   // pinned all roles to the same override — since correlated votes defeat the panel.
-  const distinctModels = new Set([...assigned.values()].map((a) => a.modelId));
-  if (roles.length > 1 && distinctModels.size === 1) {
+  // #4390: compare CANONICAL model identity, not the raw strings. The same
+  // weights arrive under different strings from different gateways —
+  // `claude-sonnet-4-6`, `anthropic/claude-sonnet-4-6` and
+  // `custom/claude-sonnet-4-6` are one model — so a raw-string set reported a
+  // collapsed panel as diverse and the warning never fired.
+  const assignedModels = [...assigned.values()].map((a) => a.modelId);
+  if (roles.length > 1 && countDistinctModels(assignedModels) === 1) {
     logger.warn(
       'Consensus panel collapsed to a single gateway model via overrides — votes may correlate',
-      { model: [...distinctModels][0], roleCount: roles.length }
+      { model: assignedModels[0], roleCount: roles.length }
     );
   }
   return assigned;
@@ -416,6 +422,20 @@ async function resolveDiverseAdapters(
 
   const cliAdapters = createCliAdapterMap(availableClis, logger);
   if (cliAdapters.size <= 1) return assignUniformAdapter(roles, fallbackAdapter);
+
+  // #4390: distinct CLIs do NOT imply distinct models. Two arms can front the
+  // same weights — opencode serving `anthropic/claude-sonnet-4-6` alongside the
+  // claude CLI, for instance — and a panel spread across them is no more
+  // independent than one on a single arm. The gateway path had this check; the
+  // CLI path had none.
+  const cliModels = [...cliAdapters.values()].map((a) => a.modelId);
+  if (roles.length > 1 && countDistinctModels(cliModels) === 1) {
+    logger.warn('Consensus panel spans multiple CLIs serving ONE model — votes may correlate', {
+      cliCount: cliAdapters.size,
+      model: cliModels[0],
+      roleCount: roles.length,
+    });
+  }
 
   return assignRoundRobinAdapters(
     roles,

--- a/packages/nexus-agents/src/config/model-equivalence.test.ts
+++ b/packages/nexus-agents/src/config/model-equivalence.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for canonical model equivalence (#4390).
+ *
+ * @module config/model-equivalence.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { canonicalModelKey, countDistinctModels } from './model-equivalence.js';
+
+describe('canonicalModelKey', () => {
+  it('collapses gateway-prefixed forms of one model', () => {
+    // The defect: these are three strings for one set of weights, and the
+    // panel diversity check counted them as three distinct models.
+    const keys = [
+      canonicalModelKey('claude-sonnet-4-6'),
+      canonicalModelKey('anthropic/claude-sonnet-4-6'),
+      canonicalModelKey('custom/claude-sonnet-4-6'),
+    ];
+
+    expect(keys[0]).not.toBeNull();
+    expect(new Set(keys).size).toBe(1);
+  });
+
+  it('keeps different versions of one family distinct', () => {
+    expect(canonicalModelKey('claude-sonnet-4-6')).not.toBe(canonicalModelKey('claude-sonnet-4-5'));
+  });
+
+  it('keeps different families of one vendor distinct', () => {
+    expect(canonicalModelKey('claude-sonnet-4-6')).not.toBe(canonicalModelKey('claude-opus-4-6'));
+  });
+
+  it('keeps different vendors distinct', () => {
+    expect(canonicalModelKey('claude-sonnet-4-6')).not.toBe(canonicalModelKey('gpt-5.5'));
+  });
+
+  describe('unresolvable identities', () => {
+    it('returns null rather than a shared placeholder', () => {
+      // `sonnet` is a real value the claude CLI adapter can report. It carries
+      // no vendor, so nothing can be concluded from it.
+      expect(canonicalModelKey('sonnet')).toBeNull();
+    });
+
+    it('returns null for empty input', () => {
+      expect(canonicalModelKey('')).toBeNull();
+    });
+  });
+});
+
+describe('countDistinctModels', () => {
+  it('counts one model reached through three gateways as one', () => {
+    expect(
+      countDistinctModels([
+        'claude-sonnet-4-6',
+        'anthropic/claude-sonnet-4-6',
+        'custom/claude-sonnet-4-6',
+      ])
+    ).toBe(1);
+  });
+
+  it('counts genuinely different models separately', () => {
+    expect(countDistinctModels(['claude-sonnet-4-6', 'claude-opus-4-6', 'gpt-5.5'])).toBe(3);
+  });
+
+  it('never claims two unresolvable models are the same', () => {
+    // The inverse error, and the worse one: collapsing distinct models because
+    // neither could be identified would UNDER-report diversity and silence a
+    // warning that should fire. Each unresolvable entry counts as its own.
+    expect(countDistinctModels(['sonnet', 'opus'])).toBe(2);
+  });
+
+  it('does not let an unresolvable entry merge into a resolvable one', () => {
+    expect(countDistinctModels(['claude-sonnet-4-6', 'sonnet'])).toBe(2);
+  });
+
+  it('counts repeated unresolvable strings by their raw value', () => {
+    // Identical strings ARE the same adapter config, even when unidentifiable.
+    expect(countDistinctModels(['sonnet', 'sonnet'])).toBe(1);
+  });
+
+  it('returns 0 for an empty panel', () => {
+    expect(countDistinctModels([])).toBe(0);
+  });
+
+  it('is order-independent', () => {
+    const a = ['claude-sonnet-4-6', 'anthropic/claude-sonnet-4-6', 'gpt-5.5'];
+    expect(countDistinctModels(a)).toBe(countDistinctModels([...a].reverse()));
+  });
+});

--- a/packages/nexus-agents/src/config/model-equivalence.ts
+++ b/packages/nexus-agents/src/config/model-equivalence.ts
@@ -1,0 +1,61 @@
+/**
+ * nexus-agents/config - Canonical model equivalence
+ *
+ * Answers "are these two model strings the same underlying model?" (#4390).
+ *
+ * The same weights are reachable through several gateways under different
+ * strings — `claude-sonnet-4-6` via the claude CLI,
+ * `anthropic/claude-sonnet-4-6` via opencode, `custom/claude-sonnet-4-6` via an
+ * OpenAI-compatible endpoint. Comparing those strings directly makes one model
+ * look like three, which is why the consensus panel's diversity check could not
+ * see two roles running identical weights, and why cost rollup prices one model
+ * as several.
+ *
+ * Measured context for why this matters at all: of 2,955 distinct model ids on
+ * models.dev, 943 are served by more than one provider. `claude-sonnet-4-6`
+ * alone is served by 19.
+ *
+ * @module config/model-equivalence
+ */
+
+import { resolveModelIdentitySync } from './model-identity.js';
+
+/**
+ * A key that is equal for two model strings iff they denote the same model, or
+ * `null` when the model cannot be identified.
+ *
+ * `null` is deliberate rather than a sentinel string. A bare alias like
+ * `sonnet` — which the claude CLI adapter really can report — resolves to
+ * `unknown` vendor and family. If unidentifiable models shared a key they would
+ * compare EQUAL to each other, so two genuinely different models would be
+ * called the same. That is the inverse of the bug this module fixes, and the
+ * worse direction: it would silence a diversity warning that should fire.
+ *
+ * Gateway prefixes are handled by `resolveModelIdentitySync`, which normalises
+ * `/` to `-` and matches vendor/family with unanchored patterns. That behaviour
+ * is incidental to its design but is test-covered for the prefixed form.
+ */
+export function canonicalModelKey(modelId: string): string | null {
+  if (modelId === '') return null;
+  const identity = resolveModelIdentitySync(modelId);
+  if (identity.vendor === 'unknown' || identity.family === 'unknown') return null;
+  return `${identity.vendor}|${identity.family}|${identity.version ?? ''}`;
+}
+
+/**
+ * How many genuinely distinct models a set of model strings represents.
+ *
+ * Unidentifiable entries are counted by their raw string: two adapters
+ * configured with the same unrecognised model ARE the same adapter config, but
+ * two different unrecognised strings must never be assumed equivalent.
+ */
+export function countDistinctModels(modelIds: readonly string[]): number {
+  const distinct = new Set<string>();
+  for (const id of modelIds) {
+    const key = canonicalModelKey(id);
+    // Prefix the raw fallback so an unresolvable string can never collide with
+    // a resolved key.
+    distinct.add(key ?? `raw:${id}`);
+  }
+  return distinct.size;
+}


### PR DESCRIPTION
Closes #4390.

## The defect

The consensus panel's diversity check built a `Set` of raw `modelId` strings:

```ts
const distinctModels = new Set([...assigned.values()].map((a) => a.modelId));
if (roles.length > 1 && distinctModels.size === 1) { /* warn */ }
```

The same weights arrive under different strings from different gateways, so one model counted as three:

| string | reaches |
|---|---|
| `claude-sonnet-4-6` | claude CLI |
| `anthropic/claude-sonnet-4-6` | opencode |
| `custom/claude-sonnet-4-6` | an OpenAI-compatible endpoint |

`size === 3`, no warning, panel treated as diverse.

## The primitive already existed

`resolveModelIdentitySync` normalises gateway prefixes today — verified by running it:

```
claude-sonnet-4-6            -> anthropic|claude-sonnet|4-6
anthropic/claude-sonnet-4-6  -> anthropic|claude-sonnet|4-6
custom/claude-sonnet-4-6     -> anthropic|claude-sonnet|4-6
claude-sonnet-4-5            -> anthropic|claude-sonnet|4-5   (stays distinct)
claude-opus-4-6              -> anthropic|claude-opus|4-6     (stays distinct)
```

`config/model-equivalence.ts` wraps it as `canonicalModelKey` / `countDistinctModels`.

## The trap, and why `null` rather than a sentinel

```
sonnet -> unknown|unknown|-
```

The claude CLI adapter really can report a bare alias. If unidentifiable models shared a placeholder key they would compare **equal to each other**, so two genuinely different models would be called the same — the inverse error, and the worse one, because it silences a warning that *should* fire. `canonicalModelKey` returns `null`, and unresolvable entries are counted by their raw string. Pinned by two tests.

## Also fixes a check the CLI path never had

Distinct CLIs do not imply distinct models. A panel spread across two arms fronting the same weights is no more independent than one on a single arm — the gateway path had this check, the CLI round-robin path had none.

## Two corrections to my own issue framing

**1. I overstated the severity.** Both checks are `logger.warn` only. Nothing reads them, nothing gates on them, voting proceeds identically. This is an observability fix — a warning that cannot fire is worse than none, because it reads as coverage — but it is not the live consensus hole I filed.

**2. The real correlation defence is different from what I implied.** I quoted the code's own comment about `higher_order` not down-weighting what it cannot tell apart. In fact `HigherOrderVotingStrategy` keys correlation off `agentId` — the voter *role* — from historical agree/disagree rates (`consensus/correlation-helpers.ts:89-106`), and never sees `modelId`. Two roles on one model *are* eventually down-weighted, empirically rather than structurally. Slower and indirect, but the panel is not defenceless.

## A consequence I had missed

`mcp/tools/decision-cost-recording.ts:51-67` prices votes via `computeCostDetail(v.model, …)`. Two gateway strings for one model are priced as two distinct models, or one resolves and the other records *unmeasured*. Same defect, second consumer — not fixed here, and worth its own change since the cost path wants a canonical id rather than a count.

## Verification

- 13 tests on the primitive, including both over- and under-collapse directions
- 3 end-to-end tests through `collectRealVotes`; the key one verified **red** against the old code by stashing the source change
- Full package suite **27805 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓

## Residual, accepted knowingly

`gemini-3.1-pro-high`, `gemini-3.1-pro-preview` and `gemini-3-pro` all resolve to `google|gemini-pro|` with no version, so they collapse. For a warn-only check, over-collapsing errs toward warning — the safe direction. It would **not** be safe if this ever gates anything, which is worth remembering if that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)