### PR TITLE
fix(ci): pass an explicit --limit to System Review issue counts

### DIFF
--- a/.github/workflows/system-review.yml
+++ b/.github/workflows/system-review.yml
@@ -158,13 +158,28 @@ jobs:
         run: |
           echo "## Phase 3: Issue Health" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          OPEN=$(gh issue list --state open --json number | jq 'length')
+          # Every count below MUST pass --limit. `gh issue list` defaults to a
+          # page size of 30, so an unlimited call silently returns a truncated
+          # page instead of a count (#4447). That is not a cosmetic bug: STALE
+          # feeds the create-issue gate below, and because gh returns the
+          # newest issues first, the 30 it returned were the ones least likely
+          # to be stale — so STALE was pinned at 0 and the stale-issue trigger
+          # never fired once. At the time of the fix the real numbers were 75
+          # open / 28 stale while this step reported 30 / 0.
+          ISSUE_LIMIT=1000
+          OPEN=$(gh issue list --state open --limit "$ISSUE_LIMIT" --json number | jq 'length')
           THIRTY_DAYS_AGO=$(date -d '30 days ago' --iso-8601)
-          STALE=$(gh issue list --state open --json updatedAt --jq "[.[] | select(.updatedAt < \"$THIRTY_DAYS_AGO\")] | length")
-          EPICS=$(gh issue list --state open --label epic --json number | jq 'length')
-          BUGS=$(gh issue list --state open --label bug --json number | jq 'length')
-          ENHANCEMENTS=$(gh issue list --state open --label enhancement --json number | jq 'length')
-          RESEARCH=$(gh issue list --state open --label research --json number | jq 'length')
+          STALE=$(gh issue list --state open --limit "$ISSUE_LIMIT" --json updatedAt --jq "[.[] | select(.updatedAt < \"$THIRTY_DAYS_AGO\")] | length")
+          EPICS=$(gh issue list --state open --limit "$ISSUE_LIMIT" --label epic --json number | jq 'length')
+          BUGS=$(gh issue list --state open --limit "$ISSUE_LIMIT" --label bug --json number | jq 'length')
+          ENHANCEMENTS=$(gh issue list --state open --limit "$ISSUE_LIMIT" --label enhancement --json number | jq 'length')
+          RESEARCH=$(gh issue list --state open --limit "$ISSUE_LIMIT" --label research --json number | jq 'length')
+          # Make a future truncation loud rather than silent. If OPEN lands
+          # exactly on the limit the list was almost certainly cut off again,
+          # and every derived count is suspect.
+          if [ "$OPEN" -ge "$ISSUE_LIMIT" ]; then
+            echo "::warning::Open-issue count hit the --limit ceiling ($ISSUE_LIMIT); counts are truncated and stale detection is unreliable. Raise ISSUE_LIMIT (#4447)."
+          fi
           echo "| Category | Count |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| Open Issues | $OPEN |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Closes #4447.

## The bug

Phase 3 of the System Review workflow counted issues with six `gh issue list` calls that omitted `--limit`. gh's default page size is **30**, so those calls returned a truncated page rather than a count. Every System Review ever filed reported `Open: 30` — that number was the page size, not a measurement.

## Why it mattered

The stale count was the load-bearing casualty. gh returns newest-first, so the 30 issues sampled were precisely the ones least likely to be stale, and `STALE` was pinned at `0`.

That value is not cosmetic. It gates whether the review is filed at all:

```yaml
needs.run-review.outputs.issues_stale != '0' || ...
```

and it gates the action item:

```bash
[ "$STALE" != "0" ] && ACTIONS="${ACTIONS}- [ ] Review $STALE stale issue(s)"
```

So the stale-issue trigger has **never fired**. #4342, #4352 and #4399 were all filed on the doc-age condition alone. The backlog-rot detector was structurally blind to backlog rot for its entire life — which is how 28 stale issues accumulated without a single one being reported.

## Before / after

Measured against this repo at the time of the fix:

| | reported | actual |
|---|---|---|
| Open | 30 | 75 |
| Stale (>30d) | 0 | 28 |

## The fix

- All six Phase 3 counts pass an explicit `--limit 1000` via a shared `ISSUE_LIMIT`.
- A `::warning::` fires if the open count lands exactly on the ceiling, so the same class of silent truncation becomes visible instead of quietly reappearing at a higher threshold.

The label-filtered counts (epics/bugs/enhancements/research) were under 30 and therefore correct *by luck*; they are fixed too, since that luck expires as the backlog grows.

## Verification

Ran the corrected step body against the live repo:

```
OPEN=71  STALE=18  EPICS=9  BUGS=6
no truncation warning (correct)
ACTION ITEM: - [ ] Review 18 stale issue(s)   <-- trigger now fires
```

(71/18 rather than 75/28 because the grooming pass that found this had already closed four issues and commented on others, which refreshes `updatedAt` — the point is that the trigger fires at all, which it previously never did.)

YAML validated via `yaml.safe_load`; all three jobs and the `issues` step parse. No `packages/nexus-agents/src/**` files touched, so no changeset applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)