### PR TITLE
fix(ci): an unpublished version is a deploy in flight, not unmeasured

### DIFF
--- a/.changeset/unpublished-is-deploying.md
+++ b/.changeset/unpublished-is-deploying.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+A version that is not published yet reports as deploying, not unmeasured ([#4516](https://github.com/nexus-substrate/nexus-agents/issues/4516) follow-up).
+
+Caught by the detector false-alarming on `main` immediately after a release, which is precisely the failure the previous two fixes were meant to remove.
+
+The chain: the grace window was unreachable because its input was never supplied (#4551), then the script was given ownership of that input so it could not be forgotten (#4557). Both correct. Neither noticed that between a version PR merging and npm publishing, the repo version is **absent from the registry** — so the lookup returned `NaN`, which the assessor honestly reported as `unmeasured` and failed on.
+
+Every release therefore had a window in which the check failed for a reason that was not a problem.
+
+An absent version is not an unreadable input. The site cannot be serving a version npm does not have yet, so that window is a deploy in flight — `deploying`, elapsed time zero. A registry that could not be **fetched** is still `unmeasured`; those are different facts and neither should be laundered into the other.
+
+Verified against the live registry: a lookup for `99.99.99` returns absent → `deploying ok=true`, while an unreadable publish time still returns `unmeasured ok=false`. And on the real transition — 3.6.10 published at 00:14:44Z — the detector now reports `[deploying] Site at 3.6.9, repo at 3.6.10, within the 45-minute deploy window.`

--- a/scripts/check-deploy-stale.test.ts
+++ b/scripts/check-deploy-stale.test.ts
@@ -145,3 +145,31 @@ describe('#4516 follow-up: the grace window has to be reachable', () => {
     expect(verdict.ok).toBe(true);
   });
 });
+
+describe('#4516 follow-up: not-yet-published is a deploy in flight', () => {
+  it('treats a zero elapsed time as inside the window', () => {
+    // What an unpublished repo version resolves to: the release is mid-flight
+    // and the site cannot be serving a version npm does not have yet.
+    // Reporting that as unmeasured failed the check on every single release.
+    const verdict = assessDeployStaleness({
+      siteVersion: '3.6.9',
+      repoVersion: '3.6.10',
+      minutesSincePublish: 0,
+    });
+
+    expect(verdict.status).toBe('deploying');
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('still reports unmeasured when the publish time is genuinely unreadable', () => {
+    // A registry that could not be fetched is a different fact from a version
+    // that is not there yet, and must not be laundered into either verdict.
+    expect(
+      assessDeployStaleness({
+        siteVersion: '3.6.9',
+        repoVersion: '3.6.10',
+        minutesSincePublish: Number.NaN,
+      }).status
+    ).toBe('unmeasured');
+  });
+});

--- a/scripts/check-deploy-stale.ts
+++ b/scripts/check-deploy-stale.ts
@@ -166,7 +166,13 @@ async function minutesSincePublish(version: string): Promise<number> {
     if (!res.ok) return Number.NaN;
     const body = (await res.json()) as { time?: Record<string, string> };
     const published = body.time?.[version];
-    if (published === undefined) return Number.NaN;
+    // Registry reachable but this version absent means it is NOT PUBLISHED
+    // YET — the window between a version PR merging and the publish landing.
+    // The site cannot be serving a version that does not exist, so this is a
+    // deploy in flight, not an unreadable input. Reporting it as unmeasured
+    // failed the check on every release, which is the same false alarm on the
+    // normal path that the grace window exists to prevent.
+    if (published === undefined) return 0;
 
     const publishedMs = Date.parse(published);
     if (Number.isNaN(publishedMs)) return Number.NaN;


### PR DESCRIPTION
Third fix in this chain, and like the first two it was found by the detector misfiring on the normal path — not by reading the code.

## The chain

1. **#4551** — the 45-minute grace window was unreachable, because the workflow never supplied `MINUTES_SINCE_PUBLISH` and the script defaulted to 9999. False alarm on every release.
2. **#4557** — gave the script ownership of that input so the wiring could not be forgotten again.
3. **This** — between a version PR merging and npm publishing, the repo version is **absent from the registry**. The lookup returned `NaN`, the assessor honestly reported `unmeasured`, and the check failed.

Each fix was correct and each left a window where the check failed for a reason that was not a problem. Observed on `main` minutes after cutting 3.6.10:

```
::error::Deploy staleness: Site at 3.6.9, repo at 3.6.10, but the publish
time could not be read — so whether this gap is a normal deploy window or a
real stall is unmeasured.
```

3.6.10 published at 00:14:44Z. The detector had simply run before that.

## The distinction

An **absent** version is not an **unreadable** input. If npm does not have the version, the site cannot possibly be serving it — that window is a deploy in flight. A registry that could not be *fetched* is genuinely unmeasured and still fails.

Those are different facts about the world and neither should be laundered into the other, which is the same principle that made the original grace window report `unmeasured` rather than assuming "a long time ago".

## Verified against the live registry

```
unpublished version lookup -> (absent) -> minutes = 0
verdict: deploying ok=true
registry-unreachable verdict: unmeasured ok=false
```

And on the real transition, once 3.6.10 landed on npm:

```
[deploying] Site at 3.6.9, repo at 3.6.10, within the 45-minute deploy window.
```

16 tests pass; lint clean.

## Worth noting

This detector has now needed three fixes, every one surfaced by watching it run against real releases rather than by review. Its unit tests were green throughout — they exercise `assessDeployStaleness` with supplied inputs, and all three bugs were in *what the inputs turned out to be*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
