### PR TITLE
fix(cli-adapters): honour a pinned gemini cliModelName instead of defaulting (#4395)

### DIFF
--- a/.changeset/olive-spoons-give.md
+++ b/.changeset/olive-spoons-give.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+fix(cli-adapters): honour a pinned gemini `cliModelName` instead of silently defaulting (#4395)
+
+`toAgyModelSlug` matched agy slugs and canonical registry ids, but not
+`cliModelName`s. A caller pinning `gemini-2.5-pro` — a real, documented registry
+value — fell through to `DEFAULT_AGY_MODEL` and silently ran a **different model
+than requested**, with no warning. The resolver now goes through
+`findCanonicalModel` before defaulting.
+
+Adds `fromAgyModelSlug`, derived from the forward map so the two directions cannot
+drift, so a raw agy slug can be resolved back to a canonical (and therefore
+priceable) registry id when one is encountered.
+
+Scope note: the original issue also claimed `getModelInfo()` misreporting the
+invoked model corrupted outcome telemetry. That was over-claimed — the reported id
+is the registry's own `cliModelName`, which resolves to the correct entry at the
+correct price. Reporting the agy slug instead would have _broken_ pricing, and
+that half was reverted before merge.

--- a/packages/nexus-agents/src/config/agy-model-map.test.ts
+++ b/packages/nexus-agents/src/config/agy-model-map.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   toAgyModelSlug,
+  fromAgyModelSlug,
   isAgyModelSlug,
   AGY_MODEL_SLUGS,
   DEFAULT_AGY_MODEL,
@@ -60,5 +61,47 @@ describe('agy model slugs', () => {
     // agy also fronts Claude and GPT-OSS. The `gemini` arm means Gemini-family
     // models; those are routed through their own adapters (#4346, 7/0 vote).
     expect(AGY_MODEL_SLUGS.every((s) => s.startsWith('gemini-'))).toBe(true);
+  });
+
+  describe('reverse mapping (#4395)', () => {
+    it('round-trips every canonical gemini model', () => {
+      const geminiIds = DEFAULT_MODEL_CAPABILITIES.models
+        .filter((m) => m.cliName === 'gemini')
+        .map((m) => m.id);
+
+      for (const id of geminiIds) {
+        const slug = toAgyModelSlug(id);
+        // Several registry entries can share a slug where agy's generations do
+        // not line up with ours, so the reverse need not return the SAME id —
+        // but it must return one that maps forward to the same slug.
+        const back = fromAgyModelSlug(slug);
+        expect(back).not.toBeNull();
+        expect(toAgyModelSlug(back as string)).toBe(slug);
+      }
+    });
+
+    it('returns null for a slug with no registry entry', () => {
+      // agy serves 3.6 Flash at high/medium; the registry only reaches -low.
+      expect(fromAgyModelSlug('gemini-3.6-flash-high')).toBeNull();
+    });
+
+    it('returns null for a string that is not an agy slug at all', () => {
+      expect(fromAgyModelSlug('claude-sonnet-4-6')).toBeNull();
+    });
+
+    it('honours a pinned registry cliModelName instead of silently defaulting', () => {
+      // #4395: callers pin Google API ids like `gemini-2.5-pro` (the registry's
+      // cliModelName for `gemini-pro`). Falling through to the default here
+      // would silently run a different model than the caller asked for.
+      expect(toAgyModelSlug('gemini-2.5-pro')).toBe(toAgyModelSlug('gemini-pro'));
+      expect(toAgyModelSlug('gemini-2.5-pro')).not.toBe(DEFAULT_AGY_MODEL);
+    });
+
+    it('resolves a reversed slug to real registry pricing', () => {
+      // The point of the reverse map: an invoked slug must be priceable.
+      const canonical = fromAgyModelSlug('gemini-3.1-pro-high');
+
+      expect(canonical).toBe('gemini-3-pro');
+    });
   });
 });

--- a/packages/nexus-agents/src/config/agy-model-map.ts
+++ b/packages/nexus-agents/src/config/agy-model-map.ts
@@ -21,6 +21,8 @@
  * @module config/agy-model-map
  */
 
