### PR TITLE
fix(doctor): a critically full scratch filesystem fails the verdict

### DIFF
--- a/.changeset/scratch-severity-affects-doctor-verdict.md
+++ b/.changeset/scratch-severity-affects-doctor-verdict.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+A critically full scratch filesystem now fails `nexus-agents doctor` ([#4488](https://github.com/nexus-substrate/nexus-agents/issues/4488) follow-up).
+
+Found by an adversarial review of the change that added the check.
+
+#4528 made the scratch check measure the right filesystems, and its changeset said the check could no longer be "unable to fail for its own motivating incident". That was true of the printed line and **false of the verdict**. `worstSeverity` shipped and was then called nowhere: `allHealthy` was computed from node version, auth method, MCP readiness and CLI status only, so `doctor` exited **0** with a 100%-full tmpfs — reporting the exact condition it exists to catch while passing.
+
+`allHealthy` now accounts for scratch space, at `critical` only. `warn` still leaves room for the current run, and failing the whole command on it would collapse the two thresholds into one.
+
+The predicate is extracted as `isAllHealthy()` so it is directly testable — the wiring was untestable in place, which is a large part of why the gap survived review.
+
+Also adds the first direct tests for `formatScratchFilesystems`. The multi-line render and the empty-list branch were both unexercised: the existing fixture only ever supplied a single-element array, so a broken separator or an `[object Object]` in real `doctor` output would have shipped unnoticed.

--- a/packages/nexus-agents/src/cli/doctor-scratch-space.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-scratch-space.test.ts
@@ -5,10 +5,12 @@ import {
   WARN_FREE_BYTES,
   checkScratchFilesystems,
   checkScratchSpace,
+  formatScratchFilesystems,
   formatScratchSpace,
   worstSeverity,
 } from './doctor-scratch-space.js';
 import type {
+  ScratchRootLabel,
   ScratchSpaceCheck,
   ScratchSpaceSeverity,
   StatfsReading,
@@ -206,5 +208,49 @@ describe('worstSeverity', () => {
 
   it('is ok when nothing was measured, since absence is not evidence of a full disk', () => {
     expect(worstSeverity([])).toBe('ok');
+  });
+});
+
+describe('formatScratchFilesystems', () => {
+  const at = (label: ScratchRootLabel, root: string, free: number): ScratchSpaceCheck =>
+    checkScratchSpace(root, () => reading(free, 32 * GIB), label);
+
+  it('renders one line per filesystem', () => {
+    // The multi-line render was untested: the doctor-formatting fixture only
+    // ever supplied a single-element array, so nothing exercised the join.
+    const out = formatScratchFilesystems([
+      at('nexus', '/data/tmp', 20 * GIB),
+      at('system', '/tmp', 18 * GIB),
+    ]);
+
+    expect(out.split('\n')).toHaveLength(2);
+    expect(out).toContain('/data/tmp');
+    expect(out).toContain('/tmp');
+  });
+
+  it('labels each line so two roots are distinguishable', () => {
+    const out = formatScratchFilesystems([
+      at('nexus', '/data/tmp', 20 * GIB),
+      at('system', '/tmp', 18 * GIB),
+    ]);
+
+    expect(out).toContain('[nexus]');
+    expect(out).toContain('[system]');
+  });
+
+  it('says nothing could be identified rather than printing an empty line', () => {
+    // An empty render would read as "checked, all fine".
+    const out = formatScratchFilesystems([]);
+
+    expect(out).toContain('no scratch filesystem could be identified');
+  });
+
+  it('keeps the remediation on the starved line when roots are mixed', () => {
+    const out = formatScratchFilesystems([
+      at('nexus', '/data/tmp', 20 * GIB),
+      at('system', '/tmp', 0),
+    ]);
+
+    expect(out).toContain('NEXUS_TMPDIR');
   });
 });

--- a/packages/nexus-agents/src/cli/doctor-verdict.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-verdict.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The doctor verdict must account for scratch space (#4488).
+ *
+ * `worstSeverity` shipped in #4528 and was then called nowhere: `allHealthy`
+ * was computed from node version, auth, MCP readiness and CLI status only, so
+ * `nexus-agents doctor` exited 0 with a 100%-full tmpfs. The check reported
+ * the exact condition it was built for and still could not fail on it.
+ *
+ * @module cli/doctor-verdict.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { isAllHealthy } from './doctor.js';
+import type { CliCheckResult } from './doctor.js';
+import type { ScratchSpaceCheck, ScratchSpaceSeverity } from './doctor-scratch-space.js';
+
+const healthyCli: CliCheckResult = {
+  name: 'claude',
+  installed: true,
+  authenticated: true,
+  version: '1.0.0',
+  versionStatus: 'supported',
+};
+
+const scratch = (severity: ScratchSpaceSeverity): ScratchSpaceCheck => ({
+  label: 'system',
+  root: '/tmp',
+  available: true,
+  freeBytes: 0,
+  totalBytes: 32 * 1024 ** 3,
+  percentUsed: 100,
+  severity,
+  message: 'test reading',
+});
+
+/** Everything healthy; each test perturbs exactly one input. */
+const base = {
+  nodeSupported: true,
+  hasAuthMethod: true,
+  mcpServerReady: true,
+  scratchSpace: [scratch('ok')],
+  clis: [healthyCli],
+};
+
+describe('isAllHealthy', () => {
+  it('is healthy when every input is fine', () => {
+    expect(isAllHealthy(base)).toBe(true);
+  });
+
+  it('is UNHEALTHY when a scratch filesystem is critical', () => {
+    expect(isAllHealthy({ ...base, scratchSpace: [scratch('critical')] })).toBe(false);
+  });
+
+  it('stays healthy on a warn-level reading', () => {
+    // warn leaves room for the current run. Failing on it would collapse the
+    // two thresholds into one and make the distinction meaningless.
+    expect(isAllHealthy({ ...base, scratchSpace: [scratch('warn')] })).toBe(true);
+  });
+
+  it('takes the WORST reading across filesystems', () => {
+    // A roomy nexus root must not mask a starved shared one — the same
+    // masking #4528 fixed in the display, now in the verdict.
+    const mixed = [scratch('ok'), scratch('critical')];
+
+    expect(isAllHealthy({ ...base, scratchSpace: mixed })).toBe(false);
+  });
+
+  it('stays healthy when no filesystem could be measured', () => {
+    // Absence of a reading is not evidence of a full disk, and doctor must
+    // not fail closed on a diagnostic it could not run.
+    expect(isAllHealthy({ ...base, scratchSpace: [] })).toBe(true);
+  });
+
+  it('still fails on the pre-existing inputs', () => {
+    expect(isAllHealthy({ ...base, nodeSupported: false })).toBe(false);
+    expect(isAllHealthy({ ...base, hasAuthMethod: false })).toBe(false);
+    expect(isAllHealthy({ ...base, mcpServerReady: false })).toBe(false);
+    expect(isAllHealthy({ ...base, clis: [{ ...healthyCli, authenticated: false }] })).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -24,7 +24,11 @@ import {
   nexusDataPath,
 } from '../config/nexus-data-dir.js';
 import { detectSandbox } from '../config/sandbox-detection.js';
-import { checkScratchFilesystems, type ScratchSpaceCheck } from './doctor-scratch-space.js';
+import {
+  checkScratchFilesystems,
+  worstSeverity,
+  type ScratchSpaceCheck,
+} from './doctor-scratch-space.js';
 import { getTimeProvider, getErrorMessage } from '../core/index.js';
 import {
   isPersistenceEnabled,
@@ -711,6 +715,37 @@ export function checkVoterTransport(): VoterTransportCheck {
   return { configured: readOpenAICompatEnv() !== null };
 }
 
+/** The inputs the overall verdict is computed from. */
+export interface HealthVerdictInput {
+  readonly nodeSupported: boolean;
+  readonly hasAuthMethod: boolean;
+  readonly mcpServerReady: boolean;
+  readonly scratchSpace: readonly ScratchSpaceCheck[];
+  readonly clis: readonly CliCheckResult[];
+}
+
+/**
+ * The overall doctor verdict.
+ *
+ * Extracted so the predicate is directly testable (#4488). It needed to be:
+ * `worstSeverity` shipped in #4528 and was then called nowhere, so `doctor`
+ * exited 0 with a 100%-full tmpfs — the check reported the very condition it
+ * was built for and still could not fail on it.
+ *
+ * Scratch space counts at `critical` only. `warn` still leaves room for the
+ * current run, and failing the whole command on it would collapse the
+ * distinction between the two thresholds into one.
+ */
+export function isAllHealthy(input: HealthVerdictInput): boolean {
+  return (
+    input.nodeSupported &&
+    input.hasAuthMethod &&
+    input.mcpServerReady &&
+    worstSeverity(input.scratchSpace) !== 'critical' &&
+    input.clis.every((c) => c.installed && c.authenticated && c.versionStatus !== 'unsupported')
+  );
+}
+
 /**
  * Runs the complete doctor check.
  */
@@ -740,11 +775,13 @@ export async function runDoctor(): Promise<DoctorResult> {
   const hasAuthMethod =
     apiKeys.some((k) => k.configured) || clis.some((c) => c.installed && c.authenticated);
 
-  const allHealthy =
-    nodeVersion.supported &&
-    hasAuthMethod &&
-    mcpServerReady &&
-    clis.every((c) => c.installed && c.authenticated && c.versionStatus !== 'unsupported');
+  const allHealthy = isAllHealthy({
+    nodeSupported: nodeVersion.supported,
+    hasAuthMethod,
+    mcpServerReady,
+    scratchSpace,
+    clis,
+  });
 
   return {
     clis,


### PR DESCRIPTION
Follow-up to #4528 (issue #4488). Found by an adversarial review of that change.

## My changeset overclaimed

#4528 said the scratch check could no longer be *"unable to fail for its own motivating incident."* That is true of the **printed line** and false of the **verdict**.

`worstSeverity` shipped in #4528 and was then called nowhere. `allHealthy` was:

```ts
nodeVersion.supported && hasAuthMethod && mcpServerReady &&
  clis.every((c) => c.installed && c.authenticated && c.versionStatus !== 'unsupported')
```

No scratch term. So `nexus-agents doctor` exits **0** with a 100%-full tmpfs — printing `✗ Scratch space [system] … 0 MiB free` and returning success. The check reports the exact condition it exists to catch, and passes.

The reviewer's phrasing is the accurate one: *a check that reports but cannot fail*. Which is the anti-pattern I have spent the day removing from other people's code and then shipped in my own, having written a changeset asserting the opposite.

## Change

`allHealthy` now includes `worstSeverity(scratchSpace) !== 'critical'`.

`critical` only, deliberately. `warn` still leaves room for the current run; failing the whole command on it would collapse the distinction between the two thresholds into one and make `warn` meaningless.

Extracted as `isAllHealthy()`. That is not incidental — the predicate was an inline boolean expression inside a 40-line function with no injection seam, so there was no way to test the wiring, and that is a large part of why the gap survived review in the first place.

## Also: the formatter had no tests

`formatScratchFilesystems` is the function that renders `doctor`'s new multi-line output, and nothing tested it directly. The existing fixture only ever supplied a **single-element** array, so the join across two filesystems and the empty-list branch were both unexercised — a broken separator, or the array rendering as `[object Object]`, would have reached real output undetected.

Four tests added, including the empty case, which must say "no scratch filesystem could be identified" rather than printing nothing (an empty render reads as "checked, all fine").

## Verification

110 tests pass across the `doctor*` suites. Typecheck and lint clean.

Falsifiability confirmed — removed the new `worstSeverity` term and watched the right two tests go red:

```
× is UNHEALTHY when a scratch filesystem is critical
× takes the WORST reading across filesystems
Tests  2 failed | 4 passed (6)
```

The other four hold under both versions, which is what makes those two meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
