### PR TITLE
fix(adapters): extract Anthropic cache-creation tokens instead of dropping them

### DIFF
--- a/.changeset/olive-crabs-shout.md
+++ b/.changeset/olive-crabs-shout.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+Stop discarding Anthropic cache-creation tokens (#4435)
+
+`ClaudeResult.usage` has declared `cache_creation_input_tokens` all along, but the parser only ever extracted `input_tokens`, `output_tokens`, and `cache_read_input_tokens`. Cache-_creation_ tokens were typed and then thrown away.
+
+They are the expensive ones — Anthropic bills cache writes at roughly 1.25x the uncached input rate, versus ~0.1x for reads — and they are not a rare case: a voter panel writes the cache on its first call, so every fresh panel silently lost its largest input measurement.
+
+Now surfaced as `TokenUsage.cacheCreationInputTokens`, kept distinct from `cachedInputTokens` because the two bill at opposite ends and collapsing them would make correct pricing impossible. Absent stays absent — a fabricated `0` would read as "no cache write happened".
+
+Purely additive: `inputTokens` still means uncached input and `totalTokens` is unchanged. Folding the cache figures into the totals is a semantics change for every consumer and stays with the threading increment on #4435.
+
+Found by the contrarian voter on #4435's panel, which was convened to decide what to do about cache _read_ tokens; the creation gap had gone unnoticed.

--- a/packages/nexus-agents/src/cli-adapters/parsers/claude-cache-tokens.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/parsers/claude-cache-tokens.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The claude parser must not silently drop cache-creation tokens (#4435).
+ *
+ * `ClaudeResult.usage` declares `cache_creation_input_tokens`, but the parser
+ * only ever extracted `input_tokens`, `output_tokens` and
+ * `cache_read_input_tokens`. Cache-CREATION tokens were typed and then thrown
+ * away — and they are the expensive ones: Anthropic bills them at ~1.25x the
+ * uncached input rate, versus ~0.1x for cache reads.
+ *
+ * They are also not a rare case. A voter panel writes the cache on its first
+ * call, so every fresh panel loses its largest input measurement entirely.
+ *
+ * Raised by the contrarian voter on #4435's panel, which was deciding what to
+ * do about cache READ tokens; the creation gap had gone unnoticed.
+ *
+ * @module cli-adapters/parsers/claude-cache-tokens.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ClaudeResponseParser } from './claude-parser.js';
+
+function resultLine(usage: Record<string, number>): string {
+  return JSON.stringify({
+    type: 'result',
+    subtype: 'success',
+    is_error: false,
+    result: 'ok',
+    session_id: 's1',
+    usage,
+  });
+}
+
+describe('claude parser cache-token extraction (#4435)', () => {
+  const parser = new ClaudeResponseParser();
+
+  it('extracts cache-creation tokens instead of discarding them', () => {
+    const out = parser.extractUsage(
+      resultLine({
+        input_tokens: 2,
+        output_tokens: 500,
+        cache_creation_input_tokens: 4000,
+        cache_read_input_tokens: 0,
+      })
+    );
+
+    expect(out?.cacheCreationInputTokens).toBe(4000);
+  });
+
+  it('still extracts cache-read tokens', () => {
+    const out = parser.extractUsage(
+      resultLine({ input_tokens: 2, output_tokens: 500, cache_read_input_tokens: 3980 })
+    );
+
+    expect(out?.cachedInputTokens).toBe(3980);
+  });
+
+  it('keeps read and creation distinct — they bill at different rates', () => {
+    // ~0.1x for reads, ~1.25x for creation. Collapsing them into one number
+    // would make correct pricing impossible later.
+    const out = parser.extractUsage(
+      resultLine({
+        input_tokens: 10,
+        output_tokens: 20,
+        cache_creation_input_tokens: 700,
+        cache_read_input_tokens: 300,
+      })
+    );
+
+    expect(out?.cacheCreationInputTokens).toBe(700);
+    expect(out?.cachedInputTokens).toBe(300);
+  });
+
+  it('omits the field entirely when the vendor did not report it', () => {
+    // Absent must stay absent — a fabricated 0 would read as "no cache write
+    // happened", which is exactly the false certainty #4430 was about.
+    const out = parser.extractUsage(resultLine({ input_tokens: 100, output_tokens: 50 }));
+
+    expect(out?.cacheCreationInputTokens).toBeUndefined();
+  });
+
+  it('leaves the uncached input count untouched', () => {
+    // inputTokens keeps meaning uncached input; this change is additive.
+    const out = parser.extractUsage(
+      resultLine({ input_tokens: 2, output_tokens: 500, cache_creation_input_tokens: 4000 })
+    );
+
+    expect(out?.inputTokens).toBe(2);
+    expect(out?.outputTokens).toBe(500);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/parsers/claude-parser.ts
+++ b/packages/nexus-agents/src/cli-adapters/parsers/claude-parser.ts
@@ -118,12 +118,24 @@ export class ClaudeResponseParser implements ICliResponseParser<ClaudeCliRespons
       }
 
       const cachedInputTokens = extractNumberField(usageRecord, 'cache_read_input_tokens');
+      // Declared on ClaudeResult.usage since forever but never read (#4435) —
+      // so a panel's FIRST call, which writes the cache, lost its largest
+      // input measurement entirely. Absent stays absent: a fabricated 0 would
+      // read as "no cache write happened".
+      const cacheCreationInputTokens = extractNumberField(
+        usageRecord,
+        'cache_creation_input_tokens'
+      );
 
       return {
         inputTokens,
         outputTokens,
+        // NOTE: still uncached input + output. Folding the cache figures in
+        // here is a semantics change for every consumer of totalTokens and
+        // belongs with the threading increment on #4435, not this extraction.
         totalTokens: inputTokens + outputTokens,
         ...(cachedInputTokens !== null && { cachedInputTokens }),
+        ...(cacheCreationInputTokens !== null && { cacheCreationInputTokens }),
       };
     } catch {
       logger.debug('Skipped malformed output line', { snippet: raw.slice(0, 100) });

--- a/packages/nexus-agents/src/cli-adapters/types-core.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-core.ts
@@ -88,8 +88,16 @@ export interface TokenUsage {
   readonly inputTokens: number;
   /** Output tokens generated */
   readonly outputTokens: number;
-  /** Cached input tokens (if applicable) */
+  /** Cached input tokens READ from an existing cache (if applicable). */
   readonly cachedInputTokens?: number;
+  /**
+   * Input tokens spent WRITING the cache, when the vendor reports them
+   * separately (#4435). Kept distinct from {@link cachedInputTokens} because
+   * they bill at opposite ends: cache writes are ~1.25x the uncached input
+   * rate, cache reads ~0.1x. Collapsing them would make correct pricing
+   * impossible.
+   */
+  readonly cacheCreationInputTokens?: number;
   /** Total tokens (input + output) */
   readonly totalTokens?: number;
 }


### PR DESCRIPTION
First increment on #4435. Decided **7/0** (`higher_order`) — and notably all seven voters converged on the *same trimmed variant*: fix the telemetry, **defer** the registry cache-read pricing as YAGNI while plan mode zeroes cost and no spend review is pending.

## The gap the panel found

I convened that vote to decide what to do about cache **read** tokens. The contrarian voter pointed out something neither I nor the issue had noticed:

`ClaudeResult.usage` declares `cache_creation_input_tokens` (`claude-parser.ts:32`) — and `extractUsage` never reads it. Only `input_tokens`, `output_tokens`, and `cache_read_input_tokens` are extracted. Cache-*creation* tokens were typed and then thrown away.

Verified before acting: it is the sole reference to the field anywhere in non-test source.

## Why it matters more than the read case

Cache writes bill at roughly **1.25x** the uncached input rate; reads at ~0.1x. So the discarded figure is the *expensive* one.

And it is not a rare path — a voter panel writes the cache on its first call, so **every fresh panel silently lost its largest input measurement**.

## The change

`TokenUsage.cacheCreationInputTokens`, kept deliberately **distinct** from `cachedInputTokens`. The two bill at opposite ends, so collapsing them into a single "cached" number would make correct pricing impossible later — which is exactly the trap that made the naive fix wrong in #4435.

Absent stays absent. A fabricated `0` would read as "no cache write happened" — the same false certainty #4430 was about.

## Deliberately not in scope

**`totalTokens` is unchanged.** It still means uncached input + output. Folding the cache figures in is a semantics change for every consumer of that field, and belongs with the threading increment (parser → `VoteUsage` → `AgentVoteResult` → `VoterCostBreakdown`, which also touches an MCP `outputSchema`). #4435 stays open for it, with the vote recorded.

**No registry pricing.** All seven voters flagged cache-read rates as new catalogue data with a demonstrated drift problem (#4417) and no consumer today.

So this PR does not yet fix the headline `inputTokens: 2` symptom — it stops the data being destroyed at the source, which the threading needs first.

## Verification

5 tests, red-first (2 of 5 failed — the other 3 pin existing behaviour that must keep holding). `src/cli-adapters`: 2,601 passed. Full suite: **1,168 files / 27,843 tests**, exit 0. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)