### PR TITLE
feat(audit): let vote records represent a multi-option split (#4452 increment 1)

### DIFF
--- a/.changeset/vote-option-tally.md
+++ b/.changeset/vote-option-tally.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': minor
+---
+
+Vote records can now represent a multi-option split (#4452, increment 1).
+
+`consensus_vote` tallies approve/reject/abstain only. On a proposal offering named options, every engaged voter returns `approve` — so a real 6-1 or 5-2 split persists as `approve: 7, approvalPercentage: 100` and reads as unanimous. Three live votes did exactly that, one of them inside a vote whose own proposal warned about the bug.
+
+Adds an optional `optionTally` to `VoteRecord` (schema 1.3), derived automatically from a new `AgentVoteResult.selectedOption`. When no voter declares an option — an ordinary yes/no vote — the field is absent and the record stays on schema 1.2.
+
+**Back-compat is the load-bearing property.** `VoteRecord` is self-hashed and `verifyVoteRecordSet` rebuilds every field in schema order, so naively adding a field would flip every historical record to `hash_mismatch` — breaking the audit chain while fixing its fidelity. `optionTally` is therefore folded into the hash **only when present, appended after the stable base**, exactly as `ratifies` was for schema 1.2. A record without it re-hashes byte-identical to the pre-1.3 projection, pinned by a literal-hash regression test.
+
+The tally is emitted in descending count with ties broken by label, so two vote sets differing only in voter arrival order produce the same hash — the array is hash-covered, so nondeterministic ordering would be a spurious `hash_mismatch`.
+
+Not yet included, tracked as increment 2: the `options` input on `consensus_vote`, the voter prompt requesting a selection, and threshold evaluation over the option tally (so `unanimous` stops being trivially clearable on a multi-option proposal).

--- a/packages/nexus-agents/src/audit/vote-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.test.ts
@@ -30,6 +30,7 @@ vi.mock('../config/nexus-data-dir.js', () => ({
   ),
 }));
 
+import type { VoteRecord } from './vote-record.js';
 import { verifyVoteRecordSet } from './vote-record.js';
 import {
   VOTE_RECORDS_PATH_ENV,
@@ -95,6 +96,56 @@ describe('buildVoteRecord', () => {
       { role: 'catfish', decision: 'reject', confidence: 0.8 },
     ]);
     expect(verifyVoteRecordSet([record])).toEqual({ ok: true, recordCount: 1 });
+  });
+
+  it('omits optionTally and stays on 1.2 when no voter declared an option (#4452)', () => {
+    const record = buildVoteRecord({
+      id: 'vote-noopt',
+      proposal: 'p',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes,
+    });
+    expect(record.optionTally).toBeUndefined();
+    expect(record.version).toBe('1.2');
+    expect(verifyVoteRecordSet([record])).toEqual({ ok: true, recordCount: 1 });
+  });
+
+  it('derives optionTally from selectedOption and bumps to 1.3 (#4452)', () => {
+    // The defect this fixes: voteCounts says approve:2 for BOTH a genuine
+    // agreement and a split across options. The tally distinguishes them.
+    const withOptions = votes.map((v, i) => ({
+      ...v,
+      selectedOption: i === 0 ? 'A' : i === 1 ? 'A' : 'C',
+    }));
+    const record = buildVoteRecord({
+      id: 'vote-opt',
+      proposal: 'p',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes: withOptions,
+    });
+    expect(record.version).toBe('1.3');
+    expect(record.optionTally).toEqual([
+      { option: 'A', count: 2 },
+      { option: 'C', count: 1 },
+    ]);
+    expect(verifyVoteRecordSet([record])).toEqual({ ok: true, recordCount: 1 });
+  });
+
+  it('orders the tally deterministically regardless of voter arrival order (#4452)', () => {
+    // The array is hash-covered, so two vote sets differing only in order must
+    // not produce different hashes.
+    const mk = (opts: readonly string[]): VoteRecord =>
+      buildVoteRecord({
+        id: 'vote-ord',
+        recordedAt: '2026-06-15T00:00:00.000Z',
+        proposal: 'p',
+        strategy: 'higher_order',
+        result: consensusResult(),
+        votes: votes.map((v, i) => ({ ...v, selectedOption: opts[i] as string })),
+      });
+    expect(mk(['A', 'C', 'A']).hash).toBe(mk(['C', 'A', 'A']).hash);
   });
 
   it('excludes error-source voters from the per-voter summary', () => {

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -48,7 +48,7 @@ import type { ConsensusResult, Vote } from '../consensus/types.js';
 import type { AgentVoteResult } from '../cli/vote-types.js';
 import { getNexusDataDir, nexusDataPath } from '../config/nexus-data-dir.js';
 
-import type { VoteRecord, VoterSummary } from './vote-record.js';
+import type { VoteRecord, VoteRecordOptionCount, VoterSummary } from './vote-record.js';
 import { VoteRecordSchema, computeVoteRecordHash, hashProposal } from './vote-record.js';
 
 /**
@@ -165,13 +165,44 @@ export interface BuildVoteRecordInput {
  * position-independent (#3927). The proposal is hashed in full but stored
  * truncated.
  */
+/**
+ * Counts how many voters chose each named option (#4452).
+ *
+ * Returns `undefined` when no vote carries a `selectedOption` — an ordinary
+ * yes/no vote — so the record stays on the pre-1.3 hash projection and every
+ * historical record keeps verifying.
+ *
+ * Options are emitted in DESCENDING count, ties broken by option label, so the
+ * tally is deterministic regardless of voter order. That matters: the array is
+ * hash-covered, and a set of votes that differed only in arrival order must not
+ * produce two different hashes.
+ */
+function tallySelectedOptions(
+  votes: readonly AgentVoteResult[]
+): VoteRecordOptionCount[] | undefined {
+  const counts = new Map<string, number>();
+  for (const v of votes) {
+    if (v.selectedOption === undefined) continue;
+    counts.set(v.selectedOption, (counts.get(v.selectedOption) ?? 0) + 1);
+  }
+  if (counts.size === 0) return undefined;
+  return [...counts.entries()]
+    .map(([option, count]) => ({ option, count }))
+    .sort((a, b) => (b.count !== a.count ? b.count - a.count : a.option.localeCompare(b.option)));
+}
+
 export function buildVoteRecord(input: BuildVoteRecordInput): VoteRecord {
   const proposalTruncated =
     input.proposal.length > MAX_PROPOSAL_RECORD_CHARS
       ? input.proposal.slice(0, MAX_PROPOSAL_RECORD_CHARS) + '...'
       : input.proposal;
+  // #4452: derive the per-option distribution from the votes themselves, so a
+  // multi-option split is recoverable from the structured record instead of by
+  // parsing seven free-text `reasoning` fields. Absent when no voter declared an
+  // option, which keeps an ordinary yes/no record on the pre-1.3 projection.
+  const optionTally = tallySelectedOptions(input.votes);
   const payload: Omit<VoteRecord, 'hash'> = {
-    version: '1.2',
+    version: optionTally !== undefined ? '1.3' : '1.2',
     id: input.id,
     sequence: input.sequence ?? 0,
     recordedAt: input.recordedAt ?? new Date().toISOString(),
@@ -189,6 +220,7 @@ export function buildVoteRecord(input: BuildVoteRecordInput): VoteRecord {
     voters: toVoterSummaries(input.votes),
     ...(input.correlationId !== undefined ? { correlationId: input.correlationId } : {}),
     ...(input.ratifies !== undefined ? { ratifies: input.ratifies } : {}),
+    ...(optionTally !== undefined ? { optionTally } : {}),
     ...(input.previousHash !== undefined ? { previousHash: input.previousHash } : {}),
   };
   return { ...payload, hash: computeVoteRecordHash(payload) };

--- a/packages/nexus-agents/src/audit/vote-record.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record.test.ts
@@ -279,3 +279,97 @@ describe('ratifies subject-binding field (#3927 item 1, schema 1.2)', () => {
     });
   });
 });
