### PR TITLE
fix(routing): let API arms record outcomes under their own id (#4400)

### DIFF
--- a/.changeset/rotten-pots-jump.md
+++ b/.changeset/rotten-pots-jump.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+fix(routing): let API arms record outcomes under their own id, and surface warm-start skips (#4400)
+
+`OutcomeCliSchema` was `CliName | 'unknown'` with no `api:*` member, so no
+`TaskOutcome.cli` could ever equal an API arm's id — even though the router
+genuinely registers `api:anthropic`, `api:openai`, `api:google` and
+`api:custom-openai` as arms under `NEXUS_BILLING_MODE=api`.
+
+`LinUCBBandit.warmStart` matches arms **by name** (`armIndex < 0 → continue`), so
+every API arm discarded its entire history and began each process cold, with the
+skip reported nowhere. The schema now accepts `ApiArmIdSchema`, kept beside the
+`ApiArmId` type so the two cannot drift. The union only grows, so previously
+persisted records stay valid.
+
+`warmStart` now counts skipped outcomes per arm and logs them. A warm-start that
+silently drops most of its input looked identical to one that worked, which is how
+this stayed invisible.
+
+Precondition for #4392: giving a gateway a routing arm before this would have
+produced an arm that looks wired and learns nothing across runs.

--- a/packages/nexus-agents/src/cli-adapters/api-arm-outcomes.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/api-arm-outcomes.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests that an API routing arm can record and replay its own outcomes (#4400).
+ *
+ * `OutcomeCliSchema` was `CliName | 'unknown'`, with no `api:*` member — so no
+ * `TaskOutcome.cli` could ever equal an API arm's id. `LinUCBBandit.warmStart`
+ * matches arms BY NAME and silently `continue`d on a miss, so every API arm
+ * discarded its entire history and began each process cold, reporting nothing.
+ *
+ * @module cli-adapters/api-arm-outcomes.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { LinUCBBandit } from './linucb-bandit.js';
+import { TaskOutcomeSchema, type TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
+import { apiArmId } from './types-core.js';
+
+function outcome(cli: string, success: boolean): TaskOutcome {
+  return {
+    id: `o-${cli}-${String(success)}-${String(cli.length * (success ? 3 : 7))}`,
+    cli,
+    category: 'code_generation',
+    model: 'claude-sonnet-4-6',
+    success,
+    durationMs: 100,
+    timestamp: '2026-08-10T00:00:00.000Z',
+    source: 'delegate',
+  } as unknown as TaskOutcome;
+}
+
+describe('API arm outcome attribution (#4400)', () => {
+  describe('schema', () => {
+    it('accepts an api:* arm id', () => {
+      const parsed = TaskOutcomeSchema.safeParse(outcome('api:custom-openai', true));
+
+      expect(parsed.success).toBe(true);
+    });
+
+    it('accepts every api arm the router can register', () => {
+      for (const vendor of ['anthropic', 'openai', 'google', 'custom-openai'] as const) {
+        expect(TaskOutcomeSchema.safeParse(outcome(apiArmId(vendor), true)).success).toBe(true);
+      }
+    });
+
+    it('still accepts the four CLI slots', () => {
+      for (const cli of ['claude', 'gemini', 'codex', 'opencode']) {
+        expect(TaskOutcomeSchema.safeParse(outcome(cli, true)).success).toBe(true);
+      }
+    });
+
+    it("still accepts 'unknown' (#3624)", () => {
+      expect(TaskOutcomeSchema.safeParse(outcome('unknown', false)).success).toBe(true);
+    });
+
+    it('still rejects a string that is not an arm at all', () => {
+      // The union grew; it did not become permissive.
+      expect(TaskOutcomeSchema.safeParse(outcome('not-an-arm', true)).success).toBe(false);
+    });
+  });
+
+  describe('warm start', () => {
+    it('replays history into an api arm', () => {
+      // Before the schema widened, this count was necessarily 0 — the outcome
+      // could not carry the arm's id in the first place.
+      const bandit = new LinUCBBandit(['claude', 'api:custom-openai']);
+
+      const replayed = bandit.warmStart([
+        outcome('api:custom-openai', true),
+        outcome('api:custom-openai', false),
+      ]);
+
+      expect(replayed).toBe(2);
+    });
+
+    it('replays CLI and api arms side by side', () => {
+      const bandit = new LinUCBBandit(['claude', 'api:custom-openai']);
+
+      expect(bandit.warmStart([outcome('claude', true), outcome('api:custom-openai', true)])).toBe(
+        2
+      );
+    });
+
+    it('still skips an arm this bandit does not have', () => {
+      const bandit = new LinUCBBandit(['claude']);
+
+      expect(bandit.warmStart([outcome('api:custom-openai', true)])).toBe(0);
+    });
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/linucb-bandit.ts
+++ b/packages/nexus-agents/src/cli-adapters/linucb-bandit.ts
@@ -10,6 +10,7 @@
 
 import type { BanditContext, LinUCBConfig } from './budget-router-types.js';
 import { DEFAULT_LINUCB_CONFIG, LinUCBConfigSchema } from './budget-router-types.js';
+import { createLogger } from '../core/index.js';
 import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
 import {
   createIdentityMatrix,
@@ -24,6 +25,8 @@ import {
   vectorScale,
   shermanMorrisonUpdate,
 } from './linucb-math.js';
+
+const logger = createLogger({ component: 'linucb-bandit' });
 
 /** Reward value assigned on successful task completion. */
 const SUCCESS_REWARD = 0.7;
@@ -292,6 +295,13 @@ export class LinUCBBandit {
    * from persisted data. Uses a neutral context (same as seedPriors) since
    * the original task context is not stored in TaskOutcome.
    *
+   * Outcomes whose arm is not among this bandit's arms are skipped. That skip
+   * used to be entirely silent, which hid a real defect: `api:*` arms could not
+   * be represented in `TaskOutcome.cli` at all (#4400), so every API arm
+   * discarded its whole history and began cold each process with nothing
+   * reported. The skip is now counted and logged — a warm-start that silently
+   * drops most of its input looks identical to one that worked.
+   *
    * @param outcomes - Persisted task outcomes to replay
    * @returns Number of outcomes successfully replayed
    */
@@ -306,13 +316,24 @@ export class LinUCBBandit {
     };
 
     let replayed = 0;
+    const skippedArms = new Map<string, number>();
     for (const outcome of outcomes) {
       const armIndex = this.armNames.indexOf(outcome.cli);
-      if (armIndex < 0) continue;
+      if (armIndex < 0) {
+        skippedArms.set(outcome.cli, (skippedArms.get(outcome.cli) ?? 0) + 1);
+        continue;
+      }
       const reward = outcome.success ? SUCCESS_REWARD : FAILURE_REWARD;
       this.update(armIndex, neutralContext, reward);
       this.recordWarmStartModelStat(outcome.cli, outcome.model, outcome.success);
       replayed++;
+    }
+    if (skippedArms.size > 0) {
+      logger.warn('Warm-start skipped outcomes for arms this bandit does not have', {
+        skippedByArm: Object.fromEntries(skippedArms),
+        replayed,
+        knownArms: this.armNames,
+      });
     }
     return replayed;
   }

--- a/packages/nexus-agents/src/cli-adapters/types-core.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-core.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CliNameLiteral } from '../config/model-capabilities-types.js';
+import { z } from 'zod';
 
 /**
  * Supported CLI names.
@@ -25,6 +26,18 @@ export type ApiVendor = 'anthropic' | 'openai' | 'google' | 'custom-openai';
 
 /** Prefixed routing arm id for a direct-API adapter, e.g. `api:anthropic` (#3422). */
 export type ApiArmId = `api:${ApiVendor}`;
+
+/**
+ * Zod schema for {@link ApiArmId}, so persisted records can validate an API arm
+ * (#4400). Kept next to the type rather than in the outcome schema so the two
+ * cannot drift as `ApiVendor` changes.
+ */
+export const ApiArmIdSchema = z.enum([
+  'api:anthropic',
+  'api:openai',
+  'api:google',
+  'api:custom-openai',
+]);
 
 /**
  * A LinUCB/routing arm id — either a canonical CLI slot or a distinct API arm

--- a/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
+++ b/packages/nexus-agents/src/orchestration/outcomes/outcome-types.ts
@@ -10,6 +10,7 @@
 
 import { z } from 'zod';
 import { CliNameSchema } from '../../config/model-capabilities-types.js';
+import { ApiArmIdSchema } from '../../cli-adapters/types-core.js';
 import { TaskCategorySchema } from '../../config/task-specialization-types.js';
 import { createLogger } from '../../core/index.js';
 
@@ -40,13 +41,26 @@ export const OutcomeFailureCategorySchema = z.enum([
 ]);
 
 /**
- * CLI attribution for an outcome. Widened beyond {@link CliNameSchema} to allow
- * an explicit `'unknown'` (#3624) — for outcomes (e.g. expert executions) whose
- * real executing CLI can't be resolved from the model. `'unknown'` is excluded
- * from CLI-quality signals (detectCliPerformanceFloor) so it can't skew a real
- * CLI, but is retained for category/failure analysis rather than fabricated.
+ * Routing-arm attribution for an outcome.
+ *
+ * Widened beyond {@link CliNameSchema} for two reasons:
+ *
+ * - an explicit `'unknown'` (#3624) — for outcomes (e.g. expert executions)
+ *   whose real executing CLI can't be resolved from the model. `'unknown'` is
+ *   excluded from CLI-quality signals (detectCliPerformanceFloor) so it can't
+ *   skew a real CLI, but is retained for category/failure analysis rather than
+ *   fabricated.
+ * - `api:*` routing arms (#4400). The router genuinely registers
+ *   `api:anthropic`, `api:openai`, `api:google` and `api:custom-openai` as arms
+ *   under `NEXUS_BILLING_MODE=api`, but this schema could not represent them —
+ *   so no outcome could be recorded under an API arm's own id.
+ *   `LinUCBBandit.warmStart` matches arms BY NAME, so those arms could never
+ *   warm-start: every process began cold no matter how much history existed,
+ *   and the skip was silent.
+ *
+ * The union only ever grows, so previously persisted records stay valid.
  */
-export const OutcomeCliSchema = z.union([CliNameSchema, z.literal('unknown')]);
+export const OutcomeCliSchema = z.union([CliNameSchema, ApiArmIdSchema, z.literal('unknown')]);
 export type OutcomeCli = z.infer<typeof OutcomeCliSchema>;
 
 /** Schema for a single recorded task outcome. */


### PR DESCRIPTION
Closes #4400. Precondition for #4392.

## The defect

`OutcomeCliSchema` was `CliName | 'unknown'` — no `api:*` member. But `RoutingArmId = CliName | ApiArmId`, and the router genuinely registers `api:anthropic`, `api:openai`, `api:google` and `api:custom-openai` as arms under `NEXUS_BILLING_MODE=api`.

So an outcome from an API arm **could not be recorded under that arm's id**. And `LinUCBBandit.warmStart` matches by name:

```ts
const armIndex = this.armNames.indexOf(outcome.cli);
if (armIndex < 0) continue;
```

`armNames` contains `api:custom-openai`; no `TaskOutcome.cli` could. Every API arm therefore began **every process cold**, no matter how much history existed — and the `continue` said nothing.

## Fix

`ApiArmIdSchema` lives beside the `ApiArmId` type in `types-core.ts`, so the schema and the type cannot drift as `ApiVendor` changes. The union only grows, so previously persisted records stay valid — checked that nothing narrows exhaustively on `TaskOutcome.cli` (consumers are `groupBy`, equality filters and string keys).

`warmStart` now counts skips per arm and logs them. **A warm-start that silently drops most of its input looks identical to one that worked** — that is precisely how this stayed invisible, and it is the same quiet-failure class as the fail-open family in #4362/#4363.

## Verification, stated precisely

8 tests. **2 were red** against the old code — the two asserting the schema accepts an `api:*` id.

The three warm-start tests were **not** red, and it is worth being clear why rather than implying otherwise: `warmStart` takes `TaskOutcome[]` and matches on the string, so the replay mechanism always worked. The schema was the gate that stopped such an outcome from ever existing at the persistence boundary. Those tests confirm the end-to-end path now that the data can exist.

The remaining tests pin that the union grew without becoming permissive — the four CLI slots and `'unknown'` still validate, and a string that is not an arm at all is still rejected.

Full package suite **27822 passed**, 1 skipped; `pnpm typecheck` ✓, `pnpm lint` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)