### PR TITLE
fix(ci): verify automated refresh PRs instead of opening them unchecked

### DIFF
--- a/.github/workflows/models-dev-sync.yml
+++ b/.github/workflows/models-dev-sync.yml
@@ -33,6 +33,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # See #4424 — without this the PR carries no checks at all.
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -57,7 +59,12 @@ jobs:
             echo "removed=$REMOVED" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify refreshed data before opening a PR
+        if: steps.changed.outputs.changed == 'true'
+        run: bash scripts/verify-refresh.sh
+
       - name: Open PR with refreshed snapshot
+        id: cpr
         if: steps.changed.outputs.changed == 'true' && inputs['dry-run'] != 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -84,3 +91,16 @@ jobs:
       - name: No-op summary
         if: steps.changed.outputs.changed == 'false'
         run: echo "Snapshot already in sync with upstream; no PR opened."
+
+      - name: Publish verification status onto the PR head
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state=success \
+            -f context=refresh/verify \
+            -f description='typecheck + registry-coverage + config tests passed' \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/registry-refresh.yml
+++ b/.github/workflows/registry-refresh.yml
@@ -34,6 +34,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Post a visible verification status on the PR head (#4424). PRs opened
+      # with GITHUB_TOKEN do not trigger pull_request workflows, so without
+      # this the PR shows NO checks and reads as verified when it is not.
+      statuses: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -87,7 +91,12 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Verify refreshed data before opening a PR
+        if: steps.changed.outputs.changed == 'true'
+        run: bash scripts/verify-refresh.sh
+
       - name: Open PR with refreshed registry
+        id: cpr
         if: steps.changed.outputs.changed == 'true' && inputs['dry-run'] != 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
@@ -103,6 +112,23 @@ jobs:
             architecture
             capabilities-matrix
             automated
+
+      - name: Publish verification status onto the PR head
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ steps.cpr.outputs.pull-request-head-sha }}
+        run: |
+          set -euo pipefail
+          # The gates above already passed (the job would have failed otherwise),
+          # so this records THAT on the commit the PR points at. Without it the
+          # PR carries no status at all and is indistinguishable from a verified
+          # one — the actual defect in #4424.
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state=success \
+            -f context=refresh/verify \
+            -f description='typecheck + registry-coverage + config tests passed' \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
       - name: Label PR needs-human-review when guardrails trip
         if: steps.changed.outputs.changed == 'true' && steps.diff.outputs.requires_review == 'true' && inputs['dry-run'] != 'true'

--- a/scripts/verify-refresh.sh
+++ b/scripts/verify-refresh.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Gate set for the automated data-refresh workflows (#4424).
+#
+# PRs opened with GITHUB_TOKEN do not trigger `on: pull_request` workflows —
+# GitHub suppresses that to prevent recursion. So the weekly registry and
+# models.dev refreshes were opening PRs with NO checks at all: not pending,
+# not failing, none. #4340 sat two weeks rewriting 2,295 lines of router data
+# that way, and its diff had already caught the model retirement that later
+# became bug #4410.
+#
+# This script is the single definition of what "verified" means for a refresh,
+# invoked by both refresh workflows so the two cannot drift apart. It runs
+# BEFORE the PR is opened: a failure here means no PR is created, rather than
+# an unverifiable one that looks identical to a verified one.
+#
+# Residual risk, stated plainly: a gate added to ci.yml later is not applied
+# here automatically. That is inherent to running gates outside the
+# pull_request event and is the reason #4424 targets a GitHub App token as the
+# end state — this script is the interim that removes the silent-green failure
+# without handing a write-capable credential to a job that ingests third-party
+# catalogue data.
+set -euo pipefail
+
+echo "::group::typecheck"
+pnpm typecheck
+echo "::endgroup::"
+
+echo "::group::registry-coverage manifest"
+npx tsx scripts/check-registry-coverage.ts
+echo "::endgroup::"
+
+echo "::group::config + registry tests"
+# Scoped to the suites that read generated model data. A full run would be
+# ~3 minutes of mostly-unrelated tests on a weekly cron; these are the ones a
+# bad refresh actually breaks.
+pnpm --filter nexus-agents exec vitest run src/config
+echo "::endgroup::"
+
+echo "verify-refresh: all gates passed"


### PR DESCRIPTION
Closes #4424. Interim step toward the voted end state; owner-blocked remainder is #4426.

## The defect

Both weekly refresh workflows opened PRs with **zero checks** — not pending, not failing, none existed. Neither passes a `token:` to `peter-evans/create-pull-request`, so it falls back to `GITHUB_TOKEN`, and GitHub deliberately does not trigger `on: pull_request` workflows for PRs it creates. The bypass is structural, not a branch filter.

The cost is demonstrated, not hypothetical: **#4340 sat two weeks rewriting 2,295 lines of `model-registry.generated.json`** — data the router reads — with no verification. Its own diff had already removed `openrouter/qwen/qwen3-coder:free`, the exact retirement that later surfaced as bug **#4410**. The refresh caught it two weeks early and nobody saw it, because a blank status is indistinguishable from a verified one.

## What changed

`scripts/verify-refresh.sh` — one definition of "verified" for a refresh (typecheck + registry-coverage + the config/registry suites), invoked by **both** workflows so they cannot drift apart. It runs **before** the PR is opened: a bad refresh fails the job rather than producing an unverifiable PR.

After the PR opens, a `refresh/verify` commit status is posted to its head SHA, so the check is visible where a reviewer actually looks. The recursion guard suppresses workflow *triggering*, not Statuses API writes.

## Why this is the interim, not the target

The vote (`higher_order`, 7 voters) split **5/7 for a GitHub App token** — the only option where the PR runs the canonical `pull_request` pipeline and inherits future gates automatically. That requires an App and `APP_ID`/`APP_PRIVATE_KEY` secrets, which is owner action; the repo currently has exactly one secret (`ANTHROPIC_API_KEY`). Filed as **#4426** with the panel's binding conditions (privilege separation, no checkout in the privileged job, least privilege, required-check enforcement).

The two dissenting voters preferred keeping gates in-workflow precisely to avoid handing a write-capable token to a job that ingests third-party catalogue data, and both suggested posting a status so the PR is not blank. That suggestion is what shipped here — it removes the silent-green failure now, with no new credential.

**Residual risk, stated in the script itself:** a gate added to `ci.yml` later is not applied here automatically. That is inherent to running gates outside the `pull_request` event, and is exactly why #4426 remains the end state rather than this being declared done.

## Verification

- `scripts/verify-refresh.sh` run locally end to end: typecheck, registry-coverage, and **44 files / 1,031 tests** — all pass.
- Both workflows parse as valid YAML with the steps in the intended order (verify → open PR → publish status) and `statuses: write` scoped to the job, not the workflow.

One thing I could not verify from here: that `GITHUB_TOKEN` specifically can write the status. The Statuses API accepts the write (confirmed against a real commit), and the documented recursion guard covers workflow triggering rather than API calls — but the definitive proof is the next scheduled run, or a `workflow_dispatch`. If it turns out to need more, the gates still run and still block a bad PR from being created; only the visible status would be missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)