### PR TITLE
fix(indexer): distinguish an unparsed file from an empty one

### DIFF
--- a/.changeset/unparsed-is-not-empty.md
+++ b/.changeset/unparsed-is-not-empty.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+`extract_symbols` now says whether it read the file ([#4517](https://github.com/nexus-substrate/nexus-agents/issues/4517)).
+
+Both empty outcomes shared one message:
+
+```
+No symbols found (file may not be TypeScript/JavaScript)
+```
+
+It was wrong in the case that prompted this. `src/exports/benchmarks.ts` is a valid TypeScript file; it returns no symbols because all 20 of its exports are re-exports, which declare nothing locally. The parenthetical sent a reader looking for a file-type problem that did not exist.
+
+These are different facts:
+
+- **Not parsed** — the extension is unsupported, so the file was never read. Nothing is claimed about its contents.
+- **Parsed, no declarations** — the file was read and genuinely declares nothing locally, typically a re-export barrel.
+
+That is the same unmeasured-versus-measured-zero distinction the governance rules already require of a gate, applied to a tool an agent uses to decide whether to go read the file itself.
+
+`extractSymbolIndexResult()` now returns either an index or a reason, and the tool renders each accordingly — naming the supported extensions when it could not parse, and naming the re-export case when it could. `SymbolExtractionResult` gains `parsed`.
+
+The superseded `extractSymbolIndex()` is removed (internal, no external consumers); it returned a bare `''` for both cases and so could not tell a caller which had happened.
+
+Also corrects `symbol-extractor.test.ts`'s header, which described the suite as validating "tree-sitter AST symbol extraction". There is no tree-sitter in the tree — extraction runs on the TypeScript compiler API. Adding tree-sitter for non-TS languages is the remaining, larger part of #4517.

--- a/packages/nexus-agents/src/indexer/symbol-extractor-benchmark.test.ts
+++ b/packages/nexus-agents/src/indexer/symbol-extractor-benchmark.test.ts
@@ -10,7 +10,18 @@
 import { describe, it, expect } from 'vitest';
 import { resolve } from 'node:path';
 import { readdir } from 'node:fs/promises';
-import { extractSymbols, extractSymbolIndex } from './symbol-extractor.js';
+import { extractSymbols, extractSymbolIndexResult } from './symbol-extractor.js';
+
+/**
+ * The rendered index, or '' when there is none.
+ *
+ * These suites sweep real source files, and a re-export barrel genuinely has
+ * no local declarations — that is a valid reading, not a failure.
+ */
+async function indexOf(filePath: string): Promise<string> {
+  const result = await extractSymbolIndexResult(filePath);
+  return result.kind === 'index' ? result.index : '';
+}
 
 const SRC_DIR = resolve(import.meta.dirname ?? '.', '..');
 
@@ -52,7 +63,7 @@ describe('codebase-wide benchmark', () => {
 
     for (const file of sample) {
       const result = await extractSymbols(file);
-      const index = await extractSymbolIndex(file);
+      const index = await indexOf(file);
       totalOriginal += result.totalChars;
       totalIndex += index.length;
       totalSymbolCount += result.symbols.length;
@@ -139,7 +150,7 @@ describe('edge cases', () => {
   it('extractSymbolIndex stays under 5KB for typical files', async () => {
     const files = await findTsFiles(SRC_DIR, 2);
     for (const file of files.slice(0, 20)) {
-      const index = await extractSymbolIndex(file);
+      const index = await indexOf(file);
       // Index should be compact — under 5KB for any single file
       expect(index.length).toBeLessThan(5000);
     }

--- a/packages/nexus-agents/src/indexer/symbol-extractor-quality.test.ts
+++ b/packages/nexus-agents/src/indexer/symbol-extractor-quality.test.ts
@@ -10,7 +10,18 @@
 import { describe, it, expect } from 'vitest';
 import { resolve } from 'node:path';
 import { readFile } from 'node:fs/promises';
-import { extractSymbols, extractSymbolIndex } from './symbol-extractor.js';
+import { extractSymbols, extractSymbolIndexResult } from './symbol-extractor.js';
+
+/**
+ * The rendered index, or '' when there is none.
+ *
+ * These suites sweep real source files, and a re-export barrel genuinely has
+ * no local declarations — that is a valid reading, not a failure.
+ */
+async function indexOf(filePath: string): Promise<string> {
+  const result = await extractSymbolIndexResult(filePath);
+  return result.kind === 'index' ? result.index : '';
+}
 
 const SRC_DIR = resolve(import.meta.dirname ?? '.', '..');
 
@@ -135,7 +146,7 @@ describe('reconstruction quality', () => {
 
   it('index format is parseable and useful', async () => {
     const filePath = resolve(SRC_DIR, 'config/model-config-helpers.ts');
-    const index = await extractSymbolIndex(filePath);
+    const index = await indexOf(filePath);
 
     // Index should start with file comment
     expect(index.startsWith('//')).toBe(true);

--- a/packages/nexus-agents/src/indexer/symbol-extractor.test.ts
+++ b/packages/nexus-agents/src/indexer/symbol-extractor.test.ts
@@ -1,15 +1,27 @@
 /**
  * Tests for symbol-extractor.ts
  *
- * Validates tree-sitter AST symbol extraction on real nexus-agents source files.
- * Uses the actual codebase as test fixtures — no mocks needed.
+ * Validates TypeScript-compiler-API symbol extraction on real nexus-agents
+ * source files. Uses the actual codebase as test fixtures — no mocks needed.
+ *
+ * (The header previously said "tree-sitter". There is no tree-sitter in the
+ * tree; adding it for non-TS languages is #4517.)
  *
  * @module indexer/symbol-extractor.test
  */
 
 import { describe, it, expect } from 'vitest';
-import { resolve } from 'node:path';
-import { extractSymbols, extractSymbolIndex } from './symbol-extractor.js';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { extractSymbols, extractSymbolIndexResult } from './symbol-extractor.js';
+
+/** The rendered index, failing loudly if extraction reported empty instead. */
+async function indexOf(filePath: string): Promise<string> {
+  const result = await extractSymbolIndexResult(filePath);
+  if (result.kind !== 'index') throw new Error(`expected an index, got ${result.reason}`);
+  return result.index;
+}
 
 const SRC_DIR = resolve(import.meta.dirname ?? '.', '..');
 
@@ -65,7 +77,7 @@ describe('token savings measurement', () => {
     for (const file of files) {
       const filePath = resolve(SRC_DIR, file);
       const result = await extractSymbols(filePath);
-      const index = await extractSymbolIndex(filePath);
+      const index = await indexOf(filePath);
       totalOriginal += result.totalChars;
       totalIndex += index.length;
       expect(result.symbols.length).toBeGreaterThan(0);
@@ -78,7 +90,7 @@ describe('token savings measurement', () => {
 
 describe('extractSymbolIndex', () => {
   it('returns compact index string', async () => {
-    const index = await extractSymbolIndex(resolve(SRC_DIR, 'config/model-capabilities-types.ts'));
+    const index = await indexOf(resolve(SRC_DIR, 'config/model-capabilities-types.ts'));
     expect(index).toContain('// ');
     expect(index).toContain('symbols');
     expect(index).toContain('CLI_NAMES');
@@ -87,7 +99,47 @@ describe('extractSymbolIndex', () => {
   });
 
   it('includes line numbers', async () => {
-    const index = await extractSymbolIndex(resolve(SRC_DIR, 'config/model-capabilities-types.ts'));
+    const index = await indexOf(resolve(SRC_DIR, 'config/model-capabilities-types.ts'));
     expect(index).toMatch(/L\d+-\d+/);
+  });
+});
+
+describe('#4517: an unparsed file is not an empty file', () => {
+  const tmp = (name: string, body: string): string => {
+    const p = join(mkdtempSync(join(tmpdir(), 'symext-')), name);
+    writeFileSync(p, body, 'utf-8');
+    return p;
+  };
+
+  it('marks an unsupported extension as not parsed', async () => {
+    const result = await extractSymbols(tmp('service.py', 'def handler():\n    return 1\n'));
+
+    expect(result.parsed).toBe(false);
+    expect(result.symbols).toEqual([]);
+  });
+
+  it('marks a supported file as parsed even when it declares nothing', async () => {
+    // The #4517 case: a valid TypeScript barrel. Zero symbols is a
+    // measurement here, not a failure to read.
+    const result = await extractSymbols(tmp('barrel.ts', "export { a } from './a.js';\n"));
+
+    expect(result.parsed).toBe(true);
+    expect(result.symbols).toEqual([]);
+  });
+
+  it('reports unsupported and no-declarations as different reasons', async () => {
+    const unsupported = await extractSymbolIndexResult(tmp('main.go', 'package main\n'));
+    const barrel = await extractSymbolIndexResult(tmp('b.ts', "export { a } from './a.js';\n"));
+
+    expect(unsupported).toEqual({ kind: 'empty', reason: 'unsupported' });
+    expect(barrel).toEqual({ kind: 'empty', reason: 'no-declarations' });
+  });
+
+  it('returns the index when there are declarations', async () => {
+    const result = await extractSymbolIndexResult(tmp('f.ts', 'export function go(): void {}\n'));
+
+    expect(result.kind).toBe('index');
+    if (result.kind !== 'index') return;
+    expect(result.index).toContain('go');
   });
 });

--- a/packages/nexus-agents/src/indexer/symbol-extractor.ts
+++ b/packages/nexus-agents/src/indexer/symbol-extractor.ts
@@ -30,6 +30,15 @@ export interface CodeSymbol {
   exported: boolean;
 }
 
+/**
+ * Extensions the TypeScript compiler API path can parse (#4517).
+ *
+ * Exported so the tool layer can name them in its error message instead of
+ * asserting a file "may not be TypeScript/JavaScript" without saying what
+ * would count.
+ */
+export const SUPPORTED_EXTENSIONS: readonly string[] = ['.ts', '.tsx', '.js', '.jsx'];
+
 /** Result of extracting symbols from a file. */
 export interface SymbolExtractionResult {
   filePath: string;
@@ -38,6 +47,16 @@ export interface SymbolExtractionResult {
   totalChars: number;
   symbolChars: number;
   savingsPercent: number;
+  /**
+   * Whether the file was actually parsed (#4517).
+   *
+   * `false` means the extension is not supported, so `symbols: []` reports
+   * that nothing was READ — not that nothing is there. An unsupported file and
+   * a genuinely symbol-free file previously returned identical results, and
+   * the tool guessed between them wrongly: a valid TypeScript barrel of 20
+   * re-exports was reported as possibly-not-TypeScript.
+   */
+  parsed: boolean;
 }
 
 function getKind(node: ts.Node): CodeSymbol['kind'] | null {
@@ -140,7 +159,7 @@ function computeSavings(totalChars: number, symbolChars: number): number {
  */
 export async function extractSymbols(filePath: string): Promise<SymbolExtractionResult> {
   const ext = extname(filePath).toLowerCase();
-  if (!['.ts', '.tsx', '.js', '.jsx'].includes(ext)) {
+  if (!SUPPORTED_EXTENSIONS.includes(ext)) {
     return {
       filePath,
       symbols: [],
@@ -148,6 +167,7 @@ export async function extractSymbols(filePath: string): Promise<SymbolExtraction
       totalChars: 0,
       symbolChars: 0,
       savingsPercent: 0,
+      parsed: false,
     };
   }
 
@@ -169,21 +189,45 @@ export async function extractSymbols(filePath: string): Promise<SymbolExtraction
     totalChars,
     symbolChars,
     savingsPercent: computeSavings(totalChars, symbolChars),
+    parsed: true,
   };
 }
 
 /**
- * Extract a compact symbol index (names + locations only, no source text).
- * This is the minimal representation for LLM context — ~95%+ token savings.
+ * Why {@link extractSymbolIndex} produced no index (#4517).
+ *
+ * `unsupported` and `no-declarations` are different facts about the world:
+ * the first says the file was never read, the second says it was read and
+ * genuinely declares nothing locally — a re-export barrel, typically. Callers
+ * that collapse them tell the user to check a file type that was never the
+ * problem.
  */
-export async function extractSymbolIndex(filePath: string): Promise<string> {
-  const result = await extractSymbols(filePath);
-  if (result.symbols.length === 0) return '';
+export type EmptyIndexReason = 'unsupported' | 'no-declarations';
 
+/** A symbol index, or the reason there is none. */
+export type SymbolIndexResult =
+  | { readonly kind: 'index'; readonly index: string }
+  | { readonly kind: 'empty'; readonly reason: EmptyIndexReason };
+
+/**
+ * Extract a compact symbol index, reporting why when there is nothing to show.
+ *
+ * Names + locations only, no source text — the minimal representation for LLM
+ * context (~95%+ token savings). Replaced the earlier `extractSymbolIndex`,
+ * which returned a bare `''` for both "could not read" and "read, found
+ * nothing" and so could not tell a caller which had happened.
+ */
+export async function extractSymbolIndexResult(filePath: string): Promise<SymbolIndexResult> {
+  const result = await extractSymbols(filePath);
+  if (!result.parsed) return { kind: 'empty', reason: 'unsupported' };
+  if (result.symbols.length === 0) return { kind: 'empty', reason: 'no-declarations' };
+  return { kind: 'index', index: renderIndex(filePath, result) };
+}
+
+function renderIndex(filePath: string, result: SymbolExtractionResult): string {
   const lines = result.symbols.map((s) => {
     const exp = s.exported ? 'export ' : '';
     return `${exp}${s.kind} ${s.name} (L${String(s.startLine)}-${String(s.endLine)})`;
   });
-
   return `// ${filePath} — ${String(result.symbols.length)} symbols\n${lines.join('\n')}`;
 }

--- a/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.test.ts
@@ -16,7 +16,8 @@ import { resolve } from 'node:path';
 // Mock the symbol extractor so we don't need real source files for every test.
 vi.mock('../../indexer/symbol-extractor.js', () => ({
   extractSymbols: vi.fn(),
-  extractSymbolIndex: vi.fn(),
+  extractSymbolIndexResult: vi.fn(),
+  SUPPORTED_EXTENSIONS: ['.ts', '.tsx', '.js', '.jsx'],
 }));
 
 import {
@@ -31,7 +32,7 @@ import type { CodeSymbol } from '../../indexer/symbol-extractor.js';
 const { extractSymbolsHandler } = _testing;
 
 const mockedExtractSymbols = vi.mocked(symbolExtractor.extractSymbols);
-const mockedExtractSymbolIndex = vi.mocked(symbolExtractor.extractSymbolIndex);
+const mockedExtractIndexResult = vi.mocked(symbolExtractor.extractSymbolIndexResult);
 
 function makeCtx(): Parameters<typeof extractSymbolsHandler>[1] {
   // Minimal RequestContext — the handler only reads ctx.logger, so the
@@ -68,7 +69,10 @@ describe('extract-symbols-tool (#2159)', () => {
     });
 
     it('accepts paths inside the cwd subtree', async () => {
-      mockedExtractSymbolIndex.mockResolvedValueOnce('fn foo:10\nfn bar:20');
+      mockedExtractIndexResult.mockResolvedValueOnce({
+        kind: 'index',
+        index: 'fn foo:10\nfn bar:20',
+      });
       const inside = resolve('./package.json'); // real file, resolves under cwd
       const result = await extractSymbolsHandler({ filePath: inside }, makeCtx());
       // Should not be flagged as traversal even if the file isn't a TS file.
@@ -106,9 +110,9 @@ describe('extract-symbols-tool (#2159)', () => {
 
   describe('mode dispatch', () => {
     it('defaults to index mode (calls extractSymbolIndex, not extractSymbols)', async () => {
-      mockedExtractSymbolIndex.mockResolvedValueOnce('fn foo:10');
+      mockedExtractIndexResult.mockResolvedValueOnce({ kind: 'index', index: 'fn foo:10' });
       await extractSymbolsHandler({ filePath: resolve('./x.ts') }, makeCtx());
-      expect(mockedExtractSymbolIndex).toHaveBeenCalledTimes(1);
+      expect(mockedExtractIndexResult).toHaveBeenCalledTimes(1);
       expect(mockedExtractSymbols).not.toHaveBeenCalled();
     });
 
@@ -119,6 +123,7 @@ describe('extract-symbols-tool (#2159)', () => {
         totalChars: 100,
         symbolChars: 50,
         savingsPercent: 50,
+        parsed: true,
         symbols: [
           {
             name: 'foo',
@@ -135,17 +140,38 @@ describe('extract-symbols-tool (#2159)', () => {
         makeCtx()
       );
       expect(mockedExtractSymbols).toHaveBeenCalledTimes(1);
-      expect(mockedExtractSymbolIndex).not.toHaveBeenCalled();
+      expect(mockedExtractIndexResult).not.toHaveBeenCalled();
       const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
       expect(text).toContain('savingsPercent');
     });
 
-    it('returns a friendly message when index is empty (non-TS/JS file)', async () => {
-      mockedExtractSymbolIndex.mockResolvedValueOnce('');
+    it('names the supported extensions when the file could not be parsed', async () => {
+      // #4517: the old message guessed "file may not be TypeScript/JavaScript"
+      // for BOTH empty cases without saying what would count.
+      mockedExtractIndexResult.mockResolvedValueOnce({ kind: 'empty', reason: 'unsupported' });
       const result = await extractSymbolsHandler({ filePath: resolve('./x.md') }, makeCtx());
+
       expect(result.isError).toBeFalsy();
       const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
-      expect(text).toMatch(/No symbols found/);
+      expect(text).toContain('.md');
+      expect(text).toContain('.ts');
+      // It must not imply anything about contents it never read.
+      expect(text).toContain('says nothing about whether the file contains symbols');
+    });
+
+    it('says a parsed file genuinely declares nothing, and why that happens', async () => {
+      // The case that misled a reader on a valid .ts barrel of 20 re-exports.
+      mockedExtractIndexResult.mockResolvedValueOnce({
+        kind: 'empty',
+        reason: 'no-declarations',
+      });
+      const result = await extractSymbolsHandler({ filePath: resolve('./barrel.ts') }, makeCtx());
+
+      const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      expect(text).toContain('Parsed successfully');
+      expect(text).toContain('re-export');
+      // Must not send the reader hunting a file-type problem that isn't there.
+      expect(text).not.toContain('may not be TypeScript');
     });
   });
 
@@ -174,6 +200,7 @@ describe('extract-symbols-tool (#2159)', () => {
         totalChars: perSymbolChars * 5,
         symbolChars: perSymbolChars * 5,
         savingsPercent: 0,
+        parsed: true,
         symbols,
       });
 
@@ -206,6 +233,7 @@ describe('extract-symbols-tool (#2159)', () => {
         totalChars: count * 5,
         symbolChars: count * 5,
         savingsPercent: 0,
+        parsed: true,
         symbols,
       });
 
@@ -233,6 +261,7 @@ describe('extract-symbols-tool (#2159)', () => {
         totalChars: 300,
         symbolChars: 300,
         savingsPercent: 0,
+        parsed: true,
         symbols,
       });
 
@@ -254,6 +283,7 @@ describe('extract-symbols-tool (#2159)', () => {
         totalChars: 100,
         symbolChars: 50,
         savingsPercent: 50,
+        parsed: true,
         symbols: [makeSymbol('foo', 20)],
       });
 
@@ -270,7 +300,7 @@ describe('extract-symbols-tool (#2159)', () => {
 
   describe('error propagation', () => {
     it('wraps extractor failures in a toolError (not a thrown exception)', async () => {
-      mockedExtractSymbolIndex.mockRejectedValueOnce(new Error('parse crashed'));
+      mockedExtractIndexResult.mockRejectedValueOnce(new Error('parse crashed'));
       const result = await extractSymbolsHandler({ filePath: resolve('./x.ts') }, makeCtx());
       expect(result.isError).toBe(true);
       const text = result.content[0]?.type === 'text' ? result.content[0].text : '';
@@ -279,7 +309,7 @@ describe('extract-symbols-tool (#2159)', () => {
     });
 
     it('coerces non-Error throws into a string message', async () => {
-      mockedExtractSymbolIndex.mockRejectedValueOnce('string error');
+      mockedExtractIndexResult.mockRejectedValueOnce('string error');
       const result = await extractSymbolsHandler({ filePath: resolve('./x.ts') }, makeCtx());
       expect(result.isError).toBe(true);
     });

--- a/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
@@ -8,13 +8,15 @@
  * @module mcp/tools/extract-symbols-tool
  */
 
-import { resolve, sep } from 'node:path';
+import { extname, resolve, sep } from 'node:path';
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { createLogger, formatZodError } from '../../core/index.js';
 import {
   extractSymbols,
-  extractSymbolIndex,
+  extractSymbolIndexResult,
+  SUPPORTED_EXTENSIONS,
+  type EmptyIndexReason,
   type CodeSymbol,
 } from '../../indexer/symbol-extractor.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
@@ -251,11 +253,15 @@ async function extractSymbolsHandler(args: unknown, ctx: HandlerContext): Promis
     }
 
     // Default: index mode (minimal tokens)
-    const index = await extractSymbolIndex(resolvedPath);
-    if (index === '') {
-      return toolSuccess('No symbols found (file may not be TypeScript/JavaScript)');
+    // #4517: report WHICH of the two empty cases this is. The old single
+    // message guessed "file may not be TypeScript/JavaScript" for both, and
+    // sent a reader hunting a file-type problem on a valid .ts barrel whose
+    // 20 exports were all re-exports declaring nothing locally.
+    const result = await extractSymbolIndexResult(resolvedPath);
+    if (result.kind === 'empty') {
+      return toolSuccess(emptyIndexMessage(result.reason, resolvedPath));
     }
-    return toolSuccess(index);
+    return toolSuccess(result.index);
   } catch (caught: unknown) {
     const e = caught instanceof Error ? caught : new Error(String(caught));
     ctx.logger.error('Symbol extraction failed', e);
@@ -264,6 +270,31 @@ async function extractSymbolsHandler(args: unknown, ctx: HandlerContext): Promis
       message: `Symbol extraction failed: ${e.message}`,
     });
   }
+}
+
+/**
+ * Explain an empty index in terms of what was actually determined (#4517).
+ *
+ * `unsupported` is an absence of measurement — the file was never parsed, so
+ * nothing is claimed about its contents. `no-declarations` is a measurement:
+ * the file parsed and declares nothing locally. Naming the re-export case
+ * matters because it is the common one and it looks like a failure otherwise.
+ */
+function emptyIndexMessage(reason: EmptyIndexReason, filePath: string): string {
+  if (reason === 'unsupported') {
+    const ext = extname(filePath).toLowerCase();
+    const shown = ext === '' ? '(no extension)' : ext;
+    return (
+      `Not parsed: extract_symbols cannot read ${shown} files. ` +
+      `Supported: ${SUPPORTED_EXTENSIONS.join(', ')}. ` +
+      `This says nothing about whether the file contains symbols.`
+    );
+  }
+  return (
+    'Parsed successfully; no local declarations found. ' +
+    'A re-export barrel (`export { X } from ...`) reports zero symbols because ' +
+    're-exports declare nothing locally.'
+  );
 }
 
 // ============================================================================


### PR DESCRIPTION
Addresses the second half of #4517 (the misleading empty-result message). The tree-sitter work — the larger half — is unchanged and still open, because its first task is a native-vs-WASM dependency decision that deserves its own research and vote.

## One message for two different facts

```ts
if (index === '') {
  return toolSuccess('No symbols found (file may not be TypeScript/JavaScript)');
}
```

I hit this on `src/exports/benchmarks.ts` — a valid TypeScript file with 20 export statements. The message was wrong twice: the file **is** TypeScript, and the actual reason is that all 20 are re-exports (`export { X } from '...'`), which declare no local symbols. The parenthetical sent me looking for a file-type problem that did not exist.

Underneath, `extractSymbols` returned an identical empty result for an unsupported extension and for a parsed-but-symbol-free file, so the tool had nothing to distinguish them with and guessed.

These are not the same claim:

- **Not parsed** — the extension is unsupported, the file was never read, and nothing is known about its contents.
- **Parsed, no declarations** — the file was read and genuinely declares nothing locally.

That is the unmeasured-versus-measured-zero distinction the governance rules already demand of a gate, applied here to a tool an agent consults precisely to decide whether it still needs to go read the file.

## Change

`SymbolExtractionResult` gains `parsed`. `extractSymbolIndexResult()` returns either an index or a typed reason, and the tool renders each honestly — naming the supported extensions when it could not parse (and stating that this says nothing about the contents), and naming the re-export case when it could.

`extractSymbolIndex()` is removed. It was internal with no external consumers, and returning a bare `''` for both cases is what made the conflation unavoidable — leaving it would invite new callers back to the version that cannot tell them apart.

Also corrects this file's own test header, which described the suite as validating *"tree-sitter AST symbol extraction"*. There is no tree-sitter in the tree; extraction runs on the TypeScript compiler API. Worth fixing here since #4517 is about actually adding tree-sitter, and a header claiming it already exists is the kind of thing that makes an audit conclude the work is done.

## Verification

361 tests pass across `indexer` and the tool suite. Run against the real files:

```
packages/nexus-agents/src/exports/benchmarks.ts -> empty: no-declarations
scripts/arch-lint.ts                            -> index (74 symbols)
README.md                                       -> empty: unsupported
```

The first line is the bug report, now reporting what is actually true of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
