### PR TITLE
fix(cli-adapters): report throttled, and let a success clear stale quota

### DIFF
--- a/.changeset/throttled-telemetry-and-quota-recovery.md
+++ b/.changeset/throttled-telemetry-and-quota-recovery.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+Report the `throttled` capacity grade, and let a success clear a stale quota assertion ([#4456](https://github.com/nexus-substrate/nexus-agents/issues/4456) follow-up).
+
+Both found by an adversarial review of the change that introduced them.
+
+**`throttled` existed in the type and nowhere in the output.** `assessCapacity` gained the grade, but `route()` sent it down the same `continue` as `healthy` — no counter, no signal, no stat. So a rate-limited candidate was indistinguishable from a healthy one in every trace, which is _worse_ than the honest binary that preceded it. Its own doc comment claimed throttling was "a reason to prefer another candidate", and nothing implemented any preference.
+
+Now emitted as `capacity:throttled-N` (only when non-zero, matching the `capacity:unmeasured-N` contract, so absence means something) and counted in `getStats().throttledCount`. The doc comment now says what the code does: the state is _reported_, not acted on. Preferring another candidate would be a routing behaviour change, and local rate-limiting is common enough that reordering on it needs its own evidence first.
+
+**A success now clears provider-asserted quota exhaustion.** Only the stated horizon elapsing cleared it, so a provider that said "retry after an hour" and then served the very next call stayed reported as exhausted — and excludable, once enforcement is on — for the full hour, against a completed request that directly contradicted it. `recordUsage` clears the assertion: a served request is more recent and more direct evidence than the earlier `retry-after`.
+
+`route()`'s classification loop is extracted to `classifyAndFilter` to stay inside its line budget.

--- a/packages/nexus-agents/src/cli-adapters/capacity-tracker.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/capacity-tracker.test.ts
@@ -467,3 +467,52 @@ describe('#4456: a local rate window is not provider-asserted quota', () => {
     expect(tracker.getCapacity().quotaExhausted).toBe(false);
   });
 });
