### PR TITLE
chore(deps): align website TypeScript to 6.0.3, ending the monorepo skew (#4478)

### DIFF
--- a/.changeset/ts-skew.md
+++ b/.changeset/ts-skew.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+Align the website's TypeScript to the rest of the monorepo (#4478).
+
+`nexus-agents` and `nexus-memory` were on `^6.0.3` while `website` sat on `^5.9.3` — a full major behind, resolving two compiler copies in one workspace. A skew like that means the website type-checks against different inference and different lib definitions than the code it documents, so a type error can exist in one and not the other.
+
+Website now on `^6.0.3`; the lockfile resolves a single `typescript@6.0.3`. Verified with `astro check` (0 errors, 0 warnings, 1 pre-existing hint) and a full website build (134 pages).
+
+TypeScript 7 is available but deliberately not taken here — it is the native-port rewrite and warrants its own evaluation rather than riding along with a skew fix.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,7 +212,7 @@ importers:
         version: 4.12.0(typedoc@0.28.20(typescript@6.0.3))
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/nexus-memory:
     dependencies:
@@ -234,13 +234,13 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
 
   website:
     dependencies:
       '@astrojs/check':
         specifier: ^0.9.10
-        version: 0.9.10(prettier@3.9.6)(typescript@5.9.3)
+        version: 0.9.10(prettier@3.9.6)(typescript@6.0.3)
       '@astrojs/markdown-satteri':
         specifier: ^0.3.5
         version: 0.3.5
@@ -249,7 +249,7 @@ importers:
         version: 3.7.3
       '@astrojs/svelte':
         specifier: ~9.0.1
-        version: 9.0.1(@types/node@26.1.1)(astro@7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(yaml@2.9.0)
+        version: 9.0.1(@types/node@26.1.1)(astro@7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@6.0.3)(yaml@2.9.0)
       astro:
         specifier: ~7.2.2
         version: 7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -263,8 +263,8 @@ importers:
         specifier: ^5.56.9
         version: 5.56.9(@typescript-eslint/types@8.67.0)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -5213,11 +5213,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -5825,12 +5820,12 @@ snapshots:
 
   '@ast-grep/setup-lang@0.0.6': {}
 
-  '@astrojs/check@0.9.10(prettier@3.9.6)(typescript@5.9.3)':
+  '@astrojs/check@0.9.10(prettier@3.9.6)(typescript@6.0.3)':
     dependencies:
-      '@astrojs/language-server': 2.16.13(prettier@3.9.6)(typescript@5.9.3)
+      '@astrojs/language-server': 2.16.13(prettier@3.9.6)(typescript@6.0.3)
       chokidar: 4.0.3
       kleur: 4.1.5
-      typescript: 5.9.3
+      typescript: 6.0.3
       yargs: 18.1.0
     transitivePeerDependencies:
       - prettier
@@ -5903,12 +5898,12 @@ snapshots:
       smol-toml: 1.8.0
       unified: 11.0.5
 
-  '@astrojs/language-server@2.16.13(prettier@3.9.6)(typescript@5.9.3)':
+  '@astrojs/language-server@2.16.13(prettier@3.9.6)(typescript@6.0.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/yaml2ts': 0.2.4
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@volar/kit': 2.4.28(typescript@5.9.3)
+      '@volar/kit': 2.4.28(typescript@6.0.3)
       '@volar/language-core': 2.4.28
       '@volar/language-server': 2.4.28
       '@volar/language-service': 2.4.28
@@ -5946,13 +5941,13 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/svelte@9.0.1(@types/node@26.1.1)(astro@7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)(yaml@2.9.0)':
+  '@astrojs/svelte@9.0.1(@types/node@26.1.1)(astro@7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0))(esbuild@0.28.2)(jiti@2.7.0)(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 7.2.0(svelte@5.56.9(@typescript-eslint/types@8.67.0))(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       astro: 7.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(jiti@2.7.0)(yaml@2.9.0)
       svelte: 5.56.9(@typescript-eslint/types@8.67.0)
-      svelte2tsx: 0.7.56(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3)
-      typescript: 5.9.3
+      svelte2tsx: 0.7.56(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@6.0.3)
+      typescript: 6.0.3
       vite: 8.1.3(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.3(@types/node@26.1.1)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
@@ -7781,7 +7776,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -7840,12 +7835,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@volar/kit@2.4.28(typescript@5.9.3)':
+  '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-service': 2.4.28
       '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
-      typescript: 5.9.3
+      typescript: 6.0.3
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -10697,12 +10692,12 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  svelte2tsx@0.7.56(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@5.9.3):
+  svelte2tsx@0.7.56(svelte@5.56.9(@typescript-eslint/types@8.67.0))(typescript@6.0.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
       svelte: 5.56.9(@typescript-eslint/types@8.67.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   svelte@5.56.9(@typescript-eslint/types@8.67.0):
     dependencies:
@@ -10908,8 +10903,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,6 @@
     "mermaid": "^11.16.1",
     "satteri": "^0.9.5",
     "svelte": "^5.56.9",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
First item from the dependency epic #4478.

## The skew

| Workspace | TypeScript |
| --- | --- |
| `nexus-agents` | `^6.0.3` |
| `nexus-memory` | `^6.0.3` |
| **`website`** | **`^5.9.3`** |

A full major behind, so pnpm resolved **two compiler copies** in one workspace. The website type-checked against different inference rules and different lib definitions than the code it documents — meaning a type error could exist in one and not the other, with no signal that the two disagreed.

## Change

Website → `^6.0.3`. The lockfile now resolves a single `typescript@6.0.3`.

## Verified on the surfaces that exercise the compiler

- `astro check` — **0 errors, 0 warnings**, 1 hint (pre-existing `set:html` hint, unrelated)
- website build — **134 pages**, clean
- package `typecheck` — clean
- `pnpm audit` — clean

`astro check` matters more than the package typecheck here: it is the job that actually runs TS over the website's `.astro` files, so it is the one that would have caught a 5→6 incompatibility.

## Deliberately not taken

**TypeScript 7 is available** (7.0.2). Not doing it here — it is the native-port rewrite, and bundling a major compiler change into a skew fix would make any regression impossible to attribute. It stays tracked in #4478 as its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)