+
+// ============================================================================
+// optionTally — multi-option vote fidelity (#4452)
+// ============================================================================
+
+/** Strip the self-hash so a payload can be re-hashed with a variation applied. */
+function payloadOf(record: VoteRecord): Omit<VoteRecord, 'hash'> {
+  const copy: Record<string, unknown> = { ...record };
+  delete copy['hash'];
+  return copy as Omit<VoteRecord, 'hash'>;
+}
+
+describe('optionTally (#4452)', () => {
+  it('leaves the hash BYTE-IDENTICAL for a record without it', () => {
+    // The load-bearing back-compat property. Every historical 1.1/1.2 record
+    // lacks optionTally; if adding the field changed their projection, the whole
+    // persisted chain would flip to hash_mismatch — breaking the audit trail in
+    // the act of fixing its fidelity. Mirrors how `ratifies` was folded in.
+    const payload: Omit<VoteRecord, 'hash'> = {
+      version: '1.1',
+      id: 'r1',
+      sequence: 0,
+      recordedAt: '2026-06-15T00:00:00.000Z',
+      proposalHash: 'a'.repeat(64),
+      proposal: 'p',
+      strategy: 'higher_order',
+      decision: 'approved',
+      approvalPercentage: 100,
+      voteCounts: { approve: 7, reject: 0, abstain: 0, total: 7 },
+      voters: [{ role: 'architect', decision: 'approve', confidence: 0.9 }],
+    };
+    // PINNED LITERAL, not a self-comparison. Recomputing the hash and comparing
+    // it to itself cannot detect a projection change — mutation testing caught
+    // exactly that weakness in the first version of this test. This constant is
+    // the pre-#4452 projection; if a change alters it, historical records stop
+    // verifying, and this fails.
+    const PRE_4452 = 'edecd8cd8ea8d978733c73c77ffeddea85b04339b62db4c665b32165468c49a6';
+    expect(computeVoteRecordHash(payload)).toBe(PRE_4452);
+    // An explicitly-undefined tally must also take the absent path.
+    expect(computeVoteRecordHash({ ...payload, optionTally: undefined })).toBe(PRE_4452);
+  });
+
+  it('changes the hash when present — the tally is tamper-evident', () => {
+    const payload = payloadOf(makeRecord('r2', 0));
+    const withTally = computeVoteRecordHash({
+      ...payload,
+      optionTally: [
+        { option: 'A', count: 6 },
+        { option: 'C', count: 1 },
+      ],
+    });
+    expect(withTally).not.toBe(computeVoteRecordHash(payload));
+  });
+
+  it('is order-independent within the tally, like every other nested object', () => {
+    const payload = payloadOf(makeRecord('r3', 0));
+    const a = computeVoteRecordHash({
+      ...payload,
+      optionTally: [
+        { option: 'A', count: 6 },
+        { option: 'C', count: 1 },
+      ],
+    });
+    // Same tally, keys of each entry written in the other order.
+    const b = computeVoteRecordHash({
+      ...payload,
+      optionTally: [
+        { count: 6, option: 'A' },
+        { count: 1, option: 'C' },
+      ],
+    });
+    expect(b).toBe(a);
+  });
+
+  it('distinguishes a 6-1 split from a 7-0 unanimity at equal approve counts', () => {
+    // The #4452 defect in one assertion: both records are approve:7 / reject:0,
+    // and today they are indistinguishable. With the tally they are not.
+    const payload = payloadOf(
+      makeRecord('r4', 0, { voteCounts: { approve: 7, reject: 0, abstain: 0, total: 7 } })
+    );
+    const split = computeVoteRecordHash({
+      ...payload,
+      optionTally: [
+        { option: 'A', count: 6 },
+        { option: 'C', count: 1 },
+      ],
+    });
+    const unanimous = computeVoteRecordHash({
+      ...payload,
+      optionTally: [{ option: 'A', count: 7 }],
+    });
+    expect(split).not.toBe(unanimous);
+  });
+});

