### PR TITLE
fix(cli-adapters): guarantee subprocess tempdir cleanup on every exit path (#4488)

### DIFF
--- a/.changeset/tmp-cleanup-guarantee.md
+++ b/.changeset/tmp-cleanup-guarantee.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+Guarantee subprocess tempdir cleanup on every exit path (#4488).
+
+`CommandConfig.cleanup` removes a tempdir the command builder created — for codex that is `nexus-codex-sysprompt-*`, holding the system prompt. It was invoked inside a wrapped `resolve()`, which covers normal completion but not a synchronous throw: `spawn()` throws on some failures (EACCES, and ENOENT on certain platforms) and handler setup can throw too. Those paths skipped cleanup entirely and rejected the promise instead of returning a `Result`, breaking the never-throws contract this adapter is meant to honour.
+
+The executor body is now wrapped, cleanup runs through a once-guard on every path, and a synchronous spawn failure returns a proper `EXECUTION_ERROR` Result.
+
+This is the same leak class `codex-adapter` already documents as having "exhausted inodes on long-running MCP daemons" — the fix there attached cleanup to the command config; this attaches it to the paths that consume it.
+
+Verified by mutation: removing the cleanup call from the new catch fails the regression test. The first version of that test passed the mutation because a nonexistent binary surfaces as an _async_ `error` event and never reaches the catch — it now forces a synchronous throw via the existing `spawn` mock.

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.test.ts
@@ -1429,3 +1429,43 @@ describe('SubprocessCliAdapter - nested retry layers (#2824)', () => {
     expect(mockSpawn).toHaveBeenCalledTimes(1);
   });
 });
