### PR TITLE
fix(research): read the negative-results registry; mark checkCodexDepth deferred

### DIFF
--- a/.changeset/wire-negative-results-registry.md
+++ b/.changeset/wire-negative-results-registry.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+The negative-results registry is finally read, and `checkCodexDepth` is honestly marked as deferred ([#4555](https://github.com/nexus-substrate/nexus-agents/issues/4555)).
+
+Two checks had no production consumer. Per the wire-vs-remove rule I checked intent first, and both turned out to be deliberate work rather than dead weight — but they needed opposite dispositions.
+
+**`research/negative-results.ts` — wired.** `docs/research/registry/negative-results.yaml` says it exists to "prevent re-researching failed implementations", and the module was added in #1572 as an "enforcement module". Nothing read it, so a technique recorded as rejected was re-suggested with no warning: maintained data with no consumer. `research_query` already takes a `techniqueId`, so the `status` and `overlap` actions now attach a `rejectionNotice` when the registry holds one.
+
+Advisory by design — the notice is attached, never used to suppress a result. A prior rejection is evidence to weigh, not a veto: the failure mode may not apply, or the record may be stale.
+
+**`checkCodexDepth` — marked, not wired.** Its sibling `checkCodexConcurrency` is wired at `voter-agents.ts:307`, but this one needs a _planned subagent nesting depth_, and nothing in the tree tracks one. The voter fan-out is flat — voters are leaf calls — and the only other `depth` values are MCTS and reasoning-forest tree depths, unrelated concepts.
+
+So it was written against information no caller has. Wiring it means first introducing depth tracking through the dispatch path, which is a feature and not a missing line. It now carries `@export-no-consumer-yet — see #4555` explaining exactly that, rather than being deleted: the knowledge it encodes (Codex `max_depth=1` rejects a nested spawn) is real and was added deliberately in #2689.
+
+Verified the registry lookup end to end: `latent-space-sharing` resolves and renders its failure mode and paper; an unknown id returns undefined.

--- a/packages/nexus-agents/src/cli-adapters/codex-limits.ts
+++ b/packages/nexus-agents/src/cli-adapters/codex-limits.ts
@@ -43,6 +43,16 @@ export function checkCodexConcurrency(codexBoundConcurrency: number): string | n
   );
 }
 
+// @export-no-consumer-yet — see #4555. Its sibling `checkCodexConcurrency` is
+// wired at `cli/voter-agents.ts:307`, but this one needs a *planned nesting
+// depth* and nothing in the tree tracks one: the voter fan-out is flat (voters
+// are leaf calls), and the only other `depth` values are MCTS and
+// reasoning-forest tree depths, which are unrelated concepts. So this was
+// written against information no caller has — wiring it means first
+// introducing depth tracking through the dispatch path, which is a feature and
+// not a missing line. Marked rather than deleted because the knowledge it
+// encodes (Codex `max_depth=1` rejects a nested spawn) is real and was added
+// deliberately in #2689.
 /**
  * A structured warning when a planned subagent nesting `depth` exceeds
  * Codex's default `max_depth`. Returns `null` when within limits.

--- a/packages/nexus-agents/src/mcp/tools/research-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-query.ts
@@ -22,6 +22,7 @@ import {
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { getResearchStatus, findOverlaps } from '../../cli/research-helpers.js';
+import { checkRejected, formatRejectionWarning } from '../../research/negative-results.js';
 import { parseRegistry } from '../../indexer/research-index/index.js';
 import { generateStatsJson } from '../../indexer/research-index/index.js';
 import { getToolAnnotations } from '../tool-annotations.js';
@@ -83,11 +84,38 @@ export interface ResearchQueryResponse {
   success: boolean;
   /** Query results */
   data: unknown;
+  /**
+   * A recorded rejection for the queried technique, when one exists (#4555).
+   *
+   * Advisory. The registry says a prior attempt failed and why; it does not
+   * suppress the result, because a prior rejection is evidence to weigh, not
+   * a veto.
+   */
+  rejectionNotice?: string;
 }
 
 // =============================================================================
 // HANDLERS
 // =============================================================================
