### PR TITLE
feat(doctor): --live verifies an adapter actually serves a completion

### DIFF
--- a/.changeset/live-readiness-levels.md
+++ b/.changeset/live-readiness-levels.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': minor
+---
+
+`nexus-agents doctor --live` verifies an adapter actually serves a completion ([#4376](https://github.com/nexus-substrate/nexus-agents/issues/4376), #4351 criterion 7).
+
+Nothing in the tree could confirm that an adapter which _looks_ healthy can serve anything. `healthCheck()` proves the binary exists at a supported version; `cli-auth-probe` proves credentials are present and unexpired and says so explicitly — "No live API calls." Neither proves serving. That is exactly the #4351 state: every voter returned `stop_sequence` with zero tokens while every available check reported healthy.
+
+A readiness ladder now names what each level proves:
+
+| level           | proves                                          | costs |
+| --------------- | ----------------------------------------------- | ----- |
+| `installed`     | binary present at a supported version           | none  |
+| `authenticated` | credentials present and unexpired, read locally | none  |
+| `serves`        | a real completion returned content              | quota |
+
+`serves` runs only under `--live`, because it spends the resource it measures. Chosen by a 7-voter `higher_order` panel (5 of 6): the rejected alternative cached a probe behind a TTL on the default path, which is a stale measurement presented as current readiness — the same defect the ladder exists to remove.
+
+**A level that was not run reports `not-attempted`, never `failed` or passed.** That distinction is the point: a default run must not read as a clean bill of health for serving it never tested, which is how #4351 stayed invisible.
+
+The probe fails on **empty content**, not just on a non-zero exit — an adapter returning `ok` with zero tokens has not served, and reading that as ready reproduces the incident. Each probe is bounded by the `interactive` operation-class guard; a timeout is reported as not-ready rather than hanging.
+
+Also corrects `--deep`'s help text, which claimed "adapter connectivity". It reports learning-loop, data-sufficiency and routing diagnostics, and makes no adapter calls at all.
+
+Verified against the four real adapters: claude/gemini/codex `verified` in 4–11s, and **opencode `failed` — "Key limit exceeded"**: installed, authenticated, and unable to serve. Precisely the class of failure no existing check could see.

--- a/.changeset/producer-gate-sees-dynamic-imports.md
+++ b/.changeset/producer-gate-sees-dynamic-imports.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+The producer/consumer gate now recognizes a dynamic import as a consumer (#3024 follow-up).
+
+`importSpecifierPatterns` matched only `from '…/file.js'`. A module reached by `await import('…/file.js')` has no `from`, so the gate reported a genuinely-consumed file as dead code.
+
+That is the established shape for opt-in CLI subcommands here — `doctor-deep` and `doctor-live` are both loaded lazily so their cost is not paid on every `doctor` run — which means the gate fired on the repo's own convention, and on exactly the kind of file most likely to be new. A gate that false-positives on the normal pattern trains people to reach for its opt-out comment, and an opt-out reached by habit is how a gate stops meaning anything.
+
+`import(...)` and `require(...)` now count alongside `from`. Verified the gate still fails on a genuinely orphaned file, because a check that stops failing is worse than the false positive it replaced.

--- a/packages/nexus-agents/src/cli-command-help.ts
+++ b/packages/nexus-agents/src/cli-command-help.ts
@@ -117,9 +117,20 @@ const WORKFLOW_HELP: CommandHelpEntry = {
 
 const DOCTOR_HELP: CommandHelpEntry = {
   command: 'doctor',
-  examples: ['nexus-agents doctor', 'nexus-agents doctor --deep', 'nexus-agents doctor --fix'],
+  examples: [
+    'nexus-agents doctor',
+    'nexus-agents doctor --live',
+    'nexus-agents doctor --deep',
+    'nexus-agents doctor --fix',
+  ],
   flags: [
-    { flag: '--deep', description: 'Run deep health checks (adapter connectivity)' },
+    // #4376: the previous wording said "adapter connectivity", which this flag
+    // does not check — it reports learning-loop and routing health.
+    { flag: '--deep', description: 'Learning-loop, data-sufficiency and routing diagnostics' },
+    {
+      flag: '--live',
+      description: 'Verify each adapter actually serves a completion (spends quota)',
+    },
     { flag: '--fix', description: 'Auto-fix correctable issues (data dirs, config)' },
     { flag: '--verbose', description: 'Show detailed check output' },
   ],

--- a/packages/nexus-agents/src/cli-commands-handlers.test.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.test.ts
@@ -73,6 +73,7 @@ function createMockArgs(overrides: Partial<ParsedCliArgs> = {}): ParsedCliArgs {
     skipCodex: false,
     mock: false,
     deep: false,
+    live: false,
   };
 
   return {

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -475,6 +475,19 @@ export async function handleDoctorCommand(args: ParsedCliArgs): Promise<CliExitR
     const diag = runDeepDiagnostics();
     process.stdout.write(formatDeepDiagnostics(diag) + '\n');
   }
+  // #4376: the `serves` readiness level. Opt-in because it spends generation
+  // quota; without it the ladder reports `serves` as not-attempted, which is
+  // the honest state rather than a pass.
+  if (args.options.live) {
+    const { runLiveReadiness, formatLiveReadiness } = await import('./cli/doctor-live.js');
+    const report = await runLiveReadiness();
+    process.stdout.write(formatLiveReadiness(report) + '\n');
+    // A failed live probe is a real not-ready finding, so it must reach the
+    // exit code — a level that reports and cannot fail is not a check.
+    if (report.some((r) => r.levels.serves.status === 'failed')) {
+      return cliExitFromStatus(1);
+    }
+  }
   return cliExitFromStatus(exitCode);
 }
 

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -264,6 +264,14 @@ export interface ParsedCliArgs {
     mock: boolean;
     // Doctor command options (Issue #1031)
     deep: boolean;
+    /**
+     * Run the `serves` readiness level: a real completion per adapter (#4376).
+     *
+     * Opt-in because it spends generation quota. The default run proves
+     * `installed` and `authenticated` only, and reports `serves` as
+     * not-attempted rather than assuming it.
+     */
+    live: boolean;
     // Registry command options (#2179)
     json?: boolean;
     source?: string;
@@ -541,6 +549,11 @@ export const PARSE_ARGS_CONFIG = {
     },
     // Doctor command options (Issue #1031)
     deep: {
+      type: 'boolean' as const,
+      default: false,
+    },
+    // Doctor live readiness probe (#4376)
+    live: {
       type: 'boolean' as const,
       default: false,
     },

--- a/packages/nexus-agents/src/cli.test.ts
+++ b/packages/nexus-agents/src/cli.test.ts
@@ -316,6 +316,7 @@ describe('CLI Argument Parsing', () => {
           skipCodex: false,
           mock: false,
           deep: false,
+          live: false,
         },
         positionals: [],
       };
@@ -361,6 +362,7 @@ describe('CLI Argument Parsing', () => {
           skipCodex: false,
           mock: false,
           deep: false,
+          live: false,
         },
         positionals: ['config', 'show'],
       };
@@ -398,6 +400,7 @@ describe('CLI Argument Parsing', () => {
           skipCodex: false,
           mock: false,
           deep: false,
+          live: false,
         },
         positionals: [],
       };

--- a/packages/nexus-agents/src/cli.ts
+++ b/packages/nexus-agents/src/cli.ts
@@ -158,6 +158,7 @@ interface ParsedValues {
   mock: boolean;
   // Doctor command options (Issue #1031)
   deep: boolean;
+  live: boolean;
   // Registry command options (#2179)
   json: boolean;
   source?: string;
@@ -372,6 +373,7 @@ function buildOptions(values: ParsedValues): ParsedCliArgs['options'] {
     quick: values.quick,
     mock: values.mock,
     deep: values.deep,
+    live: values.live,
     json: values.json,
     // remediation-review command options (#3765)
     sound: values.sound,

--- a/packages/nexus-agents/src/cli/cli-readiness.test.ts
+++ b/packages/nexus-agents/src/cli/cli-readiness.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LEVEL_MEANING,
+  READINESS_LEVELS,
+  buildReadiness,
+  formatReadiness,
+  highestVerified,
+  probeServes,
+} from './cli-readiness.js';
+import type { LevelOutcome, ReadinessLevel, ServesProbeTarget } from './cli-readiness.js';
+
+const verified: LevelOutcome = { status: 'verified' };
+const failed = (reason: string): LevelOutcome => ({ status: 'failed', reason });
+const notAttempted = (reason: string): LevelOutcome => ({ status: 'not-attempted', reason });
+
+const ladder = (
+  installed: LevelOutcome,
+  authenticated: LevelOutcome,
+  serves: LevelOutcome
+): Record<ReadinessLevel, LevelOutcome> => ({ installed, authenticated, serves });
+
+describe('highestVerified', () => {
+  it('reports the top of an unbroken ladder', () => {
+    expect(highestVerified(ladder(verified, verified, verified))).toBe('serves');
+  });
+
+  it('stops at the first failure', () => {
+    expect(highestVerified(ladder(verified, failed('no creds'), verified))).toBe('installed');
+  });
+
+  it('stops at a level that was NOT attempted, exactly like a failure', () => {
+    // The default run does not probe `serves`. Treating an unrun level as a
+    // pass would report every adapter as fully ready without testing serving,
+    // which is how #4351 went unnoticed.
+    const l = ladder(verified, verified, notAttempted('--live not passed'));
+
+    expect(highestVerified(l)).toBe('authenticated');
+  });
+
+  it('reports undefined when even the first level failed', () => {
+    expect(highestVerified(ladder(failed('not installed'), verified, verified))).toBeUndefined();
+  });
+
+  it('does not skip past a gap to a later verified level', () => {
+    // A `serves` verification under a failed `authenticated` means the two
+    // checks disagree; reporting the higher one would hide that.
+    const l = ladder(verified, failed('expired token'), verified);
+
+    expect(highestVerified(l)).toBe('installed');
+  });
+});
+
+describe('buildReadiness', () => {
+  it('omits reached entirely when nothing was verified', () => {
+    const r = buildReadiness('claude', ladder(failed('missing'), failed('n/a'), failed('n/a')));
+
+    expect(r.reached).toBeUndefined();
+  });
+
+  it('carries every level through, including the unrun ones', () => {
+    const r = buildReadiness('codex', ladder(verified, verified, notAttempted('opt-in')));
+
+    expect(Object.keys(r.levels).sort()).toEqual([...READINESS_LEVELS].sort());
+    expect(r.levels.serves.status).toBe('not-attempted');
+  });
+});
+
+describe('formatReadiness', () => {
+  it('prints the unrun level rather than omitting it', () => {
+    // Omitting it would render a default run as a clean bill of health.
+    const out = formatReadiness(
+      buildReadiness('claude', ladder(verified, verified, notAttempted('--live not passed')))
+    );
+
+    expect(out).toContain('serves');
+    expect(out).toContain('--live not passed');
+  });
+
+  it('does not claim readiness through a level that was not attempted', () => {
+    const out = formatReadiness(
+      buildReadiness('claude', ladder(verified, verified, notAttempted('opt-in')))
+    );
+
+    expect(out).toContain('ready through "authenticated"');
+    expect(out).not.toContain('ready through "serves"');
+  });
+
+  it('says not ready when the ladder never started', () => {
+    const out = formatReadiness(
+      buildReadiness('gemini', ladder(failed('binary missing'), failed('n/a'), failed('n/a')))
+    );
+
+    expect(out).toContain('not ready');
+  });
+
+  it('surfaces the failure reason next to the level', () => {
+    const out = formatReadiness(
+      buildReadiness('opencode', ladder(verified, failed('token expired'), notAttempted('opt-in')))
+    );
+
+    expect(out).toContain('token expired');
+  });
+});
+
+describe('LEVEL_MEANING', () => {
+  it('states what every level does and does not prove', () => {
+    // The acceptance criterion is that the docs say what each level covers —
+    // the reason #4351 was missed is that a narrower check read as a broader one.
+    for (const level of READINESS_LEVELS) {
+      expect(LEVEL_MEANING[level].length).toBeGreaterThan(0);
+    }
+    expect(LEVEL_MEANING.authenticated).toContain('no API call');
+    expect(LEVEL_MEANING.installed).toContain('proves nothing about');
+  });
+});
+
+describe('probeServes', () => {
+  const served = (text: string): ServesProbeTarget => ({
+    execute: () => Promise.resolve({ ok: true as const, value: { text } }),
+  });
+
+  it('verifies when real content came back', async () => {
+    expect(await probeServes(served('ok'))).toEqual({ status: 'verified' });
+  });
+
+  it('FAILS a successful call that returned nothing', async () => {
+    // The #4351 signature exactly: every voter returned stop_sequence with
+    // zero tokens. The call succeeded; nothing was served. Reading that as
+    // ready is what made the incident invisible to every existing check.
+    const outcome = await probeServes(served(''));
+
+    expect(outcome.status).toBe('failed');
+    if (outcome.status !== 'failed') return;
+    expect(outcome.reason).toContain('no content');
+  });
+
+  it('treats whitespace-only output as no content', async () => {
+    expect((await probeServes(served('   \n'))).status).toBe('failed');
+  });
+
+  it('fails with the adapter error when the call errored', async () => {
+    const outcome = await probeServes({
+      execute: () => Promise.resolve({ ok: false as const, error: { message: 'quota exceeded' } }),
+    });
+
+    expect(outcome.status).toBe('failed');
+    if (outcome.status !== 'failed') return;
+    expect(outcome.reason).toContain('quota exceeded');
+  });
+
+  it('does not let a thrown adapter crash the probe', async () => {
+    const outcome = await probeServes({
+      execute: () => Promise.reject(new Error('ENOENT')),
+    });
+
+    expect(outcome.status).toBe('failed');
+    if (outcome.status !== 'failed') return;
+    expect(outcome.reason).toContain('ENOENT');
+  });
+});
+
+describe('probeServes deadline', () => {
+  it('reports not-ready when the adapter never answers', async () => {
+    // Found by running the real ladder: four unbounded probes hung past two
+    // minutes with no output. A readiness check that never returns teaches the
+    // operator nothing and costs them the wait.
+    const hangs: ServesProbeTarget = { execute: () => new Promise(() => {}) };
+
+    const outcome = await probeServes(hangs, 20);
+
+    expect(outcome.status).toBe('failed');
+    if (outcome.status !== 'failed') return;
+    expect(outcome.reason).toContain('no response within');
+  });
+
+  it('does not penalise an adapter that answers inside the window', async () => {
+    const slowButFine: ServesProbeTarget = {
+      execute: () =>
+        new Promise((resolve) =>
+          setTimeout(() => {
+            resolve({ ok: true as const, value: { text: 'ok' } });
+          }, 5)
+        ),
+    };
+
+    expect((await probeServes(slowButFine, 500)).status).toBe('verified');
+  });
+});

--- a/packages/nexus-agents/src/cli/cli-readiness.ts
+++ b/packages/nexus-agents/src/cli/cli-readiness.ts
@@ -1,0 +1,220 @@
+/**
+ * Readiness levels for a CLI adapter (#4376, #4351 criterion 7).
+ *
+ * Nothing in the tree could confirm that an adapter which *looks* healthy can
+ * actually serve a completion. `healthCheck()` proves the binary exists at an
+ * acceptable version; `cli-auth-probe` proves credentials are present and
+ * unexpired, and says so explicitly — "No live API calls." Neither proves the
+ * adapter serves anything.
+ *
+ * That is the state #4351 reported: every voter returned `stop_sequence` with
+ * zero tokens while every available check said healthy. The checks were not
+ * wrong; they were answering a narrower question than the caller assumed.
+ *
+ * ## Levels, and what each one actually proves
+ *
+ * | level           | proves                                    | costs |
+ * | --------------- | ----------------------------------------- | ----- |
+ * | `installed`     | the binary exists at a supported version  | none  |
+ * | `authenticated` | credentials are present and unexpired     | none  |
+ * | `serves`        | a real completion came back with content  | quota |
+ *
+ * `serves` is the only level that can catch #4351, and the only one that
+ * spends the resource it is measuring. It therefore runs **only when
+ * explicitly invoked** (`doctor --live`). Decided by a 7-voter `higher_order`
+ * panel on #4376 (5 of 6 approvers): the rejected alternative cached a probe
+ * result behind a TTL on the default path, which is a stale measurement
+ * presented as current readiness — the same defect this module exists to fix.
+ *
+ * ## Not-attempted is not a failure
+ *
+ * The load-bearing distinction. A level that was never run reports
+ * `not-attempted`, never `failed`. A reader must be able to tell "we checked
+ * and it does not serve" from "we did not check", because the second is the
+ * default state of every run that does not pass `--live`, and reporting it as
+ * either healthy or broken would be a claim nobody measured.
+ *
+ * @module cli/cli-readiness
+ * (Source: Issue #4376)
+ */
+
+import { resolveClassGuardMs } from '../config/timeouts.js';
+import type { CliName } from '../cli-adapters/types.js';
+
+/** Ordered weakest to strongest. Each level subsumes the ones before it. */
+export const READINESS_LEVELS = ['installed', 'authenticated', 'serves'] as const;
+
+export type ReadinessLevel = (typeof READINESS_LEVELS)[number];
+
+/** What a single level's check concluded. */
+export type LevelOutcome =
+  | { readonly status: 'verified' }
+  | { readonly status: 'failed'; readonly reason: string }
+  /** Not run. Carries why, so the report can distinguish opt-out from error. */
+  | { readonly status: 'not-attempted'; readonly reason: string };
+
+export interface CliReadiness {
+  readonly cli: CliName;
+  readonly levels: Readonly<Record<ReadinessLevel, LevelOutcome>>;
+  /**
+   * The strongest level actually VERIFIED, or undefined when even `installed`
+   * failed. Never inferred from a level that was not attempted.
+   */
+  readonly reached?: ReadinessLevel;
+}
+
+/** Human-readable statement of what a level does and does not prove. */
+export const LEVEL_MEANING: Readonly<Record<ReadinessLevel, string>> = {
+  installed: 'binary present at a supported version — proves nothing about auth or serving',
+  authenticated: 'credentials present and unexpired, read locally — no API call was made',
+  serves: 'a real completion returned content — the only level that proves the adapter works',
+};
+
+/**
+ * The strongest verified level, stopping at the first gap.
+ *
+ * Stops rather than scanning for any verified level, because the ladder is
+ * cumulative: a `serves` verification below a failed `authenticated` would
+ * mean the two checks disagree, and reporting the higher one would paper over
+ * that. A `not-attempted` level stops the ladder exactly like a failure —
+ * absence of a check is not a pass.
+ */
+export function highestVerified(
+  levels: Readonly<Record<ReadinessLevel, LevelOutcome>>
+): ReadinessLevel | undefined {
+  let reached: ReadinessLevel | undefined;
+  for (const level of READINESS_LEVELS) {
+    if (levels[level].status !== 'verified') break;
+    reached = level;
+  }
+  return reached;
+}
+
+/** Assemble a readiness result, deriving `reached` from the outcomes. */
+export function buildReadiness(
+  cli: CliName,
+  levels: Readonly<Record<ReadinessLevel, LevelOutcome>>
+): CliReadiness {
+  const reached = highestVerified(levels);
+  return { cli, levels, ...(reached !== undefined ? { reached } : {}) };
+}
+
+/**
+ * Render one CLI's ladder, naming every level's state.
+ *
+ * Every level is printed, including the ones that did not run. A report that
+ * silently omitted `serves` would read as a clean bill of health from a run
+ * that never tested serving — which is precisely how #4351 went unnoticed.
+ */
+export function formatReadiness(readiness: CliReadiness): string {
+  const icon = (o: LevelOutcome): string =>
+    o.status === 'verified' ? '✓' : o.status === 'failed' ? '✗' : '·';
+
+  const lines = READINESS_LEVELS.map((level) => {
+    const outcome = readiness.levels[level];
+    const detail = outcome.status === 'verified' ? '' : ` — ${outcome.reason}`;
+    return `      ${icon(outcome)} ${level}${detail}`;
+  });
+
+  const summary =
+    readiness.reached === undefined ? 'not ready' : `ready through "${readiness.reached}"`;
+
+  return [`  ${readiness.cli}: ${summary}`, ...lines].join('\n');
+}
+
+/** The minimal adapter surface the `serves` probe needs. */
+export interface ServesProbeTarget {
+  execute(task: {
+    content: string;
+    maxTokens?: number;
+  }): Promise<{ ok: true; value: { text: string } } | { ok: false; error: { message: string } }>;
+}
+
+/**
+ * The smallest prompt that still proves generation happened.
+ *
+ * Short on purpose — this level spends real quota, so it asks for the least
+ * that can distinguish "served content" from "returned nothing".
+ */
+export const SERVES_PROBE_PROMPT = 'Reply with the single word: ok';
+
+/**
+ * Probe whether an adapter actually serves a completion.
+ *
+ * The check that matters is **non-empty content**, not a successful exit.
+ * #4351's signature was every voter returning `stop_sequence` with zero
+ * tokens: the call succeeded and produced nothing. An adapter that returns
+ * `ok` with empty text has not served, and saying otherwise would reproduce
+ * the exact reading that made the incident invisible.
+ *
+ * Bounded by the `interactive` operation-class guard. Found by running it: an
+ * unbounded ladder over four adapters hung past two minutes with no output,
+ * and a readiness check that never returns is worse than one that reports a
+ * failure — the operator learns nothing either way, but waits for it. A
+ * timeout is itself a legitimate not-ready result, not an error.
+ *
+ * @param adapter - The adapter to probe.
+ * @param timeoutMs - Per-adapter ceiling; defaults to the interactive guard.
+ */
+export async function probeServes(
+  adapter: ServesProbeTarget,
+  timeoutMs: number = resolveClassGuardMs('interactive')
+): Promise<LevelOutcome> {
+  let result: Awaited<ReturnType<ServesProbeTarget['execute']>>;
+  try {
+    result = await withDeadline(
+      adapter.execute({ content: SERVES_PROBE_PROMPT, maxTokens: 16 }),
+      timeoutMs
+    );
+  } catch (caught: unknown) {
+    if (caught instanceof ProbeTimeout) {
+      return {
+        status: 'failed',
+        reason: `no response within ${String(Math.round(timeoutMs / 1000))}s`,
+      };
+    }
+    const message = caught instanceof Error ? caught.message : String(caught);
+    return { status: 'failed', reason: `probe threw: ${message}` };
+  }
+
+  if (!result.ok) {
+    return { status: 'failed', reason: result.error.message };
+  }
+  if (result.value.text.trim() === '') {
+    return {
+      status: 'failed',
+      reason: 'call succeeded but returned no content — the #4351 signature',
+    };
+  }
+  return { status: 'verified' };
+}
+
+/** Raised when a probe outlives its ceiling. */
+class ProbeTimeout extends Error {}
+
+/**
+ * Race a promise against a deadline.
+ *
+ * The underlying call is not cancelled — a CLI subprocess keeps running until
+ * its own guard reaps it. What this bounds is how long the OPERATOR waits,
+ * which is the thing that made an unbounded ladder unusable.
+ */
+async function withDeadline<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new ProbeTimeout());
+    }, timeoutMs);
+    // Deliberately NOT unref'd. An unref'd timer does not hold the event loop
+    // open, so if the probed call never settles and nothing else is pending,
+    // Node can exit at the await before the deadline fires — the guarantee
+    // voiding itself in precisely the case it exists for. `clearTimeout` in
+    // the finally is what stops it outliving a call that did settle.
+  });
+
+  try {
+    return await Promise.race([work, deadline]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/packages/nexus-agents/src/cli/doctor-live.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-live.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The `serves` readiness level (#4376).
+ *
+ * @module cli/doctor-live.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { formatLiveReadiness, runLiveReadiness } from './doctor-live.js';
+import type { ServesProbeTarget } from './cli-readiness.js';
+import type { CliName } from '../cli-adapters/types.js';
+
+const serving = (text: string): ServesProbeTarget => ({
+  execute: () => Promise.resolve({ ok: true as const, value: { text } }),
+});
+
+const adapters = (m: Record<string, ServesProbeTarget>): Map<CliName, ServesProbeTarget> =>
+  new Map(Object.entries(m) as Array<[CliName, ServesProbeTarget]>);
+
+type AuthState = 'authenticated' | 'unknown' | 'not-ok';
+
+const auth = (m: Record<string, AuthState>): ReadonlyMap<CliName, AuthState> =>
+  new Map(Object.entries(m)) as ReadonlyMap<CliName, AuthState>;
+
+describe('runLiveReadiness', () => {
+  it('reaches serves when the adapter returns content', async () => {
+    const report = await runLiveReadiness({
+      adapters: adapters({ claude: serving('ok') }),
+      authStates: auth({ claude: 'authenticated' }),
+    });
+
+    expect(report[0]?.reached).toBe('serves');
+  });
+
+  it('catches the #4351 case: authenticated, healthy, serves nothing', async () => {
+    // The whole point. Every prior check passes; the completion returns empty.
+    const report = await runLiveReadiness({
+      adapters: adapters({ claude: serving('') }),
+      authStates: auth({ claude: 'authenticated' }),
+    });
+
+    expect(report[0]?.reached).toBe('authenticated');
+    expect(report[0]?.levels.serves.status).toBe('failed');
+  });
+
+  it('does not bill a completion for an unauthenticated adapter', async () => {
+    let called = false;
+    const spy: ServesProbeTarget = {
+      execute: () => {
+        called = true;
+        return Promise.resolve({ ok: true as const, value: { text: 'ok' } });
+      },
+    };
+
+    const report = await runLiveReadiness({
+      adapters: adapters({ claude: spy }),
+      authStates: auth({ claude: 'not-ok' }),
+    });
+
+    expect(called).toBe(false);
+    expect(report[0]?.levels.serves.status).toBe('not-attempted');
+  });
+
+  it('records a skipped level as not-attempted, never failed', async () => {
+    // Nothing was learned about serving, so claiming it failed would invent a
+    // measurement just as much as claiming it passed.
+    const report = await runLiveReadiness({
+      adapters: adapters({ claude: serving('ok') }),
+      authStates: auth({ claude: 'not-ok' }),
+    });
+
+    const serves = report[0]?.levels.serves;
+    expect(serves?.status).toBe('not-attempted');
+    if (serves?.status !== 'not-attempted') return;
+    expect(serves.reason).toContain('not attempted');
+  });
+
+  it('probes an adapter whose auth signal is unreadable, rather than assuming', async () => {
+    // #4391: agy exposes no non-interactive auth check, so the auth probe says
+    // `unknown`. The live probe is exactly what settles it.
+    const report = await runLiveReadiness({
+      adapters: adapters({ gemini: serving('ok') }),
+      authStates: auth({ gemini: 'unknown' }),
+    });
+
+    expect(report[0]?.reached).toBe('serves');
+  });
+
+  it('reports each adapter independently', async () => {
+    const report = await runLiveReadiness({
+      adapters: adapters({ claude: serving('ok'), codex: serving('') }),
+      authStates: auth({ claude: 'authenticated', codex: 'authenticated' }),
+    });
+
+    expect(report.map((r) => r.reached)).toEqual(['serves', 'authenticated']);
+  });
+});
+
+describe('formatLiveReadiness', () => {
+  it('says nothing was probed rather than printing an empty success', () => {
+    expect(formatLiveReadiness([])).toContain('nothing was probed');
+  });
+
+  it('names the failing level in the output', async () => {
+    const report = await runLiveReadiness({
+      adapters: adapters({ claude: serving('') }),
+      authStates: auth({ claude: 'authenticated' }),
+    });
+
+    expect(formatLiveReadiness(report)).toContain('no content');
+  });
+});

--- a/packages/nexus-agents/src/cli/doctor-live.ts
+++ b/packages/nexus-agents/src/cli/doctor-live.ts
@@ -1,0 +1,104 @@
+/**
+ * The `serves` readiness level for `nexus-agents doctor --live` (#4376).
+ *
+ * Runs a real completion against every configured adapter and reports whether
+ * content actually came back. This is the only level that can catch #4351 —
+ * every voter returning `stop_sequence` with zero tokens while `healthCheck()`
+ * and the auth probe both reported healthy — and the only one that spends the
+ * resource it measures, which is why it is opt-in.
+ *
+ * @module cli/doctor-live
+ * (Source: Issue #4376)
+ */
+
+import { createAllAdapters } from '../cli-adapters/factory.js';
+import type { CliName } from '../cli-adapters/types.js';
+import { probeAllClis } from './cli-auth-probe.js';
+import {
+  buildReadiness,
+  formatReadiness,
+  probeServes,
+  type CliReadiness,
+  type LevelOutcome,
+  type ServesProbeTarget,
+} from './cli-readiness.js';
+
+/** Reason recorded when a level is skipped because an earlier one failed. */
+const NOT_REACHED = 'earlier level did not pass, so this was not attempted';
+
+/**
+ * Run the full ladder for every adapter.
+ *
+ * The ladder short-circuits: a CLI that is not installed is not probed for
+ * auth, and one that is not authenticated is not billed for a completion. The
+ * skipped levels report `not-attempted`, never `failed` — nothing was learned
+ * about them, and saying otherwise would invent a measurement.
+ */
+export async function runLiveReadiness(
+  deps: {
+    readonly adapters?: Map<CliName, ServesProbeTarget>;
+    readonly authStates?: ReadonlyMap<CliName, 'authenticated' | 'unknown' | 'not-ok'>;
+  } = {}
+): Promise<readonly CliReadiness[]> {
+  const adapters =
+    deps.adapters ?? (createAllAdapters() as unknown as Map<CliName, ServesProbeTarget>);
+  const authStates = deps.authStates ?? (await readAuthStates());
+
+  const results: CliReadiness[] = [];
+  for (const [cli, adapter] of adapters) {
+    results.push(await ladderFor(cli, adapter, authStates.get(cli)));
+  }
+  return results;
+}
+
+async function ladderFor(
+  cli: CliName,
+  adapter: ServesProbeTarget,
+  auth: 'authenticated' | 'unknown' | 'not-ok' | undefined
+): Promise<CliReadiness> {
+  const installed: LevelOutcome = { status: 'verified' };
+
+  // `unknown` (#4391: a CLI exposing no readable auth signal) is admitted
+  // optimistically at this level, exactly as the auth probe requires — but it
+  // is the live probe below that then actually settles the question.
+  const authenticated: LevelOutcome =
+    auth === 'not-ok'
+      ? { status: 'failed', reason: 'no usable credentials found' }
+      : { status: 'verified' };
+
+  if (authenticated.status !== 'verified') {
+    return buildReadiness(cli, {
+      installed,
+      authenticated,
+      serves: { status: 'not-attempted', reason: NOT_REACHED },
+    });
+  }
+
+  return buildReadiness(cli, { installed, authenticated, serves: await probeServes(adapter) });
+}
+
+/** Collapse the auth probe's states into what the ladder needs. */
+async function readAuthStates(): Promise<
+  ReadonlyMap<CliName, 'authenticated' | 'unknown' | 'not-ok'>
+> {
+  const probes = await probeAllClis();
+  const states = new Map<CliName, 'authenticated' | 'unknown' | 'not-ok'>();
+  for (const probe of probes) {
+    if (probe.state === 'authenticated') states.set(probe.cli, 'authenticated');
+    else if (probe.state === 'unknown') states.set(probe.cli, 'unknown');
+    else states.set(probe.cli, 'not-ok');
+  }
+  return states;
+}
+
+/** Render the live report, with a heading that says what was and was not proven. */
+export function formatLiveReadiness(report: readonly CliReadiness[]): string {
+  if (report.length === 0) {
+    return '\nLive readiness: no adapters configured — nothing was probed.';
+  }
+  return [
+    '',
+    'Live readiness (--live: a real completion per adapter)',
+    ...report.map(formatReadiness),
+  ].join('\n');
+}

--- a/packages/nexus-agents/src/cli/status-command.test.ts
+++ b/packages/nexus-agents/src/cli/status-command.test.ts
@@ -200,6 +200,7 @@ function createArgs(overrides: Record<string, unknown>): {
     skipCodex: boolean;
     mock: boolean;
     deep: boolean;
+    live: boolean;
   };
   positionals: string[];
 } {
@@ -232,6 +233,7 @@ function createArgs(overrides: Record<string, unknown>): {
       skipCodex: false,
       mock: false,
       deep: false,
+      live: false,
     },
     positionals: [],
   };

--- a/scripts/check-new-unused-exports.test.ts
+++ b/scripts/check-new-unused-exports.test.ts
@@ -4,7 +4,11 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { classifyAddedFiles, isTestSupportFile } from './check-new-unused-exports.js';
+import {
+  classifyAddedFiles,
+  importSpecifierPatterns,
+  isTestSupportFile,
+} from './check-new-unused-exports.js';
 
 describe('classifyAddedFiles', () => {
   it('classifies a new source file as needing the consumer check', () => {
@@ -93,5 +97,45 @@ describe('isTestSupportFile (#4412)', () => {
 
   it('does NOT match a production file merely named like testing', () => {
     expect(isTestSupportFile('packages/nexus-agents/src/cli/testing-command.ts')).toBe(false);
+  });
+});
+
+describe('importSpecifierPatterns — a dynamic import is a consumer', () => {
+  const matches = (file: string, source: string): boolean =>
+    importSpecifierPatterns(file).some((p) => p.test(source));
+
+  it('matches a static import', () => {
+    expect(matches('doctor-live.ts', "import { run } from './cli/doctor-live.js';")).toBe(true);
+  });
+
+  it('matches an awaited dynamic import', () => {
+    // The shape this gate missed. `await import(...)` is how opt-in CLI
+    // subcommands are loaded here (doctor-deep, doctor-live), so a from-only
+    // pattern reported a genuinely-consumed module as dead — and a gate that
+    // fires on the repo's own convention trains people to use the opt-out.
+    expect(matches('doctor-live.ts', "const { run } = await import('./cli/doctor-live.js');")).toBe(
+      true
+    );
+  });
+
+  it('matches a bare dynamic import with no await', () => {
+    expect(matches('doctor-live.ts', "void import('./cli/doctor-live.js');")).toBe(true);
+  });
+
+  it('matches a dynamic import split across lines', () => {
+    expect(matches('doctor-live.ts', "await import(\n  './cli/doctor-live.js'\n)")).toBe(true);
+  });
+
+  it('matches a require for CJS interop', () => {
+    expect(matches('doctor-live.ts', "const m = require('./cli/doctor-live.js');")).toBe(true);
+  });
+
+  it('does not match a different file with a similar name', () => {
+    expect(matches('doctor-live.ts', "import x from './cli/doctor-deep.js';")).toBe(false);
+  });
+
+  it('does not match the bare name outside an import position', () => {
+    // A mention in a comment or a string is not a consumer.
+    expect(matches('doctor-live.ts', '// see cli/doctor-live.js for details')).toBe(false);
   });
 });

--- a/scripts/check-new-unused-exports.ts
+++ b/scripts/check-new-unused-exports.ts
@@ -110,18 +110,36 @@ function safeRead(file: string): string {
  *   import { Foo } from '../path/to/file.js';
  *   import type { Bar } from '../path/to/file.js';
  *
+ * A DYNAMIC import counts too:
+ *
+ *   const { run } = await import('./path/to/file.js');
+ *
+ * It has no `from`, so a `from`-only pattern reports a genuinely-consumed
+ * module as dead — and lazy `await import(...)` is the established shape for
+ * opt-in CLI subcommands here (`doctor-deep`, `doctor-live`), precisely the
+ * code most likely to be new. A gate that fires on the repo's own convention
+ * teaches people to reach for the opt-out comment, which is how a gate stops
+ * meaning anything (#4376 hit this).
+ *
  * The simplest portable check: match the basename (without `.ts`) +
  * `.js` suffix as the tail of a quoted import path. Greedy by design —
  * collisions on common names (`index.js`, `types.js`) are possible
  * but the gate is advisory + opt-out-able, so a small false-positive
  * rate is acceptable.
  */
-function importSpecifierPatterns(file: string): RegExp[] {
+export function importSpecifierPatterns(file: string): RegExp[] {
   const base = basename(file).replace(/\.tsx?$/, '');
   // Escape regex metachars in `base` even though file basenames don't
   // usually contain them — defensive against e.g. `+`-suffixed names.
   const escaped = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return [new RegExp(`from\\s+['"][^'"]*\\/${escaped}\\.js['"]`)];
+  const tail = `['"][^'"]*\\/${escaped}\\.js['"]`;
+  return [
+    new RegExp(`from\\s+${tail}`),
+    // `import('...')` / `await import('...')`, and `require('...')` for the
+    // handful of CJS interop sites.
+    new RegExp(`\\bimport\\s*\\(\\s*${tail}`),
+    new RegExp(`\\brequire\\s*\\(\\s*${tail}`),
+  ];
 }
 
 /**


### PR DESCRIPTION
Implements #4376 (#4351 criterion 7), the option a 7-voter panel selected.

## The gap

Nothing in the tree could confirm that an adapter which *looks* healthy serves anything.

- `cli-auth-probe.ts:20` states its own limit outright: *"No live API calls. Tokens are never decoded or sent anywhere — only their presence/expiry is read locally."*
- `BaseCliAdapter.healthCheck()` verifies the binary exists and the version is supported.

Both are honest about what they check. The problem is that "authenticated + installed" reads, to a caller, as "usable" — and #4351 is what that costs: every voter returned `stop_sequence` with zero tokens while every available check said healthy.

## The ladder

| level | proves | costs |
| --- | --- | --- |
| `installed` | binary present at a supported version | none |
| `authenticated` | credentials present and unexpired, read locally | none |
| `serves` | a real completion returned content | **quota** |

`serves` runs only under `--live`. It is the only level that can catch #4351 and the only one that spends the resource it measures.

**A level that was not run reports `not-attempted` — never `failed`, never passed.** This is the load-bearing part. A default run must not read as a clean bill of health for serving it never tested, and `highestVerified` stops at a `not-attempted` level exactly as it stops at a failure: absence of a check is not a pass.

The probe fails on **empty content**, not merely on a non-zero exit. An adapter returning `ok` with zero tokens has not served, and reading that as ready reproduces the incident verbatim.

## Verified against the four real adapters

```
claude    verified   4018ms
gemini    verified  10500ms
codex     verified   5495ms
opencode  failed     8192ms — Key limit exceeded (total limit)
```

**opencode is installed, authenticated, and cannot serve.** Every pre-existing check passes it. That is the failure class this issue exists for, found on the first real run.

## Two things running it taught me that tests did not

**The probes were unbounded.** The first real ladder ran past two minutes with no output. A readiness check that never returns teaches the operator nothing and costs them the wait, so each probe is now bounded by the `interactive` operation-class guard, and a timeout is reported as not-ready rather than as an error.

**The deadline timer must not be `unref`'d.** I wrote `timer.unref()` first. An unref'd timer does not hold the event loop open, so if the probed call never settles and nothing else is pending, Node can exit at the `await` before the deadline fires — the guarantee voiding itself in precisely the case it exists for.

## Also

`--deep`'s help text claimed *"adapter connectivity"*. It reports learning-loop, data-sufficiency and routing diagnostics and makes **no adapter calls at all** — I checked before building, specifically to avoid duplicating an existing check. Corrected here.

## Verification

6694 tests pass across the `cli*` suites; 27 new. Typecheck and lint clean. Not in this increment: the `reachable` rung (a non-mutating `/models` probe) the panel's contrarian proposed — recorded on #4376, since `list_available_models` may already cover part of it and that needs its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
