### PR TITLE
feat(utils): require naming the empty verdict; fix the general template

### DIFF
--- a/.changeset/named-empty-verdict.md
+++ b/.changeset/named-empty-verdict.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+Aggregating a verdict over a possibly-empty collection now requires naming what empty means — and the `general` pipeline template gains the `decompose` stage it was missing.
+
+Addresses a second defect class, distinct from #4561's "a check nothing runs": **a check that runs and returns a passing verdict for an empty input.** `[].every(p)` is `true` in JavaScript, so `checks.every((c) => c.passed)` reports pass when there are no checks.
+
+Chosen by a 7-voter `higher_order` panel at the supermajority bar (4 of 6, exactly at 2/3).
+
+**Measured before choosing.** 64 non-test `.every()` calls, but most are correct — `github-provider.ts:178` guards with `length > 0` and leaves an empty check set `pending`. A wide surface with sparse defects, so a blanket lint would be mostly false positives, and false positives teach people to bypass gates. What was missing was not enforcement but a _decision point_.
+
+`allOf` / `anyOf` / `verdictOver` take a **required** `whenEmpty`, so an author cannot aggregate without stating what nothing means.
+
+**A real instance, found by hunting for the shape.** The QA pipeline stage computed `reviews.every((r) => r.verdict === 'pass')`, and `pipeline-graph.ts:174` advances the graph on `success: true`. Reviewing zero tasks therefore reported a QA pass indistinguishable in the trace from "reviewed N, all passed".
+
+**Making that verdict honest exposed why it mattered.** The `general` template is `dev` minus `decompose` — and both `implement` and `qa` read `state[TASKS]`, which only `decompose` writes. So `general` implemented nothing, reviewed nothing, and passed. Every run of it, including the retired `research` template which aliases to it. The template now includes `decompose`; a template with implement and qa stages that cannot receive tasks is the bug, not the honest verdict.
+
+Known limitation, named by the panel: adoption is voluntary. The helper protects code that uses it. A later targeted lint over verdict-shaped modules would convert convention into mechanism, and the panel's contrarian proposed exactly that — an AST rule scoped to verdict directories — as the option nobody offered.

--- a/packages/nexus-agents/src/pipeline/stage-wrappers.ts
+++ b/packages/nexus-agents/src/pipeline/stage-wrappers.ts
@@ -17,6 +17,7 @@ import { PIPELINE_STATE_KEYS as K } from './stage-types.js';
 import { getContextPromptPrefix } from '../context/context-retriever.js';
 import { runConsensusGate } from '../orchestration/graph/consensus-node.js';
 import type { ConsensusVoter } from '../orchestration/graph/consensus-node.js';
+import { allOf } from '../utils/verdict-aggregation.js';
 
 // ============================================================================
 // Helper
