### PR TITLE
fix(audit): refuse to write the tracked pr-review chain from a test

### DIFF
--- a/.changeset/lucky-jars-repeat.md
+++ b/.changeset/lucky-jars-repeat.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+Refuse to write the source checkout's own pr-review audit chain from a test (#4415)
+
+`governance/pr-review-records.jsonl` is tracked, hash-chained, and read by `verify_audit_chain`. A test previously appended three fabricated verdicts to it — they chained correctly onto each other, so a valid chain containing fake reviews would have read as genuine. They were caught only because `git status` showed a tracked file dirty.
+
+`persistPrReviewRecord` now throws when, under a test runner, the resolved destination is the source checkout's own tracked chain. The guard keys on the **destination**, not on how it was derived, so an explicit `filePath` or `NEXUS_PR_REVIEW_RECORDS_PATH` aimed at the same file is refused too. Writes into a throwaway repo — the shape a legitimate persistence test uses — are unaffected, and production behaviour is unchanged.
+
+Path _resolution_ stays unguarded: it is a query, and tests legitimately assert its fall-through behaviour (#4278/#4312) without writing anything.
+
+The CI working-tree check now also treats a modified `governance/` file as a leak, catching any writer the runtime guard does not.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
           set -u
           leaks=$(git status --porcelain --untracked-files=all 2>/dev/null \
             | awk '{print $2}' \
-            | grep -E '^(runs/|logs/|\.nexus-pipeline/|\.nexus-agents/|predictions\.jsonl$|coverage\.json$|\.test-)' \
+            | grep -E '^(runs/|logs/|\.nexus-pipeline/|\.nexus-agents/|governance/|predictions\.jsonl$|coverage\.json$|\.test-)' \
             || true)
           if [ -n "$leaks" ]; then
             echo "::error::Tests left sprawl artifacts in the working tree:"
@@ -144,6 +144,11 @@ jobs:
             echo "Per epic #2872, runtime artifacts must land under getNexusDataDir(),"
             echo "and test temp dirs must use os.tmpdir() + mkdtempSync() with cleanup."
             echo "See packages/nexus-agents/src/cli/init-portable.test.ts for the pattern."
+            echo ""
+            echo "A governance/ entry means a test wrote to a TRACKED, hash-chained"
+            echo "audit file (#4415). Those records chain cleanly, so a fabricated one"
+            echo "is indistinguishable from a real verdict — pass an explicit repoPath"
+            echo "to a throwaway repo instead."
             exit 1
           fi
           echo "✓ Working tree clean after tests"

--- a/packages/nexus-agents/src/audit/pr-review-ambient-write-guard.test.ts
+++ b/packages/nexus-agents/src/audit/pr-review-ambient-write-guard.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Guard against tests appending to the real pr-review audit chain (#4415).
+ *
+ * `governance/pr-review-records.jsonl` is tracked, hash-chained, and read by
+ * `verify_audit_chain`. During #4412 three fabricated records were appended to
+ * it by a test — `prNumber: 4279`, `baseSha: "dddd…"` — and they chained
+ * correctly onto each other, so nothing downstream would have flagged them.
+ * They were caught only because `git status` showed a tracked file dirty.
+ *
+ * The mechanism is the cwd fallback: with no explicit target,
+ * `resolvePrReviewRecordsPath` detects the repo from `process.cwd()`, and
+ * under a test runner that is this checkout. The specific test involved had
+ * chdir'd to a temp dir to avoid exactly this, which worked only while temp
+ * dirs happened to live outside the checkout.
+ *
+ * The guard sits on the WRITE and keys on the destination, not on how the path
+ * was derived — an explicit `filePath` aimed at the same tracked file is the
+ * same harm. Resolution stays unguarded: it is a query, and tests legitimately
+ * assert its fall-through behaviour (#4278/#4312) without writing anything.
+ * That distinction was not obvious to me until guarding resolution broke two
+ * of those tests.
+ *
+ * @module audit/pr-review-ambient-write-guard.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  persistPrReviewRecord,
+  resolvePrReviewRecordsPath,
+  PR_REVIEW_RECORDS_PATH_ENV,
+  PR_REVIEW_RECORDS_REL_PATH,
+} from './pr-review-record-store.js';
+import { mkdtempOutsideRepo } from '../testing/non-repo-temp-dir.js';
+
+/** Minimal valid record input. */
+function sampleRecord(): Parameters<typeof persistPrReviewRecord>[0] {
+  return {
+    prNumber: 1,
+    baseSha: 'a'.repeat(40),
+    reviewedDiffHash: 'b'.repeat(64),
+    verdict: 'approve',
+    verified: true,
+    voteCounts: { approve: 1, request_changes: 0, abstain: 0, error: 0, total: 1 },
+    summary: 'guard fixture — must never reach the tracked chain',
+  };
+}
+
+/** A real throwaway git repo — the shape a legitimate persistence test uses. */
+function makeRepo(): string {
+  const root = mkdtempOutsideRepo('pr-review-guard-repo-');
+  execFileSync('git', ['init', '-q'], { cwd: root, stdio: 'ignore' });
+  return root;
+}
+
+describe('ambient-write guard (#4415)', () => {
+  const saved = process.env[PR_REVIEW_RECORDS_PATH_ENV];
+  const made: string[] = [];
+
+  beforeEach(() => {
+    delete process.env['NEXUS_PR_REVIEW_RECORDS_PATH'];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env['NEXUS_PR_REVIEW_RECORDS_PATH'];
+    else process.env[PR_REVIEW_RECORDS_PATH_ENV] = saved;
+    for (const d of made) rmSync(d, { recursive: true, force: true });
+    made.length = 0;
+  });
+
+  it('refuses to WRITE the ambient repo chain under a test runner', () => {
+    // cwd is this checkout, so the fallback resolves to the real tracked
+    // chain. Throwing is the point: a silent append is indistinguishable from
+    // a genuine review verdict once it is hash-chained.
+    expect(() => persistPrReviewRecord(sampleRecord())).toThrow(/#4415/);
+  });
+
+  it('names the offending path in the error', () => {
+    // A guard that fires without saying what it blocked just moves the
+    // confusion somewhere else.
+    expect(() => persistPrReviewRecord(sampleRecord())).toThrow(/pr-review-records\.jsonl/);
+  });
+
+  it('refuses an explicit filePath aimed at the same tracked file', () => {
+    // The guard is on the DESTINATION, not the derivation — otherwise the
+    // escape hatches become a way to launder the same write.
+    const here = process.cwd();
+    const target = join(here.slice(0, here.indexOf('/packages')), PR_REVIEW_RECORDS_REL_PATH);
+
+    expect(() => persistPrReviewRecord({ ...sampleRecord(), filePath: target })).toThrow(/#4415/);
+  });
+
+  it('still allows a write into a throwaway repo', () => {
+    // The legitimate persistence test must keep working end to end.
+    const repo = makeRepo();
+    made.push(repo);
+
+    const written = persistPrReviewRecord({ ...sampleRecord(), repoPathOverride: repo });
+
+    expect(written).toBeDefined();
+    expect(existsSync(join(repo, PR_REVIEW_RECORDS_REL_PATH))).toBe(true);
+  });
+
+  it('allows an explicit repoPathOverride to a throwaway repo', () => {
+    // The legitimate shape: a test that means to exercise persistence points
+    // at a repo it created. This must keep working.
+    const repo = makeRepo();
+    made.push(repo);
+
+    expect(resolvePrReviewRecordsPath(repo)).toBe(join(repo, PR_REVIEW_RECORDS_REL_PATH));
+  });
+
+  it('allows an explicit env path', () => {
+    const dir = mkdtempOutsideRepo('pr-review-guard-env-');
+    made.push(dir);
+    const target = join(dir, 'records.jsonl');
+    process.env[PR_REVIEW_RECORDS_PATH_ENV] = target;
+
+    expect(resolvePrReviewRecordsPath()).toBe(target);
+  });
+
+  it('still refuses when an override points into the source checkout', () => {
+    // The override escape hatch must not become a way to launder an ambient
+    // write: passing this repo's own root is the same destination.
+    expect(() =>
+      persistPrReviewRecord({ ...sampleRecord(), repoPathOverride: process.cwd() })
+    ).toThrow(/#4415/);
+  });
+
+  it('does not fire for an override to a nested throwaway repo', () => {
+    // A repo created *inside* a temp dir is fine — the check is "is this the
+    // source checkout", not "does the path contain governance/".
+    const repo = makeRepo();
+    made.push(repo);
+    const nested = join(repo, 'sub');
+    mkdirSync(nested, { recursive: true });
+
+    expect(resolvePrReviewRecordsPath(nested)).toBe(join(repo, PR_REVIEW_RECORDS_REL_PATH));
+  });
+});

--- a/packages/nexus-agents/src/audit/pr-review-record-store.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.ts
@@ -107,6 +107,46 @@ export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRe
   return { ...payload, hash: computePrReviewRecordHash(payload) };
 }
 
+/** True when running under a test runner (vitest sets `VITEST`). */
+function isUnderTestRunner(): boolean {
+  return process.env['VITEST'] !== undefined || process.env['NODE_ENV'] === 'test';
+}
+
+/**
+ * Refuse to WRITE the source checkout's own tracked chain from a test (#4415).
+ *
+ * `governance/pr-review-records.jsonl` is tracked and hash-chained. During
+ * #4412 a test appended three fabricated verdicts to it — they chained
+ * correctly onto each other, so `verify_audit_chain` would have read a valid
+ * chain containing fake reviews. They were noticed only because `git status`
+ * showed a tracked file dirty before a commit.
+ *
+ * A fabricated record that hash-chains cleanly is worse than a corrupt file:
+ * it is indistinguishable from a real one. The threat model already scopes the
+ * chain as tamper-*evident*, which only holds if we do not manufacture
+ * plausible entries ourselves.
+ *
+ * Guards the DESTINATION, not how it was derived — an explicit `filePath` or
+ * env var pointing at the same file is the same harm. Resolution itself stays
+ * unguarded: `resolvePrReviewRecordsPath` is a query, and tests legitimately
+ * assert its fall-through behaviour (#4278/#4312) without writing anything.
+ *
+ * A throwaway repo — the shape a legitimate persistence test uses — is
+ * untouched.
+ */
+function assertNotSourceCheckoutWrite(filePath: string): void {
+  if (!isUnderTestRunner()) return;
+  const here = findRepoRoot(process.cwd());
+  if (here === null) return;
+  if (resolve(filePath) !== resolve(join(here, PR_REVIEW_RECORDS_REL_PATH))) return;
+  throw new Error(
+    `Refusing to write ${filePath} from a test run (#4415): this is the source ` +
+      "checkout's tracked, hash-chained audit file, and a fabricated record that " +
+      'chains cleanly is indistinguishable from a real verdict. Pass repoPath to a ' +
+      'throwaway repo, or set NEXUS_PR_REVIEW_RECORDS_PATH.'
+  );
+}
+
 /**
  * Resolve the committable artifact path (mirrors #3927). Precedence:
  *  1. {@link PR_REVIEW_RECORDS_PATH_ENV} when set non-empty — a RELATIVE value is
@@ -133,8 +173,10 @@ export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRe
 export function resolvePrReviewRecordsPath(repoPathOverride?: string): string | undefined {
   const envPath = process.env[PR_REVIEW_RECORDS_PATH_ENV];
   if (envPath !== undefined && envPath.trim() !== '') {
+    // Explicit target — the caller has stated where it wants records to land.
     return isAbsolute(envPath) ? envPath : resolve(envPath);
   }
+
   if (repoPathOverride !== undefined && repoPathOverride.trim() !== '') {
     const overrideRoot = findRepoRoot(repoPathOverride);
     if (overrideRoot !== null) return join(overrideRoot, PR_REVIEW_RECORDS_REL_PATH);
@@ -260,6 +302,10 @@ export function persistPrReviewRecord(
     });
     return undefined;
   }
+  // Before the try: a swallowed guard would silently skip the write and hide
+  // the very mistake it exists to surface.
+  assertNotSourceCheckoutWrite(filePath);
+
   try {
     mkdirSync(dirname(filePath), { recursive: true });
     const { maxSequence, lastHash } = readPrReviewLedgerTip(filePath, logger);


### PR DESCRIPTION
Closes #4415.

## What happened

`governance/pr-review-records.jsonl` is tracked, hash-chained, and read by `verify_audit_chain`. During #4412 a test appended **three fabricated verdicts** to it — `prNumber: 4279`, `baseSha: "dddd…"`, summary "No repoPath supplied". They chained correctly onto each other via `previousHash`, so `verify_audit_chain` would have read a perfectly valid chain containing fake reviews.

They were noticed only because `git status` showed a tracked file dirty before a commit.

A fabricated record that hash-chains cleanly is worse than a corrupt file: it is indistinguishable from a real one. The threat model scopes this chain as tamper-*evident*, and that only holds if we do not manufacture plausible entries ourselves.

## The guard

`persistPrReviewRecord` now throws when, under a test runner, the destination is the source checkout's own tracked chain.

It keys on the **destination**, not on how the path was derived — an explicit `filePath` or `NEXUS_PR_REVIEW_RECORDS_PATH` aimed at the same file is the same harm, and leaving those unguarded would turn the escape hatches into a way to launder the write. Thrown *before* the try block: swallowing it would silently skip the write and hide the very mistake it exists to surface.

Writes into a throwaway repo — the shape a legitimate persistence test uses — are unaffected, and production behaviour is unchanged.

## A design correction worth recording

I first put the guard on `resolvePrReviewRecordsPath`, and it broke two existing tests that legitimately assert the fall-through resolution behaviour (#4278/#4312) **without writing anything**.

That was the tests telling me the design was wrong: resolution is a *query*; the harm is the *write*. Guarding the query conflated "where would this go" with "put something there". Moved to the write path, and both tests pass untouched.

## Belt and braces

The existing working-tree leak check (epic #2872) matched only untracked sprawl prefixes, so a **modified tracked** file passed straight through — which is exactly the shape this incident took. Extended it to treat a modified `governance/` file as a leak, with a message pointing at the real cause.

Verified by simulation rather than assumed: appending a record to the file is now caught by the check; reverting clears it.

## Verification

- 8 new guard tests, red-first.
- `src/audit` + pr-review tool suites: 338 passed, including the two the misplaced guard had broken.
- Full suite: **1,167 files / 27,841 tests**, exit 0 — with `governance/pr-review-records.jsonl` **byte-identical (same md5) before and after**, which is the property that actually matters here.
- Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)