### PR TITLE
feat(ci): require every gate script to be reachable from CI

### DIFF
--- a/.changeset/script-wiring-gate.md
+++ b/.changeset/script-wiring-gate.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+Every gate script must now be reachable from CI, and six that were not are wired ([#4562](https://github.com/nexus-substrate/nexus-agents/issues/4562)).
+
+Option B from the panel that chose #4561. `check-schema-fanout.ts` sat unwired for over three months while two documents said it ran in CI (#4553). An audit for the same shape found **six more**:
+
+| script                          | state                                  |
+| ------------------------------- | -------------------------------------- |
+| `check-authority-tier-drift`    | npm script existed, no workflow ran it |
+| `check-catalogue-drift`         | npm script existed, no workflow ran it |
+| `check-strategy-manifest-drift` | npm script existed, no workflow ran it |
+| `check-memory-contract`         | neither                                |
+| `check-tool-distinctness`       | neither                                |
+| `check-tool-output-consistency` | neither                                |
+
+The first calls itself _"the CI half of the authority-ladder enforcement layer"_ in its own header. It was not in CI.
+
+All six **pass today** — verified before wiring, because an unrun gate rots: `lint:arch` had existed since #570, was wired into nothing, and had drifted red with nine false positives by the time #4490 found it.
+
+`check-script-wiring.ts` asserts each `scripts/check-*.ts` is reachable, counting both a direct workflow reference and an npm-script hop where a workflow runs that script by name. It lives in the existing blocking `lint` job rather than a new workflow, so there is no separate thing to drop.
+
+**It checks itself first.** The panel that chose this option named the recursion as the reason it scored worst on immunity — a wiring gate that is not wired proves nothing — so the first assertion is its own reachability. Verified by removing its own CI line and watching it fail.
+
+**A false positive found by running it.** The first pattern required the script name immediately after `pnpm`, and `ci.yml` invokes `pnpm --silent check:model-drift`, so a genuinely-wired gate reported as unwired. False positives are what teach people to ignore a gate, so the matcher now tolerates flags and a test pins that exact case.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,36 @@ jobs:
       - name: Run architectural lint
         run: pnpm lint:arch
 
+      # #4562: a check script no workflow invokes is indistinguishable from no
+      # gate, except that its existence implies coverage. check-schema-fanout
+      # sat unwired for three months while two documents said it ran in CI
+      # (#4553); an audit then found six more, including one whose own header
+      # calls it "the CI half of the authority-ladder enforcement layer".
+      # This gate asserts its own reachability first.
+      - name: Check every gate script is reachable from CI
+        run: npx tsx scripts/check-script-wiring.ts
+
+      # The six gates that audit found unwired (#4562). All pass today —
+      # verified before wiring, because an unrun gate rots (lint:arch had
+      # drifted red with nine false positives by the time #4490 found it).
+      - name: Authority-tier declaration gate (#3841)
+        run: npx tsx scripts/check-authority-tier-drift.ts
+
+      - name: Strategy-manifest drift gate (#3837)
+        run: npx tsx scripts/check-strategy-manifest-drift.ts
+
+      - name: Memory-contract drift gate (#2766)
+        run: npx tsx scripts/check-memory-contract.ts
+
+      - name: Catalogue drift sweep (#4417)
+        run: npx tsx scripts/check-catalogue-drift.ts
+
+      - name: Tool-description distinctness (#2650)
+        run: npx tsx scripts/check-tool-distinctness.ts
+
+      - name: Tool-output consistency (#2653)
+        run: npx tsx scripts/check-tool-output-consistency.ts
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/scripts/check-script-wiring.test.ts
+++ b/scripts/check-script-wiring.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { assessWiring, isReachableFromCi } from './check-script-wiring.js';
+
+describe('isReachableFromCi', () => {
+  const noNpm = {};
+
+  it('counts a direct filename reference in a workflow', () => {
+    expect(isReachableFromCi('check-x.ts', 'run: npx tsx scripts/check-x.ts', noNpm)).toBe(true);
+  });
+
+  it('counts an npm-script hop', () => {
+    // check-pricing-drift.ts appears in no workflow; `check:pricing-drift` does.
+    expect(
+      isReachableFromCi('check-x.ts', 'run: pnpm check:x', {
+        'check:x': 'npx tsx scripts/check-x.ts',
+      })
+    ).toBe(true);
+  });
+
+  it('tolerates flags between the package manager and the script name', () => {
+    // ci.yml uses `pnpm --silent check:model-drift`. A stricter pattern reported
+    // that script as unwired — a false positive found by running the gate.
+    expect(
+      isReachableFromCi('check-x.ts', 'OUTPUT=$(pnpm --silent check:x 2>&1)', {
+        'check:x': 'npx tsx scripts/check-x.ts',
+      })
+    ).toBe(true);
+  });
+
+  it('does NOT count an npm script that no workflow invokes', () => {
+    // The exact state of check-authority-tier-drift before #4562: an npm
+    // script existed, nothing ran it.
+    expect(
+      isReachableFromCi('check-x.ts', 'run: pnpm lint', { 'check:x': 'npx tsx scripts/check-x.ts' })
+    ).toBe(false);
+  });
+
+  it('does not count a bare mention of the script name in prose', () => {
+    expect(
+      isReachableFromCi('check-x.ts', '# see check:x for details', {
+        'check:x': 'npx tsx scripts/check-x.ts',
+      })
+    ).toBe(false);
+  });
+
+  it('reports a script with neither a workflow nor an npm script as unreachable', () => {
+    expect(isReachableFromCi('check-x.ts', 'run: pnpm lint', noNpm)).toBe(false);
+  });
+});
+
+describe('assessWiring', () => {
+  it('partitions reachable from unreachable', () => {
+    const verdict = assessWiring({
+      checkScripts: ['check-a.ts', 'check-b.ts'],
+      workflowText: 'npx tsx scripts/check-a.ts',
+      npmScripts: {},
+    });
+
+    expect(verdict.wired).toEqual(['check-a.ts']);
+    expect(verdict.unwired).toEqual(['check-b.ts']);
+  });
+
+  it('reports nothing unwired when everything is reachable', () => {
+    const verdict = assessWiring({
+      checkScripts: ['check-a.ts'],
+      workflowText: 'npx tsx scripts/check-a.ts',
+      npmScripts: {},
+    });
+
+    expect(verdict.unwired).toEqual([]);
+  });
+});

--- a/scripts/check-script-wiring.ts
+++ b/scripts/check-script-wiring.ts
@@ -1,0 +1,176 @@
+/**
+ * Every check script must be reachable from CI (#4562).
+ *
+ * A gate that no workflow invokes is indistinguishable from no gate — except
+ * that it also produces false confidence, because the script, its tests and
+ * its documentation all exist. `check-schema-fanout.ts` sat unwired for over
+ * three months while two documents stated it ran in CI (#4553), and an audit
+ * then found six more in the same state, including one whose own header calls
+ * it "the CI half of the authority-ladder enforcement layer".
+ *
+ * ## Reachability
+ *
+ * A script counts as wired when a workflow names it directly, OR when a
+ * package.json script mentions it and a workflow runs THAT script name. The
+ * indirection is real and common here (`check:pricing-drift` → workflow), so
+ * a naive filename grep would report three false positives.
+ *
+ * ## This gate checks itself
+ *
+ * The first assertion is that this script is itself reachable. A wiring gate
+ * that is not wired would be the joke writing itself, and the panel that chose
+ * this option named that risk as the reason it scored worst on immunity.
+ *
+ * ## Allowlist entries carry a reason
+ *
+ * A script legitimately meant for local or manual use is fine — silence is
+ * not. Each exemption states why, so the next reader can tell a decision from
+ * an oversight.
+ *
+ * @module scripts/check-script-wiring
+ * (Source: Issue #4562)
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOW_DIR = '.github/workflows';
+const SCRIPTS_DIR = 'scripts';
+const ROOT_PACKAGE_JSON = 'package.json';
+
+/** This gate's own filename — asserted reachable before anything else. */
+export const SELF = 'check-script-wiring.ts';
+
+/**
+ * Scripts deliberately not wired into CI, each with the reason.
+ *
+ * Add an entry only when a script is genuinely meant to be run by hand. An
+ * entry without a real reason converts this gate into paperwork.
+ */
+export const MANUAL_ONLY: Readonly<Record<string, string>> = {};
+
+export interface WiringInput {
+  /** Basenames of `scripts/check-*.ts`, excluding tests. */
+  readonly checkScripts: readonly string[];
+  /** Combined text of every workflow file. */
+  readonly workflowText: string;
+  /** package.json `scripts` map. */
+  readonly npmScripts: Readonly<Record<string, string>>;
+}
+
+export interface WiringVerdict {
+  readonly wired: string[];
+  readonly unwired: string[];
+  readonly manualOnly: string[];
+}
+
+/**
+ * Is `basename` reachable from a workflow, directly or via an npm script?
+ *
+ * The npm hop matters: `check-pricing-drift.ts` appears in no workflow, but
+ * `check:pricing-drift` does, and the script body names the file. Treating
+ * that as unwired would be a false positive, and false positives are what
+ * teach people to ignore a gate.
+ */
+export function isReachableFromCi(
+  basename: string,
+  workflowText: string,
+  npmScripts: Readonly<Record<string, string>>
+): boolean {
+  if (workflowText.includes(basename)) return true;
+
+  for (const [name, body] of Object.entries(npmScripts)) {
+    if (!body.includes(basename)) continue;
+    // The workflow must invoke this npm script by name — `pnpm <name>`,
+    // `npm run <name>`, or with flags between (`pnpm --silent <name>`, which
+    // ci.yml actually uses for check:model-drift and which a stricter pattern
+    // reported as unwired. Found by running this gate, not by reading it).
+    // A bare mention of the name elsewhere is not an invocation.
+    const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (
+      new RegExp(`(?:pnpm|npm run|yarn)\\s+(?:--?[\\w-]+\\s+)*${escaped}\\b`).test(workflowText)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Partition the check scripts into wired, unwired, and deliberately manual. */
+export function assessWiring(input: WiringInput): WiringVerdict {
+  const wired: string[] = [];
+  const unwired: string[] = [];
+  const manualOnly: string[] = [];
+
+  for (const basename of input.checkScripts) {
+    if (Object.prototype.hasOwnProperty.call(MANUAL_ONLY, basename)) {
+      manualOnly.push(basename);
+      continue;
+    }
+    if (isReachableFromCi(basename, input.workflowText, input.npmScripts)) wired.push(basename);
+    else unwired.push(basename);
+  }
+  return { wired, unwired, manualOnly };
+}
+
+function readWorkflowText(): string {
+  if (!existsSync(WORKFLOW_DIR)) return '';
+  return readdirSync(WORKFLOW_DIR)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .map((f) => readFileSync(join(WORKFLOW_DIR, f), 'utf-8'))
+    .join('\n');
+}
+
+function readCheckScripts(): string[] {
+  return readdirSync(SCRIPTS_DIR)
+    .filter((f) => f.startsWith('check-') && f.endsWith('.ts') && !f.endsWith('.test.ts'))
+    .sort();
+}
+
+function readNpmScripts(): Record<string, string> {
+  const parsed: unknown = JSON.parse(readFileSync(ROOT_PACKAGE_JSON, 'utf-8'));
+  if (typeof parsed !== 'object' || parsed === null) return {};
+  const scripts = (parsed as { scripts?: unknown }).scripts;
+  if (typeof scripts !== 'object' || scripts === null) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(scripts)) if (typeof v === 'string') out[k] = v;
+  return out;
+}
+
+/* eslint-disable no-console */
+function main(): number {
+  const workflowText = readWorkflowText();
+  const npmScripts = readNpmScripts();
+
+  // Self-check first: a wiring gate that is not wired proves nothing.
+  if (!isReachableFromCi(SELF, workflowText, npmScripts)) {
+    console.error(`::error::${SELF} is not invoked by any workflow — this gate is not wired.`);
+    return 1;
+  }
+
+  const verdict = assessWiring({
+    checkScripts: readCheckScripts(),
+    workflowText,
+    npmScripts,
+  });
+
+  console.log(`Script wiring: ${String(verdict.wired.length)} reachable from CI.`);
+  for (const m of verdict.manualOnly) {
+    console.log(`  manual-only: ${m} — ${MANUAL_ONLY[m] ?? ''}`);
+  }
+
+  if (verdict.unwired.length === 0) return 0;
+
+  console.error(`\n${String(verdict.unwired.length)} check script(s) no workflow invokes:`);
+  for (const u of verdict.unwired) console.error(`  ✗ ${u}`);
+  console.error(
+    '\nA gate nothing runs is indistinguishable from no gate, and worse: the\n' +
+      'script and its docs imply coverage that does not exist (#4553).\n' +
+      'Wire it into a workflow, or add it to MANUAL_ONLY with the reason.'
+  );
+  return 1;
+}
+
+if (process.argv[1]?.endsWith('check-script-wiring.ts') === true) {
+  process.exit(main());
+}


### PR DESCRIPTION
Closes #4562 — Option B from the panel that decided #4561.

## Six more instances, found by looking

`check-schema-fanout.ts` sat unwired for over three months while two documents said it ran in CI (#4553). I checked whether it was alone. It was not:

| script | state before this PR |
| --- | --- |
| `check-authority-tier-drift` | npm script existed, **no workflow ran it** |
| `check-catalogue-drift` | npm script existed, no workflow ran it |
| `check-strategy-manifest-drift` | npm script existed, no workflow ran it |
| `check-memory-contract` | neither an npm script nor a workflow |
| `check-tool-distinctness` | neither |
| `check-tool-output-consistency` | neither |

`check-authority-tier-drift.ts` describes itself in its own header as *"The CI half of the authority-ladder enforcement layer."* It was not in CI.

Three of the six had npm scripts that nothing invoked — which is the more insidious form, because `package.json` makes them look wired.

## All six pass today — checked before wiring

An unrun gate rots. `lint:arch` had existed since #570, was wired into nothing, and had drifted red with nine false positives by the time #4490 found it. So I ran all six first rather than discovering that in CI. Every one exits 0.

## The gate

`check-script-wiring.ts` asserts each `scripts/check-*.ts` is reachable, counting a direct workflow reference **or** an npm-script hop where a workflow actually runs that script by name.

It lives in the existing blocking `lint` job — not a new workflow — so there is no separate thing to drop.

**It checks itself first.** Three voters named the recursion as this option's weakness: a wiring gate that is not wired proves nothing. So the first assertion is its own reachability, and I verified it by deleting its own CI line:

```
::error::check-script-wiring.ts is not invoked by any workflow — this gate is not wired.
```

Also verified in the ordinary direction — removing `check-memory-contract`'s step flags exactly that script — and clean when restored.

## A false positive the gate found in itself

My first matcher required the script name immediately after `pnpm`. `ci.yml` invokes `pnpm --silent check:model-drift`, so a genuinely-wired gate reported as unwired.

That mattered more than a normal bug: false positives are precisely what teach people to reach for an exemption, and I would have shipped a gate whose first act was to cry wolf. The matcher now tolerates flags, with a test pinning that exact invocation.

`MANUAL_ONLY` is empty — every check script is genuinely wired. An entry there requires a stated reason, so a future exemption reads as a decision rather than an oversight.

8 tests; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
