### PR TITLE
fix(quality-gate): run repository-declared scripts, not a hard-coded toolchain

### DIFF
--- a/.changeset/quality-gate-declared-scripts.md
+++ b/.changeset/quality-gate-declared-scripts.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+`run_quality_gate` runs the repository's own scripts instead of a hard-coded toolchain ([#4355](https://github.com/nexus-substrate/nexus-agents/issues/4355)).
+
+The gate hard-coded `npx eslint`, `npx tsc`, `npx vitest` and `pnpm build`. A project that declares Oxlint and npm got a red `lint` verdict from an ESLint it does not use and does not configure — while its own `npm run lint` was green. The gate reported a fact about a toolchain nobody had chosen.
+
+`npx` also made it a supply-chain surface: a missing checker was silently downloaded, so an unpinned, undeclared package executed _during a quality check_.
+
+Checks now resolve to the repository's declared script (`lint`, `typecheck`/`type-check`, `test`, `build`), run through the package manager its lockfile selects (pnpm / yarn / bun / npm). No script declared means the check reports **`skip`** with the reason — never a substituted guess, and never a download.
+
+**A gate that ran nothing no longer passes.** The aggregate was `fail > 0 ? 'fail' : 'pass'`, so a run in which every check was skipped reported a clean `pass`. Fixing the resolver without this would have converted a false red into a false green, which is strictly worse for a gate: an all-skipped run now reports `skip`, and feedback names every check that did not run rather than claiming "All checks passed."
+
+`skip` rather than `fail` for a missing script is deliberate. Nothing was measured, and asserting a project is broken on evidence never gathered is the same defect pointed the other way.

--- a/packages/nexus-agents/src/security/quality-gate-commands.test.ts
+++ b/packages/nexus-agents/src/security/quality-gate-commands.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { detectPackageManager, resolveCheckCommand } from './quality-gate-commands.js';
+
+/** A throwaway project dir with the given files. */
+function project(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'qgate-'));
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(dir, name), body, 'utf-8');
+  }
+  return dir;
+}
+
+const pkg = (scripts: Record<string, string>): string => JSON.stringify({ scripts });
+
+describe('detectPackageManager', () => {
+  it('picks pnpm from a pnpm lockfile', () => {
+    expect(detectPackageManager(project({ 'pnpm-lock.yaml': '' }))).toBe('pnpm');
+  });
+
+  it('picks npm from a package-lock', () => {
+    expect(detectPackageManager(project({ 'package-lock.json': '{}' }))).toBe('npm');
+  });
+
+  it('picks yarn from a yarn lockfile', () => {
+    expect(detectPackageManager(project({ 'yarn.lock': '' }))).toBe('yarn');
+  });
+
+  it('picks bun from a bun lockfile', () => {
+    expect(detectPackageManager(project({ 'bun.lockb': '' }))).toBe('bun');
+  });
+
+  it('falls back to npm when no lockfile is present', () => {
+    // npm is the one manager guaranteed to exist alongside node, so it is the
+    // safest guess — and it still only ever runs a DECLARED script.
+    expect(detectPackageManager(project({}))).toBe('npm');
+  });
+});
+
+describe('resolveCheckCommand', () => {
+  it('runs the declared lint script through the lockfile-selected manager', () => {
+    const dir = project({ 'package.json': pkg({ lint: 'oxlint' }), 'package-lock.json': '{}' });
+
+    const resolved = resolveCheckCommand(dir, 'lint');
+
+    expect(resolved).toEqual({
+      kind: 'command',
+      command: 'npm',
+      args: ['run', '--silent', 'lint'],
+      script: 'lint',
+    });
+  });
+
+  it('does NOT invent a linter when the project declares none', () => {
+    // The #4355 report: an Oxlint project got `npx eslint`, which downloaded an
+    // undeclared, unpinned ESLint and failed a repo whose own lint was green.
+    const dir = project({ 'package.json': pkg({ build: 'vite build' }) });
+
+    const resolved = resolveCheckCommand(dir, 'lint');
+
+    expect(resolved.kind).toBe('unconfigured');
+    if (resolved.kind !== 'unconfigured') return;
+    expect(resolved.reason).toContain('lint');
+  });
+
+  it('never resolves to npx', () => {
+    // Downloading a checker during a quality check is an unpinned execution on
+    // the security path, whatever the check would have concluded.
+    const dir = project({ 'package.json': pkg({ lint: 'eslint .' }), 'pnpm-lock.yaml': '' });
+
+    const resolved = resolveCheckCommand(dir, 'lint');
+
+    expect(resolved.kind).toBe('command');
+    if (resolved.kind !== 'command') return;
+    expect(resolved.command).not.toBe('npx');
+  });
+
+  it('accepts an alternate spelling of the typecheck script', () => {
+    const dir = project({ 'package.json': pkg({ 'type-check': 'tsc --noEmit' }) });
+
+    const resolved = resolveCheckCommand(dir, 'typecheck');
+
+    expect(resolved.kind).toBe('command');
+    if (resolved.kind !== 'command') return;
+    expect(resolved.script).toBe('type-check');
+  });
+
+  it('prefers the canonical script name over an alternate', () => {
+    const dir = project({
+      'package.json': pkg({ typecheck: 'tsc --noEmit', 'type-check': 'echo stale' }),
+    });
+
+    const resolved = resolveCheckCommand(dir, 'typecheck');
+
+    expect(resolved.kind).toBe('command');
+    if (resolved.kind !== 'command') return;
+    expect(resolved.script).toBe('typecheck');
+  });
+
+  it('reports unconfigured rather than guessing when package.json is unreadable', () => {
+    const dir = project({ 'package.json': 'not json at all' });
+
+    expect(resolveCheckCommand(dir, 'lint').kind).toBe('unconfigured');
+  });
+
+  it('reports unconfigured when there is no package.json', () => {
+    expect(resolveCheckCommand(project({}), 'build').kind).toBe('unconfigured');
+  });
+
+  it('treats an empty script body as undeclared', () => {
+    const dir = project({ 'package.json': pkg({ lint: '   ' }) });
+
+    expect(resolveCheckCommand(dir, 'lint').kind).toBe('unconfigured');
+  });
+});