+
+/**
+ * Surface a recorded rejection for `techniqueId`, if the registry holds one.
+ *
+ * `docs/research/registry/negative-results.yaml` exists to "prevent
+ * re-researching failed implementations", and until now nothing read it —
+ * maintained data with no consumer, so a technique explicitly recorded as
+ * rejected was re-suggested with no warning (#4555). This is the read.
+ *
+ * Advisory: the rejection is attached to the response, never used to suppress
+ * a result. A prior rejection is evidence to weigh, not a veto — the failure
+ * mode may not apply, or the record may be stale.
+ */
+function rejectionNoticeFor(techniqueId: string | undefined): string | undefined {
+  if (techniqueId === undefined || techniqueId === '') return undefined;
+  const rejected = checkRejected(techniqueId);
+  if (rejected === undefined) return undefined;
+  return formatRejectionWarning(techniqueId, rejected);
+}
 
 /** Handles status action. */
 async function handleStatus(input: ResearchQueryInput): Promise<ResearchQueryResponse> {
@@ -96,7 +124,13 @@ async function handleStatus(input: ResearchQueryInput): Promise<ResearchQueryRes
     status: input.status,
     format: 'json',
   });
-  return { action: 'status', success: result.success, data: result };
+  const rejection = rejectionNoticeFor(input.techniqueId);
+  return {
+    action: 'status',
+    success: result.success,
+    data: result,
+    ...(rejection !== undefined ? { rejectionNotice: rejection } : {}),
+  };
 }
 
 /** Handles overlap action. */
@@ -113,7 +147,13 @@ async function handleOverlap(input: ResearchQueryInput): Promise<ResearchQueryRe
     threshold: input.threshold,
     format: 'json',
   });
-  return { action: 'overlap', success: result.success, data: result };
+  const rejection = rejectionNoticeFor(input.techniqueId);
+  return {
+    action: 'overlap',
+    success: result.success,
+    data: result,
+    ...(rejection !== undefined ? { rejectionNotice: rejection } : {}),
+  };
 }
 
 /** Handles stats action. */


### PR DESCRIPTION
Closes #4555. Both findings came from the audit for checks that cannot affect any outcome.

Per `.rules/research-intent-before-wire-vs-remove` I checked history before touching either — under-wired code is often interrupted work. Both were deliberate. They needed **opposite** dispositions.

## Wired: the negative-results registry

`docs/research/registry/negative-results.yaml` states its purpose in its own header — *"Prevents re-researching failed implementations"* — and `negative-results.ts` was added in #1572 as an **"enforcement module"**. Nothing imported it outside its test.

So the data was maintained and never read. A technique explicitly recorded as rejected got re-suggested with no warning, which is the worst version of this defect class: not a dormant check, but a live promise the system was not keeping.

`research_query` already accepts a `techniqueId`, so `status` and `overlap` now attach a `rejectionNotice` when the registry has an entry.

**Advisory, not a veto.** The notice is attached; the result is never suppressed. A prior rejection is evidence to weigh — the failure mode may not apply to the new context, or the record may be stale. Silently filtering results on a one-entry registry would be a worse instrument than no registry.

Verified end to end:

```
registry ids: latent-space-sharing
lookup hit: true
⚠️ REJECTED TECHNIQUE: LatentMAS Latent Space Collaboration | Failure mode: architecture_incompatible | Paper: arxiv-2511.20639
unknown id returns undefined: true
```

## Marked, not wired: `checkCodexDepth`

Its sibling `checkCodexConcurrency` is wired at `voter-agents.ts:307`, so the obvious move was to call this one beside it. That is wrong.

`checkCodexDepth(depth)` needs a **planned subagent nesting depth**, and nothing in the tree tracks one. The voter fan-out is flat — voters are leaf calls, never nested — and the only other `depth` values are MCTS tree depth and reasoning-forest depth, unrelated concepts.

It was written against information no caller has. Wiring it means first introducing depth tracking through the dispatch path, which is a feature, not a missing line. #4555 anticipated this exact outcome and called it "a different and more interesting problem".

It now carries `@export-no-consumer-yet — see #4555` with that explanation, rather than being deleted — the knowledge it encodes (Codex `max_depth=1` rejects a nested spawn) is real and was added deliberately in #2689. The marker is the mechanism the gate provides for genuinely deferred work, and it is what distinguishes deferral from rot.

201 tests pass; typecheck and lint clean; the new export ratchet reports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
