### PR TITLE
fix(pipeline): a skipped gate must not pass a blocking ship gate

### DIFF
--- a/.changeset/skip-must-not-pass-a-blocking-gate.md
+++ b/.changeset/skip-must-not-pass-a-blocking-gate.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+A gate that measured nothing no longer passes the blocking ship gate ([#4355](https://github.com/nexus-substrate/nexus-agents/issues/4355) follow-up).
+
+Found by an adversarial security review of the change that introduced it.
+
+`createAgentStages` read the gate verdict as `result.verdict !== 'fail'`. That was equivalent to `=== 'pass'` only while the quality checks were two-valued. Making an unconfigured check return `skip` — the fix that stopped the gate inventing a linter — made `skip` reachable here, and `skip !== 'fail'` is `true`.
+
+So a repository declaring none of `lint` / `typecheck` / `test` produced: every check `skip` → aggregate `skip` → `passed: true` → `runDevPipeline` in **`blocking`** mode did not block → code shipped with zero typecheck, lint, or test coverage, recorded via `recordOutcome({ success: true })`.
+
+That is the exact regression the original change warned about — "fixing the resolver alone would have turned a false red into a false green" — fixed at the aggregation layer but missed one layer up at the consumer.
+
+Both stage consumers now use `=== 'pass'`:
+
+- **quality gate** — `skip` blocks, and progress output says "Gate unmeasured" rather than "Gate failed", so the reader looks for a missing script instead of a broken check.
+- **security scan** — pre-existing and the same class. `checkSecurityScan` returns `skip` when the scan itself _errored_, so a scanner that failed to run was recorded as "security passed" on a blocking ship gate. It now fails closed, as `.rules/untrusted-input.md` requires.
+
+**Behavior change:** a blocking pipeline against a repository with no declared quality scripts, or with an unavailable security scanner, now stops instead of shipping. That is the intent — the gate is saying it has no evidence, and on a ship gate no evidence is not consent.

--- a/packages/nexus-agents/src/pipeline/agent-executor-gate-skip.test.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor-gate-skip.test.ts
@@ -1,0 +1,113 @@
+/**
+ * A gate that measured nothing must not report a pass (#4355).
+ *
+ * `createAgentStages`' quality-gate and security stages read the gate verdict
+ * as `verdict !== 'fail'`. That was equivalent to `=== 'pass'` only while the
+ * checks were two-valued. Once an unconfigured check could return `skip`, a
+ * run in which NO check executed reported `passed: true` — and
+ * `runDevPipeline` in `blocking` mode gates on `!qaGate.passed`, so it shipped
+ * code with zero typecheck/lint/test coverage and recorded a success.
+ *
+ * @module pipeline/agent-executor-gate-skip.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock is hoisted above these declarations, so the factories must reach the
+// spies lazily via vi.hoisted rather than closing over module-level consts.
+const { runQualityGateMock, securityCheckMock } = vi.hoisted(() => ({
+  runQualityGateMock: vi.fn(),
+  securityCheckMock: vi.fn(),
+}));
+
+vi.mock('../security/quality-gate.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../security/quality-gate.js')>();
+  return { ...actual, runQualityGate: runQualityGateMock };
+});
+
+vi.mock('./security-gate.js', () => ({
+  checkSecurityScan: () => securityCheckMock,
+}));
+
+import { createAgentStages } from './agent-executor.js';
+
+beforeEach(() => {
+  runQualityGateMock.mockReset();
+  securityCheckMock.mockReset();
+});
+
+describe('#4355: an unmeasured gate does not pass', () => {
+  it('reports not-passed when every quality check was skipped', async () => {
+    runQualityGateMock.mockResolvedValue({
+      stage: 'qa',
+      verdict: 'skip',
+      checks: [],
+      summary: { pass: 0, fail: 0, skip: 3 },
+      feedback: 'No checks ran.',
+      iteration: 1,
+    });
+
+    const stages = createAgentStages();
+    const result = await stages.qualityGate?.();
+
+    expect(result?.passed).toBe(false);
+  });
+
+  it('still passes when the checks actually ran and passed', async () => {
+    runQualityGateMock.mockResolvedValue({
+      stage: 'qa',
+      verdict: 'pass',
+      checks: [],
+      summary: { pass: 3, fail: 0, skip: 0 },
+      feedback: 'All 3 check(s) that ran passed.',
+      iteration: 1,
+    });
+
+    const stages = createAgentStages();
+
+    expect((await stages.qualityGate?.())?.passed).toBe(true);
+  });
+
+  it('still reports not-passed on a real failure', async () => {
+    runQualityGateMock.mockResolvedValue({
+      stage: 'qa',
+      verdict: 'fail',
+      checks: [],
+      summary: { pass: 0, fail: 1, skip: 0 },
+      feedback: '1 check(s) failed',
+      iteration: 1,
+    });
+
+    const stages = createAgentStages();
+
+    expect((await stages.qualityGate?.())?.passed).toBe(false);
+  });
+
+  it('does not report a security scan that failed to run as clean', async () => {
+    // checkSecurityScan returns `skip` when the scan ERRORED
+    // (security-gate.ts:99-102). Reading that as passed is the one result a
+    // security gate must never launder — fail closed per untrusted-input rules.
+    securityCheckMock.mockResolvedValue({
+      name: 'security_scan',
+      verdict: 'skip',
+      details: 'Security scan skipped: scanner unavailable',
+    });
+
+    const stages = createAgentStages();
+    const result = await stages.securityScan?.();
+
+    expect(result?.passed).toBe(false);
+  });
+
+  it('passes a security scan that actually ran clean', async () => {
+    securityCheckMock.mockResolvedValue({
+      name: 'security_scan',
+      verdict: 'pass',
+      details: 'no findings',
+    });
+
+    const stages = createAgentStages();
+
+    expect((await stages.securityScan?.())?.passed).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -754,7 +754,14 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
         checkLint(target),
         checkTests(target),
       ]);
-      const passed = result.verdict !== 'fail';
+      // #4355: `=== 'pass'`, NOT `!== 'fail'`. The gate reports three states,
+      // and `skip` means no check actually ran — every declared script was
+      // missing. Reading that as passed lets a blocking gate ship code with
+      // zero typecheck/lint/test coverage and record it as a success, which is
+      // the "unreviewed work laundered as reviewed" failure the gate exists to
+      // prevent. `!== 'fail'` was equivalent while these checks could only
+      // pass or fail; making `skip` reachable is what broke it.
+      const passed = result.verdict === 'pass';
       const ms = getTimeProvider().now() - start;
       emitStageEvent('quality-gate', passed ? 'completed' : 'failed', { durationMs: ms });
       recordOutcome({
@@ -764,11 +771,13 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
         success: passed,
         durationMs: ms,
       });
-      await postProgress(
-        config,
-        'QualityGate',
-        passed ? 'Passed' : `Gate failed: ${result.feedback}`
-      );
+      // A skip is not a failure, and saying "Gate failed" for one would send
+      // the reader looking for a broken check rather than a missing script.
+      const verdictNote =
+        result.verdict === 'skip'
+          ? `Gate unmeasured: ${result.feedback}`
+          : `Gate failed: ${result.feedback}`;
+      await postProgress(config, 'QualityGate', passed ? 'Passed' : verdictNote);
       return { passed, feedback: result.feedback };
     },
 
@@ -779,7 +788,13 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
       await postProgress(config, 'Security', `Scanning ${target}...`);
       const check = checkSecurityScan(target);
       const result = await check();
-      const passed = result.verdict !== 'fail';
+      // #4355: same tri-state discipline as the quality gate above. This one
+      // predates that change: `checkSecurityScan` returns `skip` when the scan
+      // itself ERRORED (security-gate.ts:99-102), so a scanner that failed to
+      // run was recorded as "security passed" on a blocking ship gate. Fail
+      // closed instead — `.rules/untrusted-input.md` requires it, and an
+      // unmeasured scan is the one result that must never read as clean.
+      const passed = result.verdict === 'pass';
       const ms = getTimeProvider().now() - start;
       emitStageEvent('security', passed ? 'completed' : 'failed', { durationMs: ms });
       // security scan is a deterministic local check (no CLI dispatch),


### PR DESCRIPTION
Follow-up to #4536 (issue #4355). **Found by an adversarial security review of my own merged change**, which is the only reason it was caught before it shipped in a release.

## The regression

`createAgentStages` read the gate verdict as:

```ts
const passed = result.verdict !== 'fail';
```

That was equivalent to `=== 'pass'` only while the quality checks were two-valued. #4536 made an unconfigured check return `skip` — the fix that stopped the gate inventing a linter — and `skip !== 'fail'` is `true`.

Full path for a repository declaring none of `lint` / `typecheck` / `test`:

1. every check resolves `unconfigured` → `skip`
2. `aggregateResults` → overall `verdict: 'skip'` (correct — #4536 added this)
3. `agent-executor.ts:757` → `passed: true` ← **the break**
4. `dev-pipeline.ts:821` → `qualityGateMode === 'blocking' && !qaGate.passed` → does not block
5. ships, and `recordOutcome({ success: true })` writes it down as a pass

So code with zero typecheck, lint, or test coverage passes a **blocking** gate and the record says it was checked.

This is precisely what #4536's own description warned about — *"fixing the resolver alone would have turned a false red into a false green"* — and I fixed it at the aggregation layer while missing the consumer one layer above. Getting the reasoning right in prose is not the same as getting it right everywhere in the code.

## Also fixed: the security scan, same class, pre-existing

`checkSecurityScan` returns `skip` when the scan **itself errored** (`security-gate.ts:99-102`, logged as a warn). Its consumer used the same `!== 'fail'`, so *a security scanner that failed to run was recorded as "security passed"* on a blocking ship gate.

That one predates #4536 and is arguably worse — an unmeasured security scan is the single result that must never read as clean. `.rules/untrusted-input.md` requires failing closed on ambiguity. Fixed here rather than filed, because it is two lines and identical reasoning.

## Behavior change — deliberate

A blocking pipeline against a repository with no declared quality scripts, or with an unavailable security scanner, now **stops** instead of shipping. The gate is saying it has no evidence, and on a ship gate no evidence is not consent.

Progress output distinguishes the two: `Gate unmeasured: …` for a skip versus `Gate failed: …`, so a reader looks for a missing script rather than a broken check.

## Verification

2197 tests pass across `pipeline` and `security`; 5 new. Typecheck and lint clean.

The two regression tests were **verified falsifiable** — reverted to `!== 'fail'` and confirmed they go red:

```
× reports not-passed when every quality check was skipped
× does not report a security scan that failed to run as clean
Tests  2 failed | 3 passed (5)
```

The three pass/fail cases correctly hold under both versions, which is what makes the two failures meaningful rather than incidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