--- a/packages/nexus-agents/src/security/quality-gate-commands.ts
+++ b/packages/nexus-agents/src/security/quality-gate-commands.ts
@@ -1,0 +1,134 @@
+/**
+ * Resolve quality-gate checks to repository-declared commands (#4355).
+ *
+ * The gate used to hard-code `npx eslint`, `npx tsc`, `npx vitest` and
+ * `pnpm build`. Two problems, and the second is the serious one:
+ *
+ *  - **It described the wrong project.** A repo that declares Oxlint and npm
+ *    got a red `lint` verdict from an ESLint that the repo does not use and
+ *    does not configure, while `npm run lint` was green. The gate reported a
+ *    fact about a toolchain nobody had chosen.
+ *  - **`npx` downloads.** A missing checker was silently fetched — an
+ *    unpinned, undeclared package executed *during a quality check*. A gate
+ *    that installs software to reach its verdict has a supply-chain surface
+ *    its callers never opted into.
+ *
+ * So resolution is now: the repository's own declared script, run through the
+ * package manager its lockfile selects. When no script is declared the check
+ * is **unconfigured** — reported as such, never substituted with a guess.
+ *
+ * @module security/quality-gate-commands
+ * (Source: Issue #4355)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Package managers we can drive, in lockfile-detection order. */
+export type PackageManager = 'pnpm' | 'yarn' | 'bun' | 'npm';
+
+/** The checks that map to a repository script. */
+export type ScriptedCheck = 'lint' | 'typecheck' | 'tests' | 'build';
+
+const LOCKFILES: ReadonlyArray<{ file: string; manager: PackageManager }> = [
+  { file: 'pnpm-lock.yaml', manager: 'pnpm' },
+  { file: 'yarn.lock', manager: 'yarn' },
+  { file: 'bun.lockb', manager: 'bun' },
+  { file: 'package-lock.json', manager: 'npm' },
+];
+
+/**
+ * Candidate script names per check, most canonical first.
+ *
+ * Alternates are common spellings, not guesses at a tool: every candidate is
+ * still something the repository declared for itself.
+ */
+const SCRIPT_CANDIDATES: Record<ScriptedCheck, readonly string[]> = {
+  lint: ['lint'],
+  typecheck: ['typecheck', 'type-check', 'types'],
+  tests: ['test', 'tests'],
+  build: ['build'],
+};
+
+export type ResolvedCheck =
+  | {
+      readonly kind: 'command';
+      readonly command: string;
+      readonly args: readonly string[];
+      /** Which declared script this resolved to, for the result details. */
+      readonly script: string;
+    }
+  | {
+      readonly kind: 'unconfigured';
+      readonly reason: string;
+    };
+
+/**
+ * Which package manager the repository's lockfile selects.
+ *
+ * Falls back to `npm` when no lockfile is present — it ships with Node, so it
+ * is the one manager certain to be available. The fallback is safe because it
+ * only ever runs a script the repository declared; it cannot introduce a tool.
+ */
+export function detectPackageManager(projectDir: string): PackageManager {
+  for (const { file, manager } of LOCKFILES) {
+    if (existsSync(join(projectDir, file))) return manager;
+  }
+  return 'npm';
+}
+
+/** Read `scripts` from the project's package.json, or undefined if unreadable. */
+function readScripts(projectDir: string): Record<string, string> | undefined {
+  const manifest = join(projectDir, 'package.json');
+  if (!existsSync(manifest)) return undefined;
+
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(manifest, 'utf-8'));
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const scripts = (parsed as { scripts?: unknown }).scripts;
+    if (typeof scripts !== 'object' || scripts === null) return undefined;
+
+    const out: Record<string, string> = {};
+    for (const [name, body] of Object.entries(scripts)) {
+      if (typeof body === 'string') out[name] = body;
+    }
+    return out;
+  } catch {
+    // An unparseable manifest tells us nothing about the project's toolchain.
+    // Guessing one from a file we could not read is exactly the failure this
+    // module exists to remove.
+    return undefined;
+  }
+}
+
+/**
+ * Resolve a check to the repository's own command, or report it unconfigured.
+ *
+ * `--silent` keeps the package manager's own banner out of the captured
+ * output, so a failure's details are the tool's, not the runner's.
+ */
+export function resolveCheckCommand(projectDir: string, check: ScriptedCheck): ResolvedCheck {
+  const scripts = readScripts(projectDir);
+  if (scripts === undefined) {
+    return {
+      kind: 'unconfigured',
+      reason: `no readable package.json in ${projectDir}, so the "${check}" script could not be resolved`,
+    };
+  }
+
+  const candidates = SCRIPT_CANDIDATES[check];
+  const found = candidates.find((name) => (scripts[name] ?? '').trim() !== '');
+  if (found === undefined) {
+    return {
+      kind: 'unconfigured',
+      reason: `no "${check}" script declared (looked for: ${candidates.join(', ')})`,
+    };
+  }
+
+  return {
+    kind: 'command',
+    command: detectPackageManager(projectDir),
+    args: ['run', '--silent', found],
+    script: found,
+  };
+}

