### PR TITLE
test(ci): cover the seam where all three deploy-staleness bugs lived

### DIFF
--- a/.changeset/cover-the-derivation-seam.md
+++ b/.changeset/cover-the-derivation-seam.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+Test the seam where all three deploy-staleness bugs lived ([#4516](https://github.com/nexus-substrate/nexus-agents/issues/4516) follow-up).
+
+This detector has now needed three fixes — an unreachable grace window (#4551), an input supplied from outside that was never supplied (#4557), and a version absent from the registry reported as unmeasured (#4575). Its unit tests were **green through all three**, because they exercise `assessDeployStaleness` with _supplied_ inputs and every bug was in what the input turned out to be.
+
+The derivation was doing I/O with no test at all. `elapsedMinutesFrom(body, version, nowMs)` is now a pure function covering the three outcomes that must stay distinct:
+
+- published → elapsed minutes
+- **absent from the registry** → `0`, a deploy in flight; npm does not have the version, so the site cannot be serving it
+- **no `time` map, or an unparseable date** → `NaN`, reported as unmeasured
+
+Writing that test immediately found a fourth bug in the fix merged minutes earlier: a malformed response with no `time` map returned `0`, so an unreadable registry read as "just published" and passed. It now returns `NaN`. Collapsing "I could not understand this response" into "this was published just now" is the same laundering the detector exists to prevent, and it was one release away from shipping.
+
+Also covers the clock-skew composition: a registry ahead of the runner yields a negative elapsed time, which the assessor rejects rather than granting an unbounded grace — the two halves now have a test proving they compose.

--- a/scripts/check-deploy-stale.test.ts
+++ b/scripts/check-deploy-stale.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { GRACE_MINUTES, assessDeployStaleness, parseSiteVersion } from './check-deploy-stale.js';
+import {
+  GRACE_MINUTES,
+  assessDeployStaleness,
+  elapsedMinutesFrom,
+  parseSiteVersion,
+} from './check-deploy-stale.js';
 import type { StalenessInput } from './check-deploy-stale.js';
 
 describe('parseSiteVersion', () => {
@@ -169,6 +174,51 @@ describe('#4516 follow-up: not-yet-published is a deploy in flight', () => {
         siteVersion: '3.6.9',
         repoVersion: '3.6.10',
         minutesSincePublish: Number.NaN,
+      }).status
+    ).toBe('unmeasured');
+  });
+});
+
+describe('elapsedMinutesFrom — the seam all three bugs lived in', () => {
+  const NOW = Date.parse('2026-08-23T01:00:00.000Z');
+
+  it('computes elapsed minutes for a published version', () => {
+    const body = { time: { '3.6.10': '2026-08-23T00:30:00.000Z' } };
+
+    expect(elapsedMinutesFrom(body, '3.6.10', NOW)).toBe(30);
+  });
+
+  it('returns 0 for a version absent from the registry', () => {
+    // Not published yet — the window between a version PR merging and the
+    // publish landing. Returning NaN here made the check fail on every release.
+    expect(
+      elapsedMinutesFrom({ time: { '3.6.9': '2026-08-23T00:00:00.000Z' } }, '3.6.10', NOW)
+    ).toBe(0);
+  });
+
+  it('returns NaN when the registry body has no time map at all', () => {
+    // A malformed or unexpected response is unmeasured, not "just published".
+    expect(Number.isNaN(elapsedMinutesFrom({}, '3.6.10', NOW))).toBe(true);
+  });
+
+  it('returns NaN for an unparseable publish date', () => {
+    expect(
+      Number.isNaN(elapsedMinutesFrom({ time: { '3.6.10': 'not-a-date' } }, '3.6.10', NOW))
+    ).toBe(true);
+  });
+
+  it('yields a negative value on clock skew, which the assessor treats as unmeasured', () => {
+    // Registry ahead of the runner. The assessor rejects negatives rather than
+    // granting an unbounded grace, so the two halves compose correctly.
+    const body = { time: { '3.6.10': '2026-08-23T01:30:00.000Z' } };
+    const elapsed = elapsedMinutesFrom(body, '3.6.10', NOW);
+
+    expect(elapsed).toBeLessThan(0);
+    expect(
+      assessDeployStaleness({
+        siteVersion: '3.6.9',
+        repoVersion: '3.6.10',
+        minutesSincePublish: elapsed,
       }).status
     ).toBe('unmeasured');
   });

--- a/scripts/check-deploy-stale.ts
+++ b/scripts/check-deploy-stale.ts
@@ -157,6 +157,41 @@ const REGISTRY_URL = 'https://registry.npmjs.org/nexus-agents';
  * `MINUTES_SINCE_PUBLISH` still overrides, for tests and for a caller that
  * already knows.
  */
+/** The `time` map shape this reads out of the npm registry response. */
+export interface RegistryTimes {
+  readonly time?: Record<string, string>;
+}
+
+/**
+ * Minutes since `version` was published, from a registry body.
+ *
+ * Extracted as a pure function because this seam is where all three of this
+ * detector's bugs lived (#4551, #4557, and the unpublished-version case) while
+ * its unit tests stayed green throughout — they exercised the assessor with
+ * SUPPLIED inputs, and every bug was in what the input turned out to be. The
+ * I/O wrapper below is now the only untested part.
+ *
+ * Three outcomes, deliberately distinct:
+ *  - published → elapsed minutes
+ *  - **absent** → `0`, a deploy in flight; npm does not have the version, so
+ *    the site cannot be serving it
+ *  - unparseable or no `time` map → `NaN`, reported as unmeasured
+ */
+export function elapsedMinutesFrom(body: RegistryTimes, version: string, nowMs: number): number {
+  // No `time` map at all is a malformed or unexpected response — unmeasured.
+  // Collapsing it into the absent-version case would report a registry we
+  // could not understand as "just published", i.e. healthy. Caught by the
+  // test written for this seam, before it shipped.
+  if (body.time === undefined) return Number.NaN;
+
+  const published = body.time[version];
+  if (published === undefined) return 0;
+
+  const publishedMs = Date.parse(published);
+  if (Number.isNaN(publishedMs)) return Number.NaN;
+  return (nowMs - publishedMs) / 60_000;
+}
+
 async function minutesSincePublish(version: string): Promise<number> {
   const override = process.env['MINUTES_SINCE_PUBLISH'];
   if (override !== undefined && override.trim() !== '') return Number(override);
@@ -164,19 +199,7 @@ async function minutesSincePublish(version: string): Promise<number> {
   try {
     const res = await fetch(REGISTRY_URL, { redirect: 'follow' });
     if (!res.ok) return Number.NaN;
-    const body = (await res.json()) as { time?: Record<string, string> };
-    const published = body.time?.[version];
-    // Registry reachable but this version absent means it is NOT PUBLISHED
-    // YET — the window between a version PR merging and the publish landing.
-    // The site cannot be serving a version that does not exist, so this is a
-    // deploy in flight, not an unreadable input. Reporting it as unmeasured
-    // failed the check on every release, which is the same false alarm on the
-    // normal path that the grace window exists to prevent.
-    if (published === undefined) return 0;
-
-    const publishedMs = Date.parse(published);
-    if (Number.isNaN(publishedMs)) return Number.NaN;
-    return (Date.now() - publishedMs) / 60_000;
+    return elapsedMinutesFrom((await res.json()) as RegistryTimes, version, Date.now());
   } catch {
     // Unreadable, which the assessor reports as unmeasured — not as "long ago".
     return Number.NaN;


### PR DESCRIPTION
Refs #4516. Not a fix for a reported bug — a fix for *why* three bugs got through.

## Three fixes, tests green throughout

| fix | what was wrong |
| --- | --- |
| #4551 | the 45-minute grace window was unreachable — the workflow never supplied its input |
| #4557 | that input came from outside, so it could be forgotten again; the script now owns it |
| #4575 | a version absent from the registry reported as `unmeasured`, failing on every release |

Its unit tests passed through all three. They exercise `assessDeployStaleness` with **supplied** inputs, and every one of the bugs was in *what the input turned out to be*. Testing the assessor was never going to find them.

The derivation — fetch the registry, find the version, compute elapsed minutes — was doing I/O with no test at all. That is the seam.

## The extraction

`elapsedMinutesFrom(body, version, nowMs)` is now pure, with the three outcomes that must stay distinct:

- **published** → elapsed minutes
- **absent from the registry** → `0`, a deploy in flight; npm does not have the version, so the site cannot be serving it
- **no `time` map, or an unparseable date** → `NaN`, reported as unmeasured

The I/O wrapper is now the only untested part, and it does nothing but fetch and delegate.

## Writing the test found a fourth bug

Immediately. In the fix merged minutes earlier.

`elapsedMinutesFrom({}, '3.6.10', now)` — a malformed response with **no `time` map at all** — returned `0`. So an unreadable registry read as "just published", graded `deploying`, and **passed**.

Collapsing *"I could not understand this response"* into *"this was published just now"* is the exact laundering this detector exists to prevent, and it was one release away from shipping. It now returns `NaN`.

I would not have found that by reading the code. I found it by having to write down what each input should produce.

## Also covered

Clock-skew composition: a registry ahead of the runner yields a negative elapsed time, and the assessor rejects negatives rather than granting an unbounded grace. The two halves now have a test proving they compose — previously each was correct alone and nothing checked the join, which is the shape of most of today's defects.

21 tests; typecheck and lint clean. Live detector still reports `[current] Live site and package.json agree at 3.6.10.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
