### PR TITLE
fix(ci): typecheck scripts/, and fix the 14 errors found there

### DIFF
--- a/.changeset/typecheck-scripts.md
+++ b/.changeset/typecheck-scripts.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+`scripts/` is now typechecked, and the 14 errors that had accumulated there are fixed ([#4558](https://github.com/nexus-substrate/nexus-agents/issues/4558)).
+
+`pnpm typecheck` is `turbo typecheck`, which fans out to each workspace's own `tsc`. The repo-root `scripts/` tree is not a workspace, so **nothing typechecked the tree that holds the governance gates** — `check-schema-fanout`, `check-deploy-stale`, `check-release-stuck`, `inject-governance`, the drift checks. Exactly the gap #4483 found for lint, where `scripts/` sat outside every ESLint scope.
+
+Two of the fourteen were genuine API drift rather than strictness noise:
+
+- **`pr-review-local.ts` passed `simulate: false` to `buildPrReviewProposal`**, whose input type is a `Pick<>` that has never included it — an inert argument left behind by an API change.
+- **Its local `VoterResult` had drifted from `PrReviewVote`**: `role: string` where the real type is `VoterRole`, and no `processingTimeMs` at all, so it could not be passed to `aggregatePrDecisions`. `collectRealVotes` had been returning the timing all along; the mirror simply stopped following.
+- **`check-authority-tier-drift.test.ts` built an `AuditLogger` config missing five required fields.** It worked because the Zod schema supplies the same values as defaults — validation papering over a type error nothing was checking.
+
+The rest were `noUncheckedIndexedAccess` findings on regex capture groups, fixed by guarding rather than asserting, so a missing group cannot silently read as `0` or `''`.
+
+`tsconfig.scripts.json` scopes the check and includes the package's ambient `.d.ts` files: `scripts/` imports package modules transitively, and without the `better-sqlite3` augmentation those imports report two phantom errors the package's own typecheck does not see.
+
+Verified the gate can fail — a deliberate `GRACE_MINUTES: string = 45` is caught, and reverting returns to clean.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,14 @@ jobs:
       - name: Run lint (repo scripts)
         run: pnpm lint:scripts
 
+      # #4558: `pnpm typecheck` is `turbo typecheck`, which fans out to each
+      # workspace's own tsc. `scripts/` is not a workspace, so nothing
+      # typechecked the tree that holds the governance gates — 14 errors had
+      # accumulated, including two genuine API drifts. Same gap #4483 found
+      # for lint.
+      - name: Type check (repo scripts)
+        run: pnpm typecheck:scripts
+
       # #4490: `lint:arch` has existed since #570 and exits non-zero on error,
       # but was wired into no workflow and no hook, so nothing ever ran it. It
       # had drifted red (5 false-positive Test Hygiene errors, 4 false-positive

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint": "turbo lint",
     "lint:fix": "turbo lint:fix",
     "lint:scripts": "eslint scripts/",
+    "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
     "lint:arch": "npx tsx scripts/arch-lint.ts",
     "lint:md": "markdownlint 'docs/**/*.md' '*.md' --ignore 'docs/api/**' --ignore 'node_modules' --config .markdownlint.json",
     "lint:md:fix": "markdownlint 'docs/**/*.md' '*.md' --ignore 'docs/api/**' --ignore 'node_modules' --config .markdownlint.json --fix",

--- a/scripts/check-authority-tier-drift.test.ts
+++ b/scripts/check-authority-tier-drift.test.ts
@@ -567,6 +567,15 @@ describe('recoverTransitions — reads the chained transition log (#3842)', () =
         enableHashChain: true,
         flushIntervalMs: 60_000,
         minSeverity: 'info',
+        // #4558: AuditLogConfig requires these; the Zod schema supplies the
+        // same values as defaults, so the runtime never noticed and no gate
+        // typechecked scripts/. Stated explicitly rather than relying on a
+        // validation step to paper over a type error.
+        filePrefix: 'audit',
+        maxFileSizeBytes: 10 * 1024 * 1024,
+        maxFiles: 10,
+        enableCompression: false,
+        maxQueueDepth: 10_000,
       },
       storage
     );

--- a/scripts/curate-pr-review-dataset.ts
+++ b/scripts/curate-pr-review-dataset.ts
@@ -65,7 +65,11 @@ export function rubricDocVersion(rubricPath: string = RUBRIC_PATH): string {
   if (m === null) {
     throw new Error(`Could not find "**Rubric version:**" in ${rubricPath}`);
   }
-  return m[1];
+  const version = m[1];
+  if (version === undefined) {
+    throw new Error(`"**Rubric version:**" matched but captured nothing in ${rubricPath}`);
+  }
+  return version;
 }
 
 export interface ValidationResult {

--- a/scripts/generate-agents-index.ts
+++ b/scripts/generate-agents-index.ts
@@ -99,7 +99,7 @@ function extractExpertKeys(): string[] {
 }
 
 /** Verify every expert in BUILT_IN_EXPERTS has a corresponding agent file. */
-function checkGapCoverage(entries: IndexEntry[]): string[] {
+function checkGapCoverage(entries: readonly IndexEntry[]): string[] {
   const expertKeys = extractExpertKeys();
   const agentNames = new Set(entries.map((e) => e.name));
   const missing: string[] = [];

--- a/scripts/generate-docs-content.ts
+++ b/scripts/generate-docs-content.ts
@@ -65,8 +65,9 @@ function extractBuiltInTemplates(): string[] {
   const arrayMatch = src.match(/BUILT_IN_TEMPLATES\s*(?::[^=]*)?\s*=\s*\[([\s\S]*?)\]/);
   if (arrayMatch) {
     let m: RegExpExecArray | null;
-    while ((m = regex.exec(arrayMatch[1])) !== null) {
-      names.push(m[1]);
+    while ((m = regex.exec(arrayMatch[1] ?? '')) !== null) {
+      const name = m[1];
+      if (name !== undefined) names.push(name);
     }
   }
   return names;
@@ -83,8 +84,9 @@ function extractAgentRoles(): string[] {
   if (typeMatch) {
     const regex = /['"]([a-z_]+)['"]/g;
     let m: RegExpExecArray | null;
-    while ((m = regex.exec(typeMatch[1])) !== null) {
-      roles.push(m[1]);
+    while ((m = regex.exec(typeMatch[1] ?? '')) !== null) {
+      const role = m[1];
+      if (role !== undefined) roles.push(role);
     }
   }
   return roles;
@@ -155,7 +157,7 @@ function checkMcpToolCount(): void {
     const content = readFileSync(inventoryPath, 'utf-8');
     const match = content.match(/(\d+)\s+MCP\s+[Tt]ools/i);
     if (match) {
-      const documented = parseInt(match[1], 10);
+      const documented = Number.parseInt(match[1] ?? '', 10);
       if (documented !== actual) {
         drifts.push({
           file: 'docs/ops/docs-inventory.md',
@@ -177,7 +179,7 @@ function checkMcpToolCount(): void {
   if (!compMatches) return;
   const firstStale = compMatches.find((m) => {
     const numMatch = m.match(/(\d+)/);
-    return numMatch && parseInt(numMatch[1], 10) !== actual;
+    return numMatch !== null && Number.parseInt(numMatch[1] ?? '', 10) !== actual;
   });
   if (firstStale !== undefined) {
     const num = firstStale.match(/(\d+)/);
@@ -185,7 +187,7 @@ function checkMcpToolCount(): void {
       file: 'docs/design/components.md',
       section: 'MCP tool count',
       expected: String(actual),
-      actual: num ? num[1] : 'unknown',
+      actual: num?.[1] ?? 'unknown',
     });
   }
 }
@@ -197,7 +199,7 @@ function checkAdrCount(): void {
     const content = readFileSync(inventoryPath, 'utf-8');
     const match = content.match(/(\d+)\s+ADRs?/i);
     if (match) {
-      const documented = parseInt(match[1], 10);
+      const documented = Number.parseInt(match[1] ?? '', 10);
       if (documented !== actual) {
         drifts.push({
           file: 'docs/ops/docs-inventory.md',

--- a/scripts/pr-review-local.ts
+++ b/scripts/pr-review-local.ts
@@ -41,6 +41,7 @@ import {
   isFindingVerified,
   type Finding,
 } from '../packages/nexus-agents/src/mcp/tools/pr-review-findings.js';
+import type { VoterRole } from '../packages/nexus-agents/src/cli/vote-types.js';
 import {
   ensurePrCommitsLocal,
   generateCanonicalReviewDiff,
@@ -163,8 +164,21 @@ async function applyLabel(prNumber: number, label: string): Promise<void> {
 // Voter run
 // ============================================================================
 
+/**
+ * Local mirror of `PrReviewVote`, narrowed to `VoterRole` (#4558).
+ *
+ * It declared `role: string`, which is wider than `PrReviewVote['role']` and
+ * therefore not assignable to `aggregatePrDecisions`. Nothing reported it
+ * because no gate typechecked `scripts/`.
+ */
 interface VoterResult {
-  readonly role: string;
+  readonly role: VoterRole;
+  /**
+   * Required by `PrReviewVote` and previously absent here (#4558) — the local
+   * mirror drifted from the type it feeds. `collectRealVotes` already returns
+   * it, so it was available all along and simply not carried through.
+   */
+  readonly processingTimeMs: number;
   readonly decision: 'approve' | 'request_changes' | 'abstain';
   readonly confidence: number;
   readonly reasoning: string;
@@ -236,6 +250,7 @@ function mapVoterResults(voteResults: Awaited<ReturnType<typeof collectRealVotes
         : [];
     return {
       role: r.role,
+      processingTimeMs: r.processingTimeMs,
       decision: mapVoteDecisionToPrDecision(r.vote.decision),
       confidence: r.vote.confidence,
       reasoning: r.vote.reasoning,
@@ -261,7 +276,6 @@ async function runReview(prNumber: number): Promise<ReviewResult> {
     prDiff: reviewDiff,
     ...(meta.baseRef !== '' && { baseRef: meta.baseRef }),
     ...(meta.headRef !== '' && { headRef: meta.headRef }),
-    simulate: false,
   });
 
   console.log(`  running ${String(PR_REVIEW_ROLES.length)} voters via local CLI auth…`);

--- a/scripts/sync-models-dev.ts
+++ b/scripts/sync-models-dev.ts
@@ -140,7 +140,13 @@ function mapRecord(raw: ModelsDevRecord, vendor: ModelVendor): ModelEntry | null
     source: 'models-dev',
   };
   attachOptionalFields(entry, raw);
-  return entry as ModelEntry;
+  // #4558: the entry is assembled field-by-field as a `Record<string, unknown>`
+  // because `attachOptionalFields` mutates it, so TypeScript cannot see that
+  // every required `ModelEntry` field is present. The double cast says that
+  // plainly instead of a single cast the compiler rejects. There is no
+  // `ModelEntry` schema to validate against; if one is ever added, this is the
+  // call site that should use it rather than asserting.
+  return entry as unknown as ModelEntry;
 }
 
 function attachOptionalFields(entry: Record<string, unknown>, raw: ModelsDevRecord): void {

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // scripts/ runs under `tsx`, which resolves a `.ts` specifier directly.
+    // check-harness-alignment.ts imports one that way deliberately.
+    "allowImportingTsExtensions": true
+  },
+  // The ambient better-sqlite3 augmentation lives in the package and is only
+  // loaded when its source tree is in the project. scripts/ imports package
+  // modules transitively, so without it those imports report phantom errors
+  // that the package's own typecheck does not see.
+  "include": ["scripts/**/*.ts", "packages/nexus-agents/src/**/*.d.ts"],
+  "exclude": ["node_modules", "**/node_modules", "dist", "coverage"]
+}


### PR DESCRIPTION
Closes #4558.

## Nothing typechecked the tree that holds the gates

`pnpm typecheck` is `turbo typecheck`, which fans out to each **workspace's** own `tsc`. The repo-root `scripts/` tree is not a workspace, so no gate ever typechecked it — and that is where `check-schema-fanout`, `check-deploy-stale`, `check-release-stuck`, `check-script-wiring`, `inject-governance` and every drift check live.

The same gap #4483 found for lint: `pnpm lint` is `turbo lint`, which only reaches each workspace's `eslint src/`, and `scripts/` had accumulated seven unreported deprecated-API errors before anyone noticed.

14 errors had accumulated. **Two were genuine API drift**, not strictness noise:

**`pr-review-local.ts` passed `simulate: false` to `buildPrReviewProposal`**, whose input is a `Pick<>` that has never included it — an inert argument left behind when the API changed. Harmless at runtime, which is exactly why nothing surfaced it.

**Its local `VoterResult` had drifted from `PrReviewVote`.** It declared `role: string` where the real type is `VoterRole`, and omitted `processingTimeMs` entirely, so it could not be passed to `aggregatePrDecisions`. `collectRealVotes` had been returning the timing the whole time; the local mirror just stopped following. A parallel type definition quietly diverging from the one it feeds.

**`check-authority-tier-drift.test.ts` built an `AuditLogger` config missing five required fields.** It worked because `AuditLogConfigSchema` supplies those exact values as Zod defaults — runtime validation papering over a type error nothing was checking. I supplied them explicitly rather than changing `src/audit/`, which is governor-core and never auto-merged.

The remaining eleven were `noUncheckedIndexedAccess` findings on regex capture groups. Fixed by guarding, not asserting — so a missing group cannot silently read as `0` or `''`, which on a drift-detection script would mean reporting "0 documented" as a real measurement.

## One subtlety worth recording

Scoping the project to `scripts/**` surfaced two *phantom* errors in `packages/nexus-agents/src/context/mobimem-persistence.ts` that the package's own typecheck does not see. Cause: the ambient `better-sqlite3.d.ts` augmentation lives in the package and only loads when its source tree is in the project. `tsconfig.scripts.json` includes the package's `.d.ts` files for that reason — otherwise the new gate would open with two false positives against code it does not own.

## Verified it can fail

A deliberate `GRACE_MINUTES: string = 45`:

```
scripts/check-deploy-stale.ts(46,14): error TS2322: Type 'number' is not assignable to type 'string'.
scripts/check-deploy-stale.test.ts(119,38): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
```

Reverting returns to clean. Wired into the existing blocking `lint` job beside `lint:scripts`, so the new `check-script-wiring` gate (#4569) sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
