### PR TITLE
fix(ci): pin changesets/action to v1 — v2 requires Changesets CLI v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,11 @@ updates:
     labels:
       - 'ci'
       - 'dependencies'
+    ignore:
+      # changesets/action v2+ requires Changesets CLI v3; this repo is on CLI v2,
+      # and v2 also renamed every input. Bumping the action alone breaks the
+      # release with "Changesets CLI v2 is not supported" — and NO CI job
+      # exercises release.yml, so the PR goes green and the break only surfaces
+      # on the next release. Unignore once the CLI is on v3 (#4473).
+      - dependency-name: 'changesets/action'
+        update-types: ['version-update:semver-major']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,15 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
+        # PINNED TO v1 DELIBERATELY — do not let dependabot bump this to v2+.
+        # changesets/action v2 requires Changesets CLI v3; this repo is on CLI
+        # v2 (`@changesets/cli: ^2.31.1`), and v2 also renamed every input
+        # (version->version-script, publish->publish-script, title->pr-title,
+        # commit->commit-message). Bumping the action alone fails the release
+        # with "Changesets CLI v2 is not supported" AND silently ignores all
+        # four inputs — and CI never catches it, because no CI job exercises
+        # release.yml. Upgrading requires moving the CLI to v3 first (#4473).
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: pnpm changeset:version
           publish: pnpm release


### PR DESCRIPTION
**The release workflow has been failing since #4469** bumped `changesets/action` 1.9.0 → 2.1.0. Three changesets are stranded on `main` and 3.2.0 cannot publish.

```
Error: This version of the Changesets action is designed to work with
Changesets CLI v3. Changesets CLI v2 is not supported; use Changesets
action v1 instead, which is compatible with CLI v2.
```

This repo is on `@changesets/cli: ^2.31.1`.

## Two breakages, not one

v2 also renamed every input. The run warned before failing:

```
Unexpected input(s) 'version', 'publish', 'title', 'commit',
valid inputs are [... 'publish-script', 'version-script',
'commit-message', 'pr-title' ...]
```

So even on a compatible CLI, the action would have silently ignored the version script, publish script, PR title, and commit message.

## Why green CI did not catch it

**No CI job exercises `release.yml`** — it runs only on push to `main`. The dependabot PR went green and merged; the break surfaced at release time with changesets already queued. A release-only workflow has no pre-merge signal.

## Fix

- Revert to `v1.9.0` with an inline comment stating why, so the next person (or dependabot auto-merge) does not re-break it
- Add a `dependabot.yml` ignore for **major** bumps of `changesets/action`

## Follow-up

**#4473** tracks the real resolution: upgrade Changesets CLI v2 → v3, rename the four inputs, then unpin and remove the ignore. Pinning is the stopgap, not the destination.

Verified: `release.yml` and `dependabot.yml` both parse; full suite on main 27,878 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)