--- a/packages/nexus-agents/src/security/quality-gate-cwd.test.ts
+++ b/packages/nexus-agents/src/security/quality-gate-cwd.test.ts
@@ -14,6 +14,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const execFileMock = vi.fn();
 vi.mock('node:child_process', () => ({
@@ -28,44 +31,89 @@ vi.mock('node:child_process', () => ({
   },
 }));
 
+/**
+ * A project that declares every gated script.
+ *
+ * Required since #4355: the checks now run the repository's OWN scripts, so a
+ * directory with no package.json resolves to `unconfigured` and never execs —
+ * correctly. These tests are about cwd, so they need a real project.
+ */
+function fixtureProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'qgate-cwd-'));
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({
+      scripts: { lint: 'echo lint', typecheck: 'echo tsc', test: 'echo test', build: 'echo build' },
+    }),
+    'utf-8'
+  );
+  writeFileSync(join(dir, 'package-lock.json'), '{}', 'utf-8');
+  return dir;
+}
+
 describe('quality-gate checks run in projectDir (#4355)', () => {
+  let target: string;
+
   beforeEach(() => {
     execFileMock.mockClear();
+    target = fixtureProject();
   });
 
   it('runs the build check inside the target project', async () => {
     const { checkBuild } = await import('./quality-gate.js');
 
-    await checkBuild('/tmp/target-project')();
+    await checkBuild(target)();
 
     const opts = execFileMock.mock.calls[0]?.[2] as { cwd?: string };
-    expect(opts.cwd).toBe('/tmp/target-project');
+    expect(opts.cwd).toBe(target);
   });
 
   it('runs the lint check inside the target project', async () => {
     const { checkLint } = await import('./quality-gate.js');
 
-    await checkLint('/tmp/target-project')();
+    await checkLint(target)();
 
     const opts = execFileMock.mock.calls[0]?.[2] as { cwd?: string };
-    expect(opts.cwd).toBe('/tmp/target-project');
+    expect(opts.cwd).toBe(target);
   });
 
   it('runs the typecheck inside the target project', async () => {
     const { checkTypeCheck } = await import('./quality-gate.js');
 
-    await checkTypeCheck('/tmp/target-project')();
+    await checkTypeCheck(target)();
 
     const opts = execFileMock.mock.calls[0]?.[2] as { cwd?: string };
-    expect(opts.cwd).toBe('/tmp/target-project');
+    expect(opts.cwd).toBe(target);
   });
 
   it('runs tests inside the target project', async () => {
     const { checkTests } = await import('./quality-gate.js');
 
-    await checkTests('/tmp/target-project')();
+    await checkTests(target)();
 
     const opts = execFileMock.mock.calls[0]?.[2] as { cwd?: string };
-    expect(opts.cwd).toBe('/tmp/target-project');
+    expect(opts.cwd).toBe(target);
+  });
+
+  it('invokes the declared script through the lockfile manager, never npx', async () => {
+    const { checkLint } = await import('./quality-gate.js');
+
+    await checkLint(target)();
+
+    const [cmd, args] = execFileMock.mock.calls[0] as [string, readonly string[]];
+    expect(cmd).toBe('npm');
+    expect(args).toEqual(['run', '--silent', 'lint']);
+  });
+
+  it('does not exec at all when the project declares no such script', async () => {
+    // The #4355 report: an Oxlint repo received `npx eslint`, which downloaded
+    // an unpinned ESLint and failed a project whose own lint was green.
+    const { checkLint } = await import('./quality-gate.js');
+    const bare = mkdtempSync(join(tmpdir(), 'qgate-bare-'));
+
+    const result = await checkLint(bare)();
+
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(result.verdict).toBe('skip');
   });
 });

