### PR TITLE
feat(ci): detect deploy runs wedged in the queue (#4521)

### DIFF
--- a/.changeset/stuck-run-detector.md
+++ b/.changeset/stuck-run-detector.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+Detect deploy runs wedged in the queue (#4521).
+
+On 2026-08-09 a `deploy-website` run sat in `queued` for **11 days** with `runner=none`. Its build and link-check jobs passed; only `Deploy to GitHub Pages` never got picked up. With `concurrency: group: pages` and `cancel-in-progress: false`, that one run held the group and 34 later deploys were cancelled before starting a job. The site served a version a full major behind for two weeks.
+
+**Why the existing timeouts missed it.** Every job in `deploy-website.yml` already has `timeout-minutes` — the deploy job has 5. But `timeout-minutes` bounds **execution, not queueing**: it starts counting when a runner picks the job up. A job that never gets a runner is never "running", so it sat 11 days inside a 5-minute limit without contradiction. Queue residency is the one state nothing in the workflow file bounds, and GitHub Actions has no per-job knob for it — hence an external check rather than a config change.
+
+(My first proposal on #4521 was to add a `timeout-minutes` that already existed. Corrected on the issue.)
+
+The deploy-health workflow now also lists recent runs and flags any waiting past **60 minutes**. That threshold is measured, not guessed: the five most recent successful deploys ran 79s, 73s, 79s, 95s, 67s, so ~90 seconds is healthy and an hour is ~40x that.
+
+`in_progress` is deliberately never flagged however long it runs — that state _is_ bounded by the job's own timeout. Reports only; cancelling a run stays a human decision.
+
+Complements #4516, which catches the consequence (published site behind `main`) regardless of cause. This catches the cause early and names the specific run to cancel — which took real digging by hand, because `queued` does not appear in the obvious "pending runs" query.
+
+Verified by replaying the real incident: run `31293406815` at 18,248 minutes flags with exit 1, while a long-running `in_progress` correctly does not.

--- a/.github/workflows/deploy-stale-check.yml
+++ b/.github/workflows/deploy-stale-check.yml
@@ -50,8 +50,21 @@ jobs:
         continue-on-error: true
         run: npx tsx scripts/check-deploy-stale.ts
 
+      # #4521: catch the CAUSE early, not just the consequence. A run wedged in
+      # `queued` holds the `pages` concurrency group and silently cancels every
+      # later deploy — the 2026-08-09 incident ran 11 days that way. Job-level
+      # `timeout-minutes` cannot catch this: it bounds execution, not queueing.
+      - name: Look for runs wedged in the queue
+        id: stuck
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUNS_JSON=$(gh run list --workflow=deploy-website.yml --limit 30 \
+            --json databaseId,status,createdAt) npx tsx scripts/check-stuck-runs.ts
+
       - name: File or update the tracking issue
-        if: steps.assess.outcome == 'failure'
+        if: steps.assess.outcome == 'failure' || steps.stuck.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE: 'ops(website): published site is behind main'
@@ -84,8 +97,8 @@ jobs:
             gh issue create --title "$TITLE" --body-file /tmp/body.md
           fi
 
-      - name: Fail the run when the site is behind
-        if: steps.assess.outcome == 'failure'
+      - name: Fail the run when the site is behind or a run is wedged
+        if: steps.assess.outcome == 'failure' || steps.stuck.outcome == 'failure'
         run: |
-          echo "::error::Published site is behind main — see the tracking issue."
+          echo "::error::Deploy health check failed — see the tracking issue."
           exit 1

--- a/scripts/check-stuck-runs.test.ts
+++ b/scripts/check-stuck-runs.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { assessStuckRuns, STUCK_AFTER_MINUTES } from './check-stuck-runs.js';
+import type { RunSummary } from './check-stuck-runs.js';
+
+const run = (id: number, status: string, ageMinutes: number): RunSummary => ({
+  databaseId: id,
+  status,
+  ageMinutes,
+});
+
+describe('assessStuckRuns', () => {
+  it('finds nothing when every run is progressing', () => {
+    const v = assessStuckRuns([run(1, 'in_progress', 5), run(2, 'completed', 900)]);
+
+    expect(v.stuck).toEqual([]);
+    expect(v.ok).toBe(true);
+  });
+
+  it('ignores a queued run inside the grace window', () => {
+    // Runners are not always instant; a briefly queued run is normal.
+    const v = assessStuckRuns([run(1, 'queued', 10)]);
+
+    expect(v.stuck).toEqual([]);
+  });
+
+  it('flags a queued run past the window', () => {
+    const v = assessStuckRuns([run(42, 'queued', STUCK_AFTER_MINUTES + 1)]);
+
+    expect(v.stuck.map((r) => r.databaseId)).toEqual([42]);
+    expect(v.ok).toBe(false);
+  });
+
+  it('treats a long-pending run the same as queued', () => {
+    // The 2026-08-09 wedge reported `queued`; the surrounding runs reported
+    // `pending`. Both occupy the concurrency group, so both count.
+    const v = assessStuckRuns([run(7, 'pending', STUCK_AFTER_MINUTES + 1)]);
+
+    expect(v.stuck.map((r) => r.databaseId)).toEqual([7]);
+  });
+
+  it('never flags a run that is actually executing, however long', () => {
+    // in_progress is bounded by the job's own timeout-minutes. Queue
+    // residency is the state nothing bounds — that is the whole point.
+    const v = assessStuckRuns([run(9, 'in_progress', 10_000)]);
+
+    expect(v.stuck).toEqual([]);
+  });
+
+  it('reproduces the incident: an 11-day queued run', () => {
+    const elevenDays = 11 * 24 * 60;
+    const v = assessStuckRuns([run(31293406815, 'queued', elevenDays)]);
+
+    expect(v.ok).toBe(false);
+    expect(v.reason).toContain('31293406815');
+  });
+
+  it('reports every stuck run, not just the first', () => {
+    const v = assessStuckRuns([
+      run(1, 'queued', 999),
+      run(2, 'in_progress', 999),
+      run(3, 'pending', 999),
+    ]);
+
+    expect(v.stuck.map((r) => r.databaseId).sort()).toEqual([1, 3]);
+  });
+});

--- a/scripts/check-stuck-runs.ts
+++ b/scripts/check-stuck-runs.ts
@@ -1,0 +1,119 @@
+#!/usr/bin/env npx tsx
+/**
+ * Detect deploy runs wedged in the queue (#4521).
+ *
+ * On 2026-08-09 a `deploy-website` run sat in `queued` for **11 days** with
+ * `runner=none`. Its build and link-check jobs had passed; only the
+ * `Deploy to GitHub Pages` job never got picked up. Because the workflow uses
+ * `concurrency: group: pages` with `cancel-in-progress: false`, that one run
+ * held the group and 34 later deploys were cancelled before starting a job.
+ * The site served a version a full major behind for two weeks.
+ *
+ * ## Why the existing timeouts did not catch it
+ *
+ * Every job in `deploy-website.yml` already has `timeout-minutes` — the deploy
+ * job has 5. **`timeout-minutes` bounds execution, not queueing.** It starts
+ * counting when a runner picks the job up. A job that never gets a runner is
+ * never "running", so it sat 11 days inside a 5-minute limit without
+ * contradiction. Queue residency is the one state nothing in the workflow file
+ * bounds, and GitHub Actions offers no per-job knob for it.
+ *
+ * That is why this is an external check rather than a config change. My first
+ * proposal on #4521 was to add a `timeout-minutes` that already existed.
+ *
+ * ## Relationship to the staleness detector
+ *
+ * #4516 catches the *consequence* — published site behind `main` — within 6
+ * hours, and remains the primary alarm because it fires regardless of cause.
+ * This catches the *cause* early and points at the specific run to cancel,
+ * which took real digging by hand precisely because `queued` does not appear
+ * in the obvious "pending runs" query.
+ *
+ * Reports only. Cancelling a run is destructive and stays a human decision.
+ *
+ * @module scripts/check-stuck-runs
+ * (Source: Issue #4521)
+ */
+
+/**
+ * A healthy deploy completes end-to-end in about 90 seconds — measured across
+ * the five most recent successful runs (79s, 73s, 79s, 95s, 67s). An hour is
+ * ~40x that, which leaves ample room for runner-availability delays while
+ * still turning an 11-day wedge into a same-day report.
+ */
+export const STUCK_AFTER_MINUTES = 60;
+
+/** Statuses that occupy the concurrency group without executing. */
+const WAITING_STATUSES = new Set(['queued', 'pending', 'waiting', 'requested']);
+
+export interface RunSummary {
+  readonly databaseId: number;
+  readonly status: string;
+  readonly ageMinutes: number;
+}
+
+export interface StuckRunVerdict {
+  readonly ok: boolean;
+  readonly stuck: RunSummary[];
+  readonly reason: string;
+}
+
+/**
+ * Identify runs that have been waiting for a runner longer than the window.
+ *
+ * `in_progress` is deliberately never flagged however long it has run — that
+ * state IS bounded by the job's own `timeout-minutes`.
+ */
+export function assessStuckRuns(runs: readonly RunSummary[]): StuckRunVerdict {
+  const stuck = runs.filter(
+    (r) => WAITING_STATUSES.has(r.status) && r.ageMinutes > STUCK_AFTER_MINUTES
+  );
+
+  if (stuck.length === 0) {
+    return { ok: true, stuck: [], reason: 'No runs waiting past the queue window.' };
+  }
+
+  const detail = stuck
+    .map((r) => `run ${String(r.databaseId)} (${r.status}, ${String(Math.round(r.ageMinutes))}m)`)
+    .join(', ');
+
+  return {
+    ok: false,
+    stuck,
+    reason:
+      `${String(stuck.length)} run(s) waiting past ${String(STUCK_AFTER_MINUTES)}m: ${detail}. ` +
+      'A run stuck in the queue holds the `pages` concurrency group and silently ' +
+      'cancels every later deploy. Cancel it to release the queue.',
+  };
+}
+
+/* eslint-disable no-console */
+/** Read run summaries from `RUNS_JSON` (supplied by the workflow via `gh`). */
+function readRuns(): RunSummary[] {
+  const raw = process.env['RUNS_JSON'];
+  if (raw === undefined || raw.trim() === '') return [];
+  const now = Date.now();
+  const parsed = JSON.parse(raw) as Array<{
+    databaseId: number;
+    status: string;
+    createdAt: string;
+  }>;
+  return parsed.map((r) => ({
+    databaseId: r.databaseId,
+    status: r.status,
+    ageMinutes: (now - Date.parse(r.createdAt)) / 60_000,
+  }));
+}
+
+function main(): void {
+  const verdict = assessStuckRuns(readRuns());
+  console.log(verdict.reason);
+  if (!verdict.ok) {
+    console.log(`::error::${verdict.reason}`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1]?.endsWith('check-stuck-runs.ts') === true) {
+  main();
+}


### PR DESCRIPTION
Closes #4521.

## What it catches

On 2026-08-09 a `deploy-website` run sat in `queued` for **11 days** with `runner=none`. Build and link-check had passed; only `Deploy to GitHub Pages` never got picked up. With `concurrency: group: pages` and `cancel-in-progress: false`, that single run held the group and **34 later deploys were cancelled before starting a job**. The site served a version a full major behind for two weeks.

## Why every existing timeout missed it

All three jobs in `deploy-website.yml` already have `timeout-minutes` — the deploy job has 5.

**`timeout-minutes` bounds execution, not queueing.** It starts counting when a runner picks the job up. A job that never gets a runner is never "running", so it sat 11 days *inside a 5-minute limit* without contradiction. Queue residency is the one state nothing in the workflow file bounds, and GitHub Actions exposes no per-job knob for it — which is why this is an external check rather than a config change.

I filed #4521 originally asking for a `timeout-minutes` that already existed. Corrected on the issue; this PR implements what actually helps.

## The threshold is measured, not guessed

Five most recent successful deploys, end-to-end: **79s, 73s, 79s, 95s, 67s**. A healthy deploy is ~90 seconds, so the 60-minute window is roughly 40x the observed norm — ample room for runner-availability delays while still turning an 11-day wedge into a same-day report.

`in_progress` is **deliberately never flagged**, however long it has run. That state is already bounded by the job's own timeout; flagging it would duplicate an existing control and generate noise. There's a test pinning that.

## Reports only

Cancelling a run is destructive, so it stays a human decision. The check names the specific run to cancel — which mattered: finding the wedged run by hand took real digging, because `queued` does not appear in the obvious "pending runs" query. That's the same wrong-filter mistake I made in the original #4506 diagnosis.

## Relationship to #4516

#4516 catches the **consequence** — published site behind `main` — within 6 hours, and remains the primary alarm because it fires regardless of cause. This catches the **cause** early. They compose: one is cause-agnostic and slower, the other is specific and fast.

## Verification

- 7 unit tests, including a replay of the real incident and the `in_progress` control.
- **Against the live repo:** `No runs waiting past the queue window`, exit 0.
- **Replaying the actual wedged run** (`31293406815`, created 2026-08-09T03:54:23Z): flags at 18,248 minutes, exit 1.
- `eslint`, `lint:arch` clean; workflow YAML parse-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
