### PR TITLE
fix(scripts): make lint:arch a gate that runs, add tmpdir-cleanup rule

### DIFF
--- a/.changeset/arch-lint-gate.md
+++ b/.changeset/arch-lint-gate.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+Make `lint:arch` a gate that actually runs, and add a tempdir-cleanup rule (#4490).
+
+`scripts/arch-lint.ts` has existed since #570 and exits non-zero on error, but it was wired into no workflow and no hook — nothing ever ran it. An unrun gate rots like unrun code: it had drifted to 9 errors, all false positives.
+
+- **Test Hygiene (5)** — `vi.fn()`/`vi.mock(` matched inside _comments_ and inside `expert-prompts` text, which are prompt strings that teach testing practice. Whole-line comments are now skipped (trailing comments deliberately are not, so `//` cannot mask real code), and `expert-prompts` is exempt.
+- **Security (4)** — "Hardcoded API key" fired on a `${apiKey}` template interpolation, an `{env:NAME}` placeholder, a pattern quoted in a comment, and AWS's published documentation placeholder used as the _input_ to a credential-scanning example. Runtime indirections no longer count as hardcoding; the last is suppressed with a documented `arch-lint-ignore security` directive.
+
+New **`tmpdir-cleanup`** rule: a module calling `nexusMkdtemp`/`nexusMkdtempSync` must also contain an `rm`/`rmSync`/`rimraf` teardown. Stated honestly, this is a module-level smoke check — it proves teardown _exists_, not that every throw path reaches it; ordering stays a review concern. It catches the failure mode that actually occurred (#4489): a new caller landing with no teardown at all.
+
+Suppressions use `// arch-lint-ignore <rule> -- <reason>`, accepted on the line or anywhere in the contiguous comment block above it, so every suppression names its rule and is greppable.
+
+Also fixed the reporter: errors were truncated behind a 10-item-per-category cap that warnings filled, so a failing run could not say what failed. Errors now print in full, ahead of warnings.
+
+`lint:arch` now runs in CI's Lint job. Errors block; the 397 advisory warnings do not. Repo is at 0 errors.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,14 @@ jobs:
       - name: Run lint (repo scripts)
         run: pnpm lint:scripts
 
+      # #4490: `lint:arch` has existed since #570 and exits non-zero on error,
+      # but was wired into no workflow and no hook, so nothing ever ran it. It
+      # had drifted red (5 false-positive Test Hygiene errors, 4 false-positive
+      # hardcoded-credential errors) — an unrun gate rots exactly like unrun
+      # code. Errors block; the 397 advisory warnings do not.
+      - name: Run architectural lint
+        run: pnpm lint:arch
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/packages/nexus-agents/src/agents/skills/bootstrap/security-standards.ts
+++ b/packages/nexus-agents/src/agents/skills/bootstrap/security-standards.ts
@@ -170,6 +170,9 @@ export const SECURITY_SKILLS = [
       {
         description: 'Scan TypeScript file for leaked credentials',
         input: {
+          // arch-lint-ignore security -- deliberate insecure sample: this is the
+          // *input* to a credential-scanning example. AKIAIOSFODNN7EXAMPLE is
+          // AWS's published documentation placeholder, not a live credential.
           code: 'const apiKey = "AKIAIOSFODNN7EXAMPLE"; const db = "postgres://admin:pass@host/db";',
           fileType: 'ts',
         },

--- a/scripts/arch-lint.test.ts
+++ b/scripts/arch-lint.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { checkSecurity, checkTempDirCleanup, checkTestHygiene } from './arch-lint.js';
+import { SRC_ROOT } from './script-paths.js';
+
+const srcFile = (rel: string): string => join(SRC_ROOT, rel);
+
+describe('checkTempDirCleanup', () => {
+  it('flags a file that creates a nexus tempdir but never removes one', () => {
+    const content = [
+      "import { nexusMkdtempSync } from '../../config/nexus-tmp-dir.js';",
+      'export function run(): string {',
+      "  return nexusMkdtempSync('leaky-');",
+      '}',
+    ].join('\n');
+
+    const violations = checkTempDirCleanup(srcFile('mcp/tools/leaky.ts'), content);
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.rule).toBe('tmpdir-cleanup');
+    expect(violations[0]?.severity).toBe('error');
+    // Anchored to the creating call so the message points at the leak.
+    expect(violations[0]?.line).toBe(3);
+  });
+
+  it('accepts the synchronous rmSync teardown idiom', () => {
+    const content = [
+      "import { nexusMkdtempSync } from '../../config/nexus-tmp-dir.js';",
+      "const dir = nexusMkdtempSync('ok-');",
+      'try {',
+      '  work(dir);',
+      '} finally {',
+      '  rmSync(dir, { recursive: true, force: true });',
+      '}',
+    ].join('\n');
+
+    expect(checkTempDirCleanup(srcFile('mcp/tools/sync-ok.ts'), content)).toEqual([]);
+  });
+
+  it('accepts the async rm teardown idiom', () => {
+    const content = [
+      "import { nexusMkdtemp } from '../config/nexus-tmp-dir.js';",
+      "const tempDir = await nexusMkdtemp('nexus-mcp-');",
+      'const cleanup = async (): Promise<void> => {',
+      '  await rm(tempDir, { recursive: true, force: true });',
+      '};',
+    ].join('\n');
+
+    expect(checkTempDirCleanup(srcFile('cli-adapters/child-mcp-config.ts'), content)).toEqual([]);
+  });
+
+  it('does not flag the nexus-tmp-dir module that defines the helpers', () => {
+    const content = [
+      'export function nexusMkdtempSync(prefix: string): string {',
+      '  return mkdtempSync(join(nexusTmpRoot(), prefix));',
+      '}',
+    ].join('\n');
+
+    expect(checkTempDirCleanup(srcFile('config/nexus-tmp-dir.ts'), content)).toEqual([]);
+  });
+
+  it('does not flag test files, which clean up via their own fixtures', () => {
+    const content = "const dir = nexusMkdtempSync('fixture-');";
+
+    expect(checkTempDirCleanup(srcFile('mcp/tools/thing.test.ts'), content)).toEqual([]);
+  });
+
+  it('honours an explicit arch-lint-ignore escape hatch', () => {
+    const content = [
+      '// arch-lint-ignore tmpdir-cleanup -- caller owns teardown, see #4489',
+      "const dir = nexusMkdtempSync('handed-off-');",
+      'return dir;',
+    ].join('\n');
+
+    expect(checkTempDirCleanup(srcFile('mcp/tools/handoff.ts'), content)).toEqual([]);
+  });
+
+  it('ignores files that never touch the nexus tempdir helpers', () => {
+    expect(checkTempDirCleanup(srcFile('core/thing.ts'), 'export const x = 1;')).toEqual([]);
+  });
+});
+
+describe('checkSecurity hardcoded-credential detection', () => {
+  const hits = (rel: string, content: string): string[] =>
+    checkSecurity(srcFile(rel), content)
+      .filter((v) => v.severity === 'error')
+      .map((v) => v.message);
+
+  it('still flags a genuine hardcoded credential literal', () => {
+    expect(hits('core/thing.ts', 'const api_key = "sk-live-abcdef123456";')).toEqual([
+      'Hardcoded API key',
+    ]);
+  });
+
+  it('does not flag a runtime interpolation into an export line', () => {
+    expect(hits('cli/setup-custom-api.ts', 'export NEXUS_CUSTOM_API_KEY="${apiKey}"')).toEqual([]);
+  });
+
+  it('does not flag an {env:...} indirection placeholder', () => {
+    expect(hits('cli/init-opencode.ts', "      apiKey: '{env:WORKSPACE_PROXY_KEY}',")).toEqual([]);
+  });
+
+  it('does not flag a credential pattern described in a comment', () => {
+    expect(hits('mcp/tools/diff-secret-scan.ts', '  // Generic `api_key = "long-value"`')).toEqual(
+      []
+    );
+  });
+
+  it('honours an arch-lint-ignore escape hatch for intentional bad examples', () => {
+    const content = [
+      '// arch-lint-ignore security -- deliberate insecure example for the skill',
+      'const bad = { code: \'const apiKey = "AKIAIOSFODNN7EXAMPLE";\' };',
+    ].join('\n');
+
+    expect(hits('agents/skills/bootstrap/security-standards.ts', content)).toEqual([]);
+  });
+
+  it('finds the escape hatch across a multi-line justification block', () => {
+    const content = [
+      '// arch-lint-ignore security -- deliberate insecure sample: this is the',
+      "// *input* to a credential-scanning example. It is AWS's published",
+      '// documentation placeholder, not a live credential.',
+      'const bad = \'const apiKey = "AKIAIOSFODNN7EXAMPLE";\';',
+    ].join('\n');
+
+    expect(hits('agents/skills/bootstrap/security-standards.ts', content)).toEqual([]);
+  });
+
+  it('does not let a directive leak past intervening code to a later line', () => {
+    const content = [
+      '// arch-lint-ignore security -- applies to the next line only',
+      'const allowed = "api_key = \\"literal-one\\"";',
+      'const api_key = "sk-live-should-still-be-flagged";',
+    ].join('\n');
+
+    expect(hits('core/thing.ts', content)).toEqual(['Hardcoded API key']);
+  });
+});
+
+describe('checkTestHygiene', () => {
+  it('flags a genuine mock in production code', () => {
+    const violations = checkTestHygiene(srcFile('core/thing.ts'), 'const spy = vi.fn();');
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.rule).toBe('test-hygiene');
+  });
+
+  it('does not flag a mock name appearing only in a line comment', () => {
+    const content = [
+      'function loadManifestFile(path: string): Result {',
+      "  // Defensive: tests sometimes `vi.mock('node:fs', ...)` with a subset",
+      '  return read(path);',
+      '}',
+    ].join('\n');
+
+    expect(checkTestHygiene(srcFile('config/manifest-overlay.ts'), content)).toEqual([]);
+  });
+
+  it('does not flag mock guidance inside expert prompt text', () => {
+    const content = [
+      'export const TESTING_EXPERT_PROMPT = `',
+      '### Vitest 4 Gotchas',
+      '- Arrow functions in vi.fn() are NOT constructable',
+      '`;',
+    ].join('\n');
+
+    expect(
+      checkTestHygiene(srcFile('agents/experts/expert-prompts/testing-expert.ts'), content)
+    ).toEqual([]);
+  });
+});

--- a/scripts/arch-lint.ts
+++ b/scripts/arch-lint.ts
@@ -98,6 +98,137 @@ function getAllTsFiles(dir: string): string[] {
 }
 
 /**
+ * True when the line is entirely a comment (`//`, or a `/* ... *​/` body line).
+ *
+ * Deliberately conservative: only whole-line comments qualify, so a trailing
+ * comment cannot mask real code earlier on the same line.
+ */
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trim();
+  return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*');
+}
+
+/** True for tests, testing utilities, and fixture data. */
+function isTestOrFixtureFile(relPath: string): boolean {
+  return (
+    relPath.includes('.test.') ||
+    relPath.startsWith('testing/') ||
+    relPath.includes('/testing/') ||
+    relPath.includes('/fixtures/')
+  );
+}
+
+/**
+ * True for modules where a mock token is legitimate rather than production
+ * mock usage:
+ *  - tests and `testing/` mock infrastructure;
+ *  - `demo-command` files, whose demo data uses `Mock*` names illustratively;
+ *  - `expert-prompts`, which are prompt strings that *teach* testing practice
+ *    and therefore quote `vi.fn()` and friends as guidance.
+ */
+function isMockExemptFile(relPath: string): boolean {
+  return (
+    relPath.includes('.test.') ||
+    relPath.startsWith('testing/') ||
+    relPath.includes('/testing/') ||
+    relPath.includes('demo-command') ||
+    relPath.includes('expert-prompts')
+  );
+}
+
+/**
+ * True when an `arch-lint-ignore <rule>` directive covers line `index`.
+ *
+ * Accepted on the offending line itself, or anywhere in the contiguous comment
+ * block immediately above it — a suppression usually carries a multi-line
+ * justification, and the reason should not have to fit on one line. The rule
+ * name is required so every suppression is greppable by rule.
+ */
+function hasIgnoreDirective(lines: readonly string[], index: number, rule: string): boolean {
+  const directive = `arch-lint-ignore ${rule}`;
+
+  if (lines[index]?.includes(directive) === true) return true;
+
+  for (let i = index - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (line === undefined || !isCommentLine(line)) return false;
+    if (line.includes(directive)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * True when a matched credential assignment reads its value indirectly at
+ * runtime — a `${...}` template interpolation or an `{env:NAME}` placeholder —
+ * rather than embedding a literal.
+ */
+function isIndirectValue(matchText: string): boolean {
+  return matchText.includes('${') || /\{env:[^}]+\}/.test(matchText);
+}
+
+/**
+ * Check that a module creating a nexus tempdir also tears one down.
+ *
+ * `nexusMkdtemp`/`nexusMkdtempSync` allocate a directory under the gitignored
+ * scratch root. Nothing reaps that root on a schedule, so a caller that never
+ * removes what it created leaks a directory per invocation (#4489).
+ *
+ * Scope, stated honestly: this is a module-level smoke check. It proves a
+ * teardown call *exists* alongside the creating call — not that every throw or
+ * early-return path reaches it. Ordering and path coverage remain a review
+ * concern; this rule only catches the case of a new caller landing with no
+ * teardown at all, which is the failure mode that has actually occurred.
+ */
+export function checkTempDirCleanup(filePath: string, content: string): Violation[] {
+  const violations: Violation[] = [];
+  const relPath = relative(SRC_ROOT, filePath);
+
+  // The module that defines the helpers, and tests (which tear down via their
+  // own fixtures), are not callers in the sense this rule polices.
+  if (relPath.includes('nexus-tmp-dir') || relPath.includes('.test.')) {
+    return violations;
+  }
+
+  if (!/\bnexusMkdtemp(?:Sync)?\s*\(/.test(content)) {
+    return violations;
+  }
+
+  // Recognised teardown idioms, matching what the existing callers do:
+  // `rmSync(dir, ...)`, `await rm(dir, ...)`, or an explicit rimraf.
+  const hasTeardown = /\b(?:rmSync|rm|rimraf)\s*\(/.test(content);
+  if (hasTeardown) {
+    return violations;
+  }
+
+  // Escape hatch for the legitimate case where the created path is handed to a
+  // caller that owns teardown. Requires naming the rule, so it is greppable.
+  if (content.includes('arch-lint-ignore tmpdir-cleanup')) {
+    return violations;
+  }
+
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    if (!/\bnexusMkdtemp(?:Sync)?\s*\(/.test(line)) continue;
+
+    violations.push({
+      file: relPath,
+      line: i + 1,
+      rule: 'tmpdir-cleanup',
+      category: 'Resource Hygiene',
+      message:
+        'Creates a nexus tempdir but the module has no rm/rmSync teardown ' +
+        '(add cleanup, or `// arch-lint-ignore tmpdir-cleanup -- <reason>`)',
+      severity: 'error',
+    });
+  }
+
+  return violations;
+}
+
+/**
  * Check for layer boundary violations.
  */
 function checkLayerBoundaries(filePath: string, content: string): Violation[] {
@@ -190,25 +321,30 @@ function shouldSkipSecurityPattern(relPath: string, message: string, isTestFile:
 /**
  * Check for security violations.
  */
-function checkSecurity(filePath: string, content: string): Violation[] {
+export function checkSecurity(filePath: string, content: string): Violation[] {
   const violations: Violation[] = [];
   const relPath = relative(SRC_ROOT, filePath);
   const lines = content.split('\n');
-  const isTestFile =
-    relPath.includes('.test.') ||
-    relPath.startsWith('testing/') ||
-    relPath.includes('/testing/') ||
-    relPath.includes('/fixtures/');
+  const isTestFile = isTestOrFixtureFile(relPath);
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (line === undefined) continue;
 
+    // A credential shape written in prose is documentation about secrets, not
+    // a secret. The secret-scanner modules describe their own patterns.
+    if (isCommentLine(line) || hasIgnoreDirective(lines, i, 'security')) continue;
+
     for (const { pattern, message } of SECURITY_PATTERNS) {
       if (shouldSkipSecurityPattern(relPath, message, isTestFile)) continue;
 
-      if (pattern.test(line)) {
-        pattern.lastIndex = 0;
+      pattern.lastIndex = 0;
+      const match = pattern.exec(line);
+      pattern.lastIndex = 0;
+
+      // `${x}` and `{env:NAME}` are indirections that read the value at
+      // runtime — the precise opposite of hardcoding it.
+      if (match !== null && !isIndirectValue(match[0])) {
         violations.push({
           file: relPath,
           line: i + 1,
@@ -227,28 +363,23 @@ function checkSecurity(filePath: string, content: string): Violation[] {
 /**
  * Check for mocks outside test files.
  */
-function checkTestHygiene(filePath: string, content: string): Violation[] {
+export function checkTestHygiene(filePath: string, content: string): Violation[] {
   const violations: Violation[] = [];
   const relPath = relative(SRC_ROOT, filePath);
   const lines = content.split('\n');
 
-  // Skip test files and testing utilities (testing/ contains mock infrastructure)
-  if (
-    relPath.includes('.test.') ||
-    relPath.startsWith('testing/') ||
-    relPath.includes('/testing/')
-  ) {
-    return violations;
-  }
-
-  // Skip demo-command files (they contain demo data with Mock* names for illustration)
-  if (relPath.includes('demo-command')) {
+  if (isMockExemptFile(relPath)) {
     return violations;
   }
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (line === undefined) continue;
+
+    // A mock name inside a comment is prose about tests, not a mock. Only
+    // whole-line comments are skipped so a trailing `// ...` cannot be used to
+    // hide real code, and a `//` inside a string literal (a URL) is untouched.
+    if (isCommentLine(line)) continue;
 
     for (const { pattern, message } of MOCK_PATTERNS) {
       if (pattern.test(line)) {
@@ -332,6 +463,7 @@ function lint(): LintResult {
       violations.push(...checkDeterminism(filePath, content));
       violations.push(...checkSecurity(filePath, content));
       violations.push(...checkTestHygiene(filePath, content));
+      violations.push(...checkTempDirCleanup(filePath, content));
     } catch {
       // Skip files that can't be read
     }
@@ -378,12 +510,21 @@ function printResults(result: LintResult): void {
 
   for (const [category, categoryViolations] of byCategory) {
     console.log(`── ${category} ──`);
-    for (const v of categoryViolations.slice(0, 10)) {
-      const icon = v.severity === 'error' ? '✗' : '⚠';
-      console.log(`  ${icon} ${v.file}:${String(v.line)} - ${v.message}`);
+
+    // Errors decide the exit code, so they are always printed in full and
+    // ahead of warnings. Truncating them behind a wall of warnings (as this
+    // did) makes a failing run unable to explain itself.
+    const errors = categoryViolations.filter((v) => v.severity === 'error');
+    const warnings = categoryViolations.filter((v) => v.severity !== 'error');
+
+    for (const v of errors) {
+      console.log(`  ✗ ${v.file}:${String(v.line)} - ${v.message}`);
     }
-    if (categoryViolations.length > 10) {
-      console.log(`  ... and ${String(categoryViolations.length - 10)} more`);
+    for (const v of warnings.slice(0, 10)) {
+      console.log(`  ⚠ ${v.file}:${String(v.line)} - ${v.message}`);
+    }
+    if (warnings.length > 10) {
+      console.log(`  ... and ${String(warnings.length - 10)} more warnings`);
     }
     console.log('');
   }
@@ -395,7 +536,10 @@ function printResults(result: LintResult): void {
   }
 }
 
-// Run linter
-const result = lint();
-printResults(result);
-process.exit(result.passed ? 0 : 1);
+// Run linter. Guarded so the rule functions can be imported by tests without
+// the module exiting the process at import time.
+if (process.argv[1]?.endsWith('arch-lint.ts') === true) {
+  const result = lint();
+  printResults(result);
+  process.exit(result.passed ? 0 : 1);
+}


### PR DESCRIPTION
Closes #4490.

`scripts/arch-lint.ts` has existed since #570 and exits non-zero on error, but it was wired into no workflow and no hook — nothing ever ran it. It had drifted to 9 errors, every one a false positive. Same defect class as #4447 / #4451 / #4452 / #4483 / #4487: **a guard whose stated premise did not match reality.**

## What changed

**Test Hygiene false positives (5).** The mock scan matched raw text. Whole-line comments are now skipped — trailing comments deliberately are *not*, so a trailing `//` cannot be used to hide real code — and `expert-prompts` is exempt, since those modules are prompt strings that *teach* testing practice and legitimately quote `vi.fn()`.

**Security false positives (4).** "Hardcoded API key" fired on a `${apiKey}` interpolation, an `{env:NAME}` placeholder, a pattern quoted in a comment, and AWS's published documentation placeholder used as the *input* to a credential-scanning example. Runtime indirections are the opposite of hardcoding and no longer match; the example carries a documented suppression.

**New `tmpdir-cleanup` rule.** A module calling `nexusMkdtemp`/`nexusMkdtempSync` must also contain `rm`/`rmSync`/`rimraf` teardown. This is the preventive half of #4489 — that fix repaired the one leaking caller, but nothing stopped a fifth landing with no teardown.

**Reporter fix.** `printResults` truncated each category at 10, and 400+ advisory warnings crowded the errors out, so a failing run printed `FAILED` without showing a single `✗`. That is how these 9 stayed invisible. Errors now print in full, ahead of warnings.

**CI wiring.** `pnpm lint:arch` runs in the Lint job. Errors block; the 397 advisory warnings do not.

## Limitation, stated up front

`tmpdir-cleanup` is a **module-level smoke check**. It proves teardown *exists* alongside the creating call — not that every throw or early-return path reaches it. Ordering and path coverage stay a review concern. It is scoped to catch the failure mode that actually occurred, not to prove correctness. The comment on the rule says exactly this, so the next reader does not over-trust it.

Suppressions are `// arch-lint-ignore <rule> -- <reason>`, accepted on the line or anywhere in the contiguous comment block above it. Naming the rule is required, so every suppression is greppable by rule.

## Verification

- 17 new tests in `scripts/arch-lint.test.ts` (the script had none; a main-guard was added so the rules can be imported without the module exiting at import time).
- **Mutation-tested, not just green:** neutering the comment skip fails one test; forcing the teardown check to `true` fails another. Both bite.
- **End-to-end through the real entry point:** planting a leaky caller made `npx tsx scripts/arch-lint.ts` report `Resource Hygiene ✗ ... :3` and exit 1; removing it returned the repo to `Errors: 0 / PASSED`. Unit tests alone would not have proved the rule was reachable from the CLI.
- Repo now at **0 errors**, so the gate goes in green rather than with a backlog of suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