--- a/packages/nexus-agents/src/security/quality-gate.test.ts
+++ b/packages/nexus-agents/src/security/quality-gate.test.ts
@@ -36,7 +36,7 @@ describe('runQualityGate', () => {
     ]);
     expect(result.verdict).toBe('pass');
     expect(result.summary).toEqual({ pass: 3, fail: 0, skip: 0 });
-    expect(result.feedback).toBe('All checks passed.');
+    expect(result.feedback).toBe('All 3 check(s) that ran passed.');
     expect(result.stage).toBe('qa');
     expect(result.iteration).toBe(1);
   });
@@ -81,5 +81,57 @@ describe('runQualityGate', () => {
     const result = await runQualityGate('ship', []);
     expect(result.verdict).toBe('pass');
     expect(result.summary).toEqual({ pass: 0, fail: 0, skip: 0 });
+  });
+});
+
+describe('#4355: a gate that ran nothing does not pass', () => {
+  const skipped =
+    (name: string): GateCheckFn =>
+    () =>
+      Promise.resolve({ name, verdict: 'skip' as const, details: 'Not run: no script declared' });
+  const passing =
+    (name: string): GateCheckFn =>
+    () =>
+      Promise.resolve({ name, verdict: 'pass' as const, details: 'ok' });
+  const failing =
+    (name: string): GateCheckFn =>
+    () =>
+      Promise.resolve({ name, verdict: 'fail' as const, details: 'boom' });
+
+  it('reports skip, not pass, when every check was skipped', async () => {
+    // The old rule was `fail > 0 ? 'fail' : 'pass'`, so a run that measured
+    // nothing reported a clean pass — a verdict that could not fail by
+    // construction, and the most dangerous reading of "we did not look".
+    const result = await runQualityGate('qa', [skipped('lint'), skipped('tests')]);
+
+    expect(result.verdict).toBe('skip');
+    expect(result.summary).toEqual({ pass: 0, fail: 0, skip: 2 });
+  });
+
+  it('says plainly that no checks ran', async () => {
+    const result = await runQualityGate('qa', [skipped('lint')]);
+
+    expect(result.feedback).toContain('No checks ran.');
+  });
+
+  it('still passes on a partial run, while naming what did not run', async () => {
+    const result = await runQualityGate('qa', [passing('tests'), skipped('lint')]);
+
+    expect(result.verdict).toBe('pass');
+    expect(result.feedback).toContain('did not run');
+    expect(result.feedback).toContain('lint');
+  });
+
+  it('a real failure still outranks any number of skips', async () => {
+    const result = await runQualityGate('qa', [failing('tests'), skipped('lint')]);
+
+    expect(result.verdict).toBe('fail');
+  });
+
+  it('surfaces skipped checks even when the failures dominate the feedback', async () => {
+    const result = await runQualityGate('qa', [failing('tests'), skipped('lint')]);
+
+    expect(result.feedback).toContain('1 check(s) failed');
+    expect(result.feedback).toContain('did not run');
   });
 });