--- a/packages/nexus-agents/src/audit/vote-record.ts
+++ b/packages/nexus-agents/src/audit/vote-record.ts
@@ -85,6 +85,23 @@ export const VoteRecordCountsSchema = z
 export type VoteRecordCounts = z.infer<typeof VoteRecordCountsSchema>;
 
 /**
+ * One option's share of a multi-option vote (#4452).
+ *
+ * The approve/reject/abstain tally cannot express WHICH option a voter chose, so
+ * a real 6-1 split over options A and C persists as `approve: 7` — indis-
+ * tinguishable from genuine unanimity. This carries the distribution.
+ */
+export const VoteRecordOptionCountSchema = z
+  .object({
+    /** The option label as declared in the proposal (e.g. 'A'). */
+    option: z.string().min(1),
+    /** How many voters selected it. */
+    count: z.number().int().nonnegative(),
+  })
+  .strict();
+export type VoteRecordOptionCount = z.infer<typeof VoteRecordOptionCountSchema>;
+
+/**
  * One authentic, self-hashed vote record. The `hash` covers every authenticity
  * field INCLUDING `sequence` but EXCLUDING `previousHash`, so the record is
  * tamper-EVIDENT and POSITION-INDEPENDENT: any edit to a persisted line is
@@ -100,7 +117,7 @@ export const VoteRecordSchema = z
      * `ratifies` is folded into the self-hash ONLY when present (see
      * {@link computeVoteRecordHash}).
      */
