### PR TITLE
fix(audit): tally only approvers in the vote record's optionTally

### DIFF
--- a/.changeset/record-tally-population.md
+++ b/.changeset/record-tally-population.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+Tally only approvers in the vote record's `optionTally` (#4472 follow-up).
+
+Found by end-to-end validation, not by tests. A live 7-voter panel produced a record whose `optionTally` read `C:4, A:3` while the response's `optionOutcome` read `C:4, A:2`. The extra vote came from the **contrarian, who rejected the proposal but still named an option** — `tallySelectedOptions` counted every voter carrying a `selectedOption`, regardless of decision.
+
+That made the record internally inconsistent in the exact way this epic exists to prevent:
+
+- `optionTally` summed to 7 while `optionCoverage.selectedCount` said 6 — two fields in the same record describing different populations.
+- The threshold is evaluated over **approvers**, so the recorded tally described a different population than the verdict it accompanied. A reader reconstructing the decision from the ledger would compute a different leading share than the gate did.
+
+`tallySelectedOptions` now filters to approvers, matching both `coverageOf` and the gate's `tallyOptions`.
+
+The pre-existing test asserted `[{A:2},{C:1}]` for a fixture whose third voter is `catfish(reject)` — it was encoding the defect. Corrected to `[{A:2}]`, plus a new test asserting the tally and coverage always describe the same population. Mutation-verified: removing the approver filter fails two tests.

--- a/packages/nexus-agents/src/audit/vote-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.test.ts
@@ -128,11 +128,37 @@ describe('buildVoteRecord', () => {
     // #4472: a tally now always travels with its coverage, so a record
     // carrying one is 1.4. Historical 1.3 records still verify.
     expect(record.version).toBe('1.4');
-    expect(record.optionTally).toEqual([
-      { option: 'A', count: 2 },
-      { option: 'C', count: 1 },
-    ]);
+    // The fixture's third voter is catfish(reject) and was assigned 'C'. Only
+    // approvers count — this expectation previously asserted `C: 1`, encoding
+    // the very defect e2e validation later surfaced in a live record.
+    expect(record.optionTally).toEqual([{ option: 'A', count: 2 }]);
     expect(verifyVoteRecordSet([record])).toEqual({ ok: true, recordCount: 1 });
+  });
+
+  it('tallies only approvers, matching the population the verdict was computed over', () => {
+    // Found by e2e validation: a REJECTING voter named an option, and the
+    // record counted it. The threshold is evaluated over approvers only, so a
+    // record whose tally includes rejecters describes a different population
+    // than the verdict it accompanies — and disagrees with its own
+    // optionCoverage, which was already approvers-only.
+    const mixed: readonly AgentVoteResult[] = [
+      { ...agentVote('architect', 'approve'), selectedOption: 'A' },
+      { ...agentVote('catfish', 'reject'), selectedOption: 'B' },
+    ];
+    const record = buildVoteRecord({
+      id: 'vote-mixed',
+      proposal: 'p',
+      strategy: 'higher_order',
+      result: consensusResult(),
+      votes: mixed,
+    });
+
+    // 'B' came from a rejecter and must not appear.
+    expect(record.optionTally).toEqual([{ option: 'A', count: 1 }]);
+
+    // The tally and the coverage must describe the same population.
+    const tallied = (record.optionTally ?? []).reduce((n, t) => n + t.count, 0);
+    expect(tallied).toBe(record.optionCoverage?.selectedCount);
   });
 
   it('records selection coverage so a diluted share reads as partial (#4472)', () => {

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -234,6 +234,12 @@ function tallySelectedOptions(
 ): VoteRecordOptionCount[] | undefined {
   const counts = new Map<string, number>();
   for (const v of votes) {
+    // Approvers only. The threshold is evaluated over approvers, so a tally
+    // that counted rejecters would describe a different population than the
+    // verdict it accompanies — and would disagree with `optionCoverage`,
+    // which is approvers-only. Found by e2e validation when a rejecting voter
+    // named an option and the record credited it (#4472 follow-up).
+    if (v.vote.decision !== 'approve') continue;
     if (v.selectedOption === undefined) continue;
     counts.set(v.selectedOption, (counts.get(v.selectedOption) ?? 0) + 1);
   }


### PR DESCRIPTION
Follow-up to #4494, **found by end-to-end validation rather than by tests**.

## What happened

The first real multi-option vote through the shipped gate produced a record that contradicted itself:

| Source | C | A | total |
| --- | --- | --- | --- |
| record `optionTally` | 4 | **3** | **7** |
| response `optionOutcome` | 4 | **2** | **6** |
| record `optionCoverage` | — | — | `selectedCount: 6` |

The extra vote was the contrarian, who **rejected** the proposal but still named an option. `tallySelectedOptions` counted every voter carrying a `selectedOption`, regardless of decision, while `coverageOf` and the gate's `tallyOptions` count approvers only.

## Why it matters

Two failures, both squarely in the class this epic exists to remove:

1. **The record contradicts itself.** `optionTally` sums to 7; `optionCoverage.selectedCount` says 6. Two fields in one record describing different populations.
2. **The tally describes a different population than the verdict beside it.** Thresholds are evaluated over approvers. A reader reconstructing the decision from the ledger would compute a *different leading share* than the gate actually applied — 4/7 = 57% versus the real 4/6 = 67%. On a supermajority bar those land on opposite sides.

That is a fidelity defect on the governor path, inside the fix for fidelity defects.

## Fix

`tallySelectedOptions` now filters to approvers, matching `coverageOf` and `tallyOptions`.

**The pre-existing test was encoding the defect.** It asserted `[{A:2},{C:1}]` for a fixture whose third voter is `catfish(reject)` — so the wrong behaviour was pinned as correct. Corrected to `[{A:2}]`, and a new test asserts the invariant directly: the tally total must always equal `optionCoverage.selectedCount`.

## Verification

- 284 audit tests pass.
- **Mutation-verified:** removing the approver filter fails two tests, including the new invariant.
- `typecheck`, `eslint`, `lint:arch` clean.

## Why unit tests missed it

284 tests passed with the bug present, and #4494 merged on 47 green checks. No fixture contained a **rejecting voter who also selected an option** — the one shape that distinguishes the two populations. It took a live panel with a real dissenter, which is exactly the case the `e2e-validation` discipline exists to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
