### PR TITLE
fix(quality-gate): a zero-check gate is skip, and an unrun scan is not a finding

### DIFF
--- a/.changeset/zero-checks-and-security-scan-message.md
+++ b/.changeset/zero-checks-and-security-scan-message.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+A zero-check gate reports `skip`, and a security scan that could not run no longer reads as a finding.
+
+Both found by an adversarial review of the change that introduced the tri-state verdict.
+
+**`aggregateResults([])` returned `'pass'`.** The condition was `pass === 0 && skip > 0 ? 'skip' : 'pass'`, which requires at least one skip — so an _empty_ check list fell through to `pass`. A gate that ran nothing at all reported success: the same cannot-fail defect the tri-state was added to remove, one step further out. No caller passes an empty list today, but the aggregator should not depend on that. Now ordered `fail > 0 → fail`, `pass > 0 → pass`, otherwise `skip`, which covers the empty case by construction rather than by luck.
+
+The existing test asserting `expect(result.verdict).toBe('pass')` for an empty list was **encoding the defect**, and now states the corrected contract with the reason.
+
+**The security stage printed `BLOCKED: …` for a scan that never ran.** `checkSecurityScan` returns `skip` when the scanner itself errored — most commonly because semgrep is not installed — and that rendered identically to a discovered vulnerability. It now says the scan did not run, names the remedy, and points at advisory mode for anyone who wants to proceed without security evidence. The sibling quality-gate stage already made this distinction; the security stage was the asymmetric one.

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -806,7 +806,16 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
         success: passed,
         durationMs: ms,
       });
-      await postProgress(config, 'Security', passed ? 'Passed' : `BLOCKED: ${result.details}`);
+      // A scan that could not run is not a finding. `checkSecurityScan`
+      // returns `skip` when the scanner itself errored — most often because
+      // semgrep is not installed — and reporting that as BLOCKED reads
+      // identically to a discovered vulnerability. Same distinction the
+      // quality gate above makes.
+      const securityNote =
+        result.verdict === 'skip'
+          ? `Security scan did not run: ${result.details}. Install the scanner, or use qualityGate 'advisory' to proceed without security evidence.`
+          : `BLOCKED: ${result.details}`;
+      await postProgress(config, 'Security', passed ? 'Passed' : securityNote);
       // Flush pipeline memory session at end of run
       flushPipelineMemory();
       return { passed, feedback: result.details };

--- a/packages/nexus-agents/src/security/quality-gate.test.ts
+++ b/packages/nexus-agents/src/security/quality-gate.test.ts
@@ -78,8 +78,11 @@ describe('runQualityGate', () => {
   });
 
   it('handles empty checks list', async () => {
+    // Reports `skip`, not `pass`. This test previously asserted `pass`, which
+    // encoded the defect: a gate that ran nothing at all cannot report success
+    // without laundering "we did not look" as "we looked and it was fine".
     const result = await runQualityGate('ship', []);
-    expect(result.verdict).toBe('pass');
+    expect(result.verdict).toBe('skip');
     expect(result.summary).toEqual({ pass: 0, fail: 0, skip: 0 });
   });
 });
@@ -133,5 +136,16 @@ describe('#4355: a gate that ran nothing does not pass', () => {
 
     expect(result.feedback).toContain('1 check(s) failed');
     expect(result.feedback).toContain('did not run');
+  });
+});
+
+describe('partial coverage still passes on what ran', () => {
+  it('passes when something passed and something else was skipped', async () => {
+    const passing: GateCheckFn = () =>
+      Promise.resolve({ name: 'tests', verdict: 'pass' as const, details: 'ok' });
+    const skipped: GateCheckFn = () =>
+      Promise.resolve({ name: 'lint', verdict: 'skip' as const, details: 'no script' });
+
+    expect((await runQualityGate('qa', [passing, skipped])).verdict).toBe('pass');
   });
 });

--- a/packages/nexus-agents/src/security/quality-gate.ts
+++ b/packages/nexus-agents/src/security/quality-gate.ts
@@ -144,7 +144,13 @@ function aggregateResults(checks: readonly GateCheckResult[]): {
     else if (c.verdict === 'fail') fail++;
     else skip++;
   }
-  const verdict: GateVerdict = fail > 0 ? 'fail' : pass === 0 && skip > 0 ? 'skip' : 'pass';
+  // Ordered so that "nothing passed" is `skip` regardless of WHY nothing
+  // passed. The earlier form (`pass === 0 && skip > 0`) required at least one
+  // skip, so an EMPTY check list fell through to `pass` — a gate with zero
+  // checks reporting success, which is the same cannot-fail defect one step
+  // further out. No caller passes an empty list today; the point is that the
+  // aggregator should not depend on that.
+  const verdict: GateVerdict = fail > 0 ? 'fail' : pass > 0 ? 'pass' : 'skip';
   return { verdict, summary: { pass, fail, skip } };
 }
 


### PR DESCRIPTION
Two findings from an adversarial review of #4539. Refs #4355.

## 1. A gate with zero checks reported `pass`

```ts
const verdict = fail > 0 ? 'fail' : pass === 0 && skip > 0 ? 'skip' : 'pass';
```

The `skip` branch requires **at least one skip**. An *empty* check list gives `pass=0, fail=0, skip=0` and falls through to `'pass'` — a gate that ran nothing at all reporting success.

That is the same cannot-fail defect the tri-state verdict was added to remove, one layer further out, and I wrote it while fixing the inner one. Reordered:

```ts
const verdict = fail > 0 ? 'fail' : pass > 0 ? 'pass' : 'skip';
```

Now the empty case is covered by construction rather than by every caller happening to pass a non-empty list. (They all do today — `agent-executor` uses a fixed 3-element array and the MCP input is `.nonempty()`-guarded — which is exactly why it was invisible.)

The existing test `handles empty checks list` asserted `expect(result.verdict).toBe('pass')`. It was **encoding the defect**, so it now states the corrected contract along with why.

## 2. A security scan that never ran read as a finding

```ts
await postProgress(config, 'Security', passed ? 'Passed' : `BLOCKED: ${result.details}`);
```

`checkSecurityScan` returns `skip` when the scanner **itself errored** — and per `security-scan.ts:93-94` the most common cause is *semgrep not being installed*, which is most dev machines. So "the scanner isn't on this box" rendered identically to "a vulnerability was found."

Now it says the scan did not run, names the remedy, and points at advisory mode for anyone who wants to proceed without security evidence.

The sibling quality-gate stage in the same commit already made this distinction. The security stage was the asymmetric one — the reviewer's phrasing, and it was right.

## Verification

2198 tests pass across `security` and `pipeline`. Typecheck and lint clean.

Note on #1: the corrected test would have failed before this change and passes after, but I want to be precise that it is a *modified* existing assertion rather than a new falsifiable test — the behaviour it now pins is the inverse of what it previously pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
