### PR TITLE
fix(ci): the deploy detector derives its own publish time

### DIFF
--- a/.changeset/detector-owns-its-publish-time.md
+++ b/.changeset/detector-owns-its-publish-time.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+The deploy-staleness detector derives its own publish time instead of being handed one (#4516 follow-up).
+
+The grace window took elapsed-since-publish from `MINUTES_SINCE_PUBLISH`, an environment input the workflow was supposed to set. It never did, so the window was unreachable for the detector's whole life. The immediate fix wired the workflow up; this removes the dependency instead.
+
+An input supplied from outside is an input that can be forgotten — and it was, silently, for months. The script now reads npm's registry metadata for the current version itself, so there is no wiring left to drop. The env var still overrides, for tests and for a caller that already knows.
+
+Two practical consequences beyond the wiring:
+
+- Running `npx tsx scripts/check-deploy-stale.ts` by hand now works. Previously a local run always reported `unmeasured`, because the variable is workflow-only — the detector was unusable in exactly the situation where someone reaches for it.
+- The workflow step that computed it is gone, so the logic lives in one place rather than being split between a shell snippet and a TypeScript module.
+
+An unreadable registry response still reports **`unmeasured`**, never "a long time ago". Verified against the live registry: `3.6.3` → 4.1 minutes, an absent version → unmeasured.

--- a/.github/workflows/deploy-stale-check.yml
+++ b/.github/workflows/deploy-stale-check.yml
@@ -45,36 +45,14 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      # The grace window exists so a normal deploy in flight is not reported as
-      # a stall. It was never wired: the script fell back to a 9999-minute
-      # default, so the window could not apply and the check failed on every
-      # release. npm's publish timestamp is the right clock — it is when this
-      # version actually became something the site could be behind.
-      - name: Minutes since the current version was published
-        id: published
-        run: |
-          set -uo pipefail
-          version=$(node -p "require('./packages/nexus-agents/package.json').version")
-          published=$(npm view "nexus-agents@$version" time --json 2>/dev/null \
-            | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{
-                try { const t=JSON.parse(s); process.stdout.write(t['$version'] ?? ''); }
-                catch { process.stdout.write(''); }
-              })" || echo "")
-          if [ -z "$published" ]; then
-            # Empty, not a large number: the assessor reports an unreadable
-            # publish time as unmeasured rather than assuming it was long ago.
-            echo "minutes=" >> "$GITHUB_OUTPUT"
-          else
-            now=$(date -u +%s)
-            then_s=$(date -u -d "$published" +%s)
-            echo "minutes=$(( (now - then_s) / 60 ))" >> "$GITHUB_OUTPUT"
-          fi
-
+      # The script derives elapsed-since-publish itself from the npm registry.
+      # It used to take that as an env input this workflow was supposed to set,
+      # and never did — leaving the grace window unreachable for the whole life
+      # of the detector. An input supplied from outside is an input that can be
+      # forgotten, so the script owns it now and there is no wiring to drop.
       - name: Compare the live site against main
         id: assess
         continue-on-error: true
-        env:
-          MINUTES_SINCE_PUBLISH: ${{ steps.published.outputs.minutes }}
         run: npx tsx scripts/check-deploy-stale.ts
 
       # #4521: catch the CAUSE early, not just the consequence. A run wedged in

--- a/scripts/check-deploy-stale.ts
+++ b/scripts/check-deploy-stale.ts
@@ -141,6 +141,42 @@ function readRepoVersion(): string {
   return (JSON.parse(readFileSync(p, 'utf-8')) as { version: string }).version;
 }
 
+/** npm registry metadata endpoint; `time` maps each version to its publish ISO date. */
+const REGISTRY_URL = 'https://registry.npmjs.org/nexus-agents';
+
+/**
+ * Minutes since `version` was published to npm, or undefined if unreadable.
+ *
+ * The script derives this itself rather than taking it from the environment.
+ * It was an env input supplied by the workflow, the workflow never supplied
+ * it, and the grace window that depends on it was therefore unreachable for
+ * the detector's entire life — a guard broken by the one thing about it that
+ * lived somewhere else. Owning the input removes that failure mode: there is
+ * no wiring left to forget.
+ *
+ * `MINUTES_SINCE_PUBLISH` still overrides, for tests and for a caller that
+ * already knows.
+ */
+async function minutesSincePublish(version: string): Promise<number> {
+  const override = process.env['MINUTES_SINCE_PUBLISH'];
+  if (override !== undefined && override.trim() !== '') return Number(override);
+
+  try {
+    const res = await fetch(REGISTRY_URL, { redirect: 'follow' });
+    if (!res.ok) return Number.NaN;
+    const body = (await res.json()) as { time?: Record<string, string> };
+    const published = body.time?.[version];
+    if (published === undefined) return Number.NaN;
+
+    const publishedMs = Date.parse(published);
+    if (Number.isNaN(publishedMs)) return Number.NaN;
+    return (Date.now() - publishedMs) / 60_000;
+  } catch {
+    // Unreadable, which the assessor reports as unmeasured — not as "long ago".
+    return Number.NaN;
+  }
+}
+
 /** Fetch the live page, bounded; undefined on any failure (reported as unmeasured). */
 async function fetchSite(): Promise<string | undefined> {
   try {
@@ -155,16 +191,13 @@ async function fetchSite(): Promise<string | undefined> {
 
 /* eslint-disable no-console */
 async function main(): Promise<void> {
-  const html = await fetchSite();
+  const repoVersion = readRepoVersion();
+  const [html, elapsed] = await Promise.all([fetchSite(), minutesSincePublish(repoVersion)]);
+
   const verdict = assessDeployStaleness({
     siteVersion: html === undefined ? undefined : parseSiteVersion(html),
-    repoVersion: readRepoVersion(),
-    // The workflow supplies elapsed minutes; absent it, assume past the window
-    // so a genuine divergence is reported rather than excused.
-    // NaN when unset or unparseable, which `assessDeployStaleness` reports as
-    // unmeasured. Deliberately NOT a large default: that silently disabled the
-    // grace window for the detector's whole life.
-    minutesSincePublish: Number(process.env['MINUTES_SINCE_PUBLISH'] ?? 'nan'),
+    repoVersion,
+    minutesSincePublish: elapsed,
   });
 
   console.log(`[${verdict.status}] ${verdict.reason}`);


### PR DESCRIPTION
Follow-up to #4551, which wired up an input rather than removing the need for it.

## The narrower fix left the fragility in place

#4551 fixed a grace window that had been unreachable for the detector's entire life: it read elapsed-since-publish from `MINUTES_SINCE_PUBLISH`, an environment input the workflow was supposed to supply and never did.

Wiring the workflow up made it work. It did not make it robust — **an input supplied from outside is an input that can be forgotten**, and it was, silently, for months. The next person to touch that workflow can drop the step and the guard goes quiet again with nothing failing.

So the script now reads npm's registry metadata for the current version itself. There is no wiring left to drop.

`MINUTES_SINCE_PUBLISH` still overrides, for tests and for a caller that already knows.

## Two consequences beyond the wiring

**A local run works now.** `npx tsx scripts/check-deploy-stale.ts` previously always reported `unmeasured`, because the variable is workflow-only — the detector was unusable in precisely the situation where a human reaches for it. That is how I noticed: I ran it by hand while watching the release land, and got `unmeasured` from a detector I had "fixed" hours earlier.

**One place instead of two.** The workflow step that shelled out to `npm view` and did date arithmetic in bash is gone. That logic now lives in the module beside the assessor that consumes it.

No new dependency class — the script already fetches the live site over the network.

## Verification

14 tests pass; lint clean. Confirmed zero new type errors by diffing `tsc` output against `main`: **29 lines before, 29 after, identical**.

Against the live registry:

```
3.6.3    published=2026-08-22T21:50:56.058Z -> 4.1 min
3.6.2    published=2026-08-22T21:47:40.650Z -> 7.4 min
9.9.9    published=(absent)                 -> NaN (unmeasured)
```

An unreadable response reports `unmeasured`, never "a long time ago" — that default is what made the window unreachable to begin with.

## Noticed while verifying, filed separately

`pnpm typecheck` is `turbo typecheck`, which runs per-workspace. `scripts/` is not a workspace, so **nothing typechecks it** — there are 15 pre-existing type errors there that no gate reports. Same shape as #4483, which found `scripts/` outside every lint scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
