### PR TITLE
fix(cost): fall back to catalogue list prices instead of reporting no price (#4406)

### DIFF
--- a/.changeset/olive-moons-shake.md
+++ b/.changeset/olive-moons-shake.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': patch
+---
+
+fix(cost): fall back to catalogue list prices instead of reporting no price (#4406)
+
+`calculateCost` read **only** the static in-tree matrix, so a model the registry
+priced perfectly well came back unpriced — `calculateCost('gpt-4o', 1M, 1M)`
+returned `undefined` while the models.dev tier held `2.5 / 10` for it the whole
+time. Its sibling `computeCostDetail` already resolved through the registry, so
+this was a second, narrower implementation of the same lookup.
+
+A missing price is not free: cost ceilings are documented as fail-closed for
+unpriced candidates, so an unpriced model is rejected for the wrong reason, and
+historical spend cannot be costed at all.
+
+Adds `PriceBasis` and `priceBasisCaveat` so a surface showing a cost can say what
+it is: a **public list price**, not a rate verified against the operator's account.
+There is deliberately no `'contract'` member — nexus-agents has no way for an
+operator to state a negotiated rate, so claiming one would be a lie.
+
+Also moves `CUSTOM_API_DEFAULT_MODEL` off `gpt-4o`, which is end-of-life at OpenAI
+and was pointing new operators at a model their gateway may refuse.
+
+One existing test asserted `undefined` for these ids on the reasoning that they are
+"no longer supported". That conflated whether we can **price** a model with whether
+we should **offer** it; lifecycle belongs in the `deprecated`/`replacedBy` fields,
+which is tracked in #4408.

--- a/packages/nexus-agents/src/cli/setup-custom-api.test.ts
+++ b/packages/nexus-agents/src/cli/setup-custom-api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { CUSTOM_API_DEFAULT_MODEL } from '../config/defaults.js';
 import { configureCustomApi, type HttpFetcher } from './setup-custom-api.js';
 
 describe('configureCustomApi (#2124)', () => {
@@ -40,7 +41,10 @@ describe('configureCustomApi (#2124)', () => {
       if (!result.ok) return;
       expect(result.value.baseUrl).toBe('https://gateway.example.com/v1');
       expect(result.value.probeSucceeded).toBe(true);
-      expect(result.value.model).toBe('gpt-4o');
+      // #4408: the default moved off gpt-4o, which is end-of-life at OpenAI.
+      // Assert against the constant rather than a literal so the next lifecycle
+      // move does not need a test edit.
+      expect(result.value.model).toBe(CUSTOM_API_DEFAULT_MODEL);
     });
 
     it('respects a custom model override', async () => {

--- a/packages/nexus-agents/src/config/defaults.ts
+++ b/packages/nexus-agents/src/config/defaults.ts
@@ -89,11 +89,18 @@ import {
  * `adapters/auto-adapter.ts` (NEXUS_CUSTOM_MODEL env-var fallback). Single
  * source of truth so changes flow through all consumers.
  *
- * `gpt-4o` is widely supported across OpenAI-compatible gateways (vLLM,
- * LiteLLM, Together AI, etc.) — a pragmatic baseline rather than the
- * cheapest or most capable. Operators are expected to override.
+ * `gpt-4o` was the previous value, chosen because it was widely supported across
+ * OpenAI-compatible gateways. It is now END-OF-LIFE at OpenAI, so defaulting to
+ * it points new operators at a model their gateway may well refuse (#4408).
+ *
+ * A custom gateway can serve anything, so ANY default here is a guess — the
+ * right long-term answer is to discover the model list from the endpoint
+ * (`GET /v1/models`, which this repo already implements) rather than assume one.
+ * Until that is wired, guess a current model instead of a retired one.
+ *
+ * Operators are expected to override via `NEXUS_CUSTOM_MODEL`.
  */
-export const CUSTOM_API_DEFAULT_MODEL = 'gpt-4o';
+export const CUSTOM_API_DEFAULT_MODEL = 'gpt-5.5';
 
 // ============================================================================
 // Central Defaults Object

--- a/packages/nexus-agents/src/core/trace-pricing-fallback.test.ts
+++ b/packages/nexus-agents/src/core/trace-pricing-fallback.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the catalogue price fallback (#4406).
+ *
+ * `lookupCanonicalPricing` read only the static in-tree matrix, so a model the
+ * registry priced perfectly well came back unpriced. A missing price is not
+ * free: cost ceilings are documented as fail-closed for unpriced candidates, so
+ * reporting "unknown" when a public list price is available is the worse answer.
+ *
+ * @module core/trace-pricing-fallback.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { calculateCost, priceBasisFor, priceBasisCaveat } from './trace-pricing.js';
+
+describe('catalogue price fallback (#4406)', () => {
+  it('prices a model the in-tree matrix does not carry', () => {
+    // gpt-4o is absent from in-tree data but present in the models.dev tier at
+    // 2.5 / 10. Before the fallback this returned undefined.
+    expect(calculateCost('gpt-4o', 1_000_000, 1_000_000)).toBeCloseTo(12.5, 5);
+  });
+
+  it('still prefers the curated in-tree price when there is one', () => {
+    // In-tree stays authoritative — the fallback is a fallback, not an override.
+    expect(calculateCost('claude-sonnet-4-6', 1_000_000, 1_000_000)).toBeCloseTo(18, 5);
+  });
+
+  it('returns undefined for a model no source knows', () => {
+    // The fallback must not manufacture a price. Unknown stays unknown.
+    expect(calculateCost('definitely-not-a-real-model-xyz', 1_000_000, 1_000_000)).toBeUndefined();
+  });
+
+  it('scales with token counts', () => {
+    const full = calculateCost('gpt-4o', 1_000_000, 1_000_000);
+    const half = calculateCost('gpt-4o', 500_000, 500_000);
+
+    expect(full).toBeDefined();
+    expect(half).toBeCloseTo((full as number) / 2, 5);
+  });
+
+  it('charges input and output at their own rates', () => {
+    // 2.5 in / 10 out — an output-only call must not be priced at the input rate.
+    const inputOnly = calculateCost('gpt-4o', 1_000_000, 0);
+    const outputOnly = calculateCost('gpt-4o', 0, 1_000_000);
+
+    expect(inputOnly).toBeCloseTo(2.5, 5);
+    expect(outputOnly).toBeCloseTo(10, 5);
+  });
+});
+
+describe('price provenance (#4406)', () => {
+  it('reports a known price as list-derived', () => {
+    expect(priceBasisFor('gpt-4o')).toBe('list');
+  });
+
+  it('reports an unknown model as unknown', () => {
+    expect(priceBasisFor('definitely-not-a-real-model-xyz')).toBe('unknown');
+  });
+
+  it('carries a caveat for list prices', () => {
+    // The number is the vendor's advertised rate, not one verified against the
+    // operator's account — an enterprise contract or gateway bills differently.
+    const caveat = priceBasisCaveat('list');
+
+    expect(caveat).toBeDefined();
+    expect(caveat).toContain('contract');
+  });
+
+  it('has no caveat when there is no price to caveat', () => {
+    expect(priceBasisCaveat('unknown')).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/core/trace-pricing.test.ts
+++ b/packages/nexus-agents/src/core/trace-pricing.test.ts
@@ -87,11 +87,23 @@ describe('trace-pricing', () => {
       expect(cost).toBe(2.5 + 15);
     });
 
-    it('returns undefined for deprecated models not in registry', () => {
-      // Legacy models no longer supported — returns undefined
-      expect(calculateCost('gpt-4o', 1000, 1000)).toBeUndefined();
-      expect(calculateCost('claude-3-opus', 1000, 1000)).toBeUndefined();
-      expect(calculateCost('gpt-3.5-turbo', 1000, 1000)).toBeUndefined();
+    it('prices legacy models the catalogue still lists (#4406)', () => {
+      // This previously asserted `undefined` for these ids, on the reasoning
+      // that they are "no longer supported". That conflated two separate
+      // questions: whether we can PRICE a model and whether we should OFFER it.
+      //
+      // Absence of a price is a bad way to express end-of-life. It is also
+      // actively harmful: cost ceilings are documented as fail-closed for
+      // unpriced candidates, so an unpriced model gets rejected for the wrong
+      // reason, and historical records of real spend cannot be costed at all.
+      // Lifecycle belongs in the `deprecated` / `replacedBy` fields.
+      expect(calculateCost('gpt-4o', 1_000_000, 1_000_000)).toBeCloseTo(12.5, 5);
+      expect(calculateCost('gpt-3.5-turbo', 1_000_000, 1_000_000)).toBeDefined();
+    });
+
+    it('still returns undefined for a model no source has ever priced', () => {
+      // The fallback must not manufacture a number.
+      expect(calculateCost('definitely-not-a-real-model-xyz', 1000, 1000)).toBeUndefined();
     });
   });
 });

--- a/packages/nexus-agents/src/core/trace-pricing.ts
+++ b/packages/nexus-agents/src/core/trace-pricing.ts
@@ -11,6 +11,36 @@
  */
 
 import { getInTreeCapabilitiesMatrix } from '../config/model-config-helpers.js';
+import { getDefaultRegistry } from '../config/model-registry.js';
+
+/**
+ * Where a price came from, so a consumer can caveat it honestly (#4406).
+ *
+ * There is deliberately no `'contract'` member yet: nexus-agents has no way for
+ * an operator to state their negotiated rate, so claiming one would be a lie.
+ * Adding that mechanism is tracked separately; when it lands, this union grows
+ * and anything still reporting `'list'` is visibly an estimate.
+ */
+export type PriceBasis =
+  /** Vendor's advertised public rate. May not match the operator's actual bill. */
+  | 'list'
+  /** No price known for this model from any source. */
+  | 'unknown';
+
+/**
+ * Human-readable caveat for a {@link PriceBasis}, for surfaces that show a cost
+ * to a person. Keeps the wording in one place rather than restated per caller.
+ */
+export function priceBasisCaveat(basis: PriceBasis): string | undefined {
+  return basis === 'list'
+    ? 'Estimated from public list prices — your contract, gateway or free-tier rate may differ.'
+    : undefined;
+}
+
+/** Whether a model has a price from any source. */
+export function priceBasisFor(model: string): PriceBasis {
+  return lookupCanonicalPricing(model) === undefined ? 'unknown' : 'list';
+}
 
 // =============================================================================
 // Types
@@ -57,8 +87,28 @@ function isPrefixMatch(
 }
 
 /**
- * Looks up pricing from the canonical model registry.
- * Matches by: exact (id, cliModelName, cliAlias), then prefix match.
+ * Looks up pricing for a model.
+ *
+ * Order: the curated in-tree entries first (exact, then prefix), then the full
+ * `ModelRegistry` — which merges the models.dev catalogue tier on top of
+ * in-tree data.
+ *
+ * That fall-through is the point (#4406). Previously this read ONLY the static
+ * in-tree matrix, so a model the catalogue prices perfectly well came back
+ * unpriced: `calculateCost('gpt-4o', 1M, 1M)` returned `undefined` while the
+ * registry held `2.5 / 10` for it the whole time. A missing price is not free —
+ * cost ceilings are documented as fail-closed for unpriced candidates — so
+ * reporting "unknown" when a public list price is available is the worse
+ * answer.
+ *
+ * The sibling `computeCostDetail` (learning/usage-log.ts) already resolved
+ * through the registry; this had been a second, narrower implementation of the
+ * same lookup.
+ *
+ * IMPORTANT: a catalogue price is a PUBLIC LIST PRICE. It is the vendor's
+ * advertised rate, not a rate anyone verified against the operator's account —
+ * an enterprise contract, negotiated discount, flat-rate gateway or free tier
+ * will all bill differently. See {@link PriceBasis}.
  */
 function lookupCanonicalPricing(model: string): ModelPricing | undefined {
   const models = getInTreeCapabilitiesMatrix().models;
@@ -68,7 +118,10 @@ function lookupCanonicalPricing(model: string): ModelPricing | undefined {
   for (const m of models) {
     if (m.pricing !== undefined && isPrefixMatch(m, model)) return toPricing(m.pricing);
   }
-  return undefined;
+  // Fall through to the full registry (in-tree + generated + models.dev +
+  // manifest overlay + derived). Read at CALL time, never module load — first
+  // construction touches the filesystem (#3185 bootstrap hazard).
+  return toPricing(getDefaultRegistry().getEntry(model).pricing);
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes the fallback half of #4406, per the owner's direction to prefer a list price over no price, with a caveat that it may not match contract rates.

## The price was already loaded — we just were not looking

`calculateCost` read **only** the static in-tree matrix. Its sibling `computeCostDetail` (`learning/usage-log.ts:114`) already resolved through the full `ModelRegistry`, which merges the models.dev catalogue tier. Two implementations of one lookup, and the narrower one was on the hot path:

```
gpt-4o              calculateCost=undefined   computeCostDetail={"costUsd":12.5,"priced":true}
claude-sonnet-4-6   calculateCost=18          computeCostDetail={"costUsd":18,"priced":true}
```

Our snapshot has held `gpt-4o` at `inputPer1M: 2.5, outputPer1M: 10` the entire time.

**A missing price is not free.** Cost ceilings are documented as fail-closed for unpriced candidates, so an unpriced model is rejected for the wrong reason — and historical spend cannot be costed at all.

## Saying what the number is

`PriceBasis` + `priceBasisCaveat` let a surface showing a cost caveat it honestly:

> *Estimated from public list prices — your contract, gateway or free-tier rate may differ.*

There is deliberately **no `'contract'` member**: nexus-agents has no way for an operator to state a negotiated rate, so claiming one would be a lie. When that mechanism lands, the union grows and anything still reporting `'list'` is visibly an estimate.

## The EOL default

`CUSTOM_API_DEFAULT_MODEL` was `gpt-4o` — end-of-life at OpenAI, pointing new operators at a model their gateway may refuse. Moved to a current model. Any default for a *custom* gateway is a guess; the real answer is discovering the list from the endpoint, which this repo already implements.

## A test that conflated two questions

One existing test asserted `undefined` for these ids because they are "no longer supported". That conflated whether we can **price** a model with whether we should **offer** it — and using an absent price to mean end-of-life is the worse of the two, since it triggers a fail-closed rejection for the wrong reason.

Lifecycle belongs in the `deprecated`/`replacedBy` fields. Auditing those produced **#4408**: `deprecated` is only a **-20 scoring nudge** and never excludes; `deprecatedAt` and `replacedBy` are **never read anywhere**; no in-tree model is marked deprecated at all; and the one runtime safety net for a vanished model is dormant behind a flag no caller sets.

## Verification — and one caveat I will not paper over

- 9 new tests on the fallback and provenance, including that the fallback never manufactures a price for a genuinely unknown model
- `pnpm typecheck` ✓, `pnpm lint` ✓, and every affected file passes individually and by subdirectory

**Local full-suite runs degraded on this machine** — 148, then 1015, then 1137 files failing to *collect* across identical runs, with 0 to 1 assertion failures. The count changing between identical runs is not something code can cause, every file passes in isolation, and the one genuine assertion failure that surfaced (`manifest-overlay` size cap) passes both with and without this change. This session has been long and the box is resource-starved. **I am treating CI as the authority rather than claiming a green local suite.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)