### PR TITLE
fix(adapters): guard the openai-compat model-discovery fetch (#4392)

### DIFF
--- a/.changeset/lucky-pears-refuse.md
+++ b/.changeset/lucky-pears-refuse.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix(adapters): guard the openai-compat model-discovery fetch (#4392)
+
+`discoverModels` handed an operator-supplied base URL straight to the OpenAI SDK
+and called `models.list()` with SDK defaults — no SSRF guard, no timeout, no bound
+on the returned list. The sibling `custom-openai` SDK path already guards the same
+class of URL with a DNS-resolve-time check (#3426), so the two paths disagreed on
+posture, and the unguarded one is the one that can read its base URL from a **file**
+(`NEXUS_OPENCODE_CONFIG` → `opencode.json`) rather than only an env var.
+
+Now reuses the existing `assertCustomApiHostResolvesPublic` guard rather than
+growing a second one, runs it **before** any connection is opened, bounds the call
+with an explicit timeout since discovery happens during server bootstrap, and caps
+the catalogue at 256 models — `buildOpenAICompatAdapters` constructs one adapter
+per discovered model, so an unbounded list becomes unbounded objects at startup.
+The cap is a sanity ceiling on adapter construction, not a claim about what a
+gateway may offer; aggregators legitimately serve hundreds.

--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.test.ts
@@ -28,6 +28,16 @@ vi.mock('openai', () => {
 const { mockReadOpencodeGateway } = vi.hoisted(() => ({
   mockReadOpencodeGateway: vi.fn<(path: string) => unknown>(),
 }));
+// The discovery path reuses the SDK path's DNS-resolve-time SSRF guard (#3426).
+// Stubbed so these tests perform no real lookups; two tests drive the rejection
+// branch explicitly.
+const { mockAssertHostPublic } = vi.hoisted(() => ({
+  mockAssertHostPublic: vi.fn(),
+}));
+vi.mock('./sdk/custom-api-validation.js', () => ({
+  assertCustomApiHostResolvesPublic: mockAssertHostPublic,
+}));
+
 vi.mock('../config/opencode-bridge.js', () => ({
   readOpencodeGateway: mockReadOpencodeGateway,
 }));
@@ -137,6 +147,8 @@ describe('readOpenAICompatEnv (#2468 + #2503)', () => {
 describe('discoverModels (#2468)', () => {
   beforeEach(() => {
     mockList.mockReset();
+    mockAssertHostPublic.mockReset();
+    mockAssertHostPublic.mockResolvedValue({ ok: true });
   });
 
   const config: OpenAICompatConfig = {
@@ -197,6 +209,62 @@ describe('discoverModels (#2468)', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.message).toContain('NEXUS_OPENAI_COMPAT_KEY');
+  });
+
+  // #4392: this path can take its base URL from a FILE
+  // (`NEXUS_OPENCODE_CONFIG` → opencode.json), not only an env var, and it runs
+  // during server bootstrap — so it needs the guards the sibling SDK path
+  // already had.
+  describe('discovery guards (#4392)', () => {
+    it('refuses a gateway whose host resolves privately', async () => {
+      mockAssertHostPublic.mockResolvedValue({
+        ok: false,
+        error: new Error('resolves to a private address'),
+      });
+
+      const result = await discoverModels(config);
+
+      expect(result.ok).toBe(false);
+    });
+
+    it('checks the host BEFORE opening a connection', async () => {
+      // The guard is worthless if the request has already gone out.
+      mockAssertHostPublic.mockResolvedValue({ ok: false, error: new Error('blocked') });
+
+      await discoverModels(config);
+
+      expect(mockList).not.toHaveBeenCalled();
+    });
+
+    it('rejects an implausibly large catalogue rather than one adapter each', async () => {
+      mockList.mockResolvedValue({
+        data: Array.from({ length: 300 }, (_v, i) => ({
+          id: `m-${String(i)}`,
+          created: 1,
+          owned_by: 'x',
+        })),
+      });
+
+      const result = await discoverModels(config);
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toContain('cap');
+    });
+
+    it('still accepts a large-but-plausible catalogue', async () => {
+      // Aggregators legitimately serve hundreds; the cap is a sanity ceiling on
+      // adapter construction, not a claim about what a gateway may offer.
+      mockList.mockResolvedValue({
+        data: Array.from({ length: 200 }, (_v, i) => ({
+          id: `m-${String(i)}`,
+          created: 1,
+          owned_by: 'x',
+        })),
+      });
+
+      expect((await discoverModels(config)).ok).toBe(true);
+    });
   });
 });
 

--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.ts
@@ -19,6 +19,7 @@
  */
 
 import OpenAI from 'openai';
+import { assertCustomApiHostResolvesPublic } from './sdk/custom-api-validation.js';
 
 import type {
   Result,
@@ -82,6 +83,29 @@ function readGatewayFromOpencode(): OpenAICompatConfig | null {
 }
 
 /**
+ * Ceiling on how many models one gateway may contribute.
+ *
+ * `buildOpenAICompatAdapters` constructs one adapter per discovered model, so an
+ * unbounded list becomes unbounded objects during bootstrap. Aggregators
+ * legitimately serve hundreds — models.dev lists 339 for one and 620 for
+ * another — so this is a sanity ceiling on adapter construction, not a claim
+ * about what a gateway may offer.
+ */
+const MAX_DISCOVERED_MODELS = 256;
+
+/** Bound on the discovery call. Bootstrap must not hang on a dead gateway. */
+const MODEL_DISCOVERY_TIMEOUT_MS = 10_000;
+
+/** Hostname of a base URL, or the raw string when it will not parse. */
+function hostnameOf(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).hostname;
+  } catch {
+    return baseUrl;
+  }
+}
+
+/**
  * Discover available models by calling `GET {baseUrl}/v1/models`. Uses the
  * official `openai` SDK's `client.models.list()` so we benefit from its
  * pagination + retry handling. The list is the strongly authoritative
@@ -91,9 +115,34 @@ function readGatewayFromOpencode(): OpenAICompatConfig | null {
 export async function discoverModels(
   config: OpenAICompatConfig
 ): Promise<Result<readonly DiscoveredModel[], ConfigError>> {
+  // Reuse the SDK path's DNS-resolve-time SSRF guard (#3426) rather than
+  // growing a second one. This path needs it at least as much: it can read its
+  // base URL from a FILE (`NEXUS_OPENCODE_CONFIG` -> opencode.json), not only
+  // from an env var, so the input is not always direct operator intent.
+  // The guard fails OPEN on transient resolver errors and rejects only a
+  // confirmed private/loopback/link-local resolution.
+  const hostCheck = await assertCustomApiHostResolvesPublic(hostnameOf(config.baseUrl));
+  if (!hostCheck.ok) {
+    return err(new ConfigError(`Gateway URL rejected: ${hostCheck.error.message}`));
+  }
   try {
-    const client = new OpenAI({ baseURL: config.baseUrl, apiKey: config.apiKey });
+    const client = new OpenAI({
+      baseURL: config.baseUrl,
+      apiKey: config.apiKey,
+      // Discovery runs during server bootstrap, so an unresponsive gateway must
+      // not stall startup indefinitely. The SDK's own default is far longer.
+      timeout: MODEL_DISCOVERY_TIMEOUT_MS,
+      maxRetries: 1,
+    });
     const list = await client.models.list();
+    if (list.data.length > MAX_DISCOVERED_MODELS) {
+      return err(
+        new ConfigError(
+          `Gateway ${config.baseUrl} listed ${String(list.data.length)} models, above the ` +
+            `${String(MAX_DISCOVERED_MODELS)} cap. Refusing to build an adapter per model.`
+        )
+      );
+    }
     const models: readonly DiscoveredModel[] = list.data.map((m) => ({
       id: m.id,
       created: m.created,


### PR DESCRIPTION
Groundwork for #4392, found while auditing the two parallel custom-OpenAI mechanisms.

## The gap

`discoverModels` handed an operator-supplied base URL straight to the OpenAI SDK:

```ts
const client = new OpenAI({ baseURL: config.baseUrl, apiKey: config.apiKey });
const list = await client.models.list();
```

No SSRF guard, no timeout, no bound on the result. Meanwhile `adapters/sdk/sdk-adapter.ts:295-321` guards **the same class of operator-supplied gateway URL** with `ensureCustomHostResolvesPublic`, a DNS-resolve-time check rejecting private/loopback/link-local addresses (#3426).

Two paths to the same kind of endpoint, disagreeing on posture — and the unguarded one is the one that can take its base URL from a **file** (`NEXUS_OPENCODE_CONFIG` → `opencode.json`), not only an env var. It also runs during both `--mode=server` and `--mode=orchestrator` bootstrap.

## What changed

- **Reuses** `assertCustomApiHostResolvesPublic` rather than growing a second guard
- Runs it **before** any connection is opened — a guard that fires after the request has gone out is not a guard, and there is a test for exactly that ordering
- Explicit timeout, so a dead gateway cannot stall startup
- Caps the catalogue at 256. `buildOpenAICompatAdapters` builds one adapter **per discovered model**, so an unbounded list becomes unbounded objects at bootstrap. A sanity ceiling on adapter construction, not a claim about what a gateway may offer — aggregators legitimately serve hundreds, and 200 still passes.

## Severity, stated plainly

Operator-configured rather than attacker-controlled, so this is hardening rather than a live vulnerability. Recorded through the repo's security-discoveries protocol rather than described further here.

## Verification

- 4 new tests; **2 verified red** against the old code by stashing the source change — the request went out despite a rejecting guard, and a 300-model list was accepted
- Full package suite **27814 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓

## Not in this PR — and why

The convergence itself. Research turned up two blockers that change its shape, both now filed:

- **#4400** — `OutcomeCliSchema` is `CliName | 'unknown'` and **cannot represent an `api:*` arm**. `LinUCBBandit.warmStart` matches by name (`armIndex < 0 → continue`), so every API arm silently fails to warm-start, with no warning. Giving a gateway a routing arm before fixing this produces an arm that looks wired and learns nothing across runs.
- `ApiVendor` has a genuine `const exhaustive: never = vendor` switch (`auto-adapter.ts:329-332`), so **per-model arms are a type-level breaking change**, not a config change. One arm per *gateway* is the shape that fits increment B with the routing unit unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)