### PR TITLE
fix(routing): assess capacity per arm, not per display slot (#4455)

### DIFF
--- a/.changeset/arm-granular-capacity.md
+++ b/.changeset/arm-granular-capacity.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+Assess routing capacity per arm, not per display slot (#4455).
+
+`CapacityFilterStage` collapsed candidates onto vendor display slots before probing, so `claude` and `api:anthropic` — which share a slot but hold entirely independent quotas, a CLI subscription and an API key — were treated as one route. In a stage whose action is destructive exclusion, that is the wrong quantity rather than an imprecise one.
+
+Two observable failures, both now covered by regression tests:
+
+- **False positive (destructive).** CLI `claude` exhausted, `api:anthropic` healthy → the shared slot was filtered and **both** arms were removed. If it was the last candidate, the task failed closed with `capacity_exhausted` naming an arm that had capacity.
+- **False negative.** `api:anthropic` exhausted, CLI `claude` healthy → the api arm was never probed, so the router could select an exhausted arm — the exact #4351 case the stage exists to prevent.
+
+`runCapacityStage` now calls a new arm-granular `CapacityFilterStage.filterArms`, bypassing the slot-collapsing `RoutingContext` that the scoring stages legitimately use. Enforcement policy and the metric counters stay inside the stage so both paths share one rule; an unmeasured arm is still never excluded, since absence of a reading is not a reading.
+
+Not reachable under the default `plan` billing mode, where no api arm is registered — reachable under `NEXUS_BILLING_MODE=api`.
+
+The stale `KNOWN LIMITATION` block documenting this defect is removed rather than left to contradict the code.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
@@ -1055,6 +1055,53 @@ describe('runCapacityStage', () => {
     expect(result.value).toEqual(['gemini']);
   });
 
+  it("does not let a CLI arm's quota exclude a healthy api arm on the same slot (#4455)", async () => {
+    // `claude` and `api:anthropic` share the vendor display slot but have
+    // genuinely independent quotas — a CLI subscription and an API key.
+    // Collapsing them made one arm's exhaustion remove BOTH.
+    const stage = new CapacityFilterStage(
+      capacityAdapters({
+        claude: capacityStatus({ exhausted: true }),
+        'api:anthropic': capacityStatus(),
+      }),
+      { enforceHardLimits: true }
+    );
+
+    const result = await runCapacityStage(
+      capacityTask,
+      ['claude', 'api:anthropic'] as RoutingArmId[],
+      [],
+      makeDeps({ capacityFilterStage: stage })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(['api:anthropic']);
+  });
+
+  it('drops an exhausted api arm while keeping its healthy CLI sibling (#4455)', async () => {
+    // The mirror failure: the exhausted api arm was never probed at all, so
+    // the router could select it — the exact #4351 case the stage prevents.
+    const stage = new CapacityFilterStage(
+      capacityAdapters({
+        claude: capacityStatus(),
+        'api:anthropic': capacityStatus({ exhausted: true }),
+      }),
+      { enforceHardLimits: true }
+    );
+
+    const result = await runCapacityStage(
+      capacityTask,
+      ['claude', 'api:anthropic'] as RoutingArmId[],
+      [],
+      makeDeps({ capacityFilterStage: stage })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual(['claude']);
+  });
+
   it('fails closed and NAMES every excluded arm when all are exhausted', async () => {
     // Binding condition from the #4373 default-posture vote: a bare error code
     // reproduces the #4351 complaint that nexus never explained the failure.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -158,16 +158,15 @@ export function runBudgetStage(
  * with a named reason instead of routing to an adapter that cannot serve. That
  * is the behaviour #4351 was filed for.
  *
- * KNOWN LIMITATION (#4455): capacity is assessed at display-slot granularity,
- * because `armsToSlots` de-duplicates `api:*` arms onto their vendor slot. When
- * a CLI arm and an api arm share a slot, one arm's reading is applied to both —
- * so an exhausted CLI can exclude a healthy `api:*` arm with its own independent
- * quota, and vice versa. Quota is per serving route, not per vendor, so unlike
- * the scoring stages (where slot granularity is a fair approximation) this is
- * the wrong quantity rather than an imprecise one. Not reachable under the
- * default `plan` billing mode, where no api arm is ever registered
- * (`factory.ts:127`); reachable under `NEXUS_BILLING_MODE=api`. Resolves
- * structurally with the #4391 gateway work.
+ * Assessment is ARM-granular (#4455). Unlike the scoring stages, this one does
+ * NOT collapse candidates onto vendor display slots: quota belongs to the
+ * serving route, so `claude` and `api:anthropic` are probed separately even
+ * though they share a slot. Collapsing them applied one arm's reading to both,
+ * which in an exclusion stage meant an exhausted CLI could remove a healthy
+ * `api:*` arm holding an entirely independent quota — and an exhausted api arm
+ * went unprobed, the exact #4351 case this stage exists to prevent. Slot
+ * granularity is a fair approximation when scoring; here it was the wrong
+ * quantity, not an imprecise one.
  */
 export async function runCapacityStage(
   task: CliTask,
@@ -179,17 +178,18 @@ export async function runCapacityStage(
     return ok(candidates);
   }
 
-  const ctx = createRoutingContext(task.content, armsToSlots(candidates));
   stagesExecuted.push('capacity-filter');
 
-  // The try/catch is load-bearing, not defensive dressing: `route()` returning a
-  // Result does not stop it *throwing*, and an escaped throw here rejects
-  // runPipeline and the entire routing call. That is the same failure class as
-  // the synchronous-throw bug fixed inside assessAll — guarding one level down
-  // and leaving the boundary open would only have moved it.
-  let result;
+  // #4455: filter at ARM granularity, not display-slot. Capacity belongs to the
+  // serving route — a CLI subscription's quota and an API key's quota are
+  // independent — so collapsing `claude` and `api:anthropic` onto one slot
+  // applied one arm's reading to both, in a stage whose action is exclusion.
+  //
+  // The try/catch is load-bearing, not defensive dressing: a throw here would
+  // reject runPipeline and the entire routing call.
+  let outcome;
   try {
-    result = await deps.capacityFilterStage.route(ctx);
+    outcome = await deps.capacityFilterStage.filterArms(candidates);
   } catch (error) {
     deps.logger.debug('Capacity stage threw - keeping all candidates', {
       error: error instanceof Error ? error.message : String(error),
@@ -197,26 +197,14 @@ export async function runCapacityStage(
     return ok(candidates);
   }
 
-  if (!result.ok) {
-    // A stage fault must not silently shrink the pool: keep every candidate.
-    deps.logger.debug('Capacity stage failed - keeping all candidates', {
-      error: result.error.message,
-    });
-    return ok(candidates);
-  }
-
-  // Use the canonical slot->arm mapping (#3422) so distinct `api:*` arms sharing
-  // a vendor slot are preserved rather than collapsed.
-  const eligible = keepArmsForSlots(candidates, getRemainingCandidates(result.value.context));
-
-  if (eligible.length === 0) {
+  if (outcome.eligible.length === 0) {
     // Name every excluded arm and why. Two voters on the #4373 default-posture
     // panel made this binding: failing closed with a bare code reproduces the
     // #4351 complaint that nexus "did not explain it in the terminal result",
     // and an operator staring at an empty pool needs to know which adapters
     // were dropped without re-running with debug logging.
-    const reasons = [...result.value.context.filtered.entries()]
-      .map(([cli, reason]) => `${cli} (${reason})`)
+    const reasons = [...outcome.excluded.entries()]
+      .map(([arm, reason]) => `${arm} (${reason})`)
       .join(', ');
     return err(
       new CompositeRoutingError(
@@ -225,7 +213,7 @@ export async function runCapacityStage(
       )
     );
   }
-  return ok(eligible);
+  return ok(outcome.eligible);
 }
 
 /** Default complexity when no signal is available. */

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
@@ -24,7 +24,6 @@ import type { ILogger } from '../../../core/index.js';
 import { ok, createLogger, getTimeProvider } from '../../../core/index.js';
 import type { IRouterStage, RoutingContext, StageResult, StageError } from '../router-stage.js';
 import { addTrace, filterCandidate, getRemainingCandidates } from '../router-stage.js';
-import type { CliName } from '../router-stage.js';
 import type { CapacityStatus, ICliAdapter, RoutingArmId } from '../../types.js';
 
 /**
@@ -153,7 +152,11 @@ export class CapacityFilterStage implements IRouterStage {
     let exhausted = 0;
     let unmeasured = 0;
 
-    for (const [cli, assessment] of assessments) {
+    // Iterate the slot list, not the assessment map: `route()` operates on the
+    // slot-granular RoutingContext, so `filterCandidate` needs a CliName.
+    // Arm-granular callers use `assessArms` instead (#4455).
+    for (const cli of remaining) {
+      const assessment = assessments.get(cli) ?? 'unmeasured';
       if (assessment === 'unmeasured') {
         unmeasured++;
         continue;
@@ -246,18 +249,69 @@ export class CapacityFilterStage implements IRouterStage {
    * partial adapter reaches this path — which is exactly the case that must not
    * be fatal.
    */
-  private async assessAll(candidates: readonly CliName[]): Promise<Map<CliName, Assessment>> {
+  /**
+   * Assess capacity for a set of routing ARMS (#4455).
+   *
+   * Capacity belongs to the serving route, not the display slot: a CLI
+   * subscription's quota and an API key's quota are genuinely independent, so
+   * `claude` and `api:anthropic` must be probed separately even though they
+   * share a vendor slot. Callers that hold the arm list should use this rather
+   * than routing through the slot-collapsing `RoutingContext`.
+   */
+  async assessArms(arms: readonly RoutingArmId[]): Promise<Map<RoutingArmId, Assessment>> {
+    return this.assessAll(arms);
+  }
+
+  /**
+   * Arm-granular filter (#4455).
+   *
+   * The `route()` path filters at display-slot granularity because that is what
+   * `RoutingContext` carries, but capacity is a property of the serving route:
+   * `claude` and `api:anthropic` share a vendor slot and have entirely separate
+   * quotas. Assessing per slot meant one arm's exhaustion excluded both — a
+   * destructive false positive — while an exhausted api arm went unprobed.
+   *
+   * Enforcement and the metric counters stay in here rather than at the call
+   * site so both paths share one policy.
+   */
+  async filterArms(
+    arms: readonly RoutingArmId[]
+  ): Promise<{ eligible: RoutingArmId[]; excluded: Map<RoutingArmId, string> }> {
+    const assessments = await this.assessAll(arms);
+    const excluded = new Map<RoutingArmId, string>();
+    const eligible: RoutingArmId[] = [];
+    let unmeasured = 0;
+
+    for (const arm of arms) {
+      const assessment = assessments.get(arm) ?? 'unmeasured';
+      if (assessment === 'unmeasured') unmeasured++;
+
+      // Only a measured exhaustion excludes, and only under hard limits. An
+      // unmeasured arm is never dropped: absence of a reading is not a reading.
+      if (assessment === 'exhausted' && this.config.enforceHardLimits) {
+        excluded.set(arm, `${CAPACITY_EXHAUSTED}: no capacity remaining`);
+        this.excludedCount++;
+        continue;
+      }
+      eligible.push(arm);
+    }
+
+    this.unmeasuredCount += unmeasured;
+    return { eligible, excluded };
+  }
+
+  private async assessAll(
+    candidates: readonly RoutingArmId[]
+  ): Promise<Map<RoutingArmId, Assessment>> {
     const settled = await Promise.allSettled(
       candidates.map(async (cli) => {
-        // `CliName` is a member of the `RoutingArmId` union, so no cast: a
-        // slot-keyed lookup finds the CLI arm directly.
         const adapter = this.adapters.get(cli);
         if (adapter === undefined) throw new Error('no adapter registered');
         return this.probeWithTimeout(adapter);
       })
     );
 
-    const result = new Map<CliName, Assessment>();
+    const result = new Map<RoutingArmId, Assessment>();
     for (const [idx, cli] of candidates.entries()) {
       const outcome = settled[idx];
       if (outcome?.status === 'fulfilled') {


### PR DESCRIPTION
Closes #4455. This is a defect in `CapacityFilterStage` as I shipped it in #4373.

## The wrong quantity

The stage collapsed candidates onto vendor display slots before probing. `claude` and `api:anthropic` share a slot but hold **entirely independent quotas** — a CLI subscription and an API key. In a stage whose action is destructive exclusion, treating them as one serving route is the wrong quantity, not an imprecise one. (Slot granularity is a fair approximation in the *scoring* stages; those are untouched.)

Both failure modes now have regression tests, **confirmed red before the fix**:

- **False positive — destructive.** CLI `claude` exhausted, `api:anthropic` healthy → the shared slot was filtered and **both** arms removed. The test failed with `result.ok === false`: every candidate excluded, so the task would fail closed with `capacity_exhausted` naming an arm that had capacity.
- **False negative.** `api:anthropic` exhausted, CLI `claude` healthy → the api arm was never probed. The test failed with both arms surviving, meaning the router could select an exhausted arm — the exact #4351 case this stage exists to prevent.

## Fix

`runCapacityStage` now calls a new `CapacityFilterStage.filterArms`, which assesses each **arm** and bypasses the slot-collapsing `RoutingContext`. The adapter map was already keyed by `RoutingArmId`, so the arm-level probe needed no new plumbing — the slot collapse was purely an artefact of routing through `RoutingContext`.

Enforcement policy and the metric counters live inside `filterArms` rather than at the call site, so the `route()` and arm paths share one rule instead of drifting. An unmeasured arm is still never excluded: absence of a reading is not a reading.

## Scope

Not reachable under the default `plan` billing mode, where no api arm is registered (`factory.ts:127`) — reachable under `NEXUS_BILLING_MODE=api`. Fixing it now rather than waiting for #4391 because the failure is silent and destructive when it does occur.

I also **removed the `KNOWN LIMITATION` block** that documented this defect. Leaving it would have left a comment asserting behaviour the code no longer has.

## Verification

- 2 new regression tests, red before / green after.
- **2634 tests** green across the whole `cli-adapters/` tree.
- `typecheck`, `lint`, `lint:arch` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
