### PR TITLE
feat(scripts): offline catalogue-drift sweep for in-tree model entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexus-agents",
   "version": "2.8.0",
-  "description": "Intelligent orchestration platform for AI coding tools — routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus",
+  "description": "Intelligent orchestration platform for AI coding tools \u2014 routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus",
   "private": true,
   "type": "module",
   "license": "MIT",
@@ -71,7 +71,8 @@
     "changeset": "changeset",
     "changeset:version": "npx tsx scripts/changeset-version-with-retry.ts && npx tsx scripts/sync-plugin-version.ts && pnpm governance:inject && npx tsx scripts/generate-repo-index.ts && npx tsx scripts/generate-docs-content.ts && pnpm --filter nexus-agents docs",
     "changeset:publish": "changeset publish",
-    "release": "pnpm build && changeset publish"
+    "release": "pnpm build && changeset publish",
+    "check:catalogue-drift": "npx tsx scripts/check-catalogue-drift.ts"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",

--- a/scripts/check-catalogue-drift.test.ts
+++ b/scripts/check-catalogue-drift.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the catalogue-drift sweep (#4417).
+ *
+ * Two shipped bugs motivated this: #4410 (an entry pointing at a `:free` SKU
+ * that no longer existed anywhere) and #4416 (an entry carrying the *paid*
+ * variant's context window while dispatching the free one). Both were found by
+ * hand; both are mechanically detectable.
+ *
+ * The hard part is not detection, it is not crying wolf. #4408 established that
+ * inferring EOL from catalogue absence is unsound — `gpt-4o` is retired and
+ * still listed. So this sweep answers only questions that are facts:
+ * does this exact id exist, and do the numbers match. Everything judgement-like
+ * is either an advisory or absent.
+ *
+ * @module scripts/check-catalogue-drift.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  findCatalogueDrift,
+  type CatalogueEntry,
+  type InTreeModel,
+} from './check-catalogue-drift.js';
+
+const cat = (over: Partial<CatalogueEntry> & { id: string }): CatalogueEntry => ({
+  contextWindow: 100_000,
+  pricing: { inputPer1M: 1, outputPer1M: 2 },
+  ...over,
+});
+
+const model = (over: Partial<InTreeModel> & { id: string }): InTreeModel => ({
+  provider: 'openrouter',
+  cliModelName: 'vendor/thing',
+  contextWindow: 100_000,
+  pricing: { inputPer1M: 1, outputPer1M: 2 },
+  ...over,
+});
+
+describe('findCatalogueDrift — clean cases', () => {
+  it('reports nothing when the entry matches the catalogue', () => {
+    const findings = findCatalogueDrift(
+      [model({ id: 'ok' })],
+      [cat({ id: 'openrouter/vendor/thing' })]
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  it('ignores entries with no cliModelName (nothing is dispatched)', () => {
+    const findings = findCatalogueDrift([model({ id: 'x', cliModelName: undefined })], []);
+
+    expect(findings).toEqual([]);
+  });
+
+  it('does not double-prefix a cliModelName that already carries its provider', () => {
+    // `opencode-default` dispatches `anthropic/claude-sonnet-4-6` under provider
+    // `anthropic`. Naive concatenation looks up `anthropic/anthropic/...` and
+    // reports a bogus MISSING — the first version of this sweep did exactly that.
+    const findings = findCatalogueDrift(
+      [model({ id: 'dbl', provider: 'anthropic', cliModelName: 'anthropic/claude-sonnet-4-6' })],
+      [cat({ id: 'anthropic/claude-sonnet-4-6' })]
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  it('skips the local custom/ alias namespace', () => {
+    // No `custom/`-prefixed id exists in the catalogue at all — it denotes an
+    // operator-configured endpoint. Reporting these every run trains readers to
+    // ignore the output.
+    const findings = findCatalogueDrift(
+      [model({ id: 'alias', provider: 'custom-openai', cliModelName: 'custom/claude-opus-4-6' })],
+      []
+    );
+
+    expect(findings).toEqual([]);
+  });
+});
+
+describe('findCatalogueDrift — the #4410 shape (dead id)', () => {
+  it('flags an id absent from every provider as a defect', () => {
+    const findings = findCatalogueDrift(
+      [model({ id: 'dead', cliModelName: 'vendor/gone:free' })],
+      [cat({ id: 'openrouter/vendor/alive' })]
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.kind).toBe('missing-everywhere');
+    expect(findings[0]?.severity).toBe('defect');
+  });
+});
+
+describe('findCatalogueDrift — reseller-only (the gpt-4o trap)', () => {
+  it('downgrades to advisory when another provider still serves the id', () => {
+    // `gpt-5.2-codex` is gone from first-party openai but served by ten
+    // resellers. Absence from one provider is not death — #4408 proved that
+    // inference wrong at a 2/3 false-positive rate.
+    const findings = findCatalogueDrift(
+      [model({ id: 'moved', provider: 'openai', cliModelName: 'gpt-5.2-codex' })],
+      [cat({ id: 'vivgrid/gpt-5.2-codex' }), cat({ id: 'azure/gpt-5.2-codex' })]
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.kind).toBe('provider-absent');
+    expect(findings[0]?.severity).toBe('advisory');
+    expect(findings[0]?.detail).toContain('vivgrid');
+  });
+
+  it("never silently substitutes another provider's numbers", () => {
+    // The first hand-run of this cross-check fell back to an arbitrary
+    // provider's record and compared against it, producing a context
+    // "mismatch" for a model whose own provider had no record at all.
+    const findings = findCatalogueDrift(
+      [
+        model({
+          id: 'moved',
+          provider: 'openai',
+          cliModelName: 'gpt-5.2-codex',
+          contextWindow: 272_000,
+        }),
+      ],
+      [cat({ id: 'vivgrid/gpt-5.2-codex', contextWindow: 400_000 })]
+    );
+
+    expect(findings.map((f) => f.kind)).toEqual(['provider-absent']);
+  });
+});
+
+describe('findCatalogueDrift — the #4416 shape (metadata mismatch)', () => {
+  it('flags an overstated context window as a defect', () => {
+    const findings = findCatalogueDrift(
+      [model({ id: 'over', contextWindow: 1_000_000 })],
+      [cat({ id: 'openrouter/vendor/thing', contextWindow: 262_144 })]
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.kind).toBe('context-overstated');
+    expect(findings[0]?.severity).toBe('defect');
+  });
+
+  it('flags an understated context window only as an advisory', () => {
+    // Directional asymmetry: overstating fails *after* the context is built;
+    // understating merely leaves capacity unused. Ranking them alike is how a
+    // useful report becomes noise.
+    const findings = findCatalogueDrift(
+      [model({ id: 'under', contextWindow: 100_000 })],
+      [cat({ id: 'openrouter/vendor/thing', contextWindow: 400_000 })]
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.kind).toBe('context-understated');
+    expect(findings[0]?.severity).toBe('advisory');
+  });
+
+  it('flags a price mismatch as an advisory', () => {
+    // Prices drift constantly and contracts differ from list; worth surfacing,
+    // not worth calling a defect.
+    const findings = findCatalogueDrift(
+      [model({ id: 'price', pricing: { inputPer1M: 0, outputPer1M: 0 } })],
+      [cat({ id: 'openrouter/vendor/thing', pricing: { inputPer1M: 0.3, outputPer1M: 1 } })]
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.kind).toBe('price-mismatch');
+    expect(findings[0]?.severity).toBe('advisory');
+  });
+
+  it('flags a zero-cost claim against a priced catalogue entry as a defect', () => {
+    // This is #4410's second half and it is not an ordinary price drift:
+    // 0/0 is what makes the cost-aware stages *prefer* the entry, so claiming
+    // free when the catalogue charges is a routing bug, not a stale number.
+    const findings = findCatalogueDrift(
+      [model({ id: 'freeclaim', pricing: { inputPer1M: 0, outputPer1M: 0 } })],
+      [cat({ id: 'openrouter/vendor/thing', pricing: { inputPer1M: 0.3, outputPer1M: 1 } })],
+      { treatFalseFreeAsDefect: true }
+    );
+
+    expect(findings[0]?.kind).toBe('false-free');
+    expect(findings[0]?.severity).toBe('defect');
+  });
+
+  it('tolerates float noise in prices', () => {
+    const findings = findCatalogueDrift(
+      [model({ id: 'noise', pricing: { inputPer1M: 0.1, outputPer1M: 0.3 } })],
+      [
+        cat({
+          id: 'openrouter/vendor/thing',
+          pricing: { inputPer1M: 0.09999999999999999, outputPer1M: 0.3 },
+        }),
+      ]
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  it('does not compare against a catalogue entry with no numbers', () => {
+    // Some providers list an id with null cost. Absent data is not a mismatch.
+    const findings = findCatalogueDrift(
+      [model({ id: 'nullcost' })],
+      [{ id: 'openrouter/vendor/thing', contextWindow: undefined, pricing: undefined }]
+    );
+
+    expect(findings).toEqual([]);
+  });
+});
+
+describe('findCatalogueDrift — reporting discipline', () => {
+  it('reports every finding for an entry, not just the first', () => {
+    const findings = findCatalogueDrift(
+      [model({ id: 'both', contextWindow: 999_999, pricing: { inputPer1M: 5, outputPer1M: 9 } })],
+      [
+        cat({
+          id: 'openrouter/vendor/thing',
+          contextWindow: 1000,
+          pricing: { inputPer1M: 1, outputPer1M: 2 },
+        }),
+      ]
+    );
+
+    expect(findings.map((f) => f.kind).sort()).toEqual(['context-overstated', 'price-mismatch']);
+  });
+
+  it('sorts defects before advisories', () => {
+    const findings = findCatalogueDrift(
+      [
+        model({ id: 'adv', cliModelName: 'v/a', contextWindow: 10 }),
+        model({ id: 'def', cliModelName: 'v/b', contextWindow: 10_000 }),
+      ],
+      [
+        cat({ id: 'openrouter/v/a', contextWindow: 20 }),
+        cat({ id: 'openrouter/v/b', contextWindow: 100 }),
+      ]
+    );
+
+    expect(findings[0]?.severity).toBe('defect');
+  });
+});

--- a/scripts/check-catalogue-drift.ts
+++ b/scripts/check-catalogue-drift.ts
@@ -1,0 +1,312 @@
+#!/usr/bin/env npx tsx
+/* eslint-disable no-console */
+/**
+ * Catalogue-drift sweep (#4417).
+ *
+ * Compares every in-tree model entry's `cliModelName` against the generated
+ * catalogue (`model-registry.generated.json`, refreshed weekly by
+ * `.github/workflows/registry-refresh.yml`). Fully offline and deterministic:
+ * both inputs are committed files, so this never depends on models.dev being
+ * reachable and produces the same answer for the same commit.
+ *
+ * **Scope is deliberately narrow.** #4408 established that inferring EOL from
+ * catalogue absence is unsound — `gpt-4o` is retired and still listed, and
+ * catalogue diffing had a 2/3 false-positive rate against our entries. So this
+ * asks only questions with factual answers:
+ *
+ *  - does this exact id exist under this entry's provider?
+ *  - if not, does any other provider serve it? (reseller-only → advisory)
+ *  - do `contextWindow` and pricing match the catalogue record for that id?
+ *
+ * Nothing here decides what a model *should* be repointed at. #4410 needed a
+ * 7-voter vote to choose among three live siblings; a script should not
+ * pretend that is mechanical.
+ *
+ * **Severity is directional, and that matters more than it sounds.** An
+ * overstated context window fails *after* the context has been assembled — the
+ * expensive, confusing way. An understated one merely leaves capacity unused.
+ * Reporting both as "mismatch" is how a useful report becomes noise nobody
+ * reads, which is the failure mode #4424 just fixed elsewhere.
+ *
+ * Report-only by design. Exits non-zero on defects so a caller *may* gate on
+ * it, but it is not wired into CI as a blocking gate — see #4417 for why that
+ * waits until the false-positive rate is measured over real runs.
+ *
+ * @module scripts/check-catalogue-drift
+ * (Source: #4417; motivated by the hand-found #4410 and #4416)
+ */
+
+import { readFileSync } from 'node:fs';
+
+/** A model record as it appears in the generated catalogue. */
+export interface CatalogueEntry {
+  readonly id: string;
+  readonly contextWindow?: number | undefined;
+  readonly pricing?: { readonly inputPer1M?: number; readonly outputPer1M?: number } | undefined;
+}
+
+/** The subset of an in-tree model entry this sweep reads. */
+export interface InTreeModel {
+  readonly id: string;
+  readonly provider: string;
+  readonly cliModelName?: string | undefined;
+  readonly contextWindow?: number | undefined;
+  readonly pricing?: { readonly inputPer1M?: number; readonly outputPer1M?: number } | undefined;
+}
+
+export type DriftKind =
+  | 'missing-everywhere'
+  | 'provider-absent'
+  | 'context-overstated'
+  | 'context-understated'
+  | 'price-mismatch'
+  | 'false-free';
+
+export interface DriftFinding {
+  readonly modelId: string;
+  readonly kind: DriftKind;
+  readonly severity: 'defect' | 'advisory';
+  readonly detail: string;
+}
+
+export interface DriftOptions {
+  /**
+   * Treat "in-tree says 0/0, catalogue charges" as a defect rather than an
+   * ordinary price drift. Off by default because a genuinely free tier that
+   * the catalogue has not caught up with is a plausible false positive; on,
+   * it catches #4410's second half, where a zero price made the cost-aware
+   * stages actively prefer a model that could only fail.
+   */
+  readonly treatFalseFreeAsDefect?: boolean;
+}
+
+/**
+ * Local alias namespaces that never appear in a public catalogue. `custom/`
+ * denotes an operator-configured endpoint; flagging it every run is pure noise.
+ */
+const ALIAS_PREFIXES = ['custom/'];
+
+/** Prices differ in the last bits across sources; compare with a tolerance. */
+const PRICE_EPSILON = 0.001;
+
+/**
+ * The catalogue keys entries as `<provider>/<modelId>`, but a `cliModelName`
+ * sometimes already carries a vendor segment (`anthropic/claude-sonnet-4-6`
+ * under provider `anthropic`). Concatenating unconditionally yields
+ * `anthropic/anthropic/...` and a bogus "missing" — the first hand-run of this
+ * check did exactly that on three entries.
+ */
+function candidateKeys(model: InTreeModel, cliModelName: string): string[] {
+  const prefixed = `${model.provider}/${cliModelName}`;
+  return cliModelName.startsWith(`${model.provider}/`)
+    ? [cliModelName, prefixed]
+    : [prefixed, cliModelName];
+}
+
+/** Providers other than this entry's that serve the same bare model id. */
+function otherProvidersServing(
+  cliModelName: string,
+  catalogue: readonly CatalogueEntry[]
+): string[] {
+  const suffix = `/${cliModelName}`;
+  const out = new Set<string>();
+  for (const e of catalogue) {
+    if (e.id === cliModelName || e.id.endsWith(suffix)) {
+      const slash = e.id.indexOf('/');
+      out.add(slash > 0 ? e.id.slice(0, slash) : e.id);
+    }
+  }
+  return [...out].sort();
+}
+
+function priceDetail(
+  mi: number,
+  mo: number | undefined,
+  ci: number,
+  co: number | undefined
+): string {
+  const m = `${String(mi)}/${mo === undefined ? '?' : String(mo)}`;
+  const c = `${String(ci)}/${co === undefined ? '?' : String(co)}`;
+  return `in-tree ${m} vs catalogue ${c} per 1M`;
+}
+
+interface PricePair {
+  readonly mi: number;
+  readonly mo: number | undefined;
+  readonly ci: number;
+  readonly co: number | undefined;
+}
+
+/** Both sides must carry an input price, or there is nothing to compare. */
+function readPrices(model: InTreeModel, hit: CatalogueEntry): PricePair | null {
+  const mp = model.pricing;
+  const cp = hit.pricing;
+  if (mp === undefined || cp === undefined) return null;
+  const mi = mp.inputPer1M;
+  const ci = cp.inputPer1M;
+  if (mi === undefined || ci === undefined) return null;
+  return { mi, mo: mp.outputPer1M, ci, co: cp.outputPer1M };
+}
+
+function pricesDiffer(p: PricePair): boolean {
+  if (Math.abs(p.mi - p.ci) > PRICE_EPSILON) return true;
+  if (p.mo === undefined || p.co === undefined) return false;
+  return Math.abs(p.mo - p.co) > PRICE_EPSILON;
+}
+
+function comparePricing(
+  model: InTreeModel,
+  hit: CatalogueEntry,
+  opts: DriftOptions
+): DriftFinding | null {
+  const p = readPrices(model, hit);
+  if (p === null || !pricesDiffer(p)) return null;
+
+  const detail = priceDetail(p.mi, p.mo, p.ci, p.co);
+  const claimsFree = p.mi === 0 && (p.mo ?? 0) === 0;
+  const catalogueCharges = p.ci > 0 || (p.co ?? 0) > 0;
+
+  if (claimsFree && catalogueCharges && opts.treatFalseFreeAsDefect === true) {
+    return {
+      modelId: model.id,
+      kind: 'false-free',
+      severity: 'defect',
+      detail: `${detail} — a zero price makes cost-aware routing prefer this entry`,
+    };
+  }
+  return { modelId: model.id, kind: 'price-mismatch', severity: 'advisory', detail };
+}
+
+function compareContext(model: InTreeModel, hit: CatalogueEntry): DriftFinding | null {
+  const mine = model.contextWindow;
+  const theirs = hit.contextWindow;
+  if (mine === undefined || theirs === undefined || mine === theirs) return null;
+
+  return mine > theirs
+    ? {
+        modelId: model.id,
+        kind: 'context-overstated',
+        severity: 'defect',
+        detail: `claims ${String(mine)} but catalogue serves ${String(theirs)} — over-budgeted requests fail after the context is assembled`,
+      }
+    : {
+        modelId: model.id,
+        kind: 'context-understated',
+        severity: 'advisory',
+        detail: `claims ${String(mine)}, catalogue serves ${String(theirs)} — unused capacity, no failure`,
+      };
+}
+
+/** No catalogue row under this entry's provider: dead id, or reseller-only. */
+function absenceFinding(
+  model: InTreeModel,
+  cliModelName: string,
+  catalogue: readonly CatalogueEntry[]
+): DriftFinding {
+  const others = otherProvidersServing(cliModelName, catalogue);
+  if (others.length === 0) {
+    return {
+      modelId: model.id,
+      kind: 'missing-everywhere',
+      severity: 'defect',
+      detail: `"${cliModelName}" appears under no provider in the catalogue`,
+    };
+  }
+  return {
+    modelId: model.id,
+    kind: 'provider-absent',
+    severity: 'advisory',
+    detail: `not served by "${model.provider}", but ${String(others.length)} other provider(s) list it: ${others.join(', ')}`,
+  };
+}
+
+/** Compare in-tree entries against the catalogue. Pure — no I/O. */
+export function findCatalogueDrift(
+  models: readonly InTreeModel[],
+  catalogue: readonly CatalogueEntry[],
+  opts: DriftOptions = {}
+): DriftFinding[] {
+  const byId = new Map(catalogue.map((e) => [e.id, e]));
+  const findings: DriftFinding[] = [];
+
+  for (const model of models) {
+    const cliModelName = model.cliModelName;
+    if (cliModelName === undefined || cliModelName === '') continue;
+    if (ALIAS_PREFIXES.some((prefix) => cliModelName.startsWith(prefix))) continue;
+
+    const hit = candidateKeys(model, cliModelName)
+      .map((k) => byId.get(k))
+      .find((e): e is CatalogueEntry => e !== undefined);
+
+    if (hit === undefined) {
+      // Comparing numbers against some other provider's row would be
+      // inventing data, so absence ends the checks for this entry.
+      findings.push(absenceFinding(model, cliModelName, catalogue));
+      continue;
+    }
+
+    const ctx = compareContext(model, hit);
+    if (ctx !== null) findings.push(ctx);
+    const price = comparePricing(model, hit, opts);
+    if (price !== null) findings.push(price);
+  }
+
+  return findings.sort((a, b) =>
+    a.severity === b.severity ? 0 : a.severity === 'defect' ? -1 : 1
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const GENERATED = 'packages/nexus-agents/src/config/model-registry.generated.json';
+
+async function main(): Promise<void> {
+  const { DEFAULT_MODEL_CAPABILITIES } =
+    (await import('../packages/nexus-agents/src/config/in-tree-data.js')) as {
+      DEFAULT_MODEL_CAPABILITIES: { models: InTreeModel[] };
+    };
+
+  const generated = JSON.parse(readFileSync(GENERATED, 'utf8')) as {
+    generatedAt?: string;
+    entries: CatalogueEntry[];
+  };
+
+  const findings = findCatalogueDrift(DEFAULT_MODEL_CAPABILITIES.models, generated.entries, {
+    treatFalseFreeAsDefect: true,
+  });
+
+  const models = DEFAULT_MODEL_CAPABILITIES.models.length;
+  console.log(
+    `Catalogue drift: ${String(models)} in-tree entries vs ${String(generated.entries.length)} catalogue entries` +
+      (generated.generatedAt !== undefined ? ` (generated ${generated.generatedAt})` : '')
+  );
+
+  if (findings.length === 0) {
+    console.log('✓ No drift.');
+    return;
+  }
+
+  const defects = findings.filter((f) => f.severity === 'defect');
+  for (const f of findings) {
+    const mark = f.severity === 'defect' ? '✗ DEFECT  ' : '· advisory';
+    console.log(`${mark} ${f.modelId} [${f.kind}]\n            ${f.detail}`);
+  }
+  console.log(
+    `\n${String(defects.length)} defect(s), ${String(findings.length - defects.length)} advisory.`
+  );
+
+  if (defects.length > 0) {
+    console.log(
+      '\nA defect means the registry describes something the transport will not serve.\n' +
+        'Choosing the replacement is a judgement call — see #4410 for why that is not automated.'
+    );
+    process.exitCode = 1;
+  }
+}
+
+// Run only when invoked directly, so the test can import the pure function.
+if (process.argv[1]?.endsWith('check-catalogue-drift.ts') === true) {
+  void main();
+}

--- a/scripts/verify-refresh.sh
+++ b/scripts/verify-refresh.sh
@@ -45,4 +45,16 @@ echo "::group::full test suite"
 pnpm --filter nexus-agents exec vitest run
 echo "::endgroup::"
 
+echo "::group::catalogue drift (advisory)"
+# The refresh has just replaced the catalogue, which is the exact moment an
+# in-tree entry can go stale — #4340's diff caught the qwen `:free` retirement
+# two weeks before it surfaced as bug #4410, and nobody looked. Run the sweep
+# here so it lands in the job log while the diff is in front of someone.
+#
+# Deliberately non-fatal: drift means an *in-tree* entry is wrong, not that
+# this refresh is bad. Failing the job would block the correct catalogue update
+# because of a pre-existing registry defect, which is backwards.
+npx tsx scripts/check-catalogue-drift.ts || echo "^ drift reported; see #4417 — not blocking this refresh"
+echo "::endgroup::"
+
 echo "verify-refresh: all gates passed"


### PR DESCRIPTION
Closes #4417.

## Why

Two shipped bugs motivated this, both found by hand and both mechanically detectable:

- **#4410** — an entry pointing at `qwen/qwen3-coder-480b-a35b:free`, an id that existed under no provider. Priced `0/0`, so cost-aware routing actively *preferred* a model that could only fail.
- **#4416** — an entry carrying the *paid* variant's 1M context while dispatching the `:free` one that serves 262K.

The weekly refresh had already caught #4410's retirement two weeks before it surfaced. Nobody looked.

## Scope is deliberately narrow

#4408 established that inferring **EOL** from catalogue absence is unsound — `gpt-4o` is retired and still listed, and diffing had a 2/3 false-positive rate against our entries. That result should not be read as "catalogue comparison is useless"; it means the sweep must only ask questions with factual answers:

- does this exact id exist under this entry's provider?
- if not, does any *other* provider serve it? (reseller-only → advisory)
- do `contextWindow` and pricing match that id's record?

It never proposes a replacement. #4410 needed a 7-voter vote to choose among three live siblings; a script shouldn't pretend that's mechanical.

## Offline and deterministic

Reads `model-registry.generated.json` — the catalogue the weekly refresh regenerates — not the network. Same commit, same answer; no models.dev dependency, nothing to flake in CI.

## Severity is directional

An **overstated** context window fails *after* the context has been assembled — the expensive, confusing way. An **understated** one only leaves capacity unused. Reporting both as "mismatch" is how a report becomes noise nobody reads.

| kind | severity |
| --- | --- |
| `missing-everywhere`, `context-overstated`, `false-free` | defect (exit 1) |
| `provider-absent`, `context-understated`, `price-mismatch` | advisory |

## Both false-positive classes from the hand-run are handled

The manual cross-check that found #4416 also produced three bogus results, and those are now regression tests:

1. A `cliModelName` already carrying its provider (`anthropic/claude-sonnet-4-6` under provider `anthropic`) was double-prefixed into `anthropic/anthropic/...` and reported MISSING.
2. The local `custom/` alias namespace — no such id exists in any catalogue; it denotes an operator-configured endpoint.
3. On absence under the entry's own provider, the hand-run fell back to an arbitrary provider's row and compared numbers against it, fabricating a context "mismatch" for a model whose provider had no record at all. Absence now ends the checks for that entry.

## Verified by mutation, not just by passing

Reintroducing #4410 and #4416 into `in-tree-data.ts` produces exactly two defects with the right kinds and exit 1; restoring returns to 0 defects.

Current real run: **0 defects, 1 advisory** — `codex-5.2` is absent from first-party `openai` but served by a reseller, correctly an advisory rather than a defect. 15 unit tests, lint and typecheck clean.

## Wired to a real consumer

`scripts/verify-refresh.sh` now runs it, so the weekly refresh reports drift at the moment the catalogue changes — the loop that would have caught #4410 early. **Non-fatal there on purpose:** drift means an *in-tree* entry is stale, not that the refresh is bad, so failing would block a correct catalogue update over a pre-existing defect.

Not wired as a blocking CI gate. #4417 said to measure the false-positive rate over real runs first; one clean run is not that measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)