### PR TITLE
fix(consensus): an option-split veto is a rejection, not a void

### DIFF
--- a/.changeset/option-veto-is-a-rejection.md
+++ b/.changeset/option-veto-is-a-rejection.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+An option-split veto now records as `rejected`, not `no_quorum` ([#4529](https://github.com/nexus-substrate/nexus-agents/issues/4529)).
+
+`applyOptionGate` vetoed correctly but wrote its explanation to `result.policyReason`. That field means one specific thing — "an error policy VOIDED this vote" — and `resolveVoteDecision` short-circuits any non-`undefined` value straight to `no_quorum`. So every multi-option veto was stamped as a void: the panel convened, every voter was heard, the gate measured a real split, and the record said nothing was decided.
+
+The audit trail inherited it: `errorVoided` is derived from `policyReason`, which forces the persisted `VoteRecord.decision` to `no_quorum` too.
+
+Worse, `--on-no-quorum=retry` re-runs a voided vote once, on the sound theory that a missing voice is worth re-collecting. A genuinely split panel took that branch — so the substrate would re-roll the panel and discard the dissent the gate had just detected. #4452 mislabelled a split; this could erase one.
+
+The veto reason now travels on the `optionGate` verdict object, which already reaches the response and sits beside the tally that justifies it. `policyReason` keeps its single meaning, and `resolveVoteDecision` — shared by the engine and the response so the two cannot diverge (#4135) — is untouched. The response carries `optionOutcome.vetoReason`, declared in the advertised MCP schema so a strict client does not reject it.
+
+Shape chosen by a 7-voter `higher_order` panel: 6 approvers, all selecting this option, zero unattributed. The panel's reasoning against the alternative of adding a discriminator to the shared resolver was that an optional discriminator reintroduces the same conflation by omission.
+
+Why no test caught it: the gate's own unit tests are thorough and all passed. Nothing exercised the composition — `applyOptionGate` followed by `resolveVoteDecision`, the two consecutive lines in `executeVoting`. That composition now has a test.

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-option-gate.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-option-gate.ts
@@ -36,6 +36,21 @@ import {
   type OptionThreshold,
   type OptionThresholdVerdict,
 } from '../../consensus/option-tally.js';
+
+/**
+ * The option verdict as `executeVoting` stores it, with the veto explanation
+ * attached (#4529).
+ *
+ * The prose lives here rather than on {@link OptionThresholdVerdict} to keep
+ * `consensus/option-tally.ts` a pure tally module, and rather than on
+ * `policyReason` because that field means exactly one thing — "an error policy
+ * VOIDED this vote". Borrowing it for a split made `resolveVoteDecision` stamp
+ * `no_quorum` on a panel that had in fact convened and disagreed.
+ */
+export interface OptionGateVerdict extends OptionThresholdVerdict {
+  /** Human-readable explanation, present only when the gate vetoed. */
+  readonly reason?: string;
+}
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 
 /** Strategies whose bar the option gate mirrors. */

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import type { AgentVoteResult, VotingResult } from '../../cli/vote-types.js';
 import { VOTER_ROLES } from '../../cli/vote-types.js';
 import type { HigherOrderVotingResult } from '../../consensus/higher-order-types.js';
-import type { OptionThresholdVerdict } from '../../consensus/option-tally.js';
+import type { OptionGateVerdict } from './consensus-vote-option-gate.js';
 import type { DecisionCostSummary } from '../../observability/decision-cost.js';
 import type { VoteRecordPersistOutcome } from './consensus-vote-recording.js';
 
@@ -382,6 +382,13 @@ export interface ConsensusVoteResponse {
     selectedCount: number;
     unattributedApprovals: number;
     thresholdMet: boolean;
+    /**
+     * #4529: why the gate vetoed, present only when it did. Carried here rather
+     * than on `policyReason`, which means "an error policy voided this vote" —
+     * a split is a decision, not a void, and conflating them let a retry policy
+     * re-roll a panel that had already disagreed.
+     */
+    vetoReason?: string;
   };
   /**
    * #3991: whether the authentic vote record (#3897) was persisted at vote time.
@@ -409,7 +416,7 @@ export interface ExtendedVotingResult extends VotingResult {
    * declared `options`. Reported alongside `approvalPercentage` rather than
    * folded into it, so a reader can tell which bar failed.
    */
-  optionGate?: OptionThresholdVerdict;
+  optionGate?: OptionGateVerdict;
   higherOrderResult?: HigherOrderVotingResult;
   /** Reason an error policy short-circuited the vote (#3124); surfaced on the response. */
   policyReason?: string;
@@ -728,6 +735,7 @@ export function buildResponse(
       selectedCount: g.selectedCount,
       unattributedApprovals: g.unattributedApprovals,
       thresholdMet: g.approved,
+      ...(g.reason !== undefined ? { vetoReason: g.reason } : {}),
     };
   }
 

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -31,6 +31,10 @@ import {
 import type { VotingStrategy } from './consensus-vote-types.js';
 import type { AgentVoteResult } from '../../cli/vote-types.js';
 import type { ExtendedVotingResult } from './consensus-vote-types.js';
+import { applyOptionGate } from './consensus-vote.js';
+import { buildVoteRecord } from '../../audit/vote-record-store.js';
+import { resolveVoteDecision } from './consensus-vote-types.js';
+import type { ConsensusVoteInput } from './consensus-vote-types.js';
 import type { ConsensusResult } from '../../consensus/types.js';
 
 // #4132: force the contrarian expert-bridge to fail so runContrarianCheck reports
@@ -1919,5 +1923,138 @@ describe('maybeEscalateContrarian — quick-mode contrarian-check error (#4132)'
     );
     expect(out.escalated).toBeUndefined();
     expect(out.degradeReason).toBeUndefined();
+  });
+});
+
+describe('#4529: an option-split veto is a rejection, not a void', () => {
+  /** Seven approvers, `forLeading` of them choosing OPTION_A and the rest OPTION_B. */
+  const splitPanel = (forLeading: number, total = 7): AgentVoteResult[] =>
+    Array.from({ length: total }, (_, i) => ({
+      role: 'architect',
+      vote: { decision: 'approve' as const, reasoning: 'engaged', confidence: 0.9 },
+      processingTimeMs: 10,
+      source: 'llm' as const,
+      selectedOption: i < forLeading ? 'Rewrite' : 'Patch',
+    }));
+
+  const approvedResult = (votes: AgentVoteResult[]): ExtendedVotingResult => ({
+    proposal: 'Rewrite or patch?',
+    threshold: 'unanimous',
+    result: {
+      proposalId: 'p-4529',
+      proposal: { title: 't', description: 'Rewrite or patch?', algorithm: 'unanimous' },
+      // Every voter approved, so the approve/reject bar reads 100% — the #4452
+      // inversion the option gate exists to catch.
+      outcome: 'approved',
+      votes: new Map(),
+      voteCounts: { approve: votes.length, reject: 0, abstain: 0, total: votes.length },
+      approvalPercentage: 100,
+      quorumReached: true,
+      startedAt: 'now',
+      closedAt: 'now',
+      durationMs: 1,
+    },
+    votes,
+    totalTimeMs: 10,
+    simulateVotes: false,
+    strategy: 'unanimous',
+  });
+
+  const input: ConsensusVoteInput = {
+    proposal: 'Rewrite or patch?',
+    simulateVotes: false,
+    quickMode: false,
+    strategy: 'unanimous',
+    options: ['Rewrite', 'Patch'],
+  };
+
+  it('stamps rejected — the panel decided and disagreed; it was not voided', () => {
+    // Reproduces the exact two-line sequence in executeVoting (L622-623).
+    const result = approvedResult(splitPanel(6));
+
+    applyOptionGate(input, result);
+    const { decision } = resolveVoteDecision(input, result, 0);
+
+    expect(result.result.outcome).toBe('rejected');
+    // no_quorum means "a voice was missing, nothing was decided" and is
+    // recoverable by re-running. A 6-1 split is the opposite: every voice was
+    // heard. Filing it as a void lets --on-no-quorum=retry re-roll the panel
+    // and discard the dissent the gate just detected.
+    expect(decision).toBe('rejected');
+  });
+
+  it('does not mark the vote error-voided when no voter errored', () => {
+    // errorVoided is derived from policyReason (consensus-vote.ts:845) and
+    // forces the PERSISTED record's decision to no_quorum, so borrowing that
+    // field for a split corrupts the audit trail, not just the response.
+    const result = approvedResult(splitPanel(6));
+
+    applyOptionGate(input, result);
+
+    expect(result.votes.some((v) => v.source === 'error')).toBe(false);
+    expect(result.policyReason).toBeUndefined();
+  });
+
+  it('still explains the veto to the operator', () => {
+    const result = approvedResult(splitPanel(6));
+
+    applyOptionGate(input, result);
+
+    // Whatever channel carries it, the reason must survive the veto.
+    const explanation = JSON.stringify(result);
+    expect(explanation).toContain('Rewrite');
+    expect(explanation.toLowerCase()).toContain('option');
+  });
+
+  it('leaves a genuine error-policy void reading as no_quorum', () => {
+    // The gate must not steal the meaning of a real void in the other direction.
+    const result = approvedResult(splitPanel(7));
+    result.policyReason = 'fail_closed: 4 of 7 voters errored';
+
+    applyOptionGate(input, result);
+
+    expect(resolveVoteDecision(input, result, 4).decision).toBe('no_quorum');
+  });
+
+  it('surfaces the veto reason on the response, not on policyReason', () => {
+    const result = approvedResult(splitPanel(6));
+    applyOptionGate(input, result);
+    result.decision = resolveVoteDecision(input, result, 0).decision;
+
+    const response = buildResponse(input, result);
+
+    expect(response.optionOutcome?.vetoReason).toContain('Rewrite');
+    expect(response.policyReason).toBeUndefined();
+    expect(response.decision).toBe('rejected');
+  });
+
+  it('persists the split as rejected, so the audit trail is not a void', () => {
+    // errorVoided is derived from policyReason at consensus-vote.ts:845 and
+    // forces the persisted decision to no_quorum. With the reason off that
+    // field, a split records as what it was.
+    const result = approvedResult(splitPanel(6));
+    applyOptionGate(input, result);
+
+    // Drive the REAL record builder rather than reimplementing its mapping —
+    // a test that recomputes the thing it checks cannot fail for the bug.
+    const record = buildVoteRecord({
+      id: 'vr-4529',
+      proposal: result.proposal,
+      result: result.result,
+      votes: result.votes,
+      strategy: result.strategy,
+      errorVoided: result.policyReason !== undefined,
+    });
+
+    expect(record.decision).toBe('rejected');
+  });
+
+  it('does not veto — or relabel — a panel that agreed on one option', () => {
+    const result = approvedResult(splitPanel(7));
+
+    applyOptionGate(input, result);
+
+    expect(result.result.outcome).toBe('approved');
+    expect(resolveVoteDecision(input, result, 0).decision).toBe('approved');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -628,9 +628,15 @@ export async function executeVoting(
  * Veto an approved verdict whose declared-option split failed its bar.
  *
  * Mutates `result` in place: `executeVoting` owns it and has not yet published
- * it. Only ever flips approved to rejected, never the reverse.
+ * it. Only ever flips approved to rejected, never the reverse — and the
+ * resulting `decision` must be `rejected`, not `no_quorum` (#4529): the panel
+ * convened and disagreed, which is the opposite of a voided vote.
+ *
+ * Exported for the composition test (#4529): the defect this guards against
+ * lives in how this function's output feeds `resolveVoteDecision` on the very
+ * next line of `executeVoting`, not in either function alone.
  */
-function applyOptionGate(input: ConsensusVoteInput, result: ExtendedVotingResult): void {
+export function applyOptionGate(input: ConsensusVoteInput, result: ExtendedVotingResult): void {
   const declaredOptions = input.options;
   if (declaredOptions === undefined || declaredOptions.length === 0) return;
 
@@ -641,16 +647,21 @@ function applyOptionGate(input: ConsensusVoteInput, result: ExtendedVotingResult
     result.result.outcome === 'approved'
   );
 
-  result.optionGate = outcome.verdict;
-
-  if (!outcome.vetoed) return;
+  if (!outcome.vetoed) {
+    result.optionGate = outcome.verdict;
+    return;
+  }
 
   result.result.outcome = 'rejected';
-  // Preserve an existing policy reason (an error-policy short-circuit is more
-  // urgent than an option split) rather than overwriting it.
-  if (result.policyReason === undefined && outcome.reason !== undefined) {
-    result.policyReason = outcome.reason;
-  }
+  // #4529: the reason rides on the verdict, NOT on policyReason. policyReason
+  // means "an error policy voided this vote", and resolveVoteDecision
+  // short-circuits any non-undefined value straight to `no_quorum` — so
+  // borrowing the field filed a measured split as "nothing was decided", and
+  // `--on-no-quorum=retry` then re-rolled the panel and discarded the dissent
+  // the gate had just detected. Decided by a 7-voter higher_order panel
+  // (6 approvers, all selecting this shape).
+  result.optionGate =
+    outcome.reason !== undefined ? { ...outcome.verdict, reason: outcome.reason } : outcome.verdict;
 }
 
 // eslint-disable-next-line max-lines-per-function -- see block comment above
@@ -1133,6 +1144,10 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
       selectedCount: z.number().int().nonnegative(),
       unattributedApprovals: z.number().int().nonnegative(),
       thresholdMet: z.boolean(),
+      // #4529: present only on a veto. Declared here because a strict MCP
+      // client rejects any property the advertised schema omits — the same
+      // drift that made degraded-panel votes unusable before #4032.
+      vetoReason: z.string().max(400).optional(),
     })
     .optional(),
 };


### PR DESCRIPTION
Fixes #4529. Unblocks #4452 and #4464.

> **Owner ratification required — do not auto-merge.** Touches `src/mcp/` (CODEOWNERS `@williamzujkowski`). This is the governor's own judge; per the mission rule an agent must not land a change to its own review bar unilaterally.

## The bug

`applyOptionGate` vetoed correctly, then wrote its explanation to `result.policyReason`:

```ts
result.result.outcome = 'rejected';
if (result.policyReason === undefined && outcome.reason !== undefined) {
  result.policyReason = outcome.reason;   // <-- borrowed field
}
```

The very next line in `executeVoting` resolves the decision, and `resolveVoteDecision` treats **any** non-`undefined` `policyReason` as an error-policy short-circuit:

```ts
if (result.policyReason !== undefined || (!result.result.quorumReached && allErrors)) {
  return { decision: 'no_quorum' };
}
```

So `outcome = 'rejected'` never survived into `decision`. `applyOptionGate`'s own JSDoc said "Only ever flips approved to rejected" — contradicted two lines below it.

## Why p1 and not cosmetic

`no_quorum` and `rejected` mean opposite things:

- **`no_quorum`** — the vote was voided. A voice was missing. Nothing was decided. *Recoverable by re-running.*
- **`rejected`** — the panel convened, every voice was heard, and it did not agree on one option.

The audit record inherited the error: `errorVoided` is derived from `policyReason` and forces the persisted `VoteRecord.decision` to `no_quorum`.

And it was actively destructive. `--on-no-quorum=retry` re-runs a void once:

```ts
if (result.decision === 'no_quorum' && onNoQuorum === 'retry') {
  result = await runVote(options);   // a genuinely split panel takes this branch
}
```

That is a mechanism for *escaping* a split by retrying it. #4452 laundered a split as unanimous; this one could erase one.

## The fix (Option C)

The reason travels on the `optionGate` verdict — which already reaches the response, and sits beside the tally that justifies it. `policyReason` keeps its single meaning; `resolveVoteDecision`, shared by engine and response so they cannot diverge (#4135), is untouched.

`optionOutcome.vetoReason` is declared in the **advertised** MCP schema, not just the internal type — a strict client rejects any property the advertised schema omits, which is the drift that broke degraded-panel votes before #4032.

## How the shape was chosen

A 7-voter `higher_order` panel with the three candidate shapes declared as `options`: **6 approvers, all selecting C, `leadingShare: 1.0`, zero unattributed.** The panel's argument against adding a discriminator to the shared resolver: an optional discriminator must default to *something*, and a forgotten one silently degrades to the void path — reintroducing this exact bug by omission.

The contrarian voted reject on backward compatibility. Half of that is right and is addressed: `vetoReason` is in the advertised schema. The other half — migrating historical records — is infeasible **by design**: the audit chain is append-only and tamper-evident, so rewriting past records is precisely what it exists to detect. Records written before this fix keep saying `no_quorum`; they are identifiable read-only by `optionCoverage` present with no errored voters.

## Why no test caught it

The gate's unit tests are thorough and all 125 pass. None exercised the **composition** — `applyOptionGate` followed by `resolveVoteDecision`, the two consecutive lines in `executeVoting`. Each function was correct alone. That composition now has a test, including one that drives the real `buildVoteRecord` rather than reimplementing its mapping.

## Verification

- 7 new tests; 3423 pass across `mcp/tools`, `consensus`, `audit`. Typecheck and lint clean.
- Field evidence from the persisted chain: yesterday's #4504 vote recorded `approverCount: 6, selectedCount: 6` with a tally summing to **7** — a pre-fix record disagreeing with itself. Today's vote, on the current build, records 6/6 consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
