### PR TITLE
feat(ci): export-level dead-code ratchet on modified files

### DIFF
--- a/.changeset/dead-export-ratchet.md
+++ b/.changeset/dead-export-ratchet.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+The producer/consumer gate now works at export level on modified files, blocking only what a PR adds.
+
+Decided by a 7-voter `higher_order` panel at the supermajority bar: **unanimous, 6 of 6 approvers**, after a first vote was stopped mid-flight because its leading option rested on a false premise.
+
+**What was withdrawn, and why.** The original plan was to extend `knip` (already installed) to report unused exports. Measured instead of assumed: knip reports **2,355 unused exports** and flags **zero of five confirmed-dead ones**, because it counts a test-file import as consumption — and "imported only by its own test" is the defining shape of this defect class. Knip is simultaneously too noisy to promote and structurally blind to the target.
+
+**What ships.** `scripts/check-new-unused-exports.ts` already had the right semantics — a consumer is a non-test, non-barrel import — but only inspected newly _added_ files. It now also inspects _modified_ files at export granularity, splitting findings:
+
+- an export **this PR added** with no production consumer → **blocks**
+- an export **already dead** in a file the PR touched → **advisory**, listed and not blocking
+
+That split is measured, not stylistic. Blocking on pre-existing dead exports flagged 14 on a real two-file merge; a gate that bills an unrelated PR for old debt teaches people to reach for the opt-out marker, which is how a gate stops meaning anything.
+
+Verified in both directions: adding an unconsumed export to `codex-limits.ts` exits 1 and names it, while `checkCodexDepth` and two constants appear in the advisory list; a clean branch exits 0.
+
+**One bug caught by running it.** The first implementation filtered the production haystack with `isTestSupportFile`, which means "lives in `src/testing/`" — not "is a test". Test-only imports therefore counted as production use, reproducing knip's exact blindness inside the fix for it. Found because a known-dead export produced no advisory line. A regression test now pins the distinction.

