### PR TITLE
chore(ci): bring repo-root scripts/ into the lint scope (#4483)

### DIFF
--- a/.changeset/lint-scripts-scope.md
+++ b/.changeset/lint-scripts-scope.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+Bring the repo-root `scripts/` tree into the lint scope (#4483).
+
+`pnpm lint` is `turbo lint`, which only reaches each workspace's own `eslint src/`. The root `scripts/` directory — governance generators, drift gates, the tool-reference generator, the release helper — was outside every lint scope. The code that enforces the repo's rules was itself unenforced, and had accumulated 7 deprecated-API errors nothing reported.
+
+Adds `lint:scripts` and a CI step that runs it. The scope was extended **first** and confirmed to fail with all 7 errors before anything was fixed, so the gate is demonstrated to catch something rather than landing already-green.
+
+Fixes the 7: `.passthrough()` → `.loose()` and `z.string().url()` → `z.url()` in `build-model-registry-types.ts`. Verified behaviour-preserving by running the generator — it exits clean and produces a byte-identical registry, so this is a rename, not a semantic change.
+
+`sync-plugin-version.ts` gets the file-level `no-console` disable its 38 sibling scripts already carry; a build script's stdout is its interface.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,13 @@ jobs:
       - name: Run lint
         run: pnpm lint
 
+      # #4483: `pnpm lint` is `turbo lint`, which only reaches each workspace's
+      # own `eslint src/`. The repo-root `scripts/` tree — governance
+      # generators, drift gates, the release helper — was outside every lint
+      # scope and had accumulated 7 deprecated-API errors nothing reported.
+      - name: Run lint (repo scripts)
+        run: pnpm lint:scripts
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:scripts": "vitest run",
     "lint": "turbo lint",
     "lint:fix": "turbo lint:fix",
+    "lint:scripts": "eslint scripts/",
     "lint:arch": "npx tsx scripts/arch-lint.ts",
     "lint:md": "markdownlint 'docs/**/*.md' '*.md' --ignore 'docs/api/**' --ignore 'node_modules' --config .markdownlint.json",
     "lint:md:fix": "markdownlint 'docs/**/*.md' '*.md' --ignore 'docs/api/**' --ignore 'node_modules' --config .markdownlint.json --fix",

--- a/scripts/build-model-registry-types.ts
+++ b/scripts/build-model-registry-types.ts
@@ -7,7 +7,7 @@
  * generated registry pulls from upstream sources that cover hundreds of
  * providers and thousands of model ids we don't want to enumerate.
  *
- * `.passthrough()` is used on upstream shapes so a new field showing up in
+ * `.loose()` is used on upstream shapes so a new field showing up in
  * models.dev / LiteLLM doesn't break the build — it flows through and is
  * trimmed during output mapping.
  *
@@ -40,7 +40,7 @@ export const ModelsDevEntrySchema = z
         input: z.array(z.string()).optional(),
         output: z.array(z.string()).optional(),
       })
-      .passthrough()
+      .loose()
       .optional(),
     cost: z
       .object({
@@ -49,7 +49,7 @@ export const ModelsDevEntrySchema = z
         cache_read: z.number().nonnegative().optional(),
         cache_write: z.number().nonnegative().optional(),
       })
-      .passthrough()
+      .loose()
       .optional(),
     limit: z
       .object({
@@ -57,10 +57,10 @@ export const ModelsDevEntrySchema = z
         input: z.number().int().nonnegative().optional(),
         output: z.number().int().nonnegative().optional(),
       })
-      .passthrough()
+      .loose()
       .optional(),
   })
-  .passthrough();
+  .loose();
 
 export type ModelsDevEntry = z.infer<typeof ModelsDevEntrySchema>;
 
@@ -78,7 +78,7 @@ export const ModelsDevProviderSchema = z
     npm: z.string().optional(),
     models: z.record(z.string(), z.unknown()),
   })
-  .passthrough();
+  .loose();
 
 export type ModelsDevProvider = z.infer<typeof ModelsDevProviderSchema>;
 
@@ -113,7 +113,7 @@ export const LiteLlmEntrySchema = z
     supports_pdf_input: z.boolean().optional(),
     deprecation_date: z.string().optional(),
   })
-  .passthrough();
+  .loose();
 
 export type LiteLlmEntry = z.infer<typeof LiteLlmEntrySchema>;
 
@@ -140,7 +140,7 @@ export const MAX_UPSTREAM_PAYLOAD_BYTES = 5 * 1024 * 1024;
 export const GeneratedProvenanceSchema = z.object({
   source: z.enum(['models.dev', 'litellm']),
   fetchedAt: z.string(),
-  upstreamUrl: z.string().url(),
+  upstreamUrl: z.url(),
 });
 
 export type GeneratedProvenance = z.infer<typeof GeneratedProvenanceSchema>;

--- a/scripts/sync-plugin-version.ts
+++ b/scripts/sync-plugin-version.ts
@@ -7,6 +7,8 @@
  * @module scripts/sync-plugin-version
  */
 
+/* eslint-disable no-console -- build script; its stdout IS the interface (#4483) */
+
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 


### PR DESCRIPTION
Closes #4483. Third item from the dependency epic #4478.

## The gap

`pnpm lint` is `turbo lint`, which delegates to each workspace's own `eslint src/`. The repo-root `scripts/` tree was outside **every** lint scope — `inject-governance.ts`, the drift gates (`check-harness-alignment`, `check-mcp-description-drift`, `check-authority-tier-drift`), `generate-tool-reference`, `changeset-version-with-retry`.

**The code that enforces the repo's rules was itself unenforced**, and had accumulated 7 deprecated-API errors nothing reported.

## Sequenced so the gate proves itself

Extended the scope **first** and confirmed it failed with all 7 errors and exit 1 — *then* fixed them. A gate that lands already-green demonstrates nothing about whether it can fail, which is the exact defect class this session kept hitting (`release.yml` with no pre-merge signal, an override that silently stopped matching, a test that couldn't fail).

## The fixes

| Before | After | Sites |
| --- | --- | --- |
| `.passthrough()` | `.loose()` | 6 |
| `z.string().url()` | `z.url()` | 1 |

**Verified behaviour-preserving by running the generator, not by reading migration notes.** It exits 0 and produces a byte-identical registry — so this is a rename, not a semantic change. That matters: `.passthrough()` governs whether unknown upstream fields survive, and silently changing that would corrupt the model registry.

`sync-plugin-version.ts` gets the file-level `no-console` disable that its 38 sibling scripts already carry.

## Considered and rejected

A blanket `no-console: off` for `scripts/**` — cleaner in principle. But `eslint --fix` then flagged all 38 existing inline disables as unused and "fixed" them into trailing-whitespace lines across 39 files. A 39-file diff to change one scope is not reviewable, and the existing convention already works.

## Verification

`pnpm lint:scripts` exit 0 · generator runs clean with no output diff · CI step added and `ci.yml` parses

Final diff: **3 files, +11/−8.**
