### PR TITLE
fix(config): repoint the stale openrouter-qwen-coder registry entry

### DIFF
--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Repoint the stale `openrouter-qwen-coder` registry entry (#4410)
+
+The entry pointed at `qwen/qwen3-coder-480b-a35b:free`, an id absent from the live models.dev catalogue in every form, so any routing that selected it dispatched an unservable `--model` at opencode. Because it was also priced `0/0`, the cost-aware stages saw a free option that was really a guaranteed failure.
+
+OpenRouter still serves the family, but no longer at a zero-cost tier. Repointed to `qwen/qwen3-coder` — verified as the same checkpoint (`name: "Qwen3 Coder 480B A35B"`, 262K context), which is what licenses carrying the existing quality scores over — priced at the catalogue list rate of 0.3/1 per 1M, with `cost` re-scored 10 → 9 (10 is reserved for genuinely zero-cost entries) and "free" dropped from the display name and notes.
+
+The zero-cost tier now contains only `openrouter-nemotron-super`, which is an accurate reflection of the live catalogue rather than a reduction in capability. Decided 7/0 via `higher_order` consensus.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,7 +496,7 @@ _Auto-generated from source. 47 tools registered._
 
 <!-- GOVERNANCE:VERSION:START -->
 
-_Governance Version: 2026-07-06_
+_Governance Version: 2026-08-10_
 
 <!-- GOVERNANCE:VERSION:END -->
 

--- a/packages/nexus-agents/src/config/in-tree-data.ts
+++ b/packages/nexus-agents/src/config/in-tree-data.ts
@@ -422,7 +422,7 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
     },
     {
       id: 'openrouter-qwen-coder',
-      displayName: 'Qwen3 Coder 480B (free)',
+      displayName: 'Qwen3 Coder 480B A35B',
       provider: 'openrouter',
       contextWindow: 262_144,
       outputModalities: ['text', 'structured_json', 'code'],
@@ -430,12 +430,15 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       toolCapabilities: ['function_calling', 'structured_output'],
       specialFeatures: ['streaming'],
       notes:
-        'Strongest free coding model on OpenRouter. ' + '480B parameters, 262K context. Free tier.',
-      pricing: { inputPer1M: 0, outputPer1M: 0 },
-      qualityScores: { reasoning: 7, codeGeneration: 8, speed: 6, cost: 10 },
+        'Strongest coding-specialized model on OpenRouter. 480B parameters ' +
+        '(35B active), 262K context. The zero-cost SKU this entry used to ' +
+        'point at was retired (#4410); `qwen/qwen3-coder` is the same ' +
+        'checkpoint at list price.',
+      pricing: { inputPer1M: 0.3, outputPer1M: 1 },
+      qualityScores: { reasoning: 7, codeGeneration: 8, speed: 6, cost: 9 },
       maxOutputTokens: 32_768,
       cliName: 'opencode',
-      cliModelName: 'qwen/qwen3-coder-480b-a35b:free',
+      cliModelName: 'qwen/qwen3-coder',
     },
   ],
 };

