### PR TITLE
fix(config): correct the advertised context window for nemotron-super

### DIFF
--- a/.changeset/brown-hounds-shake.md
+++ b/.changeset/brown-hounds-shake.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Correct the advertised context window for `openrouter-nemotron-super` (#4416)
+
+The entry dispatches `nvidia/nemotron-3-super-120b-a12b:free` but carried `contextWindow: 1_000_000`, which is the _paid_ variant's window. models.dev lists both, and the free SKU serves 262,144.
+
+`contextWindow` is what context budgeting and model-eligibility filtering read, so a task assembling between 262K and 1M tokens passed the local check and was then rejected by the provider — after the context had been built. Unlike the dead pointer in #4410 the model is live, which is why this never surfaced.
+
+Corrected to `262_144`, keeping the free SKU: repointing to the paid id would empty the zero-cost tier, which #4410 just reduced to this single entry. Added a general assertion that no entry dispatching a `:free` SKU claims a seven-figure context, so the paid/free metadata split cannot recur silently.

--- a/packages/nexus-agents/src/config/in-tree-data.ts
+++ b/packages/nexus-agents/src/config/in-tree-data.ts
@@ -406,7 +406,10 @@ export const DEFAULT_MODEL_CAPABILITIES: ModelCapabilitiesMatrix = {
       id: 'openrouter-nemotron-super',
       displayName: 'NVIDIA Nemotron 3 Super 120B (free)',
       provider: 'openrouter',
-      contextWindow: 1_000_000,
+      // The `:free` SKU serves 262K; the paid `nvidia/nemotron-3-super-120b-a12b`
+      // is the 1M one. Copying the paid variant's headline here made every
+      // context-budgeting consumer overstate capacity by ~4x (#4416).
+      contextWindow: 262_144,
       outputModalities: ['text', 'structured_json', 'code'],
       inputModalities: ['text', 'code'],
       toolCapabilities: ['function_calling', 'structured_output'],

--- a/packages/nexus-agents/src/config/openrouter-nemotron-entry.test.ts
+++ b/packages/nexus-agents/src/config/openrouter-nemotron-entry.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Registry entry for `openrouter-nemotron-super` (#4416).
+ *
+ * The entry dispatches `nvidia/nemotron-3-super-120b-a12b:free` but took its
+ * `contextWindow` from the *paid* variant of the same model. models.dev lists
+ * both, and they differ:
+ *
+ *   nvidia/nemotron-3-super-120b-a12b        0.085 / 0.4   1,000,000
+ *   nvidia/nemotron-3-super-120b-a12b:free   0     / 0       262,144
+ *
+ * Unlike #4410 the model is live — this is a metadata mismatch, not a dead
+ * pointer, which is why nothing surfaced it. `contextWindow` is what context
+ * budgeting and eligibility filtering read, so a task assembling between 262K
+ * and 1M tokens passed the local check and was then rejected by the provider,
+ * after the context had already been built.
+ *
+ * Kept on the free variant deliberately: repointing to the paid id would empty
+ * the zero-cost tier, which #4410 just reduced to this single entry.
+ *
+ * @module config/openrouter-nemotron-entry.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_MODEL_CAPABILITIES } from './in-tree-data.js';
+
+const entry = DEFAULT_MODEL_CAPABILITIES.models.find((m) => m.id === 'openrouter-nemotron-super');
+
+describe('openrouter-nemotron-super entry (#4416)', () => {
+  it('still exists in the registry', () => {
+    expect(entry).toBeDefined();
+  });
+
+  it('advertises the context the dispatched variant actually serves', () => {
+    // The paid variant's 1,000,000 is the wrong number for a `:free` dispatch.
+    expect(entry?.contextWindow).toBe(262_144);
+  });
+
+  it('still dispatches the free variant', () => {
+    // The fix corrects the metadata, not the SKU — this is the only remaining
+    // zero-cost entry and switching it would silently retire the free tier.
+    expect(entry?.cliModelName).toBe('nvidia/nemotron-3-super-120b-a12b:free');
+  });
+
+  it('is still priced at zero, consistent with the :free SKU', () => {
+    expect(entry?.pricing?.inputPer1M).toBe(0);
+    expect(entry?.pricing?.outputPer1M).toBe(0);
+  });
+
+  it('does not claim more context than its max output allows for', () => {
+    // Sanity: an entry whose maxOutputTokens exceeds its window is incoherent.
+    expect(entry?.maxOutputTokens ?? 0).toBeLessThan(entry?.contextWindow ?? 0);
+  });
+});
+
+describe('paid/free metadata split across the registry (#4416)', () => {
+  it('no entry dispatching a :free SKU claims a seven-figure context', () => {
+    // The generalized shape of this bug: copying a paid variant's headline
+    // context onto a free-tier dispatch. Cheap to assert, catches a repeat.
+    const overclaiming = DEFAULT_MODEL_CAPABILITIES.models.filter(
+      (m) => (m.cliModelName ?? '').endsWith(':free') && m.contextWindow >= 1_000_000
+    );
+
+    expect(overclaiming.map((m) => m.id)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #4416. Found while verifying #4410 against the live catalogue.

## The defect

`openrouter-nemotron-super` dispatches `nvidia/nemotron-3-super-120b-a12b:free` but carried `contextWindow: 1_000_000` — the **paid** variant's window. models.dev lists both, and they differ:

| id | cost (in/out per 1M) | context |
| --- | --- | --- |
| `nvidia/nemotron-3-super-120b-a12b` | 0.085 / 0.4 | 1,000,000 |
| `nvidia/nemotron-3-super-120b-a12b:free` | 0 / 0 | **262,144** |

The entry took its context from one row and its `cliModelName` from the other.

`contextWindow` is what context budgeting and model-eligibility filtering read, and `CLAUDE.md` names the registry the single source of truth for it ("read via `getDefaultRegistry()`, never hardcode"), so every consumer inherited the ~4x overstatement. A task assembling between 262K and 1M tokens passed the local eligibility check and was then rejected by the provider — *after* the context had been built.

Unlike #4410 this model is live, so nothing failed on dispatch. It only bites above 262K, which is why it sat unnoticed.

## The fix

`contextWindow: 262_144`, staying on the free SKU.

Repointing at the paid id is the other defensible answer and I did not take it: that would empty the zero-cost tier, which #4410 just reduced to this single entry. That is a routing change, not a metadata correction — if the 1M window is worth paying for, it deserves its own decision.

Also added a general assertion that **no entry dispatching a `:free` SKU claims a seven-figure context**. That is the generalized shape of this bug — copying a paid variant's headline number onto a free-tier dispatch — and it is cheap to keep honest.

## Verification

- Written red-first: 2 of 6 assertions failed before the change.
- Full suite: **1,167 files / 27,858 tests passed**, exit 0. Lint, typecheck, and the registry-coverage gate clean.

## Context

Third entry in this class after #4410. The measured cross-check of all 18 in-tree entries — including the two false-positive classes it turned up — is recorded on #4417, which tracks automating the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)