+import { findCanonicalModel } from './model-config-helpers.js';
+
 /**
  * The model slugs `agy` accepts, as reported by `agy models`.
  *
@@ -75,6 +77,33 @@ const CANONICAL_TO_AGY: Readonly<Record<string, AgyModelSlug>> = {
   'gemini-flash': 'gemini-3.6-flash-low',
 };
 
+/**
+ * agy slug → canonical registry id. Derived from {@link CANONICAL_TO_AGY} so the
+ * two directions cannot drift (#4395).
+ *
+ * Needed because the forward map alone left the arm unable to describe what it
+ * actually ran: `getModelInfo()` reported the registry's `cliModelName` (a
+ * Google API id agy does not accept) while `getCommand()` spawned the slug. That
+ * mismatch reached `TaskOutcome.model`, so the routing loop was told the wrong
+ * model produced each outcome, and pricing could not resolve the slug at all.
+ */
+const AGY_TO_CANONICAL: ReadonlyMap<string, string> = new Map(
+  Object.entries(CANONICAL_TO_AGY).map(([canonical, slug]) => [slug, canonical])
+);
+
+/**
+ * Resolve an agy slug back to the canonical registry id, or null when the slug
+ * is one agy serves but the registry has no entry for.
+ *
+ * Null rather than a guess: several registry entries map onto the same slug
+ * where agy's generations do not line up with ours, so a reverse lookup is
+ * lossy by construction. Callers should fall back to the raw slug rather than
+ * inventing an entry.
+ */
+export function fromAgyModelSlug(slug: string): string | null {
+  return AGY_TO_CANONICAL.get(slug) ?? null;
+}
+
 /** The slug used when a caller names a model agy cannot serve. */
 export const DEFAULT_AGY_MODEL: AgyModelSlug = 'gemini-3.1-pro-high';
 
@@ -97,5 +126,16 @@ export function isAgyModelSlug(value: string): value is AgyModelSlug {
  */
 export function toAgyModelSlug(model: string): AgyModelSlug {
   if (isAgyModelSlug(model)) return model;
-  return CANONICAL_TO_AGY[model] ?? DEFAULT_AGY_MODEL;
+  const direct = CANONICAL_TO_AGY[model];
+  if (direct !== undefined) return direct;
+  // #4395: callers legitimately pin a registry `cliModelName` (a Google API id
+  // like `gemini-2.5-pro`) rather than the canonical entry id. Resolve it to the
+  // canonical entry before mapping, so a pinned model is honoured instead of
+  // silently falling through to the default.
+  const canonical = findCanonicalModel('gemini', model)?.id;
+  if (canonical !== undefined) {
+    const viaCanonical = CANONICAL_TO_AGY[canonical];
+    if (viaCanonical !== undefined) return viaCanonical;
+  }
+  return DEFAULT_AGY_MODEL;
 }


### PR DESCRIPTION
Partial for #4395 — the half that turned out to be a real defect.

## The genuine bug

`toAgyModelSlug` matched agy slugs and canonical registry ids, but **not `cliModelName`s**. So a caller pinning `gemini-2.5-pro` — a real, documented registry value — fell through to `DEFAULT_AGY_MODEL` and silently ran a *different model than they asked for*, with no warning.

Fixed by resolving through `findCanonicalModel` before defaulting. Also adds `fromAgyModelSlug`, derived from the forward map so the two directions cannot drift, making a raw agy slug resolvable back to a priceable canonical id when one is encountered.

## I over-claimed the other half, and my first fix was a regression

The issue also said the arm "reports a different model than it actually runs", corrupting `TaskOutcome.model` for the learning loop. Literally true; **not harmful**. I implemented the change and the suite caught it immediately:

```
calculateCost('gemini-3.1-pro-preview')  -> 14          # what it reports today
calculateCost('gemini-3-pro')            -> 14          # the canonical entry
calculateCost('gemini-3.1-pro-high')     -> undefined   # the agy slug
```

`gemini-3.1-pro-preview` is the registry's own `cliModelName` for `gemini-3-pro` — it resolves to the correct entry at the correct price. Making `getModelInfo()` report the agy slug swapped a correct, priceable identifier for an unpriceable one, and a pricing assertion failed (`expected 0.15 to be 2`). Reverted before merge.

Both halves of the original filing are corrected on the issue. The pattern worth naming: I verified the *mechanism* and inferred the *harm* instead of measuring it. Measuring took one command.

## Verification

- 4 new reverse-mapping tests including a round-trip over every registry gemini entry
- 1 new test pinning that `gemini-2.5-pro` resolves to the same slug as its canonical entry rather than the default
- Full package suite **27810 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)