+
+describe('#4456 follow-up: a success outranks a stale provider assertion', () => {
+  const config: CapacityTrackerConfig = {
+    tokenLimit: 1_000_000,
+    requestLimit: 1_000,
+    windowMs: RATE_LIMIT_WINDOW_MS,
+  };
+
+  let tracker: CapacityTracker;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    tracker = new CapacityTracker(config);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears quota exhaustion when a request subsequently succeeds', () => {
+    // A provider that says "retry after an hour" and then serves the next call
+    // has contradicted itself. The success is the more recent, more direct
+    // evidence; honouring the stale horizon would keep a working adapter
+    // excluded for an hour on a claim reality just refuted.
+    tracker.recordProviderQuotaExhaustion(RATE_LIMIT_WINDOW_MS * 60);
+    expect(tracker.getCapacity().quotaExhausted).toBe(true);
+
+    tracker.recordUsage(undefined);
+
+    expect(tracker.getCapacity().quotaExhausted).toBe(false);
+  });
+
+  it('drops the reset horizon along with the assertion', () => {
+    tracker.recordProviderQuotaExhaustion(RATE_LIMIT_WINDOW_MS * 60);
+    tracker.recordUsage(undefined);
+
+    expect(tracker.getCapacity().quotaResetAt).toBeUndefined();
+  });
+
+  it('does not resurrect the assertion on a later reading', () => {
+    tracker.recordProviderQuotaExhaustion(RATE_LIMIT_WINDOW_MS * 60);
+    tracker.recordUsage(undefined);
+
+    vi.advanceTimersByTime(RATE_LIMIT_WINDOW_MS * 10);
+
+    expect(tracker.getCapacity().quotaExhausted).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/capacity-tracker.ts
+++ b/packages/nexus-agents/src/cli-adapters/capacity-tracker.ts
@@ -160,6 +160,14 @@ export class CapacityTracker {
     this.hasObserved = true;
     this.pruneOldEntries(now);
 
+    // #4456 follow-up: a completed request is direct evidence that the
+    // provider is serving, and it outranks an earlier `retry-after` that has
+    // not yet elapsed. Without this, a provider that says "wait an hour" and
+    // then recovers in a minute stays reported as quota-exhausted — and
+    // excludable, once enforcement is on — for the full hour, against a
+    // success that contradicts it.
+    this.quotaExhaustedUntil = null;
+
     this.requestTimestamps.push(now);
     this.requestCount = this.requestTimestamps.length;
 

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.test.ts
@@ -396,3 +396,62 @@ describe('#4456: rate limiting is graded apart from quota exhaustion', () => {
     expect(assessCapacity(capacity({ observed: false, quotaExhausted: true }))).toBe('unmeasured');
   });
 });
+
+describe('#4456 follow-up: a throttled candidate is reported, not silently dropped', () => {
+  it('emits a throttled signal so the state is visible in a trace', async () => {
+    // The grade existed in the type and nowhere in the output: `route()` sent
+    // throttled down the same `continue` as healthy, so a rate-limited
+    // candidate was indistinguishable from a healthy one everywhere downstream.
+    const stage = new CapacityFilterStage(
+      adapters({ claude: capacity({ rateLimited: true }), gemini: capacity() }),
+      ENFORCING
+    );
+
+    const result = await stage.route(createRoutingContext('t', CLIS));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.context.signals).toContain('capacity:throttled-1');
+  });
+
+  it('counts throttled candidates in the stage stats', async () => {
+    const stage = new CapacityFilterStage(
+      adapters({ claude: capacity({ rateLimited: true }), gemini: capacity() }),
+      ENFORCING
+    );
+
+    await stage.route(createRoutingContext('t', CLIS));
+
+    expect(stage.getStats()['throttledCount']).toBe(1);
+  });
+
+  it('emits no throttled signal when nothing is throttled', async () => {
+    // Absence of the signal has to mean something, so it must not be emitted
+    // at zero — same contract as capacity:unmeasured-N.
+    const stage = new CapacityFilterStage(
+      adapters({ claude: capacity(), gemini: capacity() }),
+      ENFORCING
+    );
+
+    const result = await stage.route(createRoutingContext('t', CLIS));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.context.signals.some((s) => s.startsWith('capacity:throttled'))).toBe(
+      false
+    );
+  });
+
+  it('still does not exclude the throttled candidate', async () => {
+    const stage = new CapacityFilterStage(
+      adapters({ claude: capacity({ rateLimited: true }), gemini: capacity() }),
+      ENFORCING
+    );
+
+    const result = await stage.route(createRoutingContext('t', CLIS));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(getRemainingCandidates(result.value.context)).toEqual(CLIS);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
@@ -24,7 +24,7 @@ import type { ILogger } from '../../../core/index.js';
 import { ok, createLogger, getTimeProvider } from '../../../core/index.js';
 import type { IRouterStage, RoutingContext, StageResult, StageError } from '../router-stage.js';
 import { addTrace, filterCandidate, getRemainingCandidates } from '../router-stage.js';
-import type { CapacityStatus, ICliAdapter, RoutingArmId } from '../../types.js';
+import type { CapacityStatus, CliName, ICliAdapter, RoutingArmId } from '../../types.js';
 
 /**
  * Normalized exhaustion diagnostic (#4373).
@@ -90,8 +90,15 @@ const DEFAULT_CONFIG: CapacityStageConfig = {
  */
 /**
  * `throttled` (#4456) sits between healthy and exhausted: this process's own
- * rolling window is full, which is a reason to prefer another candidate but
- * never a reason to exclude one — it clears on its own within the minute.
+ * rolling window is full. It never excludes a candidate — the window clears
+ * within the minute — but it IS reported, via a `capacity:throttled-N` signal
+ * and a `throttledCount` stat.
+ *
+ * Reported rather than acted on, deliberately. Preferring another candidate
+ * would be a routing behaviour change, and local rate-limiting is common
+ * enough (an ordinary 7-voter panel trips it) that silently reordering on it
+ * needs its own evidence. Until then the honest position is to surface the
+ * state, not to hide it and not to claim a preference nothing implements.
  */
 type Assessment = 'exhausted' | 'throttled' | 'healthy' | 'unmeasured';
 
@@ -141,6 +148,8 @@ export class CapacityFilterStage implements IRouterStage {
   private readonly logger: ILogger;
   private excludedCount = 0;
   private unmeasuredCount = 0;
+  /** Candidates whose own rolling window was full (#4456). Never excluded. */
+  private throttledCount = 0;
 
   constructor(
     adapters: Map<RoutingArmId, ICliAdapter>,
@@ -163,34 +172,13 @@ export class CapacityFilterStage implements IRouterStage {
 
     const assessments = await this.assessAll(remaining);
 
-    let updatedCtx = ctx;
-    let exhausted = 0;
-    let unmeasured = 0;
+    const { updatedCtx, exhausted, unmeasured, throttled } = this.classifyAndFilter(
+      ctx,
+      remaining,
+      assessments
+    );
 
-    // Iterate the slot list, not the assessment map: `route()` operates on the
-    // slot-granular RoutingContext, so `filterCandidate` needs a CliName.
-    // Arm-granular callers use `assessArms` instead (#4455).
-    for (const cli of remaining) {
-      const assessment = assessments.get(cli) ?? 'unmeasured';
-      if (assessment === 'unmeasured') {
-        unmeasured++;
-        continue;
-      }
-      if (assessment !== 'exhausted') continue;
-
-      exhausted++;
-      if (this.config.enforceHardLimits) {
-        updatedCtx = filterCandidate(
-          updatedCtx,
-          cli,
-          `${CAPACITY_EXHAUSTED}: no capacity remaining`
-        );
-        this.excludedCount++;
-      }
-    }
-    this.unmeasuredCount += unmeasured;
-
-    const signals = this.buildSignals(ctx.signals, exhausted, unmeasured);
+    const signals = this.buildSignals(ctx.signals, exhausted, unmeasured, throttled);
     const eligible = getRemainingCandidates(updatedCtx);
     const durationMs = time.now() - startTime;
 
@@ -217,7 +205,11 @@ export class CapacityFilterStage implements IRouterStage {
   }
 
   getStats(): Record<string, unknown> {
-    return { excludedCount: this.excludedCount, unmeasuredCount: this.unmeasuredCount };
+    return {
+      excludedCount: this.excludedCount,
+      unmeasuredCount: this.unmeasuredCount,
+      throttledCount: this.throttledCount,
+    };
   }
 
   /**
@@ -300,6 +292,8 @@ export class CapacityFilterStage implements IRouterStage {
     for (const arm of arms) {
       const assessment = assessments.get(arm) ?? 'unmeasured';
       if (assessment === 'unmeasured') unmeasured++;
+      // Throttled arms stay eligible, but the count must not vanish (#4456).
+      if (assessment === 'throttled') this.throttledCount++;
 
       // Only a measured exhaustion excludes, and only under hard limits. An
       // unmeasured arm is never dropped: absence of a reading is not a reading.
@@ -340,6 +334,54 @@ export class CapacityFilterStage implements IRouterStage {
   }
 
   /**
+   * Tally each candidate's grade, excluding only the exhausted ones.
+   *
+   * Iterates the slot list rather than the assessment map: `route()` operates
+   * on the slot-granular RoutingContext, so `filterCandidate` needs a
+   * CliName. Arm-granular callers use `assessArms` instead (#4455).
+   *
+   * Extracted from `route()` to keep it inside its line budget once
+   * `throttled` gained a counter (#4456 follow-up).
+   */
+  private classifyAndFilter(
+    ctx: RoutingContext,
+    remaining: readonly CliName[],
+    assessments: Map<RoutingArmId, Assessment>
+  ): { updatedCtx: RoutingContext; exhausted: number; unmeasured: number; throttled: number } {
+    let updatedCtx = ctx;
+    let exhausted = 0;
+    let unmeasured = 0;
+    let throttled = 0;
+
+    for (const cli of remaining) {
+      const assessment = assessments.get(cli) ?? 'unmeasured';
+      if (assessment === 'unmeasured') {
+        unmeasured++;
+        continue;
+      }
+      if (assessment === 'throttled') {
+        throttled++;
+        continue;
+      }
+      if (assessment !== 'exhausted') continue;
+
+      exhausted++;
+      if (this.config.enforceHardLimits) {
+        updatedCtx = filterCandidate(
+          updatedCtx,
+          cli,
+          `${CAPACITY_EXHAUSTED}: no capacity remaining`
+        );
+        this.excludedCount++;
+      }
+    }
+
+    this.unmeasuredCount += unmeasured;
+    this.throttledCount += throttled;
+    return { updatedCtx, exhausted, unmeasured, throttled };
+  }
+
+  /**
    * Emits counts for both exhausted and unmeasured candidates.
    *
    * `capacity:unmeasured-N` lets a downstream consumer tell a genuinely healthy
@@ -348,13 +390,24 @@ export class CapacityFilterStage implements IRouterStage {
    * is the distinction that matters. (An earlier version of this comment claimed
    * the signal was emitted at zero too; it never was.)
    */
-  private buildSignals(existing: string[], exhausted: number, unmeasured: number): string[] {
+  private buildSignals(
+    existing: string[],
+    exhausted: number,
+    unmeasured: number,
+    throttled: number
+  ): string[] {
     const signals = [...existing];
     if (exhausted > 0) {
       signals.push(`${CAPACITY_EXHAUSTED}:${String(exhausted)}`);
     }
     if (unmeasured > 0) {
       signals.push(`capacity:unmeasured-${String(unmeasured)}`);
+    }
+    // #4456 follow-up: without this, a rate-limited candidate was
+    // indistinguishable from a healthy one in every trace — the grade existed
+    // in the type and nowhere in the output.
+    if (throttled > 0) {
+      signals.push(`capacity:throttled-${String(throttled)}`);
     }
     return signals;
   }


### PR DESCRIPTION
Follow-up to #4533 (issue #4456). Both findings came from an **adversarial review of my own merged change** — the same practice that caught #4539.

## 1. `throttled` existed in the type and nowhere in the output

`assessCapacity` gained a `'throttled'` grade, but `route()` sent it down the same `continue` as `'healthy'`:

```ts
if (assessment === 'unmeasured') { unmeasured++; continue; }
if (assessment !== 'exhausted') continue;   // 'throttled' vanishes here
```

No counter, no signal, no stat. A rate-limited candidate was indistinguishable from a healthy one everywhere downstream — which is **worse than the honest binary it replaced**, because the previous `exhausted`/`healthy` split at least surfaced the state.

And the grade's own doc comment said throttling was *"a reason to prefer another candidate"*. Nothing implemented any preference. I wrote a claim the code did not support, in a change whose entire subject was a field that misdescribed itself.

Now: `capacity:throttled-N` on the signals (emitted only when non-zero, matching the `capacity:unmeasured-N` contract so that absence means something), and `throttledCount` in `getStats()`. `filterArms` counts it too.

The doc comment now states what the code does: the state is **reported, not acted on**. Preferring another candidate is a routing behaviour change, and local rate-limiting is common enough — an ordinary 7-voter panel trips it — that reordering on it needs its own evidence. Reporting it honestly is the part that was missing.

## 2. A success did not clear a stale quota assertion

`quotaExhaustedUntil` was cleared only by its horizon elapsing or an explicit `reset()`. `recordUsage`, called on every successful request, never touched it.

So a provider that said "retry after an hour" and then **served the very next call** stayed reported `quotaExhausted: true` — and excludable, once enforcement is on — for the full hour, against a completed request that directly contradicted the assertion.

`recordUsage` now clears it. A served request is more recent and more direct evidence than an earlier `retry-after`, and the whole point of preferring provider-asserted signals over local guesses is that they track reality.

## Verification

3329 tests pass across `cli-adapters` and `pipeline`; 7 new. Typecheck and lint clean.

All five new behavioural tests were **verified falsifiable** — reverted both fixes and confirmed they go red:

```
× clears quota exhaustion when a request subsequently succeeds
× drops the reset horizon along with the assertion
× does not resurrect the assertion on a later reading
× emits a throttled signal so the state is visible in a trace
× counts throttled candidates in the stage stats
Tests  5 failed | 62 passed (67)
```

`route()`'s classification loop is extracted to `classifyAndFilter` to stay inside the 50-line budget once the new counter landed — extraction rather than raising the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
