### PR TITLE
feat(types): make a new union member break the build at its consumers

### DIFF
--- a/.changeset/exhaustive-verdict-consumers.md
+++ b/.changeset/exhaustive-verdict-consumers.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+A new member of a verdict, severity, or readiness union is now a compile error at its consumers ([#4563](https://github.com/nexus-substrate/nexus-agents/issues/4563)).
+
+Two defects this session had the same shape: a union gained a member and every consumer stayed silently valid. `Assessment` gained `throttled`, and `route()`'s `if (assessment !== 'exhausted') continue` swallowed it alongside `healthy` — a rate-limited candidate became invisible in every trace. `GateVerdict` gained `skip`, and a consumer testing `!== 'fail'` let a blocking ship gate pass on zero coverage.
+
+No gate can catch that after the fact; the code is valid. The compiler can catch it at the moment of the change.
+
+Three consumers converted to exhaustive `switch` with a `const exhaustive: never` assertion — the idiom already used at six sites here, rather than a new helper:
+
+- `classifyAndFilter` on `Assessment` (`capacity-stage.ts`)
+- `formatReadiness`'s icon on `LevelOutcome` (`cli-readiness.ts`) — a new status would have rendered as `·`, silently reporting "not attempted"
+- the scratch term of `isAllHealthy`, extracted as `scratchSeverityIsAcceptable` (`doctor.ts`) — `!== 'critical'` would have let a hypothetical `fatal` pass
+
+**Two measurements changed the plan.** The issue proposed enabling `@typescript-eslint/switch-exhaustiveness-check`. Measured: 32 violations across 158 switches, and **zero in the decision-bearing files** — because those used `if`/`!==` chains, which the rule does not inspect. Enabling it would have fixed 32 unrelated switches and nothing that motivated the issue.
+
+Then: a bare `switch` does not force exhaustiveness either. Verified by adding a member and watching the build stay green. The `never` assertion is what makes it fail, and it needs no lint rule — so there is no tooling to keep wired, which is the property the panel cared about.
+
+All three verified in both directions: adding a member to each union produces `TS2322 ... not assignable to type 'never'` at the consumer; reverting returns to clean.

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
@@ -354,25 +354,42 @@ export class CapacityFilterStage implements IRouterStage {
     let throttled = 0;
 
     for (const cli of remaining) {
-      const assessment = assessments.get(cli) ?? 'unmeasured';
-      if (assessment === 'unmeasured') {
-        unmeasured++;
-        continue;
-      }
-      if (assessment === 'throttled') {
-        throttled++;
-        continue;
-      }
-      if (assessment !== 'exhausted') continue;
-
-      exhausted++;
-      if (this.config.enforceHardLimits) {
-        updatedCtx = filterCandidate(
-          updatedCtx,
-          cli,
-          `${CAPACITY_EXHAUSTED}: no capacity remaining`
-        );
-        this.excludedCount++;
+      // Exhaustive switch, not an if/!== chain (#4563). When `throttled` was
+      // added to Assessment, the old chain's `if (assessment !== 'exhausted')
+      // continue;` swallowed it silently alongside `healthy` — the compiler
+      // had nothing to object to, so a rate-limited candidate went unreported
+      // in every trace. A switch with no default makes the next member a
+      // build error here instead of a silent fall-through.
+      const assessment: Assessment = assessments.get(cli) ?? 'unmeasured';
+      switch (assessment) {
+        case 'unmeasured':
+          unmeasured++;
+          break;
+        case 'throttled':
+          throttled++;
+          break;
+        case 'healthy':
+          break;
+        case 'exhausted':
+          exhausted++;
+          if (this.config.enforceHardLimits) {
+            updatedCtx = filterCandidate(
+              updatedCtx,
+              cli,
+              `${CAPACITY_EXHAUSTED}: no capacity remaining`
+            );
+            this.excludedCount++;
+          }
+          break;
+        default: {
+          // A bare switch does NOT force exhaustiveness in TypeScript —
+          // verified by adding a member and watching the build stay green.
+          // This assertion is what makes the next Assessment member a compile
+          // error here, using the `const exhaustive: never` idiom already used
+          // across the codebase rather than a new helper.
+          const exhaustive: never = assessment;
+          throw new Error(`Unhandled capacity assessment: ${String(exhaustive)}`);
+        }
       }
     }
 

--- a/packages/nexus-agents/src/cli/cli-readiness.ts
+++ b/packages/nexus-agents/src/cli/cli-readiness.ts
@@ -107,8 +107,23 @@ export function buildReadiness(
  * that never tested serving — which is precisely how #4351 went unnoticed.
  */
 export function formatReadiness(readiness: CliReadiness): string {
-  const icon = (o: LevelOutcome): string =>
-    o.status === 'verified' ? '✓' : o.status === 'failed' ? '✗' : '·';
+  // Exhaustive rather than a ternary chain (#4563): a new LevelOutcome status
+  // would otherwise fall into the '·' arm and render as "not attempted",
+  // quietly misreporting whatever the new state actually means.
+  const icon = (o: LevelOutcome): string => {
+    switch (o.status) {
+      case 'verified':
+        return '✓';
+      case 'failed':
+        return '✗';
+      case 'not-attempted':
+        return '·';
+      default: {
+        const exhaustive: never = o;
+        throw new Error(`Unhandled level outcome: ${JSON.stringify(exhaustive)}`);
+      }
+    }
+  };
 
   const lines = READINESS_LEVELS.map((level) => {
     const outcome = readiness.levels[level];

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -28,6 +28,7 @@ import {
   checkScratchFilesystems,
   worstSeverity,
   type ScratchSpaceCheck,
+  type ScratchSpaceSeverity,
 } from './doctor-scratch-space.js';
 import { getTimeProvider, getErrorMessage } from '../core/index.js';
 import {
@@ -736,12 +737,35 @@ export interface HealthVerdictInput {
  * current run, and failing the whole command on it would collapse the
  * distinction between the two thresholds into one.
  */
+/**
+ * Whether a scratch severity permits a healthy verdict (#4563).
+ *
+ * Exhaustive rather than `!== 'critical'`: a severity added later — say
+ * `fatal` — would silently satisfy a negative test and let the verdict pass,
+ * which is the same shape as the `skip`-reaching-`!== 'fail'` regression on
+ * the ship gate. Each level must be classified deliberately.
+ */
+function scratchSeverityIsAcceptable(severity: ScratchSpaceSeverity): boolean {
+  switch (severity) {
+    case 'ok':
+    case 'warn':
+      // warn still leaves room for the current run.
+      return true;
+    case 'critical':
+      return false;
+    default: {
+      const exhaustive: never = severity;
+      throw new Error(`Unhandled scratch severity: ${String(exhaustive)}`);
+    }
+  }
+}
+
 export function isAllHealthy(input: HealthVerdictInput): boolean {
   return (
     input.nodeSupported &&
     input.hasAuthMethod &&
     input.mcpServerReady &&
-    worstSeverity(input.scratchSpace) !== 'critical' &&
+    scratchSeverityIsAcceptable(worstSeverity(input.scratchSpace)) &&
     input.clis.every((c) => c.installed && c.authenticated && c.versionStatus !== 'unsupported')
   );
 }


### PR DESCRIPTION
Implements the targeted half of #4563 — Option D from the panel that decided #4561.

## The shape

Two of this session's defects were the same thing: **a union gained a member and every consumer stayed silently valid.**

- `Assessment` gained `throttled`. `route()`'s `if (assessment !== 'exhausted') continue;` swallowed it alongside `healthy` — no counter, no signal, a rate-limited candidate invisible in every trace (#4542).
- `GateVerdict` gained `skip`. A consumer testing `!== 'fail'` let a **blocking** ship gate pass on zero coverage (#4539).

No gate can catch this after the fact; the code is valid TypeScript. The compiler can catch it at the moment of the change — which makes it prevention rather than detection, with nothing to keep wired.

## Two measurements that changed the plan

**The proposed rule does not cover the motivating cases.** #4563 proposed enabling `@typescript-eslint/switch-exhaustiveness-check`. I enabled it and counted: **32 violations across 158 switches, and zero in the decision-bearing files** — because those use `if`/`!==` chains, which the rule does not inspect. Enabling it would have fixed 32 unrelated switches and done nothing for `throttled` or `skip`.

**A bare `switch` does not force exhaustiveness either.** After converting the first consumer, I added a union member expecting a build failure. The build stayed green. TypeScript only objects when something asserts it — so the conversion alone would have been theatre.

Both of those are the kind of thing that reads as obviously true after the fact and is simply wrong beforehand.

## What ships

Three consumers converted to exhaustive `switch` with a `const exhaustive: never` assertion — the idiom already used at six sites in this codebase, rather than a new shared helper:

| consumer | what the old form would have swallowed |
| --- | --- |
| `classifyAndFilter` on `Assessment` | a new grade, into the `continue` arm |
| `formatReadiness` icon on `LevelOutcome` | a new status, rendered `·` = "not attempted" |
| `isAllHealthy`'s scratch term → `scratchSeverityIsAcceptable` | a hypothetical `fatal`, passing `!== 'critical'` |

The third is the sharpest: a severity worse than `critical` would have satisfied a negative test and let the verdict pass.

## Verified in both directions

Added a member to each union and confirmed the build fails **at the consumer**:

```
cli-readiness.ts(123,15): error TS2322: Type '{ readonly status: "degraded"; … }'
  is not assignable to type 'never'.
doctor.ts(757,13): error TS2322: Type '"fatal"' is not assignable to type 'never'.
```

Reverting returns to clean. 6694 tests pass across `cli` and `cli-adapters/routing`; typecheck and lint clean.

## Left open on #4563

The repo-wide `switch-exhaustiveness-check` enable, now costed at **32 violations** — worth doing, but it protects `switch` statements only and is unrelated to the cases here. Recording the number so that decision starts from a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