--- a/packages/nexus-agents/src/config/openrouter-qwen-coder-entry.test.ts
+++ b/packages/nexus-agents/src/config/openrouter-qwen-coder-entry.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Registry entry for `openrouter-qwen-coder` (#4410).
+ *
+ * The entry pointed at `qwen/qwen3-coder-480b-a35b:free`, an id absent from the
+ * live models.dev catalogue in every form. Routing that selected it dispatched
+ * an unservable `--model` at opencode, and because the entry was priced 0/0 the
+ * cost-aware stages saw a free option that was really a guaranteed failure.
+ *
+ * `resolve-live-model.ts` looks like it would paper over this, but it needs a
+ * populated available-models catalogue to fire and is itself slated for removal
+ * (#4408) — so the registry is the only durable place to fix it.
+ *
+ * Vote: 7/0 for repointing to `qwen/qwen3-coder` (higher_order). The quality
+ * scores carry over because the live id is the SAME checkpoint — models.dev
+ * reports `name: "Qwen3 Coder 480B A35B"`, context 262,144 — not because the
+ * name looks similar.
+ *
+ * @module config/openrouter-qwen-coder-entry.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_MODEL_CAPABILITIES } from './in-tree-data.js';
+
+const entry = DEFAULT_MODEL_CAPABILITIES.models.find((m) => m.id === 'openrouter-qwen-coder');
+
+describe('openrouter-qwen-coder entry (#4410)', () => {
+  it('still exists in the registry', () => {
+    expect(entry).toBeDefined();
+  });
+
+  it('points at an id OpenRouter actually serves', () => {
+    // The retired `:free` SKU is the whole bug. Assert the live id explicitly
+    // rather than "not the old one" — the latter passes for any typo.
+    expect(entry?.cliModelName).toBe('qwen/qwen3-coder');
+  });
+
+  it('no longer claims a free tier that does not exist', () => {
+    // 0/0 is not a neutral default: it is a positive claim that steers the
+    // cost-aware stages toward a model that would fail on dispatch.
+    expect(entry?.pricing?.inputPer1M).toBeGreaterThan(0);
+    expect(entry?.pricing?.outputPer1M).toBeGreaterThan(0);
+  });
+
+  it('carries the catalogue list price', () => {
+    expect(entry?.pricing?.inputPer1M).toBeCloseTo(0.3, 5);
+    expect(entry?.pricing?.outputPer1M).toBeCloseTo(1, 5);
+  });
+
+  it('does not advertise "free" in user-facing text', () => {
+    const text = `${entry?.displayName ?? ''} ${entry?.notes ?? ''}`.toLowerCase();
+
+    expect(text).not.toContain('free');
+  });
+
+  it('keeps the 262K context the live id reports', () => {
+    expect(entry?.contextWindow).toBe(262_144);
+  });
+
+  it('keeps the coding quality scores (same checkpoint)', () => {
+    // Verified equivalence is what licenses carrying these over; a different
+    // checkpoint would have made them fabricated data.
+    expect(entry?.qualityScores?.codeGeneration).toBe(8);
+    expect(entry?.qualityScores?.reasoning).toBe(7);
+  });
+
+  it('no longer scores cost as free-tier-perfect', () => {
+    // 10 is reserved for genuinely 0/0 entries. At 0.3/1 this is the cheapest
+    // *paid* entry, which the scale puts at 9 (cf. gemini-flash at 0.3/2.5).
+    expect(entry?.qualityScores?.cost).toBe(9);
+  });
+});
+
+describe('zero-cost tier after #4410', () => {
+  it('contains only entries actually priced at zero', () => {
+    const zeroCost = DEFAULT_MODEL_CAPABILITIES.models.filter(
+      (m) => m.pricing?.inputPer1M === 0 && m.pricing?.outputPer1M === 0
+    );
+
+    expect(zeroCost.map((m) => m.id)).toEqual(['openrouter-nemotron-super']);
+  });
+});


### PR DESCRIPTION
Closes #4410. Decided **7/0** via `higher_order` consensus.

## The defect

`openrouter-qwen-coder` pointed at `qwen/qwen3-coder-480b-a35b:free` — an id absent from the live models.dev catalogue under every spelling and every provider. Any routing that selected it dispatched an unservable `--model` at opencode.

The pricing made it worse than a dead pointer: at `0/0` the entry was one of only two zero-cost entries, so the cost-aware stages actively *preferred* a model that could only fail.

`resolve-live-model.ts` (#3407) looks like it would absorb exactly this rename, but it requires a populated available-models catalogue to fire and is itself slated for removal under #4408 — so the registry is the only durable place to fix it.

## The fix

Repointed to `qwen/qwen3-coder` at the catalogue list price.

| field | before | after |
| --- | --- | --- |
| `cliModelName` | `qwen/qwen3-coder-480b-a35b:free` | `qwen/qwen3-coder` |
| `pricing` | 0 / 0 | 0.3 / 1 |
| `qualityScores.cost` | 10 | 9 |
| `displayName` | Qwen3 Coder 480B (free) | Qwen3 Coder 480B A35B |

**The quality scores carry over because the model is verifiably the same checkpoint**, not because the name looks similar. Three voters made the carry-over conditional on that equivalence and asserted it rather than checking it, so I checked: models.dev reports `qwen/qwen3-coder` as `name: "Qwen3 Coder 480B A35B"`, context 262,144 — matching the entry's existing `contextWindow` exactly. Had it been a different checkpoint, the scores would have been fabricated data and needed re-derivation.

`cost` moves 10 → 9 because 10 is reserved for genuinely 0/0 entries; at 0.3/1 this is now the cheapest *paid* entry on the existing scale (cf. `gemini-flash` at 0.3/2.5 → 9).

## Consequence worth stating

The zero-cost tier drops from two entries to one (`openrouter-nemotron-super`). That is the live catalogue being reported honestly, not capability lost — the second "free" option never worked. Under the default `NEXUS_BILLING_MODE=plan` cost is zeroed in scoring anyway, so this only changes `api`-mode cost weighting.

## Verification

- New test file asserts the live id, non-zero pricing, the exact list price, absence of "free" in user-facing text, the preserved checkpoint scores, and that the zero-cost tier now contains exactly one entry. Written red-first: 6 of 9 failed before the change.
- Full suite: **1,166 files / 27,852 tests passed**, exit 0. Typecheck and lint clean. Registry-coverage gate passes.

## Found while verifying, filed separately

- **#4416** — `openrouter-nemotron-super` is live but copies `contextWindow: 1_000_000` from the *paid* variant while dispatching the `:free` one, which serves 262K. Fails only above 262K, which is why it has not surfaced.
- **#4417** — a sweep for in-tree ids absent from the catalogue. Narrower than the EOL detection #4408 found unsound: exact-id existence is a fact, not a lifecycle inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)