### PR TITLE
fix(ci): build the website through turbo so the API reference is generated

### DIFF
--- a/.changeset/deploy-generates-api.md
+++ b/.changeset/deploy-generates-api.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+Fix the website deploy building without the API reference (#4507).
+
+#4449 moved TypeDoc generation to build time, with the ordering in `turbo.json`: `nexus-agents-website#build` → `nexus-agents#docs:api:md` → `nexus-memory#build`. But `deploy-website.yml` ran `pnpm build` with `working-directory: website`, which invokes Astro directly and **bypasses turbo entirely**, so the graph never applied.
+
+The result deployed successfully with the entire `/api/` section missing — `/api/` and `/api/cli-adapters/` returned 404 on the live site. The only trace was a warning in the build log: `[glob-loader] The base directory ".../docs/api/" does not exist`. A missing Astro content collection is not a build error, so the broken command **exits 0**.
+
+The deploy now builds through turbo from the repo root (`npx turbo run build --filter=nexus-agents-website`) so the dependency graph resolves, and a new step fails the deploy when the build output contains zero `/api/` pages.
+
+Verified both directions: the corrected command produces 20 `/api/` pages, and the previous `cd website && pnpm build` produces 0 while still exiting 0 — so the guard catches precisely the regression that shipped.

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,9 +28,27 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
+      # Must go through turbo from the repo root, NOT `pnpm build` inside
+      # website/. The API reference is generated at build time (#4449), and the
+      # ordering lives in turbo.json: nexus-agents-website#build dependsOn
+      # nexus-agents#docs:api:md dependsOn nexus-memory#build. Running astro
+      # directly bypasses that graph, so docs/api never exists and the Astro
+      # glob loader silently yields an empty `api` collection — the site
+      # deploys successfully with the entire /api section missing (#4507).
       - name: Build website
-        run: pnpm build
-        working-directory: website
+        run: npx turbo run build --filter=nexus-agents-website
+
+      # The failure mode this guards is silent: a missing collection is not a
+      # build error, so without this the site publishes minus its API
+      # reference and nothing reports it.
+      - name: Verify the API reference was generated
+        run: |
+          pages=$(find website/dist/api -name index.html 2>/dev/null | wc -l)
+          echo "Built $pages /api/ pages."
+          if [ "$pages" -eq 0 ]; then
+            echo "::error::No /api/ pages in the build output — the published API reference would 404."
+            exit 1
+          fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
Fixes a regression I introduced in #4503. **The live site currently has no API reference** — `/api/` and `/api/cli-adapters/` 404 right now.

## What happened

#4503 moved TypeDoc generation to build time, with ordering in `turbo.json`:
`nexus-agents-website#build` → `nexus-agents#docs:api:md` → `nexus-memory#build`.

But `deploy-website.yml` runs:

```yaml
- name: Build website
  run: pnpm build
  working-directory: website
```

That invokes Astro directly and **bypasses turbo entirely**, so the dependency graph never applied and `docs/api` was never generated.

## Why nothing caught it

The broken command **exits 0**. A missing Astro content collection is not a build error — the glob loader just yields nothing:

```
[WARN] [glob-loader] The base directory ".../docs/api/" does not exist.
```

So the deploy succeeded, uploaded, and published a site with its entire API section silently absent. Every check was green.

I verified #4503 with the root `pnpm build` (which goes through turbo) and with a cold rebuild — but **never ran the command the deploy actually uses**. I tested the path I assumed, not the path production takes.

## Fix

- Build through turbo from the repo root: `npx turbo run build --filter=nexus-agents-website`, so the graph resolves.
- Add a step that fails the deploy when the build output contains zero `/api/` pages.

That guard is the part that matters. The panel that reviewed #4449 warned specifically that Option 2's failure mode is "generation failure yields no docs, silently" — and that is exactly what shipped. The blocking generation check I added in #4503 lives in PR CI, which never exercises the deploy workflow, so it could not have caught this.

## Verification — both directions

| Command | Exit | `/api/` pages |
| --- | --- | --- |
| `npx turbo run build --filter=nexus-agents-website` (new) | 0 | **20** |
| `cd website && pnpm build` (what deploy did) | **0** | **0** |

The second row is the whole bug: success, zero pages. The guard fails on it.

## Context

This deploy only ran at all because I cancelled a run that had been wedged in `queued` since 2026-08-09 (the Astro 7 upgrade, #4364), holding the `pages` concurrency group and cancelling 34 successive deploys. That is #4506. Unblocking it is what exposed this — the site went from 14 days stale (v2.173.6) to current (v3.3.2), and the missing `/api/` became visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
