### PR TITLE
fix(scripts): label via REST, plug a tempdir leak, widen arch-lint to scripts (#4498)

### DIFF
--- a/.changeset/label-via-rest.md
+++ b/.changeset/label-via-rest.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+Fix `review-pr.ts` crashing on label add, plug a tempdir leak, and widen arch-lint to `scripts/` (#4498).
+
+**`gh pr edit` is broken repo-wide.** It fetches `repository.pullRequest.projectCards`, which now hard-errors on the Projects-classic deprecation. It exits 1 and **the edit is not applied** — verified by adding an already-existing label and watching the label list stay empty. Title and body edits fail the same way, silently leaving the old content live.
+
+`review-pr.ts` caught that failure and inferred _"the label must not exist"_, so it ran `gh label create cli-reviewed` — but that label already exists, so the create threw **inside the catch**, with no handler, and crashed the whole review after it had already posted. The premise encoded in the handler no longer matched reality.
+
+Labelling now goes through REST (`gh api repos/{owner}/{repo}/issues/N/labels`), which is unaffected and creates the label implicitly, so the create-then-retry dance is gone. It is wrapped so a labelling failure can never discard a review that already posted.
+
+**Tempdir leak.** `postReviewToGitHub` creates a directory with `nexusMkdtempSync` but only `unlinkSync`'d the file inside it, leaking one directory per review — the same class as #4489.
+
+**Why the guard missed it:** `arch-lint`'s `tmpdir-cleanup` rule was scanning `SRC_ROOT` only, so `scripts/` was invisible to the very check added to catch this. The walk now covers `scripts/` too, with a scope-appropriate rule subset — resource hygiene and hardcoded credentials apply everywhere, while layer boundaries, determinism and test hygiene remain package-source concepts (arch-lint _defines_ the mock patterns, so running test-hygiene over itself made it match itself). Widening the scan found the `review-pr.ts` leak immediately.

--- a/scripts/arch-lint.test.ts
+++ b/scripts/arch-lint.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { join } from 'node:path';
 
-import { checkSecurity, checkTempDirCleanup, checkTestHygiene } from './arch-lint.js';
+import {
+  checkSecurity,
+  checkTempDirCleanup,
+  checkTestHygiene,
+  collectLintTargets,
+} from './arch-lint.js';
 import { SRC_ROOT } from './script-paths.js';
 
 const srcFile = (rel: string): string => join(SRC_ROOT, rel);
@@ -78,6 +83,25 @@ describe('checkTempDirCleanup', () => {
 
   it('ignores files that never touch the nexus tempdir helpers', () => {
     expect(checkTempDirCleanup(srcFile('core/thing.ts'), 'export const x = 1;')).toEqual([]);
+  });
+});
+
+describe('collectLintTargets', () => {
+  it('scans scripts/ as well as packages src (#4498)', () => {
+    // The rule shipped scanning SRC_ROOT only, so a leaking tempdir in
+    // scripts/ — review-pr.ts, which unlinked the file but never removed the
+    // directory — went unreported by the very guard added to catch it. The
+    // gap was in the file walk, not in the rule, so that is what is asserted.
+    const targets = collectLintTargets();
+
+    expect(targets.some((f) => f.includes(join('scripts', 'review-pr.ts')))).toBe(true);
+    expect(targets.some((f) => f.startsWith(SRC_ROOT))).toBe(true);
+  });
+
+  it('does not scan its own test files for production-code rules', () => {
+    const targets = collectLintTargets();
+
+    expect(targets.every((f) => !f.endsWith('arch-lint.test.ts'))).toBe(true);
   });
 });
 

--- a/scripts/arch-lint.ts
+++ b/scripts/arch-lint.ts
@@ -17,7 +17,7 @@
 
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
-import { SRC_ROOT, DOCS_ROOT } from './script-paths.js';
+import { SRC_ROOT, DOCS_ROOT, ROOT } from './script-paths.js';
 
 interface Violation {
   readonly file: string;
@@ -449,13 +449,44 @@ function checkGovernance(): Violation[] {
 }
 
 /**
+ * Files the linter walks.
+ *
+ * #4498: `scripts/` is included, not just the package source. The
+ * `tmpdir-cleanup` rule shipped scanning `SRC_ROOT` only, so a leaking tempdir
+ * in `scripts/review-pr.ts` went unreported by the guard added to catch
+ * exactly that — a blind spot in the checker, not a missing rule. Test files
+ * are excluded: the production-code rules do not apply to them, and each rule
+ * already re-checks `.test.` for its own reasons.
+ */
+export function collectLintTargets(): string[] {
+  return [...collectSrcTargets(), ...collectScriptTargets()];
+}
+
+/** Package source — subject to every rule. */
+function collectSrcTargets(): string[] {
+  return getAllTsFiles(SRC_ROOT).filter((f) => !f.includes('.test.'));
+}
+
+/**
+ * Repo-root `scripts/` — subject only to the rules that mean something here.
+ *
+ * Layer boundaries and determinism are package-source concepts, and this
+ * module *defines* the mock patterns, so running test-hygiene over it makes it
+ * match itself. Resource hygiene and hardcoded credentials apply everywhere.
+ */
+function collectScriptTargets(): string[] {
+  return getAllTsFiles(join(ROOT, 'scripts')).filter((f) => !f.includes('.test.'));
+}
+
+/**
  * Main linting function.
  */
 function lint(): LintResult {
-  const files = getAllTsFiles(SRC_ROOT);
+  const srcFiles = collectSrcTargets();
+  const scriptFiles = collectScriptTargets();
   const violations: Violation[] = [];
 
-  for (const filePath of files) {
+  for (const filePath of srcFiles) {
     try {
       const content = readFileSync(filePath, 'utf-8');
 
@@ -463,6 +494,18 @@ function lint(): LintResult {
       violations.push(...checkDeterminism(filePath, content));
       violations.push(...checkSecurity(filePath, content));
       violations.push(...checkTestHygiene(filePath, content));
+      violations.push(...checkTempDirCleanup(filePath, content));
+    } catch {
+      // Skip files that can't be read
+    }
+  }
+
+  // #4498: scripts/ gets the scope-appropriate subset (see collectScriptTargets).
+  for (const filePath of scriptFiles) {
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+
+      violations.push(...checkSecurity(filePath, content));
       violations.push(...checkTempDirCleanup(filePath, content));
     } catch {
       // Skip files that can't be read
@@ -477,7 +520,7 @@ function lint(): LintResult {
 
   return {
     violations,
-    filesScanned: files.length,
+    filesScanned: srcFiles.length + scriptFiles.length,
     passed: errors.length === 0,
   };
 }

--- a/scripts/review-pr.ts
+++ b/scripts/review-pr.ts
@@ -22,7 +22,7 @@ import {
   type ChildProcessWithoutNullStreams,
 } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { writeFileSync, unlinkSync } from 'node:fs';
+import { writeFileSync, rmSync } from 'node:fs';
 import { nexusMkdtempSync } from '../packages/nexus-agents/src/config/nexus-tmp-dir.js';
 import { join } from 'node:path';
 
@@ -280,26 +280,54 @@ function postReviewToGitHub(prNumber: number, comment: string, addLabel: boolean
       stdio: 'inherit',
     });
   } finally {
+    // #4498: remove the DIRECTORY, not just the file. `nexusMkdtempSync`
+    // creates a fresh dir per call; unlinking only its contents leaked one
+    // directory per review — the #4489 leak class, in a file the
+    // tmpdir-cleanup rule was not yet scanning.
     try {
-      unlinkSync(file);
+      rmSync(dir, { recursive: true, force: true });
     } catch {
       // best-effort cleanup
     }
   }
 
   if (addLabel) {
-    try {
-      execSync(`gh pr edit ${String(prNumber)} --add-label "cli-reviewed"`, { stdio: 'inherit' });
-    } catch {
-      console.warn('Creating cli-reviewed label...');
-      execSync(
-        'gh label create cli-reviewed --description "Reviewed using CLI tools" --color 0E8A16',
-        {
-          stdio: 'inherit',
-        }
-      );
-      execSync(`gh pr edit ${String(prNumber)} --add-label "cli-reviewed"`, { stdio: 'inherit' });
-    }
+    applyReviewedLabel(prNumber);
+  }
+}
+
+/**
+ * Add the `cli-reviewed` label via REST.
+ *
+ * #4498: `gh pr edit` fails repo-wide against this repo — it fetches
+ * `repository.pullRequest.projectCards`, which now hard-errors on the
+ * Projects-classic deprecation — and the edit is NOT applied. The previous
+ * code caught that failure and inferred "the label must not exist", so it ran
+ * `gh label create` on an already-existing label; that threw *inside* the
+ * catch, with no handler, and crashed the whole review.
+ *
+ * The REST endpoint is unaffected and creates the label implicitly if missing,
+ * so no create-then-retry dance is needed. Labelling is a convenience: a
+ * failure here must never discard a review that already posted.
+ */
+function applyReviewedLabel(prNumber: number): void {
+  try {
+    execFileSync(
+      'gh',
+      [
+        'api',
+        `repos/{owner}/{repo}/issues/${String(prNumber)}/labels`,
+        '-X',
+        'POST',
+        '-f',
+        'labels[]=cli-reviewed',
+      ],
+      { stdio: 'inherit' }
+    );
+  } catch (error) {
+    console.warn(
+      `Could not add the cli-reviewed label: ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 }
 


### PR DESCRIPTION
Closes #4498.

## `gh pr edit` is broken repo-wide

It fetches `repository.pullRequest.projectCards`, which now hard-errors on the Projects-classic deprecation. Exit 1, and **the edit is not applied**. Verified rather than inferred — adding an *already-existing* label left the PR's label list unchanged:

```console
$ gh pr edit 4494 --add-label bug
GraphQL: Projects (classic) is being deprecated ... (repository.pullRequest.projectCards)
$ gh pr view 4494 --json labels --jq '[.labels[].name]|join(",")'
                    # still empty
```

Title and body fail the same way. This bit me live: #4494 kept a body saying "deliberately incomplete — threshold evaluation does not yet read the tally" after that work had landed, because the edit reported an error and I moved on.

## The crash

`review-pr.ts` caught the edit failure and inferred *"the label must not exist"*, so it ran `gh label create cli-reviewed`. But that label **already exists** in this repo, so the create threw — **inside the catch, with no handler** — and killed the review *after it had already posted the comment*. The intended worst case was a graceful retry.

Same defect class as #4447 / #4451 / #4483 / #4490: a handler whose stated premise no longer matches reality.

Labelling now uses REST, which is unaffected and creates the label implicitly, so the create-then-retry dance is gone. Wrapped so a labelling failure can never discard a posted review — it is a convenience, not the deliverable.

## A tempdir leak, and why the guard missed it

`postReviewToGitHub` creates a directory via `nexusMkdtempSync` but only `unlinkSync`'d the file inside it. One leaked directory per review — the #4489 class.

The `tmpdir-cleanup` rule I added in #4490 should have caught this. It didn't, because `arch-lint` walks `SRC_ROOT` only: `scripts/` was invisible to the very guard added to catch this failure. **A checker with a blind spot over half the repo is the thing it exists to prevent.**

The walk now covers `scripts/` with a **scope-appropriate rule subset**:

| Scope | Rules |
| --- | --- |
| `packages/**/src` | all five |
| `scripts/` | resource hygiene + hardcoded credentials |

Layer boundaries and determinism are package-source concepts. Test hygiene is excluded for a concrete reason: `arch-lint` *defines* the mock patterns, so running that rule over itself made it match its own pattern table four times.

Widening the scan surfaced the `review-pr.ts` leak on the first run — which is the argument for the change.

## On the test

My first scope test **passed vacuously**. It called `checkTempDirCleanup` directly with a `scripts/` path, but that function accepts any path — the gap was in the *file walk*, not the rule. It asserted nothing about the bug. Rewrote it against `collectLintTargets`, where it fails for the right reason.

## Verification

- `arch-lint`: **0 errors**, 1539 files, and it now reports the leak if reintroduced — that rule is the regression guard.
- 524 script tests green; full `pnpm typecheck` clean; `lint`/`lint:scripts` clean.
- **Live-tested the exact REST invocation** the script now runs — applied `cli-reviewed` to a real PR, confirmed it appeared, removed it. A mocked test would not have proven the endpoint is unaffected by the deprecation, which is the whole premise of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