+
+// ============================================================================
+// Tempdir cleanup is guaranteed on every exit path (#4488)
+// ============================================================================
+
+describe('subprocess tempdir cleanup', () => {
+  it('runs cleanup when spawn fails, not only on the resolve path', async () => {
+    // spawn() throws synchronously on some failures (EACCES, and ENOENT on
+    // certain platforms). That path never reaches resolve(), so before the
+    // try/catch the tempdir the command builder created leaked once per
+    // invocation — the leak codex-adapter's own comment records as having
+    // exhausted inodes on long-running MCP daemons.
+    const cleanup = vi.fn();
+    const adapter = new TestSubprocessAdapter();
+    adapter.setCommandConfig({ command: 'whatever', args: [], cleanup });
+    // Force the SYNCHRONOUS throw. A nonexistent binary is not enough — on
+    // Linux that surfaces as an async 'error' event, which reaches resolve()
+    // and would exercise the pre-existing path instead of the new catch.
+    mockSpawn.mockImplementationOnce(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    const result = await adapter.execute({ content: 'hi' });
+
+    expect(result.ok).toBe(false);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs cleanup exactly once', async () => {
+    // The once-guard is independent of resolveOnce: a second invocation must
+    // not re-rm a path that may have been reused by then.
+    const cleanup = vi.fn();
+    const adapter = new TestSubprocessAdapter();
+    adapter.setCommandConfig({ command: 'echo', args: ['ok'], cleanup });
+
+    await adapter.execute({ content: 'hi' });
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/subprocess-adapter.ts
@@ -12,7 +12,7 @@ import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 
 import type { Result } from '../core/index.js';
-import { ok, err, getTimeProvider, createLogger } from '../core/index.js';
+import { ok, err, getTimeProvider, createLogger, getErrorMessage } from '../core/index.js';
 
 import type {
   CliTransport,
@@ -385,6 +385,40 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
    * + model and surface tail-latency outliers") requires a way to
    * disambiguate which timing row belongs to which call.
    */
+  /**
+   * Wraps a command's cleanup in a once-guard (#4488).
+   *
+   * `CommandConfig.cleanup` removes a tempdir the command builder created (e.g.
+   * codex's `nexus-codex-sysprompt-*` holding the system prompt). It must run on
+   * EVERY exit path — a path that skips it leaks a directory per invocation, the
+   * leak codex-adapter's own comment records as having exhausted inodes on
+   * long-running MCP daemons — and exactly ONCE, since a second rm could hit a
+   * path the OS has already handed to someone else.
+   */
+  /**
+   * Result for a synchronous spawn failure (#4488).
+   *
+   * `spawn()` throws synchronously on some failures (EACCES, and ENOENT on
+   * certain platforms), and handler setup can throw too. Those paths never
+   * reach `resolve`, so without catching them the tempdir leaks AND the promise
+   * rejects instead of returning a Result — breaking the never-throws contract
+   * this adapter is supposed to honour.
+   */
+  private spawnFailure(command: string, error: unknown): Result<CliResponse, CliError> {
+    return err(
+      this.createError('EXECUTION_ERROR', `Failed to spawn ${command}: ${getErrorMessage(error)}`)
+    );
+  }
+
+  private onceCleanup(cleanup: CommandConfig['cleanup']): () => void {
+    let done = false;
+    return (): void => {
+      if (done) return;
+      done = true;
+      this.runSubprocessCleanup(cleanup);
+    };
+  }
+
   private spawnSubprocess(
     task: CliTask,
     options: ResolvedExecutionOptions,
@@ -402,43 +436,49 @@ export abstract class SubprocessCliAdapter extends BaseCliAdapter {
     }
 
     return new Promise((resolveOuter) => {
-      const resolve = (result: Result<CliResponse, CliError>): void => {
-        this.runSubprocessCleanup(cmdConfig.cleanup);
-        resolveOuter(result);
+      const runCleanupOnce = this.onceCleanup(cmdConfig.cleanup);
+      const resolve = (r: Result<CliResponse, CliError>): void => {
+        runCleanupOnce();
+        resolveOuter(r);
       };
-      // Curated child env: base infrastructure vars + only this CLI's
-      // own vendor credentials, so cross-vendor API keys don't leak
-      // into the spawned CLI (#2865). Also drops CLAUDECODE — a nested
-      // CLI must not believe it's already inside Claude Code.
-      const childEnv = buildChildEnv(this.name);
+      try {
+        // Curated child env: base infrastructure vars + only this CLI's
+        // own vendor credentials, so cross-vendor API keys don't leak
+        // into the spawned CLI (#2865). Also drops CLAUDECODE — a nested
+        // CLI must not believe it's already inside Claude Code.
+        const childEnv = buildChildEnv(this.name);
 
-      const child = spawn(cmdConfig.command, cmdConfig.args, {
-        stdio: ['pipe', 'pipe', 'pipe'],
-        env: childEnv,
-      });
+        const child = spawn(cmdConfig.command, cmdConfig.args, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env: childEnv,
+        });
 
-      const onProgress = options.onProgress;
-      const state = this.setupChildProcessHandlers({
-        child,
-        startTime,
-        timeoutMs: options.timeoutMs,
-        resolve,
-        requestId,
-        ...(onProgress !== undefined ? { onProgress } : {}),
-      });
+        const onProgress = options.onProgress;
+        const state = this.setupChildProcessHandlers({
+          child,
+          startTime,
+          timeoutMs: options.timeoutMs,
+          resolve,
+          requestId,
+          ...(onProgress !== undefined ? { onProgress } : {}),
+        });
 
-      if (signal !== undefined) {
-        this.attachAbortSignal(child, signal, resolve);
+        if (signal !== undefined) {
+          this.attachAbortSignal(child, signal, resolve);
+        }
+
+        // Write stdin content if provided and close stdin
+        if (cmdConfig.stdin !== undefined) {
+          child.stdin.write(cmdConfig.stdin);
+        }
+        child.stdin.end();
+
+        // Reference state to prevent unused variable warning
+        void state;
+      } catch (error: unknown) {
+        runCleanupOnce();
+        resolveOuter(this.spawnFailure(cmdConfig.command, error));
       }
-
-      // Write stdin content if provided and close stdin
-      if (cmdConfig.stdin !== undefined) {
-        child.stdin.write(cmdConfig.stdin);
-      }
-      child.stdin.end();
-
-      // Reference state to prevent unused variable warning
-      void state;
     });
   }
 


### PR DESCRIPTION
First of the cleanup-guarantee items from #4488.

## The gap

`CommandConfig.cleanup` removes a tempdir the command builder created — for codex that is `nexus-codex-sysprompt-*`, holding the system prompt on disk.

It was invoked inside a wrapped `resolve()`:

```ts
const resolve = (result) => {
  this.runSubprocessCleanup(cmdConfig.cleanup);
  resolveOuter(result);
};
```

That covers normal completion, but **not a synchronous throw**. `spawn()` throws on some failures (EACCES, and ENOENT on certain platforms), and handler setup can throw too. Those paths never reach `resolve`, so they:

1. **leaked the tempdir**, and
2. **rejected the promise** instead of returning a `Result` — breaking the never-throws contract this adapter is supposed to honour.

Same leak class `codex-adapter` already documents as having *"exhausted inodes on long-running MCP daemons."* That fix attached cleanup to the command config; this attaches it to the paths that consume it.

## The fix

- Executor body wrapped in `try/catch`
- Cleanup behind a **once-guard** — runs on every path, exactly once (a second `rm` could hit a path the OS has since reused)
- Synchronous spawn failure returns a proper `EXECUTION_ERROR` Result
- `onceCleanup()` and `spawnFailure()` extracted to keep `spawnSubprocess` under the 50-line budget

## Mutation-verified — and the first attempt failed that check

Worth recording, because it is the interesting part: **the first version of the regression test passed the mutation.** Deleting the cleanup call from the new `catch` did not fail it.

The reason: a nonexistent binary does not make `spawn()` throw on Linux — it surfaces as an **async `error` event**, which reaches `resolve()` and exercises the *pre-existing* path. The test verified cleanup ran, but not the code it was written for.

It now forces a synchronous throw through the file's existing `spawn` mock, and the mutation kills it. Re-verified after the helper extraction.

## Verification

`tsc` clean · `eslint` clean · `cli-adapters` suite **2,632 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
