### PR TITLE
fix(mcp): advertise options on the consensus_vote tool schema

### DIFF
--- a/.changeset/expose-options-on-mcp-schema.md
+++ b/.changeset/expose-options-on-mcp-schema.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+Expose `options` on the advertised `consensus_vote` MCP schema (#4472 follow-up).
+
+#4494 added `options` to `ConsensusVoteInputSchema` — the schema the handler validates against — but **not** to `CONSENSUS_VOTE_TOOL_SCHEMA`, the schema advertised to MCP clients. MCP callers therefore could not pass `options` at all, so the multi-option threshold gate was unreachable through the tool that every caller actually uses. The internal capability shipped; the advertised capability did not.
+
+The tool description also still carried the #4452 caveat asserting "the tally is approve/reject/abstain only", which became false for declared-option votes the moment #4494 landed — a description telling callers the opposite of what the tool now does.
+
+Both are fixed, and a **drift contract** now pins the two schemas together: the advertised input schema must expose every field the handler accepts (excluding the documented async-dispatch internals `mode`/`idempotencyKey`) and must advertise nothing the handler would reject. Verified by removing `options` again — two of the three parity tests fail.
+
+This is the same defect class the surrounding work has been clearing: a capability whose advertised surface does not match its real behaviour.

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -9,6 +9,7 @@ import { RateLimiter } from '../middleware/index.js';
 import {
   ConsensusVoteInputSchema,
   CONSENSUS_VOTE_OUTPUT_SCHEMA,
+  CONSENSUS_VOTE_TOOL_SCHEMA,
   createPolicyFailedResult,
   maybeEscalateContrarian,
   type ConsensusVoteDeps,
@@ -1383,6 +1384,32 @@ describe('buildResponse error counting (Issue #815)', () => {
 // ============================================================================
 // Output Schema Validation (Issue #1246)
 // ============================================================================
+
+describe('CONSENSUS_VOTE_TOOL_SCHEMA input drift contract (#4494 follow-up)', () => {
+  // #4494 shipped `options` on ConsensusVoteInputSchema but NOT on the schema
+  // advertised to MCP clients, so the feature was unreachable through the tool
+  // — the surface every caller actually uses. Internal capability and
+  // advertised capability must not drift.
+  const internal = Object.keys(ConsensusVoteInputSchema.shape).sort();
+  const advertised = Object.keys(CONSENSUS_VOTE_TOOL_SCHEMA).sort();
+
+  it('advertises `options`, the field whose absence made #4472 unreachable', () => {
+    expect(advertised).toContain('options');
+  });
+
+  it('advertises every input the handler accepts, except documented internals', () => {
+    // `mode` and `idempotencyKey` are async-dispatch plumbing added by the
+    // job wrapper, not user-facing vote inputs.
+    const INTERNAL_ONLY = new Set(['mode', 'idempotencyKey']);
+    const missing = internal.filter((k) => !INTERNAL_ONLY.has(k) && !advertised.includes(k));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('advertises nothing the handler would reject', () => {
+    expect(advertised.filter((k) => !internal.includes(k))).toEqual([]);
+  });
+});
 
 describe('CONSENSUS_VOTE_OUTPUT_SCHEMA validation (Issue #1246)', () => {
   const outputValidator = z.object(CONSENSUS_VOTE_OUTPUT_SCHEMA);

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -1138,8 +1138,21 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
 };
 
 /** Advertised MCP input schema for consensus_vote (hoisted to keep the register fn within its line budget). */
-const CONSENSUS_VOTE_TOOL_SCHEMA = {
+export const CONSENSUS_VOTE_TOOL_SCHEMA = {
   proposal: z.string().min(1).max(MAX_PROPOSAL_LENGTH).describe('Proposal text to vote on'),
+  options: z
+    .array(z.string().min(1).max(200))
+    .min(2)
+    .max(10)
+    .optional()
+    .describe(
+      'Named alternatives for a multi-option proposal (#4472). When present, the threshold must ' +
+        'ALSO be cleared by the leading option: `unanimous` requires every approver to have chosen ' +
+        "the SAME option, and `supermajority`/`majority` measure the leading option's share of " +
+        'approvers. An approving voter whose selection is absent or matches no declared option ' +
+        'stays in the denominator and credits no option, so a degraded response can only lower the ' +
+        'leading share, never raise it. Omit for an ordinary yes/no vote.'
+    ),
   threshold: z
     .enum(['majority', 'supermajority', 'unanimous'])
     .optional()
@@ -1174,9 +1187,11 @@ const CONSENSUS_VOTE_DESCRIPTION =
   'Supports higher_order strategy for Bayesian-optimal aggregation with correlation awareness (Issue #514). ' +
   "Supports async mode (mode: 'async') — returns a jobId to poll via get_job_result. " +
   'Pass ratifies=<subject> to bind an authority-ladder ratification vote into its authentic record. ' +
-  'CAVEAT (#4452): the tally is approve/reject/abstain only. A proposal that asks voters to pick ' +
-  'among named options records as unanimous even when they picked DIFFERENT options — recover the ' +
-  "real split from each voter's reasoning, and do not report the percentage as agreement.";
+  'If your proposal asks voters to choose among named alternatives, you MUST pass them in ' +
+  '`options` (#4472) — the threshold is then measured over WHICH option won, and the record ' +
+  'carries the per-option tally plus selection coverage. WITHOUT `options` the tally is ' +
+  'approve/reject/abstain only, so every voter who engages returns `approve` and a 6-1 split on ' +
+  'which option persists as 7-0, 100% (#4452).';
 
 /**
  * Registers the consensus_vote tool with the MCP server.


### PR DESCRIPTION
Follow-up to #4494. **The multi-option threshold gate shipped unreachable through MCP.**

## The bug

There are two schemas:

- `ConsensusVoteInputSchema` — what the handler validates against. #4494 added `options` here.
- `CONSENSUS_VOTE_TOOL_SCHEMA` — what is **advertised to MCP clients**. #4494 did not touch it.

So MCP callers could not pass `options` at all. The capability shipped; the advertised surface did not. Every caller using the tool — which is every caller — was structurally unable to reach the feature that PR existed to deliver.

The tool description also still carried the #4452 caveat:

> CAVEAT (#4452): the tally is approve/reject/abstain only... do not report the percentage as agreement.

That became false for declared-option votes the moment #4494 landed. The tool was describing the opposite of its own behaviour.

## How it was found

After an MCP restart I read the loaded tool schema instead of assuming the release had made the feature reachable. `options` was absent and the stale caveat was still there.

This also corrects an earlier diagnosis of mine. When a validation vote persisted as schema 1.2 with no tally, I attributed it solely to a stale server process. That was **incomplete** — the process was stale, but even a restarted server would have failed, because the parameter was never advertised. Two independent faults; I stopped at the first.

## Fix

- `options` added to the advertised schema, with the same semantics text as the handler schema.
- Description rewritten: tells callers to pass `options` rather than warning them the tally cannot represent their vote.
- **Drift contract** pinning the two schemas together in both directions — the advertised schema must expose every field the handler accepts (excluding the documented async-dispatch internals `mode`/`idempotencyKey`) and must advertise nothing the handler would reject.

The drift contract is the part that matters. An output-schema parity test already existed (#4032); the input side had none, which is exactly why this slipped through a PR with 47 green checks.

## Verification

- 118 tests pass in `consensus-vote.test.ts`.
- **Mutation-tested:** deleting `options` from the advertised schema again fails 2 of the 3 new parity tests.
- `typecheck`, `eslint`, `lint:arch` clean.

## Not yet validated

The end-to-end path — declare `options` through MCP, get a record at schema 1.4 with `optionTally` and `optionCoverage` — still has never run. It needs this merged, published, the global install updated, and the MCP server restarted. I would rather say that plainly than infer success from a green response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
