### PR TITLE
feat(lint): enable switch-exhaustiveness-check repo-wide

### DIFF
--- a/.changeset/repo-wide-switch-exhaustiveness.md
+++ b/.changeset/repo-wide-switch-exhaustiveness.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+`switch-exhaustiveness-check` is enabled repo-wide ([#4563](https://github.com/nexus-substrate/nexus-agents/issues/4563)).
+
+Completes the pattern work from #4565, which made a new union member a compile error at three decision-bearing consumers via `never` assertions. Those protect the consumers that use `if`/`!==`; this protects `switch` statements, which the assertions do not reach.
+
+**The cost estimate on this issue was wrong by 16×.** I recorded "32 violations across 158 switches" an hour ago, measured with the rule's default options — which require every union member to be covered _even when a `default` clause exists_. That flags `mapStopReason(openaiReason: string | null | undefined)`, a mapper over an external API value with a perfectly sensible fallback, as a violation. Unsatisfiable, and wrong to try.
+
+With `considerDefaultExhaustiveForUnions: true` — the correct configuration, where a `default` clause satisfies the rule — there are **2**, both in `hook-router.ts`.
+
+Both switched on `keyof HookCliOptions` while handling a subset, so an unhandled key silently did nothing. Fixed by narrowing the parameter types to `BooleanOptionKey` and `StringOptionKey`, the keys each setter actually handles, rather than by adding a `default`. That makes the signature true and turns a mismatch into a compile error at the flag map instead of a no-op at runtime.
+
+Verified the rule fires: adding an unhandled member yields `Switch is not exhaustive. Cases not matched: "newKey"`, and reverting is clean.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,6 +51,10 @@ export default defineConfig([
       },
     },
     rules: {
+      '@typescript-eslint/switch-exhaustiveness-check': [
+        'error',
+        { considerDefaultExhaustiveForUnions: true },
+      ],
       // Code structure limits (enforced)
       'max-lines': [
         'error',

--- a/packages/nexus-agents/src/cli/hooks/hook-router.ts
+++ b/packages/nexus-agents/src/cli/hooks/hook-router.ts
@@ -196,8 +196,28 @@ export interface HookCliOptions {
   reason?: string;
 }
 
+/**
+ * The option keys the boolean setter handles (#4563).
+ *
+ * Narrower than `keyof HookCliOptions` on purpose: the setter's switch covers
+ * exactly these, and typing the parameter as every key meant an unhandled one
+ * silently did nothing. Naming the set makes a mismatch a compile error at the
+ * flag map instead of a no-op at runtime.
+ */
+type BooleanOptionKey =
+  | 'validate'
+  | 'loadContext'
+  | 'trackMetrics'
+  | 'format'
+  | 'checkTasks'
+  | 'generateSummary'
+  | 'exportMetrics';
+
+/** The option keys the string setter handles (#4563). */
+type StringOptionKey = 'tool' | 'source' | 'reason';
+
 /** Boolean flags that don't require a value */
-const BOOLEAN_FLAGS: ReadonlyMap<string, keyof HookCliOptions> = new Map([
+const BOOLEAN_FLAGS: ReadonlyMap<string, BooleanOptionKey> = new Map([
   ['--validate', 'validate'],
   ['--load-context', 'loadContext'],
   ['--track-metrics', 'trackMetrics'],
@@ -208,7 +228,7 @@ const BOOLEAN_FLAGS: ReadonlyMap<string, keyof HookCliOptions> = new Map([
 ]);
 
 /** Value flags that require a following argument */
-const VALUE_FLAGS: ReadonlyMap<string, keyof HookCliOptions> = new Map([
+const VALUE_FLAGS: ReadonlyMap<string, StringOptionKey> = new Map([
   ['--tool', 'tool'],
   ['--source', 'source'],
   ['--reason', 'reason'],
@@ -247,7 +267,7 @@ export function parseHookArgs(args: string[]): HookCliOptions {
 }
 
 /** Sets a boolean option on HookCliOptions. */
-function setBooleanOption(options: HookCliOptions, key: keyof HookCliOptions): void {
+function setBooleanOption(options: HookCliOptions, key: BooleanOptionKey): void {
   switch (key) {
     case 'validate':
       options.validate = true;
@@ -274,7 +294,7 @@ function setBooleanOption(options: HookCliOptions, key: keyof HookCliOptions): v
 }
 
 /** Sets a string option on HookCliOptions. */
-function setStringOption(options: HookCliOptions, key: keyof HookCliOptions, value: string): void {
+function setStringOption(options: HookCliOptions, key: StringOptionKey, value: string): void {
   switch (key) {
     case 'tool':
       options.tool = value;


### PR DESCRIPTION
Completes #4563. #4565 shipped the targeted half — `never` assertions making a new union member a compile error at three decision-bearing consumers. Those cover `if`/`!==` chains; this covers `switch` statements, which they do not reach.

## My cost estimate was wrong by 16×

An hour ago I recorded on #4563: *"32 violations across 158 switches."* That was measured with the rule's **default** options, which require every union member to be covered **even when a `default` clause exists**.

Under those options, this is a violation:

```ts
export function mapStopReason(openaiReason: string | null | undefined): StopReason {
  switch (openaiReason) {
    case 'stop': return 'end_turn';
    …
    default: return 'end_turn';
  }
}
```

A mapper over an **external** API value, with a sensible fallback, switching on `string`. Every possible string is a "missing case". Unsatisfiable, and wrong to try — forcing exhaustiveness on external input would delete a defensive fallback that belongs there.

With `considerDefaultExhaustiveForUnions: true`, where a `default` clause satisfies the rule, the real count is **2**.

That is the second wrong assumption on this issue: first the rule didn't cover the cases that motivated it, then the cost was inflated 16× by my own configuration. Both only surfaced by running it.

## The two

Both in `hook-router.ts`, both switching on `keyof HookCliOptions` while handling a subset — so an unhandled key **silently did nothing**.

Fixed by narrowing the parameter types to `BooleanOptionKey` and `StringOptionKey` — the keys each setter actually handles — rather than adding a `default`. A `default` would have satisfied the linter while preserving the silent no-op. Narrowing makes the signature true, and turns a mismatch into a compile error at the flag map rather than a runtime no-op at the setter.

## Verified it fires

```
298:11  error  Switch is not exhaustive. Cases not matched: "newKey"
```

Reverting is clean. Rides the existing blocking `lint` job — no new wiring, and the #4569 wiring gate sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
