### PR TITLE
fix(ci): scan recursively in the TypeDoc coverage gate — #4504's premise was false

### DIFF
--- a/.changeset/gate-scans-recursively.md
+++ b/.changeset/gate-scans-recursively.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+Fix the TypeDoc coverage gate reporting live pages as missing (#4504).
+
+**#4504's premise was false, and this corrects it.** The issue claimed three declared entry points — `pipeline`, `benchmarks`, `agents-ictm` — produced no documentation, leaving `PipelineRunner` (a canonical path) with no published API reference.
+
+They produce pages. All three are **live right now**:
+
+```
+/api/exports/pipeline/     HTTP 200   (PipelineRunner appears 6×)
+/api/exports/benchmarks/   HTTP 200
+/api/exports/agents-ictm/  HTTP 200
+```
+
+TypeDoc emits them into `docs/api/exports/` because each module carries a slash-bearing `@module exports/<name>` tag, and `outputFileStrategy: "modules"` derives the output path from the module name. The 16 modules without such a tag fall back to their filename and land flat.
+
+The real defect was in the gate added by #4513: `readGenerated()` used a **non-recursive** `readdirSync`, so nested pages read as absent. `KNOWN_MISSING` was therefore documenting a bug in the checking script, not a gap in the documentation — a measurement error dressed as a finding.
+
+Fixed: the scan is recursive and comparison is on basename, so a nested emission counts as present. `KNOWN_MISSING` is now empty, and the gate reports **"All 19 declared entry points produced a page."** A genuinely missing page still fails (verified by removing one: exit 1).
+
+Any future entry added to `KNOWN_MISSING` must be verified against the published site, not a directory listing.
+
+Diagnosis produced by `run_dev_pipeline` during an e2e validation run, then independently verified against the live site before acting on it.

--- a/scripts/check-typedoc-coverage.test.ts
+++ b/scripts/check-typedoc-coverage.test.ts
@@ -20,6 +20,21 @@ describe('assessCoverage', () => {
     expect(v.reason).toContain('benchmarks');
   });
 
+  it('counts a page emitted into a subdirectory as present, not missing', () => {
+    // The gate shipped with a non-recursive readdir, so the three pages
+    // TypeDoc emits to docs/api/exports/ read as absent — and they are LIVE
+    // on the published site. The allowlist was documenting a gate bug, not a
+    // documentation gap.
+    const v = assessCoverage({
+      declared: EPS,
+      generated: ['core', 'exports/pipeline', 'exports/benchmarks'],
+      allowlist: [],
+    });
+
+    expect(v.missing).toEqual([]);
+    expect(v.ok).toBe(true);
+  });
+
   it('tolerates a known-missing entry point that is on the allowlist', () => {
     const v = assessCoverage({
       declared: EPS,

--- a/scripts/check-typedoc-coverage.ts
+++ b/scripts/check-typedoc-coverage.ts
@@ -44,12 +44,21 @@ import { basename, join } from 'node:path';
 import { ROOT } from './script-paths.js';
 
 /**
- * Entry points known to emit no page, pending diagnosis in #4504.
+ * Entry points known to emit no page.
  *
- * Every entry here is a documented gap in the published API reference, not an
- * intentional omission. Remove an entry the moment it starts generating.
+ * **Empty, and that is the finding.** This list originally held `pipeline`,
+ * `benchmarks` and `agents-ictm` on the belief that they produced no
+ * documentation. They do: TypeDoc emits them to `docs/api/exports/*.md`
+ * because each carries a slash-bearing `@module exports/<name>` tag, and
+ * `outputFileStrategy: "modules"` derives the output path from the module
+ * name. All three are live on the published site. The gate's non-recursive
+ * scan could not see them, so the allowlist was documenting a defect in this
+ * script rather than a gap in the docs.
+ *
+ * Any entry added here must be verified against the PUBLISHED site, not just
+ * against a directory listing.
  */
-export const KNOWN_MISSING = ['pipeline', 'benchmarks', 'agents-ictm'] as const;
+export const KNOWN_MISSING: readonly string[] = [];
 
 export interface CoverageInput {
   readonly declared: readonly string[];
@@ -70,7 +79,13 @@ export interface CoverageVerdict {
 
 /** Compare declared entry points against pages actually produced. */
 export function assessCoverage(input: CoverageInput): CoverageVerdict {
-  const generated = new Set(input.generated);
+  // Compare on basename. TypeDoc emits a page into a SUBDIRECTORY when the
+  // module carries a slash-bearing `@module exports/<name>` tag, because
+  // outputFileStrategy:"modules" derives the path from the module name. Those
+  // pages are real and published — the gate's original non-recursive scan
+  // reported them absent, and the resulting allowlist documented a gate bug
+  // rather than a documentation gap (#4504).
+  const generated = new Set(input.generated.map((g) => g.split('/').pop() ?? g));
   const allowed = new Set(input.allowlist);
 
   const absent = input.declared.filter((e) => !generated.has(e)).sort();
@@ -116,8 +131,10 @@ function readDeclared(): string[] {
 function readGenerated(): string[] {
   const dir = join(ROOT, 'docs/api');
   if (!existsSync(dir)) return [];
-  return readdirSync(dir)
-    .filter((f) => f.endsWith('.md') && f !== 'index.md')
+  // Recursive: nested emissions are real pages. A non-recursive scan is what
+  // made three live, published pages read as missing (#4504).
+  return readdirSync(dir, { recursive: true, encoding: 'utf-8' })
+    .filter((f) => f.endsWith('.md') && basename(f) !== 'index.md')
     .map((f) => basename(f, '.md'));
 }
 


### PR DESCRIPTION
Corrects #4504, whose premise was false, and fixes the real defect — which was in the gate I shipped for it in #4513.

## The claim, and what is actually true

#4504 said three declared entry points produce no documentation, leaving `PipelineRunner` (a CLAUDE.md canonical path) with no published API reference.

They produce pages. All three are **live**:

```
/api/exports/pipeline/      HTTP 200   (PipelineRunner appears 6×)
/api/exports/benchmarks/    HTTP 200
/api/exports/agents-ictm/   HTTP 200
```

TypeDoc emits them into `docs/api/exports/` because each module carries a slash-bearing `@module exports/<name>` tag, and `outputFileStrategy: "modules"` derives the output path from the module name. The 16 modules without such a tag fall back to their filename and land flat. Coverage was **always 19/19**.

## The real defect

`readGenerated()` in the gate used a **non-recursive** `readdirSync`, so nested pages read as absent:

```ts
return readdirSync(dir)                       // top level only
  .filter((f) => f.endsWith('.md') && f !== 'index.md')
```

`KNOWN_MISSING` therefore enumerated three non-problems. It was documenting a bug in the checking script, not a gap in the documentation — a measurement error presented as a finding, which is exactly the failure class the gate was built to catch.

## Fix

- Recursive scan, comparison on basename, so a nested emission counts as present.
- `KNOWN_MISSING` is now **empty**. The gate reports `All 19 declared entry points produced a page.`
- A genuinely missing page still fails — verified by removing `security.md`: `exit 1`, `1 entry point(s) produced no page: security`.
- The constant's doc now requires any future entry to be verified **against the published site**, not a directory listing.

## How this was found

`run_dev_pipeline` (dryRun) during an e2e validation run produced the diagnosis with a standalone three-file minimal reproduction isolating the `@module` slash behaviour. I then verified it independently against the live site before acting — the plan was an LLM output, not evidence.

## What I got wrong, for the record

I filed #4504 on a false premise, ran a **7-voter panel** on it, and shipped a gate that could not see what it was measuring. The panel's reasoning was sound; the input was not. The claim then propagated into a changeset, a PR body, and the DocOps skill ledger, all asserting a canonical path was undocumented. Those are corrected alongside this.

The one thing that worked as designed: the e2e discipline exists to catch claims that unit tests cannot, and it caught mine. 7 tests passed against the buggy gate because every fixture used flat names.

## Still genuinely open

Whether 3 nested + 16 flat is the right shape is a real question this does **not** decide. Flattening would change published URLs that currently serve, so it is a deliberate call rather than a cleanup. `scm.ts` also carries a slash-bearing tag that lands flat anyway — the rename is silently voided by a trailing prose line, so it works by accident. Both are follow-ups, not blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
