### PR TITLE
fix(governance): match keywords on word boundaries, not raw substrings (#4518)

### DIFF
--- a/.changeset/keyword-word-boundaries.md
+++ b/.changeset/keyword-word-boundaries.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+Match governance keywords on word boundaries, not raw substrings (#4518).
+
+`governance-enforcer.ts` classified a task's domain with `SECURITY_KEYWORDS.some(kw => lower.includes(kw))`. With `'auth'` in the list as an unbounded substring, **"author" matched**. Two live reproductions from an e2e run:
+
+- A CHANGELOG formatting task — _"list the pull request author name"_ — escalated to `domain: security, votingThreshold: supermajority`.
+- A TypeDoc diagnosis escalated because the task text named the file `security.ts`.
+
+This is the governance path, so the cost is not just noise: the recorded `promotionReason` asserted security keywords in work with no security dimension, meaning an auditor reading why a task required supermajority read a false justification. And if most escalations are "author" collisions, the domain signal stops being worth reading — which is when a genuine one slips through.
+
+**The trap in fixing it.** A naive `\bauth\b` does not match "authentication" or "authorization", so real security work would stop escalating — a false negative on the governor path, strictly worse than the over-matching. Both are handled: bare `auth` on a word boundary catches "auth flow" without catching "author", and the longer forms are enumerated explicitly. Precision in the data rather than cleverness in the matcher.
+
+Three matching modes, because the lists always mixed three intents: stems (`vulnerabilit`, `cve-`) anchored at word start; regex entries compiled as regex; everything else on word boundaries. That revives `'refactor.*system'`, which was **dead** — a regex sitting in a list documented as substring-matched could only ever match the literal text `refactor.*system`.
+
+Filenames and paths are stripped before matching, so naming `security.ts` no longer classifies a task as security work.
+
+**One call site deliberately keeps substring matching.** `isSecuritySignal` in the remediation shadow has the opposite risk profile, stated in its own docstring: a false negative auto-remediates a security issue _without human review_. Broad matching is the fail-safe direction there, so it stays — and the divergence is documented in place rather than quietly unified.

--- a/packages/nexus-agents/src/mcp/gateway/gateway-keywords.ts
+++ b/packages/nexus-agents/src/mcp/gateway/gateway-keywords.ts
@@ -8,7 +8,19 @@
  * @module mcp/gateway/gateway-keywords
  */
 
-/** Keywords that indicate security-related work (case-insensitive substring match). */
+/**
+ * Keywords that indicate security-related work.
+ *
+ * Matched on word boundaries by `keyword-match.ts`, NOT raw substring (#4518).
+ *
+ * `'auth'` used to be here as a bare stem and fired on **author**, escalating
+ * a CHANGELOG formatting task to a security supermajority. Replacing it with
+ * a bare word ALONE would have been worse: `\bauth\b` does not match
+ * "authentication" or "authorization", so real security work would stop being
+ * detected. Both are kept — `auth` on a word boundary catches "auth flow"
+ * without catching "author", and the longer forms are enumerated explicitly.
+ * Precision in the data rather than cleverness in the matcher.
+ */
 export const SECURITY_KEYWORDS = [
   'security',
   'vulnerabilit',
@@ -18,6 +30,13 @@ export const SECURITY_KEYWORDS = [
   'xss',
   'csrf',
   'auth',
+  'authentication',
+  'authorization',
+  'authn',
+  'authz',
+  'oauth',
+  'unauthenticated',
+  'unauthorized',
   'penetration',
   'threat',
   'malware',

--- a/packages/nexus-agents/src/mcp/gateway/governance-enforcer.ts
+++ b/packages/nexus-agents/src/mcp/gateway/governance-enforcer.ts
@@ -40,6 +40,7 @@ export interface GovernanceClassification {
   promotionReason: string | null;
 }
 
+import { matchesAnyKeyword, findMatchingKeyword as matchKeyword } from './keyword-match.js';
 import {
   SECURITY_KEYWORDS,
   ARCHITECTURE_KEYWORDS,
@@ -122,10 +123,10 @@ function detectGovernanceDomain(params: Record<string, unknown>): GovernanceDoma
   for (const field of textFields) {
     const value = params[field];
     if (typeof value !== 'string') continue;
-    const lower = value.toLowerCase();
-
-    if (SECURITY_KEYWORDS.some((kw) => lower.includes(kw))) return 'security';
-    if (ARCHITECTURE_KEYWORDS.some((kw) => lower.includes(kw))) return 'architecture';
+    // #4518: word-boundary matching. Raw substring escalated "author" to
+    // security supermajority via the 'auth' stem.
+    if (matchesAnyKeyword(value, SECURITY_KEYWORDS)) return 'security';
+    if (matchesAnyKeyword(value, ARCHITECTURE_KEYWORDS)) return 'architecture';
   }
 
   return 'none';
@@ -153,10 +154,9 @@ function buildPromotionReason(domain: GovernanceDomain, params: Record<string, u
 
 /** Finds the first matching keyword in text for the given domain. */
 function findMatchingKeyword(text: string, domain: GovernanceDomain): string | null {
-  const lower = text.toLowerCase();
+  // Must use the SAME matcher as classification — otherwise the recorded
+  // `promotionReason` can name a keyword that did not actually trigger the
+  // escalation, which is the fidelity defect #4518 is about.
   const keywords = domain === 'security' ? SECURITY_KEYWORDS : ARCHITECTURE_KEYWORDS;
-  for (const kw of keywords) {
-    if (lower.includes(kw)) return kw;
-  }
-  return null;
+  return matchKeyword(text, keywords) ?? null;
 }

--- a/packages/nexus-agents/src/mcp/gateway/keyword-match.test.ts
+++ b/packages/nexus-agents/src/mcp/gateway/keyword-match.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { findMatchingKeyword, stripCodeLikeTokens } from './keyword-match.js';
+import { SECURITY_KEYWORDS, ARCHITECTURE_KEYWORDS } from './gateway-keywords.js';
+
+const sec = (text: string): string | undefined => findMatchingKeyword(text, SECURITY_KEYWORDS);
+const arch = (text: string): string | undefined => findMatchingKeyword(text, ARCHITECTURE_KEYWORDS);
+
+describe('stripCodeLikeTokens', () => {
+  it('removes filenames so a path cannot classify the task', () => {
+    expect(stripCodeLikeTokens('compare core.ts and security.ts')).not.toContain('security');
+  });
+
+  it('leaves ordinary prose intact', () => {
+    expect(stripCodeLikeTokens('review the security model')).toContain('security');
+  });
+});
+
+describe('security keyword matching', () => {
+  it('does NOT fire on "author" (the #4518 reproduction)', () => {
+    expect(sec('list the pull request author name and the merge date')).toBeUndefined();
+  });
+
+  it('does NOT fire on other auth-prefixed words', () => {
+    for (const w of ['authored', 'authoring', 'authority', 'authoritative', 'authentic']) {
+      expect(sec(`the ${w} source of truth`)).toBeUndefined();
+    }
+  });
+
+  it('does NOT fire on a filename that merely contains a keyword', () => {
+    expect(sec('why does src/exports/security.ts emit no page')).toBeUndefined();
+  });
+
+  it('still fires on the auth-family terms that are genuinely security', () => {
+    // The trap in fixing #4518: a naive \bauth\b stops matching
+    // "authentication"/"authorization", which is a FALSE NEGATIVE on the
+    // governor path — strictly worse than the over-matching being fixed.
+    for (const w of ['authentication', 'authorization', 'authn', 'authz', 'oauth']) {
+      expect(sec(`harden the ${w} path`)).toBeDefined();
+    }
+  });
+
+  it('still fires on genuine security work', () => {
+    expect(sec('review the auth flow for this endpoint')).toBe('auth');
+    expect(sec('patch the SQL injection in the query builder')).toBe('injection');
+    expect(sec('rotate the leaked credentials')).toBe('credentials');
+    expect(sec('threat model the new gateway')).toBe('threat');
+  });
+
+  it('honours deliberate stems rather than requiring an exact word', () => {
+    // 'vulnerabilit' is a prefix on purpose — it must cover both inflections.
+    expect(sec('a vulnerability in the parser')).toBe('vulnerabilit');
+    expect(sec('several vulnerabilities were found')).toBe('vulnerabilit');
+    expect(sec('tracking CVE-2026-1234')).toBe('cve-');
+  });
+
+  it('is case-insensitive', () => {
+    expect(sec('SECURITY review requested')).toBe('security');
+  });
+});
+
+describe('architecture keyword matching', () => {
+  it('matches the regex-shaped entry against real prose', () => {
+    // 'refactor.*system' was dead: substring matching could only ever match
+    // the literal text "refactor.*system".
+    expect(arch('refactor the pipeline system')).toBe('refactor.*system');
+  });
+
+  it('matches multi-word phrases', () => {
+    expect(arch('this is a breaking change to the API')).toBe('breaking change');
+  });
+
+  it('does not fire on a substring collision', () => {
+    // 'database' must not match inside an unrelated compound token.
+    expect(arch('the ratabasement value')).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/mcp/gateway/keyword-match.ts
+++ b/packages/nexus-agents/src/mcp/gateway/keyword-match.ts
@@ -1,0 +1,92 @@
+/**
+ * Word-boundary keyword matching for governance domain classification (#4518).
+ *
+ * The classifier previously used a raw substring test:
+ *
+ * ```ts
+ * if (SECURITY_KEYWORDS.some((kw) => lower.includes(kw))) return 'security';
+ * ```
+ *
+ * `'auth'` as an unbounded substring fires on **author**, so a CHANGELOG
+ * formatting task ("list the pull request author name") was classified as
+ * security work and escalated to a supermajority voting bar. A TypeDoc
+ * question was escalated too, because the task text named the file
+ * `security.ts`.
+ *
+ * That is worse than noise on the governance path. The recorded
+ * `promotionReason` asserts security keywords were detected in work with no
+ * security dimension, so an auditor reading why a task required supermajority
+ * reads a false justification — and if most escalations are "author"
+ * collisions, the domain signal stops being worth reading at all.
+ *
+ * ## Three matching modes, because the keyword lists mix three intents
+ *
+ *  - **Stems** (`vulnerabilit`, `cve-`) are deliberate prefixes covering
+ *    inflections. Anchored at a word start, open at the end.
+ *  - **Regex entries** (`refactor.*system`) were already regex-shaped but sat
+ *    in a list documented as substring-matched, so that entry could only ever
+ *    match the literal text `refactor.*system` — it was dead. Now compiled.
+ *  - **Everything else** is a word or phrase and is matched on word
+ *    boundaries.
+ *
+ * @module mcp/gateway/keyword-match
+ * (Source: Issue #4518)
+ */
+
+/** Keywords that are intentionally prefixes, not whole words. */
+const STEM_KEYWORDS = new Set(['vulnerabilit', 'cve-']);
+
+/** Keywords authored as regular expressions rather than literals. */
+const REGEX_KEYWORDS = new Set(['refactor.*system']);
+
+/** Escape a literal for safe use inside a RegExp. */
+function escapeLiteral(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Drop tokens that look like code rather than prose.
+ *
+ * A task that merely *names* `security.ts` is not security work. Filenames,
+ * dotted identifiers and paths are stripped before matching so the classifier
+ * reads intent rather than incidental symbols.
+ */
+export function stripCodeLikeTokens(text: string): string {
+  return text
+    .replace(/\S+\.(?:ts|tsx|js|jsx|mjs|cjs|json|ya?ml|md|toml|lock)\b/gi, ' ')
+    .replace(/\b[\w.-]+\/[\w./-]+/g, ' ');
+}
+
+/** Build the matcher for one keyword, honouring its intended mode. */
+function toPattern(keyword: string): RegExp {
+  if (REGEX_KEYWORDS.has(keyword)) return new RegExp(keyword, 'i');
+  if (STEM_KEYWORDS.has(keyword)) return new RegExp(`\\b${escapeLiteral(keyword)}`, 'i');
+  return new RegExp(`\\b${escapeLiteral(keyword)}\\b`, 'i');
+}
+
+/** Compiled once per keyword — these lists are module constants. */
+const PATTERNS = new Map<string, RegExp>();
+function patternFor(keyword: string): RegExp {
+  const cached = PATTERNS.get(keyword);
+  if (cached !== undefined) return cached;
+  const built = toPattern(keyword);
+  PATTERNS.set(keyword, built);
+  return built;
+}
+
+/**
+ * Return the first keyword genuinely present in `text`, or undefined.
+ *
+ * Returns the keyword rather than a boolean so the caller can record WHICH
+ * term triggered the classification — the `promotionReason` is only
+ * trustworthy if it names the real match.
+ */
+export function findMatchingKeyword(text: string, keywords: readonly string[]): string | undefined {
+  const prose = stripCodeLikeTokens(text);
+  return keywords.find((kw) => patternFor(kw).test(prose));
+}
+
+/** Boolean convenience for call sites that do not need the matched term. */
+export function matchesAnyKeyword(text: string, keywords: readonly string[]): boolean {
+  return findMatchingKeyword(text, keywords) !== undefined;
+}

--- a/packages/nexus-agents/src/mcp/gateway/tier-classifier.ts
+++ b/packages/nexus-agents/src/mcp/gateway/tier-classifier.ts
@@ -15,6 +15,7 @@
  */
 
 import { SECURITY_KEYWORDS, ARCHITECTURE_KEYWORDS, PROMOTED_ROLES } from './gateway-keywords.js';
+import { matchesAnyKeyword } from './keyword-match.js';
 
 /** Request processing tier. Higher = more orchestration overhead. */
 export enum RequestTier {
@@ -147,12 +148,10 @@ export function parseTierOverrides(
 
 /** Checks if text contains any security or architecture promotion keyword. */
 function containsPromotionKeyword(text: string): boolean {
-  const lower = text.toLowerCase();
-  for (const kw of SECURITY_KEYWORDS) {
-    if (lower.includes(kw)) return true;
-  }
-  for (const kw of ARCHITECTURE_KEYWORDS) {
-    if (new RegExp(kw, 'i').test(text)) return true;
-  }
-  return false;
+  // #4518: shared word-boundary matcher. Previously security used raw
+  // substring (so "author" promoted) while architecture used bare RegExp —
+  // two different semantics over two lists documented as one.
+  return (
+    matchesAnyKeyword(text, SECURITY_KEYWORDS) || matchesAnyKeyword(text, ARCHITECTURE_KEYWORDS)
+  );
 }

--- a/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-remediation-shadow.ts
@@ -43,6 +43,13 @@ import { scanForSecrets, describeSecretFindings } from './diff-secret-scan.js';
 export function isSecuritySignal(signal: ImprovementSignal): boolean {
   if (signal.category === 'security') return true;
   const haystack = `${signal.signalKey}\n${signal.title}\n${signal.body}`.toLowerCase();
+  // #4518 DELIBERATELY NOT APPLIED HERE. The governance classifier moved to
+  // word-boundary matching because over-matching escalated unrelated work to a
+  // supermajority bar — an annoyance. This predicate has the opposite risk
+  // profile, stated above: a false negative auto-remediates a security issue
+  // WITHOUT human review. Broad substring matching is the fail-safe direction
+  // for this call site, so it stays, and the divergence is recorded rather
+  // than quietly unified for consistency's sake.
   return SECURITY_KEYWORDS.some((kw) => haystack.includes(kw));
 }
 


### PR DESCRIPTION
Closes #4518. Found by an e2e validation run, reproduced live twice.

## The bug

`governance-enforcer.ts:127` classified a task's domain with a raw substring test. `'auth'` in `SECURITY_KEYWORDS` is unbounded, so **"author" matched**:

```
task: "Update the CHANGELOG formatting so each entry lists the pull request author name..."
→ { domain: "security", votingThreshold: "supermajority",
    promotionReason: 'security governance: keyword "auth" detected' }
```

A second reproduction: a TypeDoc diagnosis escalated because the task text named the file `security.ts`.

## Why it is more than noise

This is the governance path. The recorded `promotionReason` asserted security keywords in work with **no security dimension** — so anyone auditing why a task required supermajority reads a false justification. And if most escalations are "author" collisions, operators learn to discount the domain classification, which is exactly when a real one slips through. Same failure class the surrounding work keeps hitting: an instrument whose output stops meaning what it says.

## The trap I nearly shipped

My first fix was `\bauth\b`. That **does not match "authentication" or "authorization"** — real security terms would silently stop escalating. A false negative on the governor path is strictly worse than the over-matching being fixed, and I only caught it by writing the test before believing the fix.

Resolved by being precise in the data rather than clever in the matcher: bare `auth` on a word boundary catches "auth flow" without catching "author", and the longer forms are enumerated explicitly.

## Three matching modes

The keyword lists always mixed three intents; the matcher now honours each:

| Intent | Example | Treatment |
| --- | --- | --- |
| Stem | `vulnerabilit`, `cve-` | anchored at word start, open end |
| Regex | `refactor.*system` | compiled as regex |
| Word / phrase | `security`, `breaking change` | word boundaries |

That third row revives a **dead entry**: `'refactor.*system'` sat in a list documented as substring-matched, so it could only ever match text containing the literal string `refactor.*system`. Verified before and after.

Filenames and paths are stripped before matching, so naming `security.ts` no longer classifies a task.

## One call site deliberately unchanged

`isSecuritySignal` in `improvement-remediation-shadow.ts` keeps substring matching. Its docstring states the risk profile plainly: *a false negative auto-remediates a security issue unreviewed*. Broad matching is the **fail-safe** direction there, so tightening it would weaken a safety property in the name of consistency. The divergence is documented in place.

## Verification

- 12 tests on the matcher, including both live reproductions, the five auth-family false-negative cases, the revived regex entry, and case-insensitivity.
- 124 tests pass across `src/mcp/gateway/` plus the delegate-governance suite.
- `typecheck`, `eslint`, `lint:arch` clean.

`ARCHITECTURE_KEYWORDS` shared the defect and is fixed by the same matcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
