### PR TITLE
feat(ci): detect a stalled release and file a tracking issue (#4500)

### DIFF
--- a/.changeset/release-stall-detector.md
+++ b/.changeset/release-stall-detector.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+Add a stuck-release detector (#4500).
+
+`changesets/action`'s PR-creation call has 502'd four times out of five in a single day, with GitHub Status green throughout. When it does, the release run ends **red** — but a failed `release.yml` is not a required check, blocks nothing, and alerts no one, so merging continues and `main` accumulates changesets with no version PR. It went unnoticed for several merges.
+
+A scheduled check (every 6h) now evaluates the durable condition — **unconsumed `.changeset/*.md` on `main` AND no open "Version Packages" PR** — and files or updates a single deduplicated tracking issue.
+
+Three deliberate exclusions, all decided by a 3-voter panel:
+
+- **Not a required PR check.** Merging to `main` is the only path that has ever recovered this state, so a merge-blocking detector would deadlock its own remedy.
+- **No automatic re-dispatch.** Re-running the failed run has never recovered it, so an automatic retry against a flaking API would be a retry storm with no demonstrated payoff.
+- **Keyed on repo state, not run outcome.** A release run can finish green and still produce no PR, which an outcome-keyed check would miss entirely.
+
+The issue, not the run's colour, is the output that matters — a red scheduled run would reproduce the exact "reported but nobody consumes it" failure the detector exists to fix.
+
+The predicate is a pure function in `scripts/check-release-stuck.ts` with unit tests over all four state quadrants; the workflow is a thin shell. Verified against the live stalled state: it correctly reports stalled with a real pending changeset and clears when a version PR is open.

--- a/.github/workflows/release-stall-check.yml
+++ b/.github/workflows/release-stall-check.yml
@@ -1,0 +1,88 @@
+name: Release Stall Check
+
+# Detects a stalled release: unconsumed changesets on `main` with no open
+# "Version Packages" PR (#4500).
+#
+# Deliberately NOT a required PR check. Merging to `main` is the only path that
+# has ever recovered this state, so a merge-blocking detector would deadlock its
+# own remedy. Decided by a 3-voter panel on #4500, unanimous on that exclusion.
+#
+# Deliberately does NOT re-dispatch `release.yml`. Re-running the failed run has
+# never recovered it, so an automatic retry against a flaking API would be a
+# retry storm with no demonstrated payoff. This reports; a human decides.
+#
+# The issue — not this run's colour — is the output that matters. A red
+# scheduled run would reproduce the exact "reported but nobody consumes it"
+# failure the detector exists to fix.
+
+on:
+  schedule:
+    # Every 6h. The failure is accumulative and reversible, so detection lag
+    # costs little; historical stalls persisted for days.
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: release-stall-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Release Stall Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Needed only to file/update the tracking issue.
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - uses: ./.github/actions/setup-node
+
+      - name: Look for an open Version Packages PR
+        id: version-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          count=$(gh pr list --state open --json title \
+            --jq '[.[] | select(.title | startswith("chore(release): version packages"))] | length')
+          echo "has_open=$([ "$count" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Assess release stall
+        id: assess
+        continue-on-error: true
+        env:
+          HAS_OPEN_VERSION_PR: ${{ steps.version-pr.outputs.has_open }}
+        run: npx tsx scripts/check-release-stuck.ts
+
+      - name: File or update the tracking issue
+        if: steps.assess.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: 'ops(release): release pipeline is stalled — changesets on main with no version PR'
+        run: |
+          set -euo pipefail
+          # The body was rendered by the assess step into release-stall-body.md.
+          # Dedupe on the exact title so repeated detection updates one issue
+          # rather than filing a new one every 6 hours.
+          existing=$(gh issue list --state open --search "in:title $TITLE" --json number,title \
+            --jq "[.[] | select(.title == \"$TITLE\")] | .[0].number // empty")
+
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #$existing"
+            gh issue edit "$existing" --body-file release-stall-body.md
+          else
+            echo "Filing a new stall issue"
+            gh issue create --title "$TITLE" --body-file release-stall-body.md
+          fi
+
+      - name: Fail the run when stalled
+        if: steps.assess.outcome == 'failure'
+        run: |
+          echo "::error::Release pipeline is stalled — see the tracking issue."
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ tsundoku/
 # Pinned by name so legitimate docs/research/ entries stay tracked.
 docs/research/timeout-mismatch-v1.md
 docs/research/nexus-agents-multi-harness-alignment-audit.md
+release-stall-body.md

--- a/scripts/check-release-stuck.test.ts
+++ b/scripts/check-release-stuck.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  STALL_ISSUE_MARKER,
+  assessReleaseStall,
+  pendingChangesets,
+  stallIssueBody,
+} from './check-release-stuck.js';
+
+describe('pendingChangesets', () => {
+  it('counts only real changeset files', () => {
+    expect(pendingChangesets(['README.md', 'config.json', 'brave-pugs-sing.md'])).toEqual([
+      'brave-pugs-sing.md',
+    ]);
+  });
+
+  it('returns empty when only the scaffolding files are present', () => {
+    expect(pendingChangesets(['README.md', 'config.json'])).toEqual([]);
+  });
+
+  it('ignores non-markdown entries', () => {
+    expect(pendingChangesets(['notes.txt', 'real-one.md'])).toEqual(['real-one.md']);
+  });
+});
+
+describe('assessReleaseStall', () => {
+  it('flags changesets on main with no open version PR', () => {
+    const verdict = assessReleaseStall({
+      pendingChangesets: ['a.md', 'b.md'],
+      hasOpenVersionPr: false,
+    });
+
+    expect(verdict.stalled).toBe(true);
+    expect(verdict.reason).toContain('2');
+  });
+
+  it('is clear when a version PR is open, however many changesets are queued', () => {
+    // The PR is what consumes them; its existence means the release is moving.
+    const verdict = assessReleaseStall({
+      pendingChangesets: ['a.md'],
+      hasOpenVersionPr: true,
+    });
+
+    expect(verdict.stalled).toBe(false);
+  });
+
+  it('is clear when there is nothing to release', () => {
+    expect(assessReleaseStall({ pendingChangesets: [], hasOpenVersionPr: false }).stalled).toBe(
+      false
+    );
+  });
+
+  it('is clear when there is nothing to release and a PR is somehow open', () => {
+    expect(assessReleaseStall({ pendingChangesets: [], hasOpenVersionPr: true }).stalled).toBe(
+      false
+    );
+  });
+
+  it('does not depend on the release run outcome', () => {
+    // Keyed on durable state, deliberately: a run can go GREEN and still
+    // produce no PR, which an outcome-keyed check would miss entirely (#4500).
+    const verdict = assessReleaseStall({
+      pendingChangesets: ['a.md'],
+      hasOpenVersionPr: false,
+    });
+
+    expect(verdict.stalled).toBe(true);
+    expect(Object.keys(verdict)).not.toContain('runConclusion');
+  });
+});
+
+describe('stallIssueBody', () => {
+  it('names the pending changesets so the issue is actionable', () => {
+    const body = stallIssueBody(['brave-pugs-sing.md', 'lucky-cats-nap.md']);
+
+    expect(body).toContain('brave-pugs-sing.md');
+    expect(body).toContain('lucky-cats-nap.md');
+  });
+
+  it('carries a stable marker so the detector updates one issue instead of spamming', () => {
+    expect(stallIssueBody(['a.md'])).toContain(STALL_ISSUE_MARKER);
+  });
+
+  it('does not tell the operator to re-run the failed run', () => {
+    // Re-running the same run has never recovered this; the panel was explicit
+    // that the detector must not push a remedy the evidence contradicts.
+    expect(stallIssueBody(['a.md']).toLowerCase()).not.toContain('re-run the failed');
+  });
+});

--- a/scripts/check-release-stuck.ts
+++ b/scripts/check-release-stuck.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env npx tsx
+/**
+ * Stuck-release detector (#4500).
+ *
+ * `changesets/action` opens the "Version Packages" PR after bumping versions.
+ * Its PR-creation call has 502'd repeatedly, and when it does the run ends RED
+ * but blocks nothing and alerts no one — so `main` accumulates changesets with
+ * no version PR while merging continues. It went unnoticed for several merges.
+ *
+ * ## Why the predicate is durable state, not run outcome
+ *
+ * Keying on the release run's conclusion is insufficient in both directions: a
+ * run can go green and still produce no PR, and a red run may be red for an
+ * unrelated reason. The condition that actually matters is
+ * **changesets present on `main` AND no open version PR**, which is a property
+ * of the repo, not of any one run.
+ *
+ * ## Why it does not block PRs, and does not retry
+ *
+ * Decided by a 3-voter panel on #4500 (2-1 for this shape, unanimous on both
+ * exclusions):
+ *
+ *  - **Not a required check.** Merging to `main` is the only path that has ever
+ *    recovered this state; a merge-blocking detector would deadlock its own
+ *    remedy. That is a design error, not a tradeoff.
+ *  - **No auto re-dispatch.** Re-running the failed run has never recovered it,
+ *    so an automatic retry against a flaking API is a retry storm with no
+ *    demonstrated payoff. The detector reports; a human decides.
+ *  - **Files an issue, not just a red run.** A red scheduled run would
+ *    reproduce the exact "reported but unconsumed" failure this exists to fix.
+ *    The issue is the consumable artifact; it is deduplicated by a marker so
+ *    repeated detection updates one issue rather than spamming.
+ *
+ * @module scripts/check-release-stuck
+ * (Source: Issue #4500)
+ */
+
+import { readdirSync, existsSync, appendFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { ROOT } from './script-paths.js';
+
+/** Files that live in `.changeset/` but are not changesets. */
+const SCAFFOLDING = new Set(['README.md', 'config.json']);
+
+/** Where `main` writes the rendered issue body for the workflow to pick up. */
+export const BODY_FILENAME = 'release-stall-body.md';
+
+/** Hidden marker used to find and update the existing issue instead of filing a new one. */
+export const STALL_ISSUE_MARKER = '<!-- nexus-release-stall-detector -->';
+
+export interface ReleaseStallInput {
+  readonly pendingChangesets: readonly string[];
+  readonly hasOpenVersionPr: boolean;
+}
+
+export interface ReleaseStallVerdict {
+  readonly stalled: boolean;
+  readonly reason: string;
+}
+
+/** Filter a `.changeset/` listing down to actual changeset files. */
+export function pendingChangesets(entries: readonly string[]): string[] {
+  return entries.filter((e) => e.endsWith('.md') && !SCAFFOLDING.has(e));
+}
+
+/**
+ * Decide whether the release is stalled.
+ *
+ * An open version PR clears the verdict regardless of how many changesets are
+ * queued — the PR is what consumes them, so its existence means the release is
+ * moving.
+ */
+export function assessReleaseStall(input: ReleaseStallInput): ReleaseStallVerdict {
+  const count = input.pendingChangesets.length;
+
+  if (count === 0) {
+    return { stalled: false, reason: 'No unconsumed changesets on main.' };
+  }
+  if (input.hasOpenVersionPr) {
+    return {
+      stalled: false,
+      reason: `${String(count)} changeset(s) queued and a version PR is open — release is moving.`,
+    };
+  }
+  return {
+    stalled: true,
+    reason: `${String(count)} unconsumed changeset(s) on main with no open "chore(release): version packages" PR.`,
+  };
+}
+
+/** The issue body, carrying the dedupe marker and the actionable detail. */
+export function stallIssueBody(pending: readonly string[]): string {
+  const list = pending.map((f) => `- \`.changeset/${f}\``).join('\n');
+  return `${STALL_ISSUE_MARKER}
+
+The release is stalled: \`main\` carries unconsumed changesets but no
+\`chore(release): version packages\` PR is open.
+
+Pending changesets:
+
+${list}
+
+**Why this is reported here rather than as a red workflow run:** a failed
+\`release.yml\` blocks nothing and is not a required check, so it is easy to
+merge past for days. This issue is the durable surface (#4500).
+
+**Diagnosis notes.** The condition is keyed on repo state, not on a run's
+outcome — a release run can finish green and still produce no PR. When the
+observed \`changesets/action\` 502 causes it, \`changeset-release/main\` is left
+byte-identical to \`main\` with **no version bump**, so the PR cannot simply be
+opened by hand; the version script has to run again.
+
+**Recovery.** A fresh push to \`main\` re-triggers \`release.yml\`, which is the
+path that has actually cleared this before. Re-running the failed run has not.
+See [docs/ops/release-changeset-race.md](../blob/main/docs/ops/release-changeset-race.md).
+
+This issue is updated in place by the detector; it will not file duplicates.
+It is safe to close once a version PR is open — the detector reopens the
+report if the condition recurs.`;
+}
+
+/** Read `.changeset/` from the repo, returning [] when the directory is absent. */
+function readChangesetDir(): string[] {
+  const dir = join(ROOT, '.changeset');
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir);
+}
+
+/* eslint-disable no-console */
+function main(): void {
+  const pending = pendingChangesets(readChangesetDir());
+  // The workflow supplies the PR presence; keeping the API call out of here
+  // leaves the predicate pure and unit-testable.
+  const hasOpenVersionPr = process.env['HAS_OPEN_VERSION_PR'] === 'true';
+  const verdict = assessReleaseStall({ pendingChangesets: pending, hasOpenVersionPr });
+
+  console.log(verdict.reason);
+
+  if (!verdict.stalled) {
+    console.log('::notice::Release pipeline is not stalled.');
+    return;
+  }
+
+  console.log(`::error::${verdict.reason}`);
+
+  // Write the issue body here rather than letting the workflow re-import this
+  // module inline: `npx tsx -e` does not resolve relative imports, so that
+  // shape fails at runtime. Keeping it in the script also honours the
+  // "YAML stays a thin shell" condition from the #4500 panel.
+  writeFileSync(join(ROOT, BODY_FILENAME), stallIssueBody(pending), 'utf8');
+
+  const out = process.env['GITHUB_OUTPUT'];
+  if (out !== undefined && out !== '') {
+    appendFileSync(out, `stalled=true\n`);
+  }
+  process.exitCode = 1;
+}
+
+if (process.argv[1]?.endsWith('check-release-stuck.ts') === true) {
+  main();
+}


### PR DESCRIPTION
Closes #4500.

`changesets/action`'s PR-creation call has 502'd **four times out of five in one day**, with GitHub Status green throughout. The run ends **red** — but a failed `release.yml` is not a required check, blocks nothing, and alerts no one. Merging continues, `main` accumulates changesets with no version PR, and it went unnoticed for several merges.

A scheduled check (every 6h) evaluates the durable condition — **unconsumed `.changeset/*.md` on `main` AND no open "Version Packages" PR** — and files or updates **one deduplicated** tracking issue.

## Design — 3-voter panel, 2-1 for this shape

The vote itself recorded as "approved, 3/3, 100%" while splitting 2-1 on the actual option. That is #4452 again, on a vote about release safety, because `options` isn't merged yet (#4494). Worth noting as a third live specimen.

Unanimous on both exclusions:

- **Not a required PR check.** Merging to `main` is the only path that has ever recovered this state — re-running the failed run never has. A merge-blocking detector would deadlock its own remedy. Every voter called this out independently; the security voter framed it as a self-inflicted DoS on the recovery path.
- **No automatic re-dispatch.** Evidence shows re-runs don't recover it, so auto-retrying a flaking API is a retry storm with no demonstrated payoff. It reports; a human decides.

Both A-voters made issue-filing **mandatory rather than optional**: a red scheduled run would reproduce the exact "reported but nobody consumes it" failure the detector exists to fix. The issue is the consumable artifact. That folds the escalation half of the dissenting option into A and drops its PR-annotation half as a second mechanism with no marginal value.

**Keyed on repo state, not run outcome** — a release run can finish green and still produce no PR, which an outcome-keyed check misses entirely. There's a test asserting the verdict carries no run-conclusion input.

## Two things I verified instead of assuming

**The inline `npx tsx -e` form I first wrote does not work.** Relative imports don't resolve under `tsx -e`, so the body-rendering step would have failed at runtime, in a workflow that only runs on a 6-hour cron — a failure that could have sat undiscovered for a long time. Body rendering now lives in the script, which also satisfies the panel's "YAML stays a thin shell" condition.

**`gh issue edit` still works.** Having just found that `gh pr edit` is broken repo-wide by the Projects-classic deprecation (#4498), I tested the issue path rather than assuming it shared the fault. It doesn't — verified by round-tripping a real issue body and restoring it.

## Verification

- 11 unit tests over the pure predicate, covering all four state quadrants plus the changeset/scaffolding filter and the dedupe marker.
- **Validated against the live stalled state** — the best end-to-end test this will ever get, since the condition is currently reproducible: reports stalled with the real pending changeset (exit 1), clears when a version PR is open (exit 0).
- Least privilege: `permissions: read-all` at workflow level, `issues: write` only on the job that files.
- `lint`, `typecheck`, `lint:arch` clean; workflow YAML parse-validated.

Merging this also pushes to `main`, which retriggers `release.yml` — the path that has actually cleared the current stall before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
