### PR TITLE
fix(observability): require token evidence before certifying a voter measured

### DIFF
--- a/.changeset/red-buses-clap.md
+++ b/.changeset/red-buses-clap.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+A voter that reported no tokens is no longer certified as measured (#4430)
+
+`isMeasured` keyed on `costUsd` alone. Because the breakdown coerces absent counts (`inputTokens ?? 0`), any voter whose adapter reported no usage still produced a `0 / 0` line flagged `unmeasured: false` — the rollup certified a non-measurement as measured.
+
+Observed live across three 7-voter panels: every `gpt-5.5` voter returned full reasoning that counted toward the verdict while reporting `0` input and `0` output, all flagged measured. That also defeats the natural mitigation — a consumer told to discard zero-token voters would have dropped 3 of 7 in one of those votes, enough to move a supermajority.
+
+Now requires a computable cost **and** at least one reported token counter. An explicit `0` is still a measurement (a genuinely free model stays measured, #4165); absent is not. Either counter suffices, since some adapters report only completion tokens and demanding both would newly discard voters that were previously counted.
+
+The separate "cached input tokens are parsed then discarded" half of #4430 is tracked in #4435 — folding them into `inputTokens` would overstate cost, since cache reads bill at roughly a tenth of the uncached rate.

--- a/packages/nexus-agents/src/observability/decision-cost-measured.test.ts
+++ b/packages/nexus-agents/src/observability/decision-cost-measured.test.ts
@@ -1,0 +1,84 @@
+/**
+ * `unmeasured` must not certify a voter that reported no tokens (#4430).
+ *
+ * `isMeasured` keyed on `costUsd` alone. A voter whose adapter reported no
+ * usage still got `inputTokens ?? 0` → 0, and — because a cost was supplied —
+ * `unmeasured: false`. The rollup therefore certified 0/0 as a measurement.
+ *
+ * Observed live across three 7-voter panels at 2.176.2: every `gpt-5.5` voter
+ * returned full reasoning that was counted in the verdict while reporting
+ * `0` input and `0` output, all flagged measured. The natural mitigation a
+ * consumer would reach for — drop zero-token voters — would have discarded
+ * 3 of 7 voters in one of those votes, enough to move a supermajority.
+ *
+ * A real zero-token call and a call that reported nothing must be
+ * distinguishable, because only one of them is evidence.
+ *
+ * @module observability/decision-cost-measured.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { rollupDecisionCost, type VoterCostInput } from './decision-cost.js';
+
+const voter = (over: Partial<VoterCostInput> = {}): VoterCostInput => ({
+  role: 'architect',
+  model: 'claude-fable-5',
+  inputTokens: 100,
+  outputTokens: 200,
+  costUsd: 0.01,
+  ...over,
+});
+
+describe('isMeasured requires token evidence (#4430)', () => {
+  it('flags a voter that reported no tokens as unmeasured, even with a cost', () => {
+    // The live shape: reasoning returned, usage absent, cost supplied.
+    const out = rollupDecisionCost(
+      [voter({ inputTokens: undefined, outputTokens: undefined })],
+      'plan'
+    );
+
+    expect(out.perVoter[0]?.unmeasured).toBe(true);
+    expect(out.unmeasuredVoters).toBe(1);
+    expect(out.measuredVoters).toBe(0);
+  });
+
+  it('keeps a genuinely zero-token call measured', () => {
+    // Explicit 0 is a measurement; absent is not. Collapsing the two is the bug.
+    const out = rollupDecisionCost([voter({ inputTokens: 0, outputTokens: 0 })], 'plan');
+
+    expect(out.perVoter[0]?.unmeasured).toBe(false);
+    expect(out.measuredVoters).toBe(1);
+  });
+
+  it('accepts a partial report (output only) as measured', () => {
+    // Some adapters report only completion tokens. That is still evidence, and
+    // demanding both would newly discard voters that were previously counted.
+    const out = rollupDecisionCost([voter({ inputTokens: undefined })], 'plan');
+
+    expect(out.perVoter[0]?.unmeasured).toBe(false);
+  });
+
+  it('still flags a voter with tokens but no cost as unmeasured', () => {
+    // The pre-existing rule (#4165) must survive: no computable cost ⇒ unmeasured.
+    const out = rollupDecisionCost([voter({ costUsd: undefined })], 'api');
+
+    expect(out.perVoter[0]?.unmeasured).toBe(true);
+  });
+
+  it('leaves a fully-reported voter measured', () => {
+    const out = rollupDecisionCost([voter()], 'plan');
+
+    expect(out.perVoter[0]?.unmeasured).toBe(false);
+    expect(out.measuredVoters).toBe(1);
+  });
+
+  it('splits a mixed panel correctly', () => {
+    const out = rollupDecisionCost(
+      [voter(), voter({ role: 'security', inputTokens: undefined, outputTokens: undefined })],
+      'plan'
+    );
+
+    expect(out.measuredVoters).toBe(1);
+    expect(out.unmeasuredVoters).toBe(1);
+  });
+});

--- a/packages/nexus-agents/src/observability/decision-cost.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.ts
@@ -66,6 +66,9 @@ export interface VoterCostInput {
    * API-mode cost in USD for the voter call, when computable. Absent ⇒ the
    * voter is unmeasured (see module doc). Present ⇒ used as-is in `api` mode,
    * zeroed in `plan` mode.
+   *
+   * A cost alone no longer certifies a measurement: a voter that reported
+   * neither token count is unmeasured regardless of cost (#4430).
    */
   readonly costUsd?: number | undefined;
 }
@@ -109,11 +112,11 @@ export interface DecisionCostSummary {
   readonly billingMode: DecisionBillingMode;
   /** Total voters folded into this decision. */
   readonly voterCount: number;
-  /** Voters with a computable cost (`costUsd` present on the input). */
+  /** Voters with a computable cost AND at least one reported token count. */
   readonly measuredVoters: number;
   /**
-   * Voters whose cost could not be computed — no usage report, or an unpriced
-   * model (#4165). Counted, not zeroed-as-fact.
+   * Voters whose cost could not be computed — an unpriced model (#4165) — or
+   * which reported no token counts at all (#4430). Counted, not zeroed-as-fact.
    */
   readonly unmeasuredVoters: number;
   readonly totalInputTokens: number;
@@ -174,14 +177,29 @@ export const DecisionCostSummarySchema = z.object({
 });
 
 /**
- * A voter's cost is measured iff a cost was computable for it (`costUsd`
- * present — a genuinely free model arrives as `costUsd: 0`, still measured).
- * Token counts alone do NOT make a voter cost-measured (#4165): an unpriced
- * model's tokens are kept in the consumption totals, but its unknown cost must
- * surface as UNMEASURED — a measured $0 would silently understate spend.
+ * A voter is measured iff BOTH hold:
+ *
+ *  - a cost was computable (`costUsd` present — a genuinely free model arrives
+ *    as `costUsd: 0`, still measured). Token counts alone do NOT make a voter
+ *    cost-measured (#4165): an unpriced model's tokens stay in the consumption
+ *    totals, but its unknown cost must surface as UNMEASURED, because a
+ *    measured $0 would silently understate spend; and
+ *  - at least one token counter was reported (#4430). Cost alone certified
+ *    `0/0` token lines as measurements, since the breakdown coerces absent
+ *    counts to 0. An explicit 0 is evidence; absent is not, and collapsing the
+ *    two makes the consumption totals a floor that claims to be exact.
  */
 function isMeasured(v: VoterCostInput): boolean {
-  return v.costUsd !== undefined;
+  // Cost alone is not evidence (#4430). A voter whose adapter reported no usage
+  // still gets `inputTokens ?? 0` below, so keying only on cost certified 0/0
+  // as a measurement — observed live on every gpt-5.5 voter across three
+  // panels, each returning full reasoning that counted toward the verdict.
+  //
+  // An explicit 0 IS a measurement and stays measured; absent is not. Either
+  // counter suffices, because some adapters report only completion tokens and
+  // demanding both would newly discard voters that were previously counted.
+  const reportedTokens = v.inputTokens !== undefined || v.outputTokens !== undefined;
+  return v.costUsd !== undefined && reportedTokens;
 }
 
 /** Round to micro-USD so summaries don't drift to floating-point noise. */
@@ -200,7 +218,8 @@ interface ModelAcc {
 /**
  * Resolve one voter into its per-decision breakdown line under the billing mode.
  * Plan mode zeroes cost (tokens kept); unmeasured voters surface zeros flagged
- * as placeholders.
+ * as placeholders — including the TOKEN zeros, which previously passed as a
+ * measurement whenever a cost happened to be present (#4430).
  */
 function toVoterBreakdown(v: VoterCostInput, isPlan: boolean): VoterCostBreakdown {
   const measured = isMeasured(v);


### PR DESCRIPTION
Partially closes #4430 — the certification half. The cached-token half is #4435.

## The defect

`isMeasured(v)` returned `v.costUsd !== undefined`. But `toVoterBreakdown` coerces absent counts (`v.inputTokens ?? 0`), so any voter whose adapter reported **no usage at all** still produced a `0 / 0` line flagged `unmeasured: false`.

The rollup certified a non-measurement as measured — which is the one thing the `unmeasured` flag exists to prevent.

## Not theoretical

Across three live `higher_order` 7-voter panels at 2.176.2, **every `gpt-5.5` voter** returned full grounded reasoning that counted toward the verdict while reporting `0` input and `0` output — all flagged measured:

| vote | zero-token voters |
| --- | --- |
| registry fix (#4410) | security, pm |
| CI governance (#4424) | security, ai_ml, catfish |
| lifecycle close-out (#4408) | security, pm |

It also defeats the mitigation the flag invites. A consumer told to "discard zero-token voters before counting" would have dropped **3 of 7** voters in the CI-governance vote — enough to change whether a supermajority was reached.

## The fix

Measured now requires a computable cost **and** at least one reported token counter.

Two boundaries kept deliberately:

- **An explicit `0` stays measured.** A genuinely free model arrives as `costUsd: 0` with real counts (#4165). Absent is not evidence; zero is. Collapsing the two is the bug.
- **Either counter suffices.** Some adapters report only completion tokens; demanding both would newly discard voters that were previously counted correctly — trading a false positive for a false negative.

Docs updated at the four sites that stated the cost-only rule.

## Not fixed here, and why

The other half of #4430 — voters reporting `inputTokens: 2` for a 4,000-character proposal — turned out to have a different cause worth separating. All three parsers *do* correctly split `cache_read_input_tokens` into `cachedInputTokens`; **nothing consumes it.** Outside the parsers, the only reference is its type declaration.

The obvious fix (fold it into `inputTokens`) would make the number look right and the cost wrong: cache reads bill at roughly a tenth of the uncached rate, so summing them and pricing at the input rate overstates spend on exactly the cheapest calls. That is a fork needing registry pricing that doesn't exist yet — filed as **#4435** with three options.

## Verification

6 new tests, red-first (2 of 6 failed before the change — the other 4 pin boundaries that already held and must keep holding). `src/observability`: 436 passed. Full suite: **1,167 files / 27,838 tests**, exit 0. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)