### PR TITLE
fix(quality-gate): run every check inside the target project

### DIFF
--- a/.changeset/brave-moons-shake.md
+++ b/.changeset/brave-moons-shake.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Run quality-gate checks inside the target project (#4355)
+
+`runCommandCheck` never set `cwd`, so every `run_quality_gate` check executed in the MCP server's own working directory. Three checks partly masked it by passing `projectDir` as an argument (`tsc --project`, `eslint <dir>`, `vitest --dir`), but `checkBuild` passed nothing at all — so `pnpm build` built whatever project happened to sit at that directory. Under a global install (`npx -y nexus-agents --mode=server`) that is arbitrary, meaning the build verdict described an unrelated project.
+
+All four checks now execute in `projectDir`, and `checkBuild` takes it as a parameter.
+
+This is the unambiguous half of #4355. The reported half — the gate hard-codes ESLint/vitest/pnpm and ignores the target's declared scripts, producing a false RED on an oxlint/npm project — is decided (7/0, Option A) and tracked there.

--- a/packages/nexus-agents/src/mcp/tools/quality-gate-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/quality-gate-tool.ts
@@ -121,7 +121,7 @@ function buildCheck(name: QualityCheck, projectDir: string): GateCheckFn {
     case 'tests':
       return checkTests(projectDir);
     case 'build':
-      return checkBuild();
+      return checkBuild(projectDir);
     case 'security':
       return checkSecurityScan(projectDir);
   }

--- a/packages/nexus-agents/src/security/quality-gate-cwd.test.ts
+++ b/packages/nexus-agents/src/security/quality-gate-cwd.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Every quality-gate check must execute in the target project (#4355).
+ *
+ * `runCommandCheck` called `exec(cmd, args, { timeout })` with **no `cwd`**, so
+ * all four checks ran in the MCP server's own working directory. Three of them
+ * partly compensated by passing `projectDir` as an argument (`--project`,
+ * `eslint <dir>`, `--dir`), but `checkBuild` passed nothing at all — so
+ * `pnpm build` built whatever project happened to be at the server's cwd.
+ *
+ * Under a global install (`npx -y nexus-agents --mode=server`) that directory
+ * is arbitrary, so the build check's verdict was about an unrelated project.
+ *
+ * @module security/quality-gate-cwd.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const execFileMock = vi.fn();
+vi.mock('node:child_process', () => ({
+  execFile: (
+    cmd: string,
+    args: readonly string[],
+    opts: unknown,
+    cb: (e: unknown, r: unknown) => void
+  ) => {
+    execFileMock(cmd, args, opts);
+    cb(null, { stdout: '', stderr: '' });
+  },
+}));
+
+describe('quality-gate checks run in projectDir (#4355)', () => {
+  beforeEach(() => {
+    execFileMock.mockClear();
+  });
+
+  it('runs the build check inside the target project', async () => {
+    const { checkBuild } = await import('./quality-gate.js');
+
+    await checkBuild('/tmp/target-project')();
+
+    const opts = execFileMock.mock.calls[0]?.[2] as { cwd?: string };
+    expect(opts.cwd).toBe('/tmp/target-project');
+  });
+
+  it('runs the lint check inside the target project', async () => {
+    const { checkLint } = await import('./quality-gate.js');
+
+    await checkLint('/tmp/target-project')();
+
+    const opts = execFileMock.mock.calls[0]?.[2] as { cwd?: string };
+    expect(opts.cwd).toBe('/tmp/target-project');
+  });
+
+  it('runs the typecheck inside the target project', async () => {
+    const { checkTypeCheck } = await import('./quality-gate.js');
+
+    await checkTypeCheck('/tmp/target-project')();
+
+    const opts = execFileMock.mock.calls[0]?.[2] as { cwd?: string };
+    expect(opts.cwd).toBe('/tmp/target-project');
+  });
+
+  it('runs tests inside the target project', async () => {
+    const { checkTests } = await import('./quality-gate.js');
+
+    await checkTests('/tmp/target-project')();
+
+    const opts = execFileMock.mock.calls[0]?.[2] as { cwd?: string };
+    expect(opts.cwd).toBe('/tmp/target-project');
+  });
+});

--- a/packages/nexus-agents/src/security/quality-gate.ts
+++ b/packages/nexus-agents/src/security/quality-gate.ts
@@ -25,14 +25,19 @@ export type GateCheckFn = () => Promise<GateCheckResult>;
 async function runCommandCheck(
   name: string,
   command: string,
-  args: readonly string[]
+  args: readonly string[],
+  cwd: string
 ): Promise<GateCheckResult> {
   const start = Date.now();
   try {
     const { execFile } = await import('node:child_process');
     const { promisify } = await import('node:util');
     const exec = promisify(execFile);
-    await exec(command, [...args], { timeout: 120_000 });
+    // #4355: `cwd` was never set, so every check ran in the MCP server's own
+    // working directory. Three checks partly hid it by passing projectDir as
+    // an argument; `pnpm build` passed nothing and built whatever project sat
+    // at that cwd — arbitrary under a global install.
+    await exec(command, [...args], { timeout: 120_000, cwd });
     return {
       name,
       verdict: 'pass',
@@ -56,22 +61,30 @@ async function runCommandCheck(
 
 /** Check: TypeScript compilation passes. */
 export function checkTypeCheck(projectDir: string): GateCheckFn {
-  return () => runCommandCheck('type_check', 'npx', ['tsc', '--noEmit', '--project', projectDir]);
+  return () =>
+    runCommandCheck('type_check', 'npx', ['tsc', '--noEmit', '--project', projectDir], projectDir);
 }
 
 /** Check: ESLint passes. */
 export function checkLint(projectDir: string): GateCheckFn {
-  return () => runCommandCheck('lint', 'npx', ['eslint', '--max-warnings', '0', projectDir]);
+  return () =>
+    runCommandCheck('lint', 'npx', ['eslint', '--max-warnings', '0', projectDir], projectDir);
 }
 
 /** Check: Tests pass. */
 export function checkTests(projectDir: string): GateCheckFn {
-  return () => runCommandCheck('tests', 'npx', ['vitest', 'run', '--dir', projectDir]);
+  return () => runCommandCheck('tests', 'npx', ['vitest', 'run', '--dir', projectDir], projectDir);
 }
 
-/** Check: Build succeeds. */
-export function checkBuild(): GateCheckFn {
-  return () => runCommandCheck('build', 'pnpm', ['build']);
+/**
+ * Check: Build succeeds.
+ *
+ * Takes `projectDir` (#4355). It previously took no argument and ran
+ * `pnpm build` wherever the server happened to be, so its verdict described
+ * an unrelated project.
+ */
+export function checkBuild(projectDir: string): GateCheckFn {
+  return () => runCommandCheck('build', 'pnpm', ['build'], projectDir);
 }
 
 // ============================================================================


### PR DESCRIPTION
Partial fix for #4355 — the unambiguous half. The reported half is decided 7/0 and tracked on the issue.

## The bug

`runCommandCheck` called `exec(cmd, args, { timeout: 120_000 })` with **no `cwd`**. So every `run_quality_gate` check executed in the MCP server's own working directory.

Three checks partly masked this by passing `projectDir` as an argument — `tsc --project <dir>`, `eslint <dir>`, `vitest --dir <dir>`. **`checkBuild` passed nothing**, so `pnpm build` built whatever project happened to sit at the server's cwd. Under a global install (`npx -y nexus-agents --mode=server`) that directory is arbitrary, which means the build verdict described an unrelated project.

`checkBuild()` took no arguments at all — it had no idea what it was building.

## The fix

All four checks execute in `projectDir`, and `checkBuild(projectDir)` takes it as a parameter. Single call site updated.

## Found while investigating something else

#4355 reports that the gate hard-codes ESLint/vitest/pnpm and ignores the target's declared scripts, giving a false RED on an oxlint/npm project. Reading the code for that turned up this separate, larger defect: the gate was not merely running the wrong *tools*, it was running one of them in the wrong *directory*.

That reported half is now decided — **7/0 for Option A** (prefer declared scripts, fall back) with hardening conditions the panel attached: resolve the fallback from `node_modules/.bin` rather than `npx` (killing an unpinned network download triggered by an untrusted directory), surface `NOT_APPLICABLE` rather than `FAIL` when neither a script nor a tool exists, scrub the child environment so repo code does not inherit resident secrets, and rewrite the module's "allowlist" docstring, which the panel unanimously judged false in substance — `eslint` already loads repo-authored config and plugins, and `vitest` already executes repo-authored tests.

That is a larger change with its own conditions, so it is deliberately not bundled here.

## Verification

4 new tests, red-first — all four asserted `cwd` and all four failed before the change. Full suite: **1,172 files / 27,868 tests**, exit 0. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)