--- a/scripts/check-new-unused-exports.test.ts
+++ b/scripts/check-new-unused-exports.test.ts
@@ -6,8 +6,11 @@ import { describe, it, expect } from 'vitest';
 
 import {
   classifyAddedFiles,
+  classifyDeadExports,
+  exportedNames,
   importSpecifierPatterns,
   isTestSupportFile,
+  nameHasProductionUse,
 } from './check-new-unused-exports.js';
 
 describe('classifyAddedFiles', () => {
@@ -137,5 +140,122 @@ describe('importSpecifierPatterns — a dynamic import is a consumer', () => {
   it('does not match the bare name outside an import position', () => {
     // A mention in a comment or a string is not a consumer.
     expect(matches('doctor-live.ts', '// see cli/doctor-live.js for details')).toBe(false);
+  });
+});
+
+describe('classifyDeadExports — block what this PR added, report what it inherited', () => {
+  const allDead = (): boolean => true;
+
+  it('flags an export this PR added as new', () => {
+    const result = classifyDeadExports(
+      'f.ts',
+      'export function old(): void {}',
+      'export function old(): void {}\nexport function fresh(): void {}',
+      allDead
+    );
+
+    expect(result.newDead.map((d) => d.name)).toEqual(['fresh']);
+  });
+
+  it('classifies an export that already existed as pre-existing', () => {
+    const result = classifyDeadExports(
+      'f.ts',
+      'export function old(): void {}',
+      'export function old(): void {}',
+      allDead
+    );
+
+    expect(result.preexistingDead.map((d) => d.name)).toEqual(['old']);
+    expect(result.newDead).toEqual([]);
+  });
+
+  it('does not flag an export that has a consumer', () => {
+    const result = classifyDeadExports(
+      'f.ts',
+      '',
+      'export function used(): void {}',
+      (n) => n !== 'used'
+    );
+
+    expect(result.newDead).toEqual([]);
+    expect(result.preexistingDead).toEqual([]);
+  });
+
+  it('separates the two kinds in one file', () => {
+    // The realistic case: you touch a file carrying old debt and add one thing.
+    const result = classifyDeadExports(
+      'f.ts',
+      'export const a = 1;',
+      'export const a = 1;\nexport const b = 2;',
+      allDead
+    );
+
+    expect(result.newDead.map((d) => d.name)).toEqual(['b']);
+    expect(result.preexistingDead.map((d) => d.name)).toEqual(['a']);
+  });
+
+  it('treats a brand-new file as all-new', () => {
+    const result = classifyDeadExports('f.ts', '', 'export type T = string;', allDead);
+
+    expect(result.newDead.map((d) => d.name)).toEqual(['T']);
+  });
+});
+
+describe('exportedNames', () => {
+  it('finds each exported declaration kind', () => {
+    const src = [
+      'export function f(): void {}',
+      'export const c = 1;',
+      'export class K {}',
+      'export interface I { a: string }',
+      'export type T = string;',
+      'export enum E { A }',
+      'export async function g(): Promise<void> {}',
+    ].join('\n');
+
+    expect(exportedNames(src).sort()).toEqual(['E', 'I', 'K', 'T', 'c', 'f', 'g']);
+  });
+
+  it('ignores a non-exported declaration', () => {
+    expect(exportedNames('function hidden(): void {}')).toEqual([]);
+  });
+
+  it('ignores the word export inside a comment or string', () => {
+    expect(exportedNames('// export function fake(): void {}')).toEqual([]);
+  });
+});
+
+describe('nameHasProductionUse', () => {
+  const read = (f: string): string => ({ 'a.ts': 'uses thing()', 'b.ts': 'nothing' })[f] ?? '';
+
+  it('counts a reference in another production file', () => {
+    expect(nameHasProductionUse('thing', 'decl.ts', ['a.ts', 'b.ts'], read)).toBe(true);
+  });
+
+  it('does not count the declaring file itself', () => {
+    expect(nameHasProductionUse('thing', 'a.ts', ['a.ts'], read)).toBe(false);
+  });
+
+  it('matches on a word boundary, not a substring', () => {
+    const r = (): string => 'somethingElse';
+    expect(nameHasProductionUse('thing', 'd.ts', ['x.ts'], r)).toBe(false);
+  });
+});
+
+describe('isTestSupportFile is not a test-file predicate', () => {
+  it('does NOT classify a .test.ts file as test-support', () => {
+    // The distinction that bit me: isTestSupportFile means "lives in
+    // src/testing/", not "is a test". Using it to filter the production
+    // haystack let a test-only import count as production use — the exact
+    // blindness that disqualified knip for this job.
+    expect(isTestSupportFile('packages/nexus-agents/src/cli-adapters/codex-limits.test.ts')).toBe(
+      false
+    );
+  });
+
+  it('classifies a src/testing/ module as test-support', () => {
+    expect(isTestSupportFile('packages/nexus-agents/src/testing/adapters/mock-adapter.ts')).toBe(
+      true
+    );
   });
 });

--- a/scripts/check-new-unused-exports.ts
+++ b/scripts/check-new-unused-exports.ts
@@ -226,20 +226,100 @@ function findConsumers(file: string, patterns: RegExp[]): string[] {
   return [...consumers];
 }
 
+/**
+ * Exported declaration names in a source text (#4560).
+ *
+ * Regex-level, matching the import-detection heuristic already used here.
+ * Deliberately not an AST pass: the file-level check has always been greedy
+ * and opt-out-able, and a heavier analysis would not change which cases this
+ * ratchet blocks on — only how many pre-existing ones it can list.
+ */
+export function exportedNames(source: string): string[] {
+  const names = new Set<string>();
+  const decl =
+    /^export\s+(?:async\s+)?(?:function|const|let|class|interface|type|enum)\s+([A-Za-z_$][\w$]*)/gm;
+  for (const m of source.matchAll(decl)) {
+    if (m[1] !== undefined) names.add(m[1]);
+  }
+  return [...names];
+}
+
+/**
+ * Is `name` referenced by any production file other than the one declaring it?
+ *
+ * Barrels COUNT here, unlike the file-level check. A re-export is how most
+ * callers reach a symbol, and excluding barrels made 2,509 of ~2,700 exports
+ * look dead — measured, not assumed.
+ */
+export function nameHasProductionUse(
+  name: string,
+  declaringFile: string,
+  productionFiles: readonly string[],
+  read: (f: string) => string
+): boolean {
+  const re = new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`);
+  return productionFiles.some((f) => f !== declaringFile && re.test(read(f)));
+}
+
 /** True when the file opts out of the gate via the marker comment. */
 function hasOptOutMarker(file: string): boolean {
   return OPT_OUT_MARKER.test(safeRead(file));
 }
 
+/** An export with no production consumer, and whether this PR introduced it. */
+export interface DeadExport {
+  readonly file: string;
+  readonly name: string;
+}
+
 export interface CheckResult {
   /** New source files that have no production consumer. */
   unconsumed: string[];
+  /**
+   * Exports this PR ADDED that nothing consumes (#4560). Blocking: the author
+   * wrote them in this change, so the finding is actionable and near-zero
+   * false-positive.
+   */
+  newDeadExports: DeadExport[];
+  /**
+   * Exports that were ALREADY dead in a file this PR touched. Advisory only.
+   *
+   * Measured before choosing: blocking on these flagged 14 exports on a real
+   * two-file merge, because touching a file surfaces every pre-existing dead
+   * export in it. A gate that punishes an unrelated PR for old debt teaches
+   * people to reach for the opt-out marker, which is how a gate stops meaning
+   * anything.
+   */
+  preexistingDeadExports: DeadExport[];
   /** New source files that opted out via the marker. */
   optedOut: string[];
   /** New source files with at least one production consumer. */
   consumed: { file: string; consumers: string[] }[];
   /** Files skipped (tests, barrels, declarations). */
   skipped: string[];
+}
+
+/**
+ * Classify dead exports in a MODIFIED file as newly-added or pre-existing.
+ *
+ * `baseSource` is the file as it was at the merge base; `headSource` is now.
+ * A name absent from base and dead at head is this PR's doing.
+ */
+export function classifyDeadExports(
+  file: string,
+  baseSource: string,
+  headSource: string,
+  isDead: (name: string) => boolean
+): { newDead: DeadExport[]; preexistingDead: DeadExport[] } {
+  const before = new Set(exportedNames(baseSource));
+  const newDead: DeadExport[] = [];
+  const preexistingDead: DeadExport[] = [];
+
+  for (const name of exportedNames(headSource)) {
+    if (!isDead(name)) continue;
+    (before.has(name) ? preexistingDead : newDead).push({ file, name });
+  }
+  return { newDead, preexistingDead };
 }
 
 /** Run the producer-without-consumer check across the PR's added files. */
@@ -262,7 +342,14 @@ export function checkAddedFiles(files: string[]): CheckResult {
       consumed.push({ file, consumers });
     }
   }
-  return { unconsumed, optedOut, consumed, skipped };
+  return {
+    unconsumed,
+    optedOut,
+    consumed,
+    skipped,
+    newDeadExports: [],
+    preexistingDeadExports: [],
+  };
 }
 
 /** Log the success-path summary lines (consumed / opted-out / skipped). */
@@ -308,6 +395,111 @@ function logFailure(unconsumed: string[]): void {
   console.error('  3. Delete the file if the consumer is no longer needed.');
 }
 
+/** Files MODIFIED (not added) since `base`, filtered to production source. */
+function modifiedSourceFiles(base: string): string[] {
+  const out = execSync(`git diff --name-status --diff-filter=M ${base}...HEAD`, {
+    encoding: 'utf-8',
+  });
+  return out
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .map((l) => l.split(/\s+/).slice(1).join(' '))
+    .filter(
+      (f) =>
+        f.startsWith('packages/nexus-agents/src/') &&
+        /\.tsx?$/.test(f) &&
+        !isTestSupportFile(f) &&
+        !/\/index\.tsx?$/.test(f) &&
+        !f.endsWith('.d.ts')
+    );
+}
+
+/** Every production source file, used as the haystack for name references. */
+function productionSourceFiles(): string[] {
+  // isTestFile, NOT isTestSupportFile — the latter means "lives in src/testing/",
+  // a different concept. Using it here let a test-only import count as
+  // production use, which is precisely the blindness that disqualified knip
+  // for this job. Caught by running the ratchet against a known-dead export
+  // and getting no advisory line.
+  return listSourceFiles(SRC_DIR).filter((f) => !isTestFile(f));
+}
+
+/**
+ * Export-level ratchet over MODIFIED files (#4560).
+ *
+ * Blocks only on exports this PR added, and merely reports ones already dead
+ * in a file it touched. That split is measured, not stylistic: blocking on
+ * pre-existing dead exports flagged 14 on a real two-file merge, and a gate
+ * that bills an unrelated PR for old debt gets routed around.
+ */
+function checkModifiedFiles(base: string): {
+  newDead: DeadExport[];
+  preexisting: DeadExport[];
+} {
+  const modified = modifiedSourceFiles(base);
+  if (modified.length === 0) return { newDead: [], preexisting: [] };
+
+  const production = productionSourceFiles();
+  const cache = new Map<string, string>();
+  const read = (f: string): string => {
+    const hit = cache.get(f);
+    if (hit !== undefined) return hit;
+    const body = safeRead(f);
+    cache.set(f, body);
+    return body;
+  };
+
+  const newDead: DeadExport[] = [];
+  const preexisting: DeadExport[] = [];
+
+  for (const rel of modified) {
+    const abs = rel;
+    if (hasOptOutMarker(abs)) continue;
+
+    let baseSource = '';
+    try {
+      baseSource = execSync(`git show ${base}:${rel}`, { encoding: 'utf-8' });
+    } catch {
+      // Absent at base (renamed, or the ref is shallow): treat every export as
+      // pre-existing rather than blaming this PR for code it may not have added.
+      baseSource = safeRead(abs);
+    }
+
+    const classified = classifyDeadExports(
+      rel,
+      baseSource,
+      safeRead(abs),
+      (name) => !nameHasProductionUse(name, abs, production, read)
+    );
+    newDead.push(...classified.newDead);
+    preexisting.push(...classified.preexistingDead);
+  }
+  return { newDead, preexisting };
+}
+
+/** Print the export ratchet's two lists, blocking one and advisory one. */
+function reportExportRatchet(ratchet: { newDead: DeadExport[]; preexisting: DeadExport[] }): void {
+  if (ratchet.preexisting.length > 0) {
+    console.log(
+      `\nAlready-dead exports in files this PR touched (${String(ratchet.preexisting.length)}, advisory):`
+    );
+    for (const d of ratchet.preexisting) console.log(`  - ${d.file} :: ${d.name}`);
+    console.log('  Not blocking — this PR did not add them. Removing one is a welcome cleanup.');
+  }
+
+  if (ratchet.newDead.length === 0) return;
+
+  console.error(
+    `\nExports added by this PR with no production consumer (${String(ratchet.newDead.length)}):`
+  );
+  for (const d of ratchet.newDead) console.error(`  ✗ ${d.file} :: ${d.name}`);
+  console.error(
+    '\nA test importing it is not a consumer. Wire it up, or add the\n' +
+      '`@export-no-consumer-yet — see #<issue>` marker with a tracking issue.'
+  );
+}
+
 function main(): number {
   const base = process.argv[2] ?? 'origin/main';
   let files: string[];
@@ -325,9 +517,24 @@ function main(): number {
 
   const result = checkAddedFiles(files);
   logSummary(result);
-  if (result.unconsumed.length === 0) return 0;
-  logFailure(result.unconsumed);
-  return 1;
+
+  let exportRatchet = { newDead: [] as DeadExport[], preexisting: [] as DeadExport[] };
+  try {
+    exportRatchet = checkModifiedFiles(base);
+  } catch (err) {
+    console.warn(
+      'check-new-unused-exports: export ratchet skipped — ' +
+        (err instanceof Error ? err.message : String(err))
+    );
+  }
+
+  reportExportRatchet(exportRatchet);
+
+  if (result.unconsumed.length > 0) {
+    logFailure(result.unconsumed);
+    return 1;
+  }
+  return exportRatchet.newDead.length > 0 ? 1 : 0;
 }
 
 // Guard the CLI so the test file can import the check functions without a run.


### PR DESCRIPTION
Implements the option a 7-voter `higher_order` panel chose **unanimously (6 of 6 approvers)** at the supermajority bar, to address a defect class that produced eight fixes in one session: a check whose output nothing consumes, whose input is never supplied, or that cannot fail by construction.

Refs #3024. Follow-ups filed separately (see bottom).

## I stopped the first vote — its leading option was false

The original Option A was "extend `knip` (already installed) to report unused exports — the smallest lift." I ran knip before implementing:

- **2,355 unused exports** and 1,657 unused types reported
- **zero of the five confirmed-dead exports** among them

Knip counts a test-file import as consumption, and *"imported only by its own test"* is the defining shape of this class. So knip is simultaneously too noisy to promote and structurally blind to the target. I killed the panel and re-ran with a corrected option rather than deciding on a false premise — the same mistake as #4504 earlier today, caught this time before the decision instead of after.

Measuring also found the right mechanism, already in the tree: `check-new-unused-exports.ts` defines a consumer as **non-test, non-barrel** — precisely the semantics knip lacks.

## What ships

The gate inspected only newly *added* files (`--diff-filter=A`). It now also inspects *modified* files at export granularity, splitting findings by who is responsible:

| finding | behaviour |
| --- | --- |
| export **this PR added**, no production consumer | **blocks** |
| export **already dead** in a file this PR touched | advisory, listed |

That split is measured, not stylistic. I checked what blocking on pre-existing dead exports would cost across recent merges: most flag 0, but one two-file merge flagged **14**. A gate that bills an unrelated PR for old debt teaches people to reach for the opt-out marker — the failure I fixed in #4548 and did not want to recreate.

## Verified in both directions

Adding an unconsumed export to `codex-limits.ts`:

```
Already-dead exports in files this PR touched (3, advisory):
  - …/codex-limits.ts :: CODEX_DEFAULT_MAX_DEPTH
  - …/codex-limits.ts :: CODEX_DEFAULT_MAX_THREADS
  - …/codex-limits.ts :: checkCodexDepth
  Not blocking — this PR did not add them.

Exports added by this PR with no production consumer (1):
  ✗ …/codex-limits.ts :: probeDeadExport
```

Real exit code **1**. Clean branch exits **0**. `checkCodexDepth` — one of the confirmed-dead exports from the audit — surfaces in the advisory list, which was the panel's acceptance criterion.

## A bug the verification caught

My first implementation filtered the production haystack with `isTestSupportFile`. That means *"lives in `src/testing/`"*, **not** *"is a test"* — so test-only imports counted as production use, reproducing knip's exact blindness inside the fix for knip's blindness.

Found because a known-dead export produced no advisory line, which is only visible if you run the thing against a case you already know the answer to. A regression test now pins the distinction between the two predicates.

## Deliberately not covered

The panel was explicit that these be tracked, not left as prose:

- **Unwired scripts and unsupplied env inputs** — instances (3) and (4), the two longest-lived at 3 months and "the detector's entire life". A wiring meta-gate was Option B.
- **Compiler-enforced exhaustiveness** (`switch-exhaustiveness-check` on the existing ESLint gate) — Option D, near-free, prevents the new-enum-variant cases structurally.

31 tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
