### PR TITLE
fix(test): stop pinning a third-party SKU that upstream can retire

### DIFF
--- a/packages/nexus-agents/src/learning/usage-log.test.ts
+++ b/packages/nexus-agents/src/learning/usage-log.test.ts
@@ -10,6 +10,7 @@ import { join } from 'node:path';
 
 import {
   ModelRegistry,
+  getDefaultRegistry,
   peekDefaultRegistry,
   setDefaultRegistry,
   type ModelEntry,
@@ -130,6 +131,21 @@ describe('computeCostDetail (#4165)', () => {
     });
   });
 
+  /**
+   * Pick a `:free` catalogue id that exists right now, priced 0/0.
+   *
+   * Read from the registry rather than hardcoded so the weekly catalogue refresh
+   * cannot turn an expired example into a false regression (#4417 / the refresh
+   * in #4340 retired the id this test used to pin).
+   */
+  function findFirstFreeCatalogId(): string | undefined {
+    return getDefaultRegistry()
+      .allEntries()
+      .find(
+        (e) => e.id.endsWith(':free') && e.pricing?.inputPer1M === 0 && e.pricing.outputPer1M === 0
+      )?.id;
+  }
+
   describe('against the real default registry (full chain)', () => {
     it('prices a long-tail catalog id from the generated tier', () => {
       // 'amazon-bedrock/amazon.nova-micro-v1:0' has NO in-tree entry — its
@@ -148,11 +164,19 @@ describe('computeCostDetail (#4165)', () => {
       // loader keeps their $0/$0 pricing (exempt from the #4176 placeholder
       // guard), so the full chain prices them at a real, measured $0 — not
       // priced:false/UNMEASURED (#3855/#4165 semantics).
-      const detail = computeCostDetail(
-        'openrouter/meta-llama/llama-3.3-70b-instruct:free',
-        1_000_000,
-        500_000
-      );
+      //
+      // The id is chosen from the catalogue at run time rather than hardcoded.
+      // This test previously pinned `openrouter/meta-llama/llama-3.3-70b-instruct:free`
+      // and went red the moment the weekly refresh retired that SKU — the
+      // invariant under test ("a :free entry prices at a measured $0") was
+      // still true; only the example had expired. Binding a behavioural
+      // assertion to a third-party SKU makes upstream churn look like a
+      // regression in our code.
+      const freeId = findFirstFreeCatalogId();
+      expect(freeId, 'no `:free` entry in the generated catalogue to exercise').toBeDefined();
+
+      const detail = computeCostDetail(freeId as string, 1_000_000, 500_000);
+
       expect(detail.priced).toBe(true);
       expect(detail.costUsd).toBe(0);
     });

--- a/scripts/verify-refresh.sh
+++ b/scripts/verify-refresh.sh
@@ -29,11 +29,20 @@ echo "::group::registry-coverage manifest"
 npx tsx scripts/check-registry-coverage.ts
 echo "::endgroup::"
 
-echo "::group::config + registry tests"
-# Scoped to the suites that read generated model data. A full run would be
-# ~3 minutes of mostly-unrelated tests on a weekly cron; these are the ones a
-# bad refresh actually breaks.
-pnpm --filter nexus-agents exec vitest run src/config
+echo "::group::full test suite"
+# Deliberately the FULL suite, not a scoped subset.
+#
+# The first version of this gate ran only `src/config`, reasoning that those
+# were "the ones a bad refresh actually breaks". That reasoning failed on its
+# first real use: the #4340 refresh retired an openrouter `:free` SKU that
+# `src/learning/usage-log.test.ts` had hardcoded, and main went red with the
+# gate green. Guessing which suites depend on generated catalogue data is
+# exactly the kind of judgement a gate should not be making — any test may
+# reach the registry through `getDefaultRegistry()`.
+#
+# Cost is ~3 minutes on a weekly cron. That is cheap next to shipping a red
+# main and then bisecting it.
+pnpm --filter nexus-agents exec vitest run
 echo "::endgroup::"
 
 echo "verify-refresh: all gates passed"


### PR DESCRIPTION
**main is currently red.** This fixes it.

## What broke

`usage-log.test.ts` asserts that a `:free` catalogue entry prices at a *measured* `$0` (`priced: true`) rather than UNMEASURED. Sound invariant — but it was bound to one hardcoded id, `openrouter/meta-llama/llama-3.3-70b-instruct:free`.

The #4340 weekly refresh retired that SKU. The lookup missed, `priced` came back `false`, and the suite went red. **The invariant was still true; only the example had expired.** Binding a behavioural assertion to a third-party SKU makes upstream churn look like a regression in our own code.

Now the test picks a live `:free` entry from the registry at run time (14 currently qualify) and asserts on that, with an explicit failure message if the catalogue ever has none.

## The more important part: my gate was too narrow

`scripts/verify-refresh.sh` (#4427, merged yesterday) was supposed to stop exactly this — an unverified refresh reaching main. It ran and passed. It missed this because **I scoped it to `src/config`**, reasoning those were "the ones a bad refresh actually breaks".

That reasoning failed on the gate's first real use: the breakage was in `src/learning`. Any test can reach generated catalogue data through `getDefaultRegistry()`, so guessing which subset is affected is precisely the judgement a gate should not be making.

Widened to the full suite. It costs ~3 minutes on a weekly cron, which is cheap next to shipping a red main and then bisecting it.

## Verification

Full suite green: **1,166 files / 27,833 tests**, exit 0. Lint and typecheck clean.

Confirmed the failure was pre-existing on `main` and not introduced by the PR I was working on when I found it — the same test fails at `main`'s HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)