### PR TITLE
fix(ci): the deploy-staleness grace window was never reachable

### DIFF
--- a/.changeset/deploy-grace-window-was-never-wired.md
+++ b/.changeset/deploy-grace-window-was-never-wired.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+The deploy-staleness grace window is now reachable ([#4516](https://github.com/nexus-substrate/nexus-agents/issues/4516) follow-up).
+
+`assessDeployStaleness` has a 45-minute window so a deploy in flight is not reported as a stall. The workflow never set `MINUTES_SINCE_PUBLISH`, and the script fell back to `9999`, so that branch **could never be taken**. The guard was unreachable for the detector's entire life.
+
+The consequence is a false alarm on every release. Observed today: 3.5.6 published at 06:40:42Z, the check ran at 07:09:54Z — **29 minutes, well inside the window** — and failed, one second before the deploy run that would have fixed it even started. A detector that cries wolf on the normal path gets muted, which is the same reasoning that kept a second npm-skew detector from being built earlier.
+
+The workflow now derives the elapsed time from npm's publish timestamp for the current version — the point at which the site could first be behind.
+
+An unreadable publish time is reported as **`unmeasured`**, not as "a long time ago". Defaulting it to a large number is precisely what made the window unreachable, and quietly disabling a guard is worse than reporting that its input is missing. A negative elapsed time (clock skew between runner and registry) is also unmeasured rather than an unbounded grace.
+
+Verified by replaying the real inputs: 29 minutes → `deploying`, 60 minutes → `stale`, unreadable → `unmeasured`.

--- a/.github/workflows/deploy-stale-check.yml
+++ b/.github/workflows/deploy-stale-check.yml
@@ -45,9 +45,36 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
+      # The grace window exists so a normal deploy in flight is not reported as
+      # a stall. It was never wired: the script fell back to a 9999-minute
+      # default, so the window could not apply and the check failed on every
+      # release. npm's publish timestamp is the right clock — it is when this
+      # version actually became something the site could be behind.
+      - name: Minutes since the current version was published
+        id: published
+        run: |
+          set -uo pipefail
+          version=$(node -p "require('./packages/nexus-agents/package.json').version")
+          published=$(npm view "nexus-agents@$version" time --json 2>/dev/null \
+            | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{
+                try { const t=JSON.parse(s); process.stdout.write(t['$version'] ?? ''); }
+                catch { process.stdout.write(''); }
+              })" || echo "")
+          if [ -z "$published" ]; then
+            # Empty, not a large number: the assessor reports an unreadable
+            # publish time as unmeasured rather than assuming it was long ago.
+            echo "minutes=" >> "$GITHUB_OUTPUT"
+          else
+            now=$(date -u +%s)
+            then_s=$(date -u -d "$published" +%s)
+            echo "minutes=$(( (now - then_s) / 60 ))" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Compare the live site against main
         id: assess
         continue-on-error: true
+        env:
+          MINUTES_SINCE_PUBLISH: ${{ steps.published.outputs.minutes }}
         run: npx tsx scripts/check-deploy-stale.ts
 
       # #4521: catch the CAUSE early, not just the consequence. A run wedged in

--- a/scripts/check-deploy-stale.test.ts
+++ b/scripts/check-deploy-stale.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { assessDeployStaleness, parseSiteVersion } from './check-deploy-stale.js';
+import { GRACE_MINUTES, assessDeployStaleness, parseSiteVersion } from './check-deploy-stale.js';
+import type { StalenessInput } from './check-deploy-stale.js';
 
 describe('parseSiteVersion', () => {
   it('extracts a semver from the real page markup', () => {
@@ -94,5 +95,53 @@ describe('assessDeployStaleness', () => {
 
     expect(v.ok).toBe(false);
     expect(v.status).toBe('stale');
+  });
+});
+
+describe('#4516 follow-up: the grace window has to be reachable', () => {
+  const gap = (minutesSincePublish: number): StalenessInput => ({
+    siteVersion: '3.5.5',
+    repoVersion: '3.5.6',
+    minutesSincePublish,
+  });
+
+  it('reports deploying inside the grace window', () => {
+    // The real 2026-08-22 case: 3.5.6 published at 06:40Z, the check ran at
+    // 07:09Z — 29 minutes, well inside the window — and still failed, because
+    // the workflow never supplied the input and the script defaulted to 9999.
+    const verdict = assessDeployStaleness(gap(29));
+
+    expect(verdict.status).toBe('deploying');
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('still reports stale once the window has passed', () => {
+    expect(assessDeployStaleness(gap(GRACE_MINUTES + 1)).status).toBe('stale');
+  });
+
+  it('reports unmeasured when the publish time could not be read', () => {
+    // NOT "a long time ago". Treating an unreadable input as a large number is
+    // exactly what made the window unreachable for the detector's whole life.
+    const verdict = assessDeployStaleness(gap(Number.NaN));
+
+    expect(verdict.status).toBe('unmeasured');
+    expect(verdict.reason).toContain('unmeasured');
+  });
+
+  it('reports unmeasured rather than trusting a negative elapsed time', () => {
+    // Clock skew between the runner and the registry should not silently buy
+    // an unbounded grace.
+    expect(assessDeployStaleness(gap(-5)).status).toBe('unmeasured');
+  });
+
+  it('does not consult the window at all when the versions already agree', () => {
+    const verdict = assessDeployStaleness({
+      siteVersion: '3.5.6',
+      repoVersion: '3.5.6',
+      minutesSincePublish: Number.NaN,
+    });
+
+    expect(verdict.status).toBe('current');
+    expect(verdict.ok).toBe(true);
   });
 });

--- a/scripts/check-deploy-stale.ts
+++ b/scripts/check-deploy-stale.ts
@@ -101,6 +101,23 @@ export function assessDeployStaleness(input: StalenessInput): StalenessVerdict {
     };
   }
 
+  // An unreadable publish time is not "a long time ago". Defaulting it that
+  // way is what made the grace window dead: the workflow never supplied
+  // MINUTES_SINCE_PUBLISH, the script fell back to 9999, and the branch below
+  // could not be reached — so the detector fired on every release during the
+  // normal deploy window. Report the gap in the input rather than guessing
+  // past it.
+  if (!Number.isFinite(input.minutesSincePublish) || input.minutesSincePublish < 0) {
+    return {
+      status: 'unmeasured',
+      ok: false,
+      reason:
+        `Site at ${input.siteVersion}, repo at ${input.repoVersion}, but the publish time ` +
+        'could not be read — so whether this gap is a normal deploy window or a real stall ' +
+        'is unmeasured. Not evidence of either.',
+    };
+  }
+
   if (input.minutesSincePublish < GRACE_MINUTES) {
     return {
       status: 'deploying',
@@ -144,7 +161,10 @@ async function main(): Promise<void> {
     repoVersion: readRepoVersion(),
     // The workflow supplies elapsed minutes; absent it, assume past the window
     // so a genuine divergence is reported rather than excused.
-    minutesSincePublish: Number(process.env['MINUTES_SINCE_PUBLISH'] ?? '9999'),
+    // NaN when unset or unparseable, which `assessDeployStaleness` reports as
+    // unmeasured. Deliberately NOT a large default: that silently disabled the
+    // grace window for the detector's whole life.
+    minutesSincePublish: Number(process.env['MINUTES_SINCE_PUBLISH'] ?? 'nan'),
   });
 
   console.log(`[${verdict.status}] ${verdict.reason}`);


### PR DESCRIPTION
Follow-up to #4516. Found by the detector failing on `main` after a routine release.

## A guard that could not fire

`assessDeployStaleness` carries a 45-minute grace window so a deploy in flight is not reported as a stall — added on the contrarian's argument during #4516 that "no threshold" would false-positive on every release.

The workflow never set `MINUTES_SINCE_PUBLISH`. The script read:

```ts
minutesSincePublish: Number(process.env['MINUTES_SINCE_PUBLISH'] ?? '9999'),
```

So the input was always `9999`, the `< GRACE_MINUTES` branch was unreachable, and the window has been dead for the detector's entire life. The contrarian's objection was accepted, the code was written, and the wiring never happened — which is indistinguishable, in effect, from having ignored the objection.

Observed today: **3.5.6 published at 06:40:42Z, the check ran at 07:09:54Z — 29 minutes, well inside the window — and failed**, one second before the deploy run that would have resolved it even started.

That is how a detector gets muted. It is also the same reasoning I used two hours ago to *decline* building a second npm-skew detector, so it is worth being consistent about here.

## Change

The workflow derives the elapsed time from **npm's publish timestamp** for the current version — the moment the site could first be behind. No git history needed, so it works under the shallow checkout the workflow already uses.

An unreadable publish time is reported as **`unmeasured`**, not as "a long time ago":

```ts
minutesSincePublish: Number(process.env['MINUTES_SINCE_PUBLISH'] ?? 'nan'),
```

Defaulting an unknown to a large number is exactly what made the window unreachable, and quietly disabling a guard is worse than saying its input is missing. A negative elapsed time — clock skew between runner and registry — is also unmeasured rather than an unbounded grace.

## Verification

14 tests pass; 5 new. Lint clean.

Replayed against the real inputs from this morning's false alarm:

```
real 07:09 alarm (29 min)      → deploying   ok=true
past window (60 min)           → stale       ok=false
unreadable publish time        → unmeasured  ok=false
```

The first line is the run that failed on `main`. The second confirms a genuine stall still reports — a grace window that swallowed real staleness would be a worse bug than the one being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
