### PR TITLE
refactor(observability): rename the session aggregate to SessionTokenTotals

### DIFF
--- a/.changeset/warm-pears-guess.md
+++ b/.changeset/warm-pears-guess.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Rename the observability session aggregate to `SessionTokenTotals` (#4440)
+
+`agents/observability` defined a `TokenUsage` interface that models a **running session total**, sharing a name and a shape with the per-call `TokenUsage` in `core/types/model.ts`. The clash was already known — `exports/observability.ts` aliased it as `ObserverTokenUsage` with the comment _"Renamed: core.ts exports TokenUsage"_ — but the workaround lived at the export boundary while the confusing name stayed at the source.
+
+That is not harmless: it led me to file #4439 claiming three duplicate per-call usage types, when there were two and the third was this session aggregate. Conflating them would have been strictly worse than leaving them alone.
+
+Internal name is now `SessionTokenTotals`. The public export keeps the name `ObserverTokenUsage`, so this is not a breaking change.

--- a/packages/nexus-agents/src/agents/observability/index.ts
+++ b/packages/nexus-agents/src/agents/observability/index.ts
@@ -15,7 +15,7 @@ export {
   type AgentState,
   type TrackedAgent,
   type RoutingDecision,
-  type TokenUsage,
+  type SessionTokenTotals,
   type CostMetrics,
   type SessionMetrics,
   type OrchestrationStats,

--- a/packages/nexus-agents/src/agents/observability/orchestration-observer-helpers.test.ts
+++ b/packages/nexus-agents/src/agents/observability/orchestration-observer-helpers.test.ts
@@ -8,7 +8,7 @@ import type { DomainEvent } from '../collaboration/event-bus-types.js';
 import type {
   RoutingDecision,
   SessionMetrics,
-  TokenUsage,
+  SessionTokenTotals,
 } from './orchestration-observer-types.js';
 import {
   extractStringField,
@@ -281,13 +281,13 @@ describe('identifySessionsToRemove', () => {
 
 describe('calculateTokenCost', () => {
   it('calculates cost from tokens and rate', () => {
-    const tokens: TokenUsage = { inputTokens: 100, outputTokens: 200, totalTokens: 1000 };
+    const tokens: SessionTokenTotals = { inputTokens: 100, outputTokens: 200, totalTokens: 1000 };
     // 1000 / 1000 * 0.01 = 0.01
     expect(calculateTokenCost(tokens, 0.01)).toBeCloseTo(0.01);
   });
 
   it('returns 0 for zero tokens', () => {
-    const tokens: TokenUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    const tokens: SessionTokenTotals = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
     expect(calculateTokenCost(tokens, 0.01)).toBe(0);
   });
 });

--- a/packages/nexus-agents/src/agents/observability/orchestration-observer-helpers.ts
+++ b/packages/nexus-agents/src/agents/observability/orchestration-observer-helpers.ts
@@ -15,7 +15,7 @@ import type {
   AgentState,
   RoutingDecision,
   SessionMetrics,
-  TokenUsage,
+  SessionTokenTotals,
   CostMetrics,
 } from './orchestration-observer-types.js';
 
@@ -118,9 +118,9 @@ export function createInitialSessionMetrics(sessionId: string): SessionMetrics {
 /**
  * Creates initial token usage with zero values.
  *
- * @returns A new TokenUsage object with zero values
+ * @returns A new SessionTokenTotals object with zero values
  */
-export function createInitialTokenUsage(): TokenUsage {
+export function createInitialTokenUsage(): SessionTokenTotals {
   return {
     inputTokens: 0,
     outputTokens: 0,
@@ -274,6 +274,6 @@ export function identifySessionsToRemove(
  * @param ratePerThousand - Cost rate per 1000 tokens
  * @returns The calculated cost in USD
  */
-export function calculateTokenCost(tokens: TokenUsage, ratePerThousand: number): number {
+export function calculateTokenCost(tokens: SessionTokenTotals, ratePerThousand: number): number {
   return (tokens.totalTokens / 1000) * ratePerThousand;
 }

--- a/packages/nexus-agents/src/agents/observability/orchestration-observer-types.ts
+++ b/packages/nexus-agents/src/agents/observability/orchestration-observer-types.ts
@@ -64,9 +64,17 @@ export interface RoutingDecision {
 // ============================================================================
 
 /**
- * Token usage tracking per model.
+ * Running token totals for an observability SESSION, aggregated across calls.
+ *
+ * Named to distinguish it from the per-call `SessionTokenTotals` in
+ * `core/types/model.ts` (#4440). The two shared a name and a shape while
+ * modelling different things — session aggregate vs. one call's usage — and
+ * `exports/observability.ts` already had to alias this one as
+ * `ObserverTokenUsage` to avoid the clash. That collision is not harmless: it
+ * led me to file #4439 claiming three duplicate per-call types when there were
+ * two, and the third was this.
  */
-export interface TokenUsage {
+export interface SessionTokenTotals {
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
@@ -91,7 +99,7 @@ export interface SessionMetrics {
   taskCount: number;
   successCount: number;
   failureCount: number;
-  tokenUsage: TokenUsage;
+  tokenUsage: SessionTokenTotals;
   costMetrics: CostMetrics;
   routingDecisions: number;
   eventsProcessed: number;
@@ -231,7 +239,7 @@ export interface IOrchestrationObserver {
   recordRoutingDecision(decision: RoutingDecision): void;
 
   /** Record token usage for a session */
-  recordTokenUsage(sessionId: string, model: CliName, tokens: TokenUsage): void;
+  recordTokenUsage(sessionId: string, model: CliName, tokens: SessionTokenTotals): void;
 
   /** Check if observer is active */
   isActive(): boolean;

--- a/packages/nexus-agents/src/agents/observability/orchestration-observer.test.ts
+++ b/packages/nexus-agents/src/agents/observability/orchestration-observer.test.ts
@@ -12,7 +12,7 @@ import { OrchestrationObserver, createOrchestrationObserver } from './orchestrat
 import type {
   OrchestrationObserverEvent,
   RoutingDecision,
-  TokenUsage,
+  SessionTokenTotals,
 } from './orchestration-observer-types.js';
 
 describe('OrchestrationObserver', () => {
@@ -282,7 +282,7 @@ describe('OrchestrationObserver', () => {
         })
       );
 
-      const tokens: TokenUsage = {
+      const tokens: SessionTokenTotals = {
         inputTokens: 500,
         outputTokens: 200,
         totalTokens: 700,

--- a/packages/nexus-agents/src/agents/observability/orchestration-observer.ts
+++ b/packages/nexus-agents/src/agents/observability/orchestration-observer.ts
@@ -19,7 +19,7 @@ import {
   type AgentState,
   type RoutingDecision,
   type SessionMetrics,
-  type TokenUsage,
+  type SessionTokenTotals,
   type OrchestrationStats,
   type OrchestrationObserverListener,
   type OrchestrationObserverEvent,
@@ -399,7 +399,7 @@ export class OrchestrationObserver implements IOrchestrationObserver {
     this.emitObserverEvent({ type: 'routing_decision', decision });
   }
 
-  recordTokenUsage(sessionId: string, model: CliName, tokens: TokenUsage): void {
+  recordTokenUsage(sessionId: string, model: CliName, tokens: SessionTokenTotals): void {
     const metrics = this.sessionMetrics.get(sessionId);
     if (metrics === undefined) return;
 

--- a/packages/nexus-agents/src/exports/observability.ts
+++ b/packages/nexus-agents/src/exports/observability.ts
@@ -140,7 +140,9 @@ export {
   type IOrchestrationObserver,
   type ConsensusStats,
   type SessionMetrics as ObserverSessionMetrics,
-  type TokenUsage as ObserverTokenUsage, // Renamed: core.ts exports TokenUsage
+  // Public name kept as ObserverTokenUsage so this is not a breaking change;
+  // the underlying type was renamed to say what it is (#4440).
+  type SessionTokenTotals as ObserverTokenUsage,
   type CostMetrics as ObserverCostMetrics,
   type TrackedAgent as ObserverTrackedAgent, // Renamed: core types may also export TrackedAgent
   type OrchestrationStats,


### PR DESCRIPTION
Part of #4440 — the bounded, non-breaking half. The two-per-call-type reconciliation stays open there.

## The problem

`agents/observability` defined a `TokenUsage` interface that models a **running session total**, sharing a name *and* a shape with the per-call `TokenUsage` in `core/types/model.ts`.

The collision was already known. `exports/observability.ts` aliased it:

```ts
type TokenUsage as ObserverTokenUsage, // Renamed: core.ts exports TokenUsage
```

So the workaround lived at the **export boundary** while the misleading name stayed at the source. That is the shape of problem that costs time rather than causing outages — and it cost time here: it led me to file #4439 claiming three duplicate per-call usage types. There were two. The third was this aggregate, and unifying it would have conflated "what this call used" with "what this session has used so far" — strictly worse than leaving it.

## The change

Internal name is now `SessionTokenTotals`, with a docstring saying what it is and why it is not the per-call type.

**The public export keeps the name `ObserverTokenUsage`**, so nothing breaks for consumers — the alias now points at a type whose name matches its meaning instead of papering over a clash.

## Verification

Full suite: **1,170 files / 27,856 tests**, exit 0. Typecheck and lint clean. Pure rename — no behaviour change.

## Still open on #4440

Reconciling the two *genuine* per-call types (`core/types/model.ts` vs `cli-adapters/types-core.ts`), which model the same fact at different widths. #4439 widened the response side as a targeted fix; whether they should become one type with an explicit conversion is the remaining question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)