### PR TITLE
feat(observability): thread cache token figures into the decision-cost record

### DIFF
--- a/.changeset/fresh-lions-tell.md
+++ b/.changeset/fresh-lions-tell.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+Thread cache token figures into the decision-cost record (#4435)
+
+Completes the chain the last three changes opened: the parser extracts cache tokens (#4438), the adapter response carries them (#4439), and they now reach `VoteUsage` → `AgentVoteResult` → `VoterCostInput` → `VoterCostBreakdown`. An operator reading a decision's cost record can finally see that a voter's `inputTokens: 2` sits beside 3,980 cached tokens rather than being the whole story.
+
+Reads and writes stay separate all the way down — cache reads bill at roughly a tenth of the uncached input rate and cache writes at roughly 1.25x, so a single merged "cached" number could not be priced correctly later.
+
+Both fields are optional and omitted when the adapter reported no cache activity, consistent with #4439: absent is not zero.
+
+`DecisionCostSummarySchema` and the persisted store schema declare the new fields. That matters because the summary schema rides `consensus_vote`'s MCP `outputSchema` — a field the producer emits but the schema omits is a `-32602 additional properties` rejection at a strict client (#4032). The existing guard test that validates a real rollup strictly is extended to cover rollups with and without cache figures.
+
+**`totalTokens` is unchanged** — still uncached input + output. Redefining a widely-read field is a semantics change for every existing consumer and every record already written, so it is tracked separately rather than slipped in. Cost is likewise still priced on uncached input only, per the 7/0 decision to defer registry cache-read pricing until a consumer needs it.

--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -60,13 +60,7 @@ export interface VoteCommandOptions {
  * + biases toward "don't build."
  */
 export type VoterRole =
-  | 'architect'
-  | 'security'
-  | 'devex'
-  | 'ai_ml'
-  | 'pm'
-  | 'catfish'
-  | 'scope_steward';
+  'architect' | 'security' | 'devex' | 'ai_ml' | 'pm' | 'catfish' | 'scope_steward';
 
 /**
  * Agent role descriptions for prompt generation.
@@ -119,6 +113,17 @@ export interface AgentVoteResult {
    * (#3910). See {@link AgentVoteResult.inputTokens}.
    */
   readonly outputTokens?: number | undefined;
+  /**
+   * Input tokens read from an existing prompt cache, when the adapter
+   * reported them (#4435). Separate from {@link inputTokens} because cache
+   * reads bill at roughly a tenth of the uncached rate.
+   */
+  readonly cachedInputTokens?: number | undefined;
+  /**
+   * Input tokens spent writing the cache, when reported (#4435). Bills at
+   * roughly 1.25x the uncached rate — the opposite end from a cache read.
+   */
+  readonly cacheCreationInputTokens?: number | undefined;
   /** Error message if vote fell back to simulation or encountered an error */
   readonly error?: string;
 }

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -149,6 +149,12 @@ function buildLlmVoteResult(
     model: adapter.modelId,
     ...(usage.inputTokens !== undefined ? { inputTokens: usage.inputTokens } : {}),
     ...(usage.outputTokens !== undefined ? { outputTokens: usage.outputTokens } : {}),
+    ...(usage.cachedInputTokens !== undefined
+      ? { cachedInputTokens: usage.cachedInputTokens }
+      : {}),
+    ...(usage.cacheCreationInputTokens !== undefined
+      ? { cacheCreationInputTokens: usage.cacheCreationInputTokens }
+      : {}),
   };
 }
 

--- a/packages/nexus-agents/src/cli/voter-execution.ts
+++ b/packages/nexus-agents/src/cli/voter-execution.ts
@@ -297,6 +297,10 @@ function isStructuredOutputUnsupported(errorMessage: string): boolean {
 export interface VoteUsage {
   readonly inputTokens?: number | undefined;
   readonly outputTokens?: number | undefined;
+  /** Input tokens read from an existing prompt cache, when reported (#4435). */
+  readonly cachedInputTokens?: number | undefined;
+  /** Input tokens spent writing the cache, when reported (#4435). */
+  readonly cacheCreationInputTokens?: number | undefined;
 }
 
 /** Read a usage token count when the adapter actually reported a number (#3910). */
@@ -330,11 +334,17 @@ async function runVoteCompletion(
     | {
         inputTokens?: unknown;
         outputTokens?: unknown;
+        cachedInputTokens?: unknown;
+        cacheCreationInputTokens?: unknown;
       }
     | undefined;
   const usage: VoteUsage = {
     inputTokens: readTokenCount(reported?.inputTokens),
     outputTokens: readTokenCount(reported?.outputTokens),
+    // #4435: an `inputTokens: 2` next to 3,980 cached tokens tells a very
+    // different story than `inputTokens: 2` alone.
+    cachedInputTokens: readTokenCount(reported?.cachedInputTokens),
+    cacheCreationInputTokens: readTokenCount(reported?.cacheCreationInputTokens),
   };
   return { ok: true, output: extractTextFromResponse(response.value.content), usage };
 }

--- a/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/decision-cost-recording.ts
@@ -48,6 +48,26 @@ export function resolveBillingMode(): DecisionBillingMode {
  * (#4165), `costUsd` is OMITTED — tokens are kept — so the rollup counts the
  * voter as UNMEASURED (#3855: missing cost is unmeasured, never a measured $0).
  */
+/**
+ * Copy only the token counters the adapter actually reported. Every field is
+ * spread conditionally so an absent counter stays absent — a fabricated 0
+ * would read as a measurement (#4439).
+ *
+ * The cache figures ride along for visibility only: cost is still priced on
+ * uncached input, because the registry carries no cache-read rate and pricing
+ * the cached portion at the input rate would overstate spend (#4435).
+ */
+function reportedTokenFields(v: AgentVoteResult): Partial<VoterCostInput> {
+  return {
+    ...(v.inputTokens !== undefined ? { inputTokens: v.inputTokens } : {}),
+    ...(v.outputTokens !== undefined ? { outputTokens: v.outputTokens } : {}),
+    ...(v.cachedInputTokens !== undefined ? { cachedInputTokens: v.cachedInputTokens } : {}),
+    ...(v.cacheCreationInputTokens !== undefined
+      ? { cacheCreationInputTokens: v.cacheCreationInputTokens }
+      : {}),
+  };
+}
+
 export function votesToCostInputs(votes: readonly AgentVoteResult[]): VoterCostInput[] {
   return votes.map((v) => {
     const hasTokens = v.inputTokens !== undefined || v.outputTokens !== undefined;
@@ -58,8 +78,7 @@ export function votesToCostInputs(votes: readonly AgentVoteResult[]): VoterCostI
     const input: VoterCostInput = {
       role: v.role,
       model: v.model,
-      ...(v.inputTokens !== undefined ? { inputTokens: v.inputTokens } : {}),
-      ...(v.outputTokens !== undefined ? { outputTokens: v.outputTokens } : {}),
+      ...reportedTokenFields(v),
       ...(detail?.priced === true ? { costUsd: detail.costUsd } : {}),
     };
     return input;

--- a/packages/nexus-agents/src/observability/cache-token-threading.test.ts
+++ b/packages/nexus-agents/src/observability/cache-token-threading.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Cache token figures must reach the decision-cost rollup (#4435).
+ *
+ * The parser extracts them (#4438) and the adapter response now carries them
+ * (#4439). This is the last hop: VoteUsage → AgentVoteResult → VoterCostInput
+ * → VoterCostBreakdown, so an operator reading a decision's cost record can
+ * see that a voter's `inputTokens: 2` sits next to 3,980 cached tokens rather
+ * than being the whole story.
+ *
+ * Read and creation stay separate all the way down: cache reads bill at ~0.1x
+ * the uncached input rate and cache writes at ~1.25x, so a single merged
+ * "cached" number could not be priced correctly later.
+ *
+ * @module observability/cache-token-threading.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  rollupDecisionCost,
+  DecisionCostSummarySchema,
+  type VoterCostInput,
+} from './decision-cost.js';
+
+const voter = (over: Partial<VoterCostInput> = {}): VoterCostInput => ({
+  role: 'architect',
+  model: 'claude-fable-5',
+  inputTokens: 2,
+  outputTokens: 500,
+  costUsd: 0.01,
+  ...over,
+});
+
+describe('cache tokens reach the rollup (#4435)', () => {
+  it('surfaces cache-read tokens on the per-voter line', () => {
+    const out = rollupDecisionCost([voter({ cachedInputTokens: 3980 })], 'plan');
+
+    expect(out.perVoter[0]?.cachedInputTokens).toBe(3980);
+  });
+
+  it('surfaces cache-creation tokens separately from reads', () => {
+    // Different billing rates — merging them would foreclose correct pricing.
+    const out = rollupDecisionCost(
+      [voter({ cachedInputTokens: 300, cacheCreationInputTokens: 700 })],
+      'plan'
+    );
+
+    expect(out.perVoter[0]?.cachedInputTokens).toBe(300);
+    expect(out.perVoter[0]?.cacheCreationInputTokens).toBe(700);
+  });
+
+  it('omits the fields entirely when the voter reported no cache activity', () => {
+    // Absent stays absent, consistent with #4439 — a 0 would assert "no cache
+    // was used", which is a different claim from "we were not told".
+    const out = rollupDecisionCost([voter()], 'plan');
+
+    expect(out.perVoter[0]?.cachedInputTokens).toBeUndefined();
+    expect(out.perVoter[0]?.cacheCreationInputTokens).toBeUndefined();
+  });
+
+  it('leaves totalTokens meaning uncached input + output', () => {
+    // Deliberately unchanged in this increment. Redefining a widely-read field
+    // is a semantics change for every existing consumer and record, and needs
+    // its own decision — see the follow-up filed alongside this.
+    const out = rollupDecisionCost([voter({ cachedInputTokens: 3980 })], 'plan');
+
+    expect(out.perVoter[0]?.totalTokens).toBe(502);
+    expect(out.totalTokens).toBe(502);
+  });
+
+  it('does not let cache tokens affect measured/unmeasured', () => {
+    // Cache figures are extra detail, not the evidence #4436 gates on.
+    const out = rollupDecisionCost([voter({ cachedInputTokens: 10 })], 'plan');
+
+    expect(out.perVoter[0]?.unmeasured).toBe(false);
+  });
+});
+
+describe('schema still pins the producer (#4032 guard extended)', () => {
+  it('strictly accepts a rollup carrying cache fields', () => {
+    // The schema rides consensus_vote's MCP outputSchema. A field the producer
+    // emits but the schema omits is a `-32602 additional properties` rejection
+    // at a strict client, so this must fail here rather than there.
+    const out = rollupDecisionCost(
+      [voter({ cachedInputTokens: 300, cacheCreationInputTokens: 700 })],
+      'api'
+    );
+
+    expect(() => DecisionCostSummarySchema.strict().parse(out)).not.toThrow();
+  });
+
+  it('strictly accepts a rollup with no cache fields at all', () => {
+    const out = rollupDecisionCost([voter()], 'api');
+
+    expect(() => DecisionCostSummarySchema.strict().parse(out)).not.toThrow();
+  });
+});

--- a/packages/nexus-agents/src/observability/decision-cost-store.ts
+++ b/packages/nexus-agents/src/observability/decision-cost-store.ts
@@ -35,6 +35,10 @@ const VoterCostBreakdownSchema = z.object({
   inputTokens: z.number().int().nonnegative(),
   outputTokens: z.number().int().nonnegative(),
   totalTokens: z.number().int().nonnegative(),
+  // #4435 — optional: absent means the adapter reported no cache activity,
+  // which is a different claim from "zero cache tokens were used".
+  cachedInputTokens: z.number().int().nonnegative().optional(),
+  cacheCreationInputTokens: z.number().int().nonnegative().optional(),
   costUsd: z.number().nonnegative(),
   unmeasured: z.boolean(),
 });

--- a/packages/nexus-agents/src/observability/decision-cost.ts
+++ b/packages/nexus-agents/src/observability/decision-cost.ts
@@ -62,6 +62,10 @@ export interface VoterCostInput {
   readonly inputTokens?: number | undefined;
   /** Output tokens for the voter call, when the adapter reported them. */
   readonly outputTokens?: number | undefined;
+  /** Input tokens read from an existing prompt cache, when reported (#4435). */
+  readonly cachedInputTokens?: number | undefined;
+  /** Input tokens spent writing the cache, when reported (#4435). */
+  readonly cacheCreationInputTokens?: number | undefined;
   /**
    * API-mode cost in USD for the voter call, when computable. Absent ⇒ the
    * voter is unmeasured (see module doc). Present ⇒ used as-is in `api` mode,
@@ -77,9 +81,25 @@ export interface VoterCostInput {
 export interface VoterCostBreakdown {
   readonly role: string;
   readonly model: string;
+  /** Uncached input tokens. See {@link cachedInputTokens} for the rest. */
   readonly inputTokens: number;
   readonly outputTokens: number;
+  /**
+   * Uncached input + output.
+   *
+   * Deliberately EXCLUDES the cache figures (#4435). Redefining this field to
+   * include them is a semantics change for every existing consumer and every
+   * record already written, so it is tracked separately rather than slipped in
+   * — read it alongside `cachedInputTokens` for true consumption.
+   */
   readonly totalTokens: number;
+  /**
+   * Input tokens read from an existing prompt cache, when reported. Omitted
+   * when the adapter said nothing — absent is not zero (#4439).
+   */
+  readonly cachedInputTokens?: number | undefined;
+  /** Input tokens spent writing the cache, when reported. */
+  readonly cacheCreationInputTokens?: number | undefined;
   /** Effective cost after billing-mode application (0 in plan mode). */
   readonly costUsd: number;
   /**
@@ -160,6 +180,8 @@ export const DecisionCostSummarySchema = z.object({
       inputTokens: z.number(),
       outputTokens: z.number(),
       totalTokens: z.number(),
+      cachedInputTokens: z.number().optional(),
+      cacheCreationInputTokens: z.number().optional(),
       costUsd: z.number(),
       unmeasured: z.boolean(),
     })
@@ -235,6 +257,10 @@ function toVoterBreakdown(v: VoterCostInput, isPlan: boolean): VoterCostBreakdow
     inputTokens,
     outputTokens,
     totalTokens: inputTokens + outputTokens,
+    ...(v.cachedInputTokens !== undefined ? { cachedInputTokens: v.cachedInputTokens } : {}),
+    ...(v.cacheCreationInputTokens !== undefined
+      ? { cacheCreationInputTokens: v.cacheCreationInputTokens }
+      : {}),
     costUsd,
     unmeasured: !measured,
   };


### PR DESCRIPTION
Closes #4435. Completes the chain #4438 and #4439 opened.

## What lands

Cache figures now travel the full path: parser (#4438) → adapter response (#4439) → `VoteUsage` → `AgentVoteResult` → `VoterCostInput` → `VoterCostBreakdown`.

A decision's cost record can finally show that a voter's `inputTokens: 2` sits beside 3,980 cached tokens rather than being the whole story — which is the symptom that opened #4430 and misled me into filing it as an accounting bug.

Reads and writes stay separate end to end. Cache reads bill at roughly a tenth of the uncached input rate and writes at roughly 1.25x, so a single merged "cached" number would foreclose correct pricing later. Both fields are optional and omitted when nothing was reported — absent is not zero, per #4439.

## The schema part is load-bearing

`DecisionCostSummarySchema` rides `consensus_vote`'s MCP `outputSchema`. A field the producer emits but the schema omits is a `-32602 additional properties` rejection at a spec-strict client — that is #4032, and it is why this hop needed care rather than speed.

Both the summary schema and the persisted store schema declare the new fields, and the existing guard test that strictly validates a *real* rollup is extended to cover rollups **with and without** cache figures. So producer↔schema drift fails here rather than at a client.

## Deliberately unchanged, and why

**`totalTokens` still means uncached input + output.** Several voters on the #4435 panel wanted the consumption totals made truthful, and they are right that a total omitting 4,000 cached tokens is odd. But redefining a widely-read field changes the meaning of every record already written and every consumer reading it — that deserves its own decision rather than riding along inside a threading change. The field now carries a docstring saying exactly what it excludes and pointing at `cachedInputTokens`.

**Cost is still priced on uncached input only**, per the 7/0 decision to defer registry cache-read pricing until a consumer needs it. Conservative rather than overstated.

## Verification

7 new tests covering per-voter surfacing, read/write separation, absence-omission, the unchanged `totalTokens` contract, and strict schema acceptance both ways. Full suite: **1,170 files / 27,856 tests**, exit 0. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)