-    version: z.enum(['1.1', '1.2']),
+    version: z.enum(['1.1', '1.2', '1.3']),
     /** Unique record id (also usable as a `ratificationVoteRef`). */
     id: z.string().min(1),
     /**
@@ -140,6 +157,20 @@ export const VoteRecordSchema = z
     voters: z.array(VoterSummarySchema),
     /** Optional correlation/decision id linking to the cost rollup / trace. */
     correlationId: z.string().min(1).optional(),
+    /**
+     * Per-option distribution for a multi-option proposal (#4452, schema 1.3).
+     *
+     * Present only when the vote declared `options`. Absent on an ordinary
+     * yes/no vote, and absent on every 1.1/1.2 record — which is why it is
+     * folded into the self-hash ONLY when present (see
+     * {@link computeVoteRecordHash}), exactly as `ratifies` was.
+     *
+     * Without this, a 6-1 or 5-2 option split is recorded as `approve: 7` and
+     * reads as unanimous. Threshold semantics invert too: `unanimous` becomes
+     * the EASIEST bar to clear, because every engaged voter approves while
+     * choosing different things.
+     */
+    optionTally: z.array(VoteRecordOptionCountSchema).min(1).optional(),
     /**
      * The loop/strategy subject this vote RATIFIES (#3927 item 1). Present only on
      * a ratification vote; set at vote time and bound into the self-hash (so it is
@@ -211,8 +242,19 @@ export function computeVoteRecordHash(payload: VoteRecordPayload): string {
   // `ratifies`) re-hashes unchanged (back-compat). It stays fully tamper-evident:
   // adding, removing, or editing `ratifies` on a persisted record flips the hash
   // (an absent field re-hashes one way, a present field the other).
+  // `optionTally` (#4452) is folded in on the same principle as `ratifies`:
+  // ONLY when present, appended after the stable base, with each entry rebuilt
+  // field-by-field in schema order. A record without it re-hashes byte-identical
+  // to the pre-1.3 form, so every historical record still verifies.
+  const withTally =
+    payload.optionTally !== undefined
+      ? {
+          ...base,
+          optionTally: payload.optionTally.map((o) => ({ option: o.option, count: o.count })),
+        }
+      : base;
   const canonical = JSON.stringify(
-    payload.ratifies !== undefined ? { ...base, ratifies: payload.ratifies } : base
+    payload.ratifies !== undefined ? { ...withTally, ratifies: payload.ratifies } : withTally
   );
   return crypto.createHash('sha256').update(canonical).digest('hex');
 }

--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -95,6 +95,16 @@ export interface AgentVoteResult {
   /** CLI that executed this vote (for adaptive routing feedback). */
   readonly cli?: string | undefined;
   /**
+   * Which named option this voter chose, when the proposal declared `options`
+   * (#4452). Absent on an ordinary yes/no vote.
+   *
+   * The approve/reject/abstain tally cannot express option choice: on a
+   * multi-option proposal every engaged voter returns `approve`, so a real 6-1
+   * split records as unanimous. This is what makes the split recoverable
+   * without parsing free-text `reasoning`.
+   */
+  readonly selectedOption?: string | undefined;
+  /**
    * Model id that executed this vote, when known (e.g. 'claude-sonnet'). Carried
    * so per-decision cost aggregation can attribute spend per model (#3855). Absent
    * for error/simulation votes that never reached a model.


### PR DESCRIPTION
Increment 1 of #4452. CODEOWNERS-protected (`src/audit/`, `src/cli/`) — for your ratification.

## The defect

`consensus_vote` tallies approve/reject/abstain only. On a proposal offering named options, every engaged voter returns `approve` — so a real split persists as unanimity:

```json
{"decision":"approved","approvalPercentage":100,
 "voteCounts":{"approve":7,"reject":0,"abstain":0}}
```

Three live votes this week did exactly that (6-1, 5-2, and one genuine 7-0). One was a vote whose **own proposal warned about this bug** and instructed voters to state their letter explicitly. They all complied — and the record still lost the split. That's what makes it structural rather than a prompting problem.

## What lands here

An optional `optionTally` on `VoteRecord` (schema **1.3**), derived automatically from a new `AgentVoteResult.selectedOption`. Absent when no voter declares an option, so an ordinary yes/no record stays on 1.2.

## The part that could have gone badly

`VoteRecord` is **self-hashed**, and `verifyVoteRecordSet` rebuilds every field in schema order to recompute it. Naively adding a field flips **every historical record** to `hash_mismatch` — breaking the audit chain in the act of fixing its fidelity.

There's already a precedent for this exact problem, documented at `vote-record.ts:209`: `ratifies` (#3927) is folded in **only when present, appended after the stable base**, keeping the projection byte-identical for records that lack it. `optionTally` follows it exactly.

Guarded by a **pinned literal hash**, not a self-comparison:

```ts
const PRE_4452 = 'edecd8cd8ea8d978733c73c77ffeddea85b04339b62db4c665b32165468c49a6';
expect(computeVoteRecordHash(payload)).toBe(PRE_4452);
```

The first version of that test recomputed the hash and compared it to itself. Mutation testing showed it **could not detect a projection change at all** — the pre-existing `ratifies` test was doing the work. Pinning the literal fixed it.

## Determinism

The tally sorts by descending count, ties by label. The array is hash-covered, so two vote sets differing only in **voter arrival order** must not produce different hashes — otherwise concurrent panels would emit spurious `hash_mismatch`.

## Mutation-verified

| Mutation | Test that fails |
| --- | --- |
| Fold `optionTally` into the base unconditionally | back-compat pinned-hash test |
| Remove the tally sort | determinism test |

## Verification

`tsc` clean · `eslint` clean · `src/audit/` 282 passing · `audit` + `mcp/tools` + `cli` **6,377 passing**

## Deferred to increment 2

The `options` input on `consensus_vote`, the voter prompt requesting a selection, and **threshold evaluation over the option tally** — so `unanimous` stops being the *easiest* bar to clear on a multi-option proposal. Filed separately; this increment is the foundation those depend on, and is independently valuable: the record can now represent a split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)