--- a/packages/nexus-agents/src/security/quality-gate.ts
+++ b/packages/nexus-agents/src/security/quality-gate.ts
@@ -7,6 +7,7 @@
  * @module security/quality-gate
  */
 
+import { resolveCheckCommand, type ScriptedCheck } from './quality-gate-commands.js';
 import type {
   PipelineStage,
   GateCheckResult,
@@ -59,39 +60,78 @@ async function runCommandCheck(
 // Built-in Checks
 // ============================================================================
 
-/** Check: TypeScript compilation passes. */
+/**
+ * Build a check that runs the repository's OWN declared script (#4355).
+ *
+ * When the repository declares no such script the check reports `skip` with
+ * the reason, rather than substituting a tool the project never chose. The
+ * previous behaviour hard-coded `npx eslint` / `npx tsc` / `npx vitest` /
+ * `pnpm build`, which failed an Oxlint+npm repo whose own lint was green and
+ * downloaded an unpinned ESLint to do it.
+ *
+ * `skip` is deliberate rather than `fail`: nothing was measured, and a gate
+ * asserting a project is broken on evidence it never gathered is the same
+ * defect in the other direction. {@link runQualityGate} makes sure a skip
+ * cannot be read as a pass.
+ */
+function scriptedCheck(name: string, check: ScriptedCheck, projectDir: string): GateCheckFn {
+  return async () => {
+    const resolved = resolveCheckCommand(projectDir, check);
+    if (resolved.kind === 'unconfigured') {
+      return {
+        name,
+        verdict: 'skip',
+        details: `Not run: ${resolved.reason}. Declare the script to enable this check.`,
+        durationMs: 0,
+      };
+    }
+    return runCommandCheck(name, resolved.command, resolved.args, projectDir);
+  };
+}
+
+/** Check: the repository's declared typecheck script passes. */
 export function checkTypeCheck(projectDir: string): GateCheckFn {
-  return () =>
-    runCommandCheck('type_check', 'npx', ['tsc', '--noEmit', '--project', projectDir], projectDir);
+  return scriptedCheck('type_check', 'typecheck', projectDir);
 }
 
-/** Check: ESLint passes. */
+/** Check: the repository's declared lint script passes. */
 export function checkLint(projectDir: string): GateCheckFn {
-  return () =>
-    runCommandCheck('lint', 'npx', ['eslint', '--max-warnings', '0', projectDir], projectDir);
+  return scriptedCheck('lint', 'lint', projectDir);
 }
 
-/** Check: Tests pass. */
+/** Check: the repository's declared test script passes. */
 export function checkTests(projectDir: string): GateCheckFn {
-  return () => runCommandCheck('tests', 'npx', ['vitest', 'run', '--dir', projectDir], projectDir);
+  return scriptedCheck('tests', 'tests', projectDir);
 }
 
 /**
- * Check: Build succeeds.
+ * Check: the repository's declared build script succeeds.
  *
  * Takes `projectDir` (#4355). It previously took no argument and ran
  * `pnpm build` wherever the server happened to be, so its verdict described
  * an unrelated project.
  */
 export function checkBuild(projectDir: string): GateCheckFn {
-  return () => runCommandCheck('build', 'pnpm', ['build'], projectDir);
+  return scriptedCheck('build', 'build', projectDir);
 }
 
 // ============================================================================
 // Gate Runner
 // ============================================================================
 
-/** Aggregate individual check results into a gate verdict. */
+/**
+ * Aggregate individual check results into a gate verdict.
+ *
+ * A gate that ran nothing does NOT pass (#4355). The old rule was
+ * `fail > 0 ? 'fail' : 'pass'`, so a run in which every check was skipped
+ * reported `pass` — a verdict that could not fail by construction, and the
+ * most dangerous possible reading of "we did not look". Now an all-skipped
+ * run reports `skip`: the gate is telling the caller it has no opinion, which
+ * is the truth.
+ *
+ * A partial run still passes on the checks that did run; the `summary.skip`
+ * count and each skipped check's details say what was not covered.
+ */
 function aggregateResults(checks: readonly GateCheckResult[]): {
   verdict: GateVerdict;
   summary: { pass: number; fail: number; skip: number };
@@ -104,15 +144,33 @@ function aggregateResults(checks: readonly GateCheckResult[]): {
     else if (c.verdict === 'fail') fail++;
     else skip++;
   }
-  return { verdict: fail > 0 ? 'fail' : 'pass', summary: { pass, fail, skip } };
+  const verdict: GateVerdict = fail > 0 ? 'fail' : pass === 0 && skip > 0 ? 'skip' : 'pass';
+  return { verdict, summary: { pass, fail, skip } };
 }
 
 /** Generate actionable feedback from failed checks. */
 function generateFeedback(checks: readonly GateCheckResult[]): string {
   const failures = checks.filter((c) => c.verdict === 'fail');
-  if (failures.length === 0) return 'All checks passed.';
+  const skipped = checks.filter((c) => c.verdict === 'skip');
+
+  // #4355: a skip has to be visible in the feedback too. "All checks passed"
+  // over a run where half of them never executed is the report a human
+  // spot-check trusts, and it would be wrong.
+  const skipNote =
+    skipped.length > 0
+      ? `\n${String(skipped.length)} check(s) did not run:\n${skipped
+          .map((s) => `- ${s.name}: ${s.details}`)
+          .join('\n')}`
+      : '';
+
+  if (failures.length === 0) {
+    const ran = checks.length - skipped.length;
+    const headline = ran === 0 ? 'No checks ran.' : `All ${String(ran)} check(s) that ran passed.`;
+    return `${headline}${skipNote}`;
+  }
+
   const lines = failures.map((f) => `- ${f.name}: ${f.details}`);
-  return `${String(failures.length)} check(s) failed:\n${lines.join('\n')}`;
+  return `${String(failures.length)} check(s) failed:\n${lines.join('\n')}${skipNote}`;
 }
 
 /**


### PR DESCRIPTION
Fixes #4355. Downstream report: williamzujkowski/progress-quest-ii#47.

> Touches `src/security/` (CODEOWNERS `@williamzujkowski`). Flagging it — though note this change *raises* the gate's bar rather than lowering it.

## The gate described a toolchain nobody chose

```ts
npx eslint --max-warnings 0 <projectDir>
npx tsc --noEmit --project <projectDir>
npx vitest run --dir <projectDir>
pnpm build
```

A project declaring **Oxlint** and **npm** received:

```
verdict: fail
check: lint
ESLint couldn't find an eslint.config.(js|mjs|cjs) file.
```

while `npm run lint` was green. ESLint is not a dependency of that project and has no config there *by design*.

And `npx` resolved ESLint 10.8.0 to say so — an unpinned, undeclared package **executed during a quality check**. A gate that installs software to reach its verdict has a supply-chain surface its callers never opted into, which matters more on `src/security/` than the wrong verdict does.

## Resolution is now the repository's own

`resolveCheckCommand()` reads the project's declared script (`lint`, `typecheck`/`type-check`/`types`, `test`, `build`) and runs it through the manager its lockfile selects — pnpm / yarn / bun / npm. Alternates are spelling variants, never guesses at a tool: every candidate is something the repository declared for itself.

No script declared → `skip`, with the reason. Never a substitute, never a download.

`skip` rather than `fail` is deliberate. Nothing was measured, and asserting a project is broken on evidence never gathered is the same defect pointed the other way.

## The part that made this worth doing carefully

Aggregation was:

```ts
verdict: fail > 0 ? 'fail' : 'pass'
```

So a run in which **every check was skipped reported `pass`** — a verdict that could not fail by construction.

That interacts badly with the fix above. Making unconfigured checks skip, *without* touching aggregation, would have converted #4355's false red into a false green: a repo with no declared scripts would get a clean pass from a gate that ran nothing. For a gate, that is the more dangerous direction — a red verdict gets investigated, a green one gets trusted.

So an all-skipped run now reports `skip`, and feedback names every check that did not run instead of claiming "All checks passed." A partial run still passes on what actually ran, with the skips listed.

## Verification

2203 tests pass across `security`, `pipeline`, and the tool suite; 19 new. Typecheck and lint clean.

Resolved live against this repo:

```
.  pm=pnpm
   lint       -> pnpm run --silent lint
   typecheck  -> pnpm run --silent typecheck
   tests      -> pnpm run --silent test
   build      -> pnpm run --silent build
```

The reporter's project is not on this machine, so the Oxlint path is covered by unit test (`lint: 'oxlint'` + `package-lock.json` → `npm run --silent lint`) rather than by a live run. Named here because that is the exact case #4355 reported and I could not reproduce it end to end.

Named regression tests: `does not exec at all when the project declares no such script`, and `reports skip, not pass, when every check was skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