@@ -213,7 +214,13 @@ export function createQaStageWrapper(stages: DevPipelineStages): IPipelineStage 
         : [];
       try {
         const reviews = await Promise.all(tasks.map((t, i) => stages.qaReview(t, impls[i] ?? '')));
-        const allPass = reviews.every((r) => r.verdict === 'pass');
+        // #4580: `[].every()` is true, so reviewing ZERO tasks reported
+        // success and `pipeline-graph.ts:174` advanced the graph — a QA pass
+        // indistinguishable in the trace from "reviewed N, all passed".
+        // Reachable: `parseTasksFromResponse` returns `[]` when the PM's
+        // response parses to an empty array, with no fallback on that path.
+        // Empty means nothing was reviewed, which is not a pass.
+        const allPass = allOf(reviews, (r) => r.verdict === 'pass', false);
         return output(K.QA_ITERATIONS, reviews, getTimeProvider().now() - start, allPass);
       } catch (e) {
         return failOutput(K.QA_ITERATIONS, getErrorMessage(e), getTimeProvider().now() - start);

--- a/packages/nexus-agents/src/pipeline/templates.ts
+++ b/packages/nexus-agents/src/pipeline/templates.ts
@@ -65,7 +65,13 @@ export const GREENFIELD_PIPELINE_TEMPLATE: PipelineTemplate = {
 export const GENERAL_PIPELINE_TEMPLATE: PipelineTemplate = {
   id: 'general',
   name: 'General Pipeline',
-  stages: ['research', 'plan', 'vote', 'implement', 'qa', 'security'],
+  // #4580: `decompose` was missing. Both `implement` and `qa` read
+  // `state[TASKS]`, which only `decompose` writes — so this template
+  // implemented nothing and reviewed nothing, and the QA stage reported
+  // success over an empty review set (`[].every()` is true). Surfaced by
+  // making that verdict honest; a template with implement+qa stages that
+  // cannot receive tasks is the bug, not the honest verdict.
+  stages: ['research', 'plan', 'vote', 'decompose', 'implement', 'qa', 'security'],
   dryRunStopAfter: 'vote',
 };
 

--- a/packages/nexus-agents/src/utils/verdict-aggregation.test.ts
+++ b/packages/nexus-agents/src/utils/verdict-aggregation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { allOf, anyOf, verdictOver } from './verdict-aggregation.js';
+
+describe('allOf', () => {
+  it('returns whenEmpty for an empty collection, not vacuous true', () => {
+    // The whole point: `[].every(p)` is `true`, and that is how a gate with
+    // zero checks reports success.
+    expect(allOf([], () => true, false)).toBe(false);
+  });
+
+  it('honours whenEmpty: true when vacuous truth is genuinely the contract', () => {
+    expect(allOf([], () => false, true)).toBe(true);
+  });
+
+  it('matches every() on a non-empty collection', () => {
+    expect(allOf([1, 2, 3], (n) => n > 0, false)).toBe(true);
+    expect(allOf([1, -2, 3], (n) => n > 0, true)).toBe(false);
+  });
+
+  it('does not consult whenEmpty when the collection is non-empty', () => {
+    // A passing collection must not be overridden by the empty verdict.
+    expect(allOf([1], (n) => n > 0, false)).toBe(true);
+  });
+});
+
+describe('anyOf', () => {
+  it('returns whenEmpty for an empty collection', () => {
+    expect(anyOf([], () => true, true)).toBe(true);
+    expect(anyOf([], () => true, false)).toBe(false);
+  });
+
+  it('matches some() on a non-empty collection', () => {
+    expect(anyOf([1, -2], (n) => n < 0, false)).toBe(true);
+    expect(anyOf([1, 2], (n) => n < 0, true)).toBe(false);
+  });
+});
+
+describe('verdictOver', () => {
+  it('returns whenEmpty rather than folding an empty collection', () => {
+    // A severity fold over nothing is `unmeasured`, not the best value —
+    // which is the `worstSeverity([])` question in general form.
+    expect(verdictOver<number, string>([], () => 'ok', 'unmeasured')).toBe('unmeasured');
+  });
+
+  it('folds a non-empty collection', () => {
+    expect(verdictOver([1, 2], (xs) => xs.length, 0)).toBe(2);
+  });
+
+  it('passes the whole collection to the aggregator', () => {
+    expect(verdictOver([3, 1, 2], (xs) => Math.max(...xs), -1)).toBe(3);
+  });
+});

--- a/packages/nexus-agents/src/utils/verdict-aggregation.ts
+++ b/packages/nexus-agents/src/utils/verdict-aggregation.ts
@@ -1,0 +1,91 @@
+/**
+ * Aggregating a verdict over a collection that might be empty (#4580).
+ *
+ * `[].every(p)` is `true` in JavaScript. So `checks.every((c) => c.passed)`
+ * reports **pass** when `checks` is empty — absence rendered as health, on
+ * exactly the code paths where that is most dangerous.
+ *
+ * Confirmed instances of the shape:
+ *  - `verify_audit_chain` returns `ok: true` over zero events, so deleting
+ *    every audit log file makes a tamper-evident chain verify clean (#4579)
+ *  - a quality gate with zero checks reported `pass` (#4544)
+ *  - the QA pipeline stage reported `success` after reviewing zero tasks,
+ *    letting the graph advance as though implementations had been reviewed
+ *
+ * ## Why a helper rather than a lint or a type
+ *
+ * Measured before choosing: 64 non-test `.every()` calls, and most are fine —
+ * `github-provider.ts:178` guards with `length > 0` and correctly leaves an
+ * empty check set `pending`. A wide surface with sparse defects, so a blanket
+ * lint would be mostly false positives, and false positives are what teach
+ * people to bypass a gate.
+ *
+ * What was missing is not enforcement but a *decision point*: nothing made the
+ * author say what empty means. `whenEmpty` is a required argument, so they
+ * must. Chosen by a 7-voter `higher_order` panel at the supermajority bar.
+ *
+ * ## Choosing `whenEmpty`
+ *
+ * Ask what an empty collection is evidence OF. Usually nothing — in which case
+ * the honest answer is the non-committal verdict (`pending`, `unmeasured`,
+ * `skip`), not the optimistic one. Reserve `true` for cases where vacuous truth
+ * is genuinely the contract, and say so at the call site.
+ *
+ * @module utils/verdict-aggregation
+ * (Source: Issue #4580)
+ */
+
+/**
+ * `predicate` holds for every item — with the empty case named, not defaulted.
+ *
+ * @param items - The collection to judge.
+ * @param predicate - Must hold for each item.
+ * @param whenEmpty - The verdict when there is nothing to judge. Required.
+ */
+export function allOf<T>(
+  items: readonly T[],
+  predicate: (item: T) => boolean,
+  whenEmpty: boolean
+): boolean {
+  if (items.length === 0) return whenEmpty;
+  return items.every(predicate);
+}
+
+/**
+ * `predicate` holds for at least one item — with the empty case named.
+ *
+ * `[].some(p)` is already `false`, which is usually right, but not always: a
+ * "did anything fail?" check over zero results should often be `unmeasured`
+ * rather than a clean `false`. Naming it keeps the reasoning visible.
+ *
+ * @param items - The collection to judge.
+ * @param predicate - Must hold for at least one item.
+ * @param whenEmpty - The verdict when there is nothing to judge. Required.
+ */
+export function anyOf<T>(
+  items: readonly T[],
+  predicate: (item: T) => boolean,
+  whenEmpty: boolean
+): boolean {
+  if (items.length === 0) return whenEmpty;
+  return items.some(predicate);
+}
+
+/**
+ * Reduce a collection to an arbitrary verdict, with the empty case named.
+ *
+ * For verdicts richer than a boolean — a severity, a tri-state gate result —
+ * where the empty case is usually `unmeasured` rather than the best value.
+ *
+ * @param items - The collection to judge.
+ * @param aggregate - Folds a non-empty collection into a verdict.
+ * @param whenEmpty - The verdict when there is nothing to judge. Required.
+ */
+export function verdictOver<T, V>(
+  items: readonly T[],
+  aggregate: (items: readonly T[]) => V,
+  whenEmpty: V
+): V {
+  if (items.length === 0) return whenEmpty;
+  return aggregate(items);
+}


### PR DESCRIPTION
Addresses a **second** defect class, distinct from the one #4561 handled. That was *"a check nothing runs."* This is *"a check that runs and returns a passing verdict for an empty input"* — absence rendered as health.

Chosen by a 7-voter `higher_order` panel at the supermajority bar: **4 of 6, `leadingShare` 0.667** — exactly at 2/3, cleared by the thinnest possible margin.

## Measured before choosing

`[].every(p)` is `true` in JavaScript, so every `.every()` over a possibly-empty collection is a potential vacuous pass. There are **64** non-test call sites.

But most are correct. `github-provider.ts:178` guards with `length > 0` and leaves an empty check set `pending` — exactly right. `verify-command.ts` and `validate-command.ts` aggregate over array literals. `review-demo-helpers.ts` has unconditional pushes before any conditional one.

**Wide surface, sparse defects.** That measurement is what ruled out the instinctive remedies: a blanket lint would be overwhelmingly false positives, and false positives are what teach people to bypass a gate. What was missing was not enforcement but a **decision point** — nothing made the author say what empty means.

`allOf` / `anyOf` / `verdictOver` take a **required** `whenEmpty`.

## A real instance, and what it exposed

A hunt with a strict five-point bar returned one finding from seven candidates: the QA pipeline stage computed `reviews.every((r) => r.verdict === 'pass')`, and `pipeline-graph.ts:174` advances the graph on `success: true`. So reviewing **zero** tasks reported a QA pass, indistinguishable in the trace from "reviewed N, all passed".

Making that verdict honest broke a test — and the break was the point.

**The `general` template is `dev` minus `decompose`.** Both `implement` and `qa` read `state[TASKS]`, which only `decompose` writes. So `general` implemented nothing, reviewed nothing, and reported success. Every run of it, including the retired `research` template, which aliases to `general`.

The template now includes `decompose`. A template with implement and qa stages that cannot receive tasks is the bug; the honest verdict merely surfaced it.

There is some irony in the neighbourhood: the comment directly above the consumer documents #4362, which fixed the *opposite* failure — `output.success` being discarded so a failed stage looked successful. Success is honoured now, and could be vacuously true.

## Verification

674 pipeline tests pass, 9 new for the helper. Typecheck, lint, and the export ratchet all clean.

## Known limitation, named by the panel

Adoption is voluntary — the helper protects code that uses it, and nothing routes an unaware author to it. Several voters flagged this as the option's real weakness, and the contrarian proposed the option nobody offered: an AST-based ESLint rule scoped to verdict-generating directories, giving mechanical enforcement without a repo-wide type migration. That is the natural follow-up, and it is worth more than another convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
