### PR TITLE
fix(verdict): nine aggregations no longer report a pass over zero items

### DIFF
--- a/.changeset/vacuous-verdict-every-sites.md
+++ b/.changeset/vacuous-verdict-every-sites.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+fix: nine verdict aggregations no longer report a pass over zero items
+
+`[].every(p)` is `true`, so a verdict aggregated over an empty collection reported success having measured nothing. A census of all 68 non-test `.every()` call sites found ten that were both unguarded and verdict-shaped; nine are fixed here (the tenth is on the governance path and is tracked separately for owner ratification).
+
+- `release-announce`: `--channels=bogus` filtered to zero channels and the command reported `success: true`, printed the all-clear banner, and exited 0 having announced nothing. Unknown channels are now rejected outright, and the three downstream verdicts name the empty case.
+- `voting-protocol`: an empty committee made `allVoted` true, finalizing a session as `completed` on zero ballots.
+- `collaboration-session`: a session with zero participants recorded `All experts failed` — a failure attributed to nobody.
+- `parallel-executor`: `allSucceeded([])` reported a branch that produced no step results as fully successful.
+- `scenario-runner`: a scenario with no expectations reported `passed: true` having asserted nothing.
+- `pr-reviewer-helpers`: with zero reviews `allApproved` was true, so a HIGH-severity finding downgraded from `request_changes` to `comment` on an unreviewed PR.
+- `ab-test-tracker`: an experiment with zero variants reported `hasMinimumSampleSize: true`, so a zero-sample experiment read as statistically powered.
+
+Each site now goes through `allOf` from `verdict-aggregation` with an explicit `whenEmpty`, and each carries a comment saying what empty means there and why.

--- a/packages/nexus-agents/src/agents/collaboration/collaboration-session.test.ts
+++ b/packages/nexus-agents/src/agents/collaboration/collaboration-session.test.ts
@@ -451,6 +451,27 @@ describe('CollaborationSession', () => {
     });
   });
 
+  describe('progress checks with no participants (#4581)', () => {
+    it('should not report "All experts failed" when the participant list is empty', () => {
+      session.start(createTestConfig({ pattern: 'parallel' }));
+
+      // getStatus() returns a shallow copy that shares the live participants
+      // array, and emitEvent runs before checkProgress — so a listener can empty
+      // the roster mid-call. `[].every()` used to make zero participants read as
+      // a total expert failure that never happened.
+      session.addEventListener(() => {
+        session.getStatus()?.participants.splice(0);
+      });
+
+      session.submitResult('expert-1', createTestResult('test-task-1'));
+
+      const status = session.getStatus();
+      expect(status?.participants).toHaveLength(0);
+      expect(status?.error).toBeUndefined();
+      expect(status?.status).not.toBe('failed');
+    });
+  });
+
   describe('getTaskAssignments', () => {
     it('should return empty array when no session', () => {
       expect(session.getTaskAssignments()).toEqual([]);

--- a/packages/nexus-agents/src/agents/collaboration/collaboration-session.ts
+++ b/packages/nexus-agents/src/agents/collaboration/collaboration-session.ts
@@ -30,6 +30,7 @@ import type {
   ConsensusReachedEvent,
 } from './event-bus-types.js';
 import { createEvent } from './event-bus.js';
+import { allOf } from '../../utils/verdict-aggregation.js';
 import { validateConfig, createSessionState, shouldFinalize } from './session-helpers.js';
 import {
   MAX_EVENT_LISTENERS,
@@ -404,7 +405,13 @@ export class CollaborationSession {
       this.setStatus('finalizing');
     }
 
-    if (participants.every((p) => p.status === 'failed')) {
+    // whenEmpty = false: "all experts failed" is a claim about experts that ran.
+    // With zero participants no expert failed, so `[].every()` used to record a
+    // total failure that never happened. An empty roster is a different
+    // condition — absence of participants, not their collective failure — and
+    // this check is not the instrument that measures it, so it stays silent
+    // rather than attributing a failure to nobody. (#4581)
+    if (allOf(participants, (p) => p.status === 'failed', false)) {
       this.state.error = 'All experts failed';
       this.setStatus('failed');
     }

--- a/packages/nexus-agents/src/cli/release-announce-command.test.ts
+++ b/packages/nexus-agents/src/cli/release-announce-command.test.ts
@@ -327,7 +327,10 @@ describe('runReleaseAnnounce', () => {
     logSpy.mockRestore();
   });
 
-  it('should handle empty channels array', async () => {
+  // This test previously asserted `success: true` for an empty channel list —
+  // it pinned the vacuous pass rather than catching it (#4581). Announcing
+  // nothing is not a successful announcement.
+  it('should not report success when no channels were announced', async () => {
     const result = await runReleaseAnnounce({
       version: '3.0.0',
       channels: [],
@@ -335,7 +338,7 @@ describe('runReleaseAnnounce', () => {
       verbose: false,
     });
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
     expect(result.channels).toHaveLength(0);
   });
 });
@@ -519,5 +522,24 @@ describe('releaseAnnounceCommand', () => {
     });
 
     expect(exitCode).toBe(0);
+  });
+  it('should reject an unrecognised channel rather than announcing nothing', async () => {
+    const exitCode = await releaseAnnounceCommand({
+      positionals: ['release-announce'],
+      options: { version: '3.0.0', channels: 'bogus', dryRun: true },
+    });
+
+    expect(exitCode).toBe(1);
+  });
+
+  it('should not print the all-clear banner when no channels were announced', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    printReleaseAnnounceResult(makeSuccessResult({ success: false, channels: [] }));
+
+    const output = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    expect(output).not.toContain('All announcements generated');
+    expect(output).toContain('No announcements');
+    logSpy.mockRestore();
   });
 });

--- a/packages/nexus-agents/src/cli/release-announce-command.ts
+++ b/packages/nexus-agents/src/cli/release-announce-command.ts
@@ -33,6 +33,7 @@ import {
   groupCommitsByCategory,
 } from './release-notes-helpers.js';
 import { getBlueskyConfig, createBlueskyPost } from './bluesky-client.js';
+import { allOf } from '../utils/verdict-aggregation.js';
 
 /**
  * Default options for the release-announce command.
@@ -373,7 +374,9 @@ export async function runReleaseAnnounce(
     results.push(result);
   }
 
-  const allSuccess = results.every((r) => r.success);
+  // Announcing nothing is not a successful announcement (#4581): `[].every()`
+  // is `true`, so a filtered-to-empty channel list used to report a clean run.
+  const allSuccess = allOf(results, (r) => r.success, false);
 
   return {
     success: allSuccess,
@@ -418,8 +421,9 @@ export function printReleaseAnnounceResult(result: ReleaseAnnounceResult, verbos
     console.log('');
   }
 
-  const allSuccess = result.channels.every((c) => c.success);
-  if (allSuccess) {
+  if (result.channels.length === 0) {
+    console.log(`${colors.yellow}${colors.bold}⚠ No announcements were generated${colors.reset}`);
+  } else if (allOf(result.channels, (c) => c.success, false)) {
     console.log(`${colors.green}${colors.bold}✓ All announcements generated${colors.reset}`);
   } else {
     console.log(`${colors.yellow}${colors.bold}⚠ Some announcements failed${colors.reset}`);
@@ -465,6 +469,13 @@ export async function releaseAnnounceCommand(args: {
   const channels = channelList.filter(
     (c): c is AnnouncementChannel => c === 'blog' || c === 'bluesky'
   );
+  if (channels.length === 0) {
+    console.error(
+      `${colors.red}Error: No known announcement channels in "${channelList.join(',')}" ` +
+        `(known: blog, bluesky)${colors.reset}`
+    );
+    return 1;
+  }
 
   const result = await runReleaseAnnounce({
     version,
@@ -475,5 +486,5 @@ export async function releaseAnnounceCommand(args: {
   });
 
   printReleaseAnnounceResult(result, args.options.verbose);
-  return result.channels.every((c) => c.success) ? 0 : 1;
+  return allOf(result.channels, (c) => c.success, false) ? 0 : 1;
 }

--- a/packages/nexus-agents/src/consensus/voting-protocol.test.ts
+++ b/packages/nexus-agents/src/consensus/voting-protocol.test.ts
@@ -476,6 +476,26 @@ describe('VotingProtocol', () => {
       const result = await protocol.getResult(session.id);
       expect(result).toBeNull();
     });
+
+    it('should not finalize a session whose committee became empty (#4581)', async () => {
+      const ownCommittee = [...committee];
+      const session = protocol.createSession(topic, ownCommittee);
+      await protocol.startAnalysisRound(session.id);
+      await protocol.startDeliberationRound(session.id);
+      await protocol.startConsensusRound(session.id);
+
+      // createSession stores the caller's array by reference, so a caller that
+      // clears its own committee array empties the session's committee. Zero
+      // members have cast zero votes: `[].every()` used to make that read as
+      // "everyone voted" and finalize the session on no evidence.
+      const live = protocol.getSession(session.id);
+      live?.committee.splice(0);
+
+      const result = await protocol.getResult(session.id);
+      expect(result).toBeNull();
+      expect(protocol.getSession(session.id)?.status).toBe('active');
+      expect(protocol.getSession(session.id)?.finalResult).toBeUndefined();
+    });
   });
 
   describe('Error branches', () => {

--- a/packages/nexus-agents/src/consensus/voting-protocol.ts
+++ b/packages/nexus-agents/src/consensus/voting-protocol.ts
@@ -10,6 +10,7 @@
  */
 
 import { createLogger } from '../core/logger.js';
+import { allOf } from '../utils/verdict-aggregation.js';
 import { getTimeProvider } from '../core/index.js';
 import type { ILogger } from '../core/index.js';
 import type {
@@ -307,7 +308,17 @@ export class VotingProtocol implements IVotingProtocol {
     const consensusRound = session.rounds[2];
     if (!consensusRound) return Promise.resolve(null);
 
-    const allVoted = session.committee.every((agentId) => consensusRound.finalVotes.has(agentId));
+    // whenEmpty = false: a committee of zero members has cast zero votes, and
+    // `[].every()` used to report that as "everyone voted" — finalizing the
+    // session as `completed` with an outcome derived from no ballots at all.
+    // Zero voters is the absence of consensus, not unanimous consensus, so the
+    // empty case takes the same path as a partial vote: no result, session stays
+    // active, and the record never claims a vote that was never held. (#4581)
+    const allVoted = allOf(
+      session.committee,
+      (agentId) => consensusRound.finalVotes.has(agentId),
+      false
+    );
     if (!allVoted) return Promise.resolve(null);
 
     const result = this.buildFinalResult(session);

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
@@ -360,6 +360,14 @@ describe('Decision Helpers', () => {
       expect(determineDecision(reviews, findings)).toBe('comment');
     });
 
+    it('should request changes on high findings when there are no reviews at all (#4581)', () => {
+      const findings: ReviewFinding[] = [createMockFinding({ severity: 'high' })];
+
+      // Zero expert reviews is not unanimous approval: nobody signed off, so a
+      // HIGH finding must not be downgraded to a comment.
+      expect(determineDecision([], findings)).toBe('request_changes');
+    });
+
     it('should comment when medium/low findings exist', () => {
       const findings: ReviewFinding[] = [createMockFinding({ severity: 'medium' })];
       const reviews: ExpertReviewResult[] = [createMockExpertReview({ approved: true })];

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.ts
@@ -28,6 +28,7 @@ import {
   DECISION_EMOJI,
 } from './pr-review-types.js';
 import { sanitizeInput } from '../security/input-sanitizer.js';
+import { allOf } from '../utils/verdict-aggregation.js';
 import {
   assessReputation,
   gateWithReputation,
@@ -256,7 +257,10 @@ export function determineDecision(
 ): ReviewDecision {
   const hasCritical = findings.some((f) => f.severity === 'critical');
   const hasHigh = findings.some((f) => f.severity === 'high');
-  const allApproved = reviews.every((r) => r.approved);
+  // Zero expert reviews is not unanimous approval (#4581): with `true` here the
+  // `hasHigh && !allApproved` branch could never fire on an unreviewed PR, so a
+  // HIGH finding silently downgraded from request_changes to comment.
+  const allApproved = allOf(reviews, (r) => r.approved, false);
 
   if (hasCritical) return 'request_changes';
   if (hasHigh && !allApproved) return 'request_changes';

--- a/packages/nexus-agents/src/learning/ab-test-tracker.test.ts
+++ b/packages/nexus-agents/src/learning/ab-test-tracker.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { AbTestTracker, createAbTestTracker } from './ab-test-tracker.js';
-import type { ExperimentOutcome } from './ab-test-types.js';
+import type { ExperimentDefinition, ExperimentOutcome } from './ab-test-types.js';
 
 describe('ab-test-tracker', () => {
   let tracker: AbTestTracker;
@@ -342,6 +342,29 @@ describe('ab-test-tracker', () => {
 
       expect(summary?.result?.comparison.significant).toBe(true);
       expect(summary?.recommendation).toBe('stop_winner');
+    });
+
+    it('should not report minimum sample size for an experiment with zero variants (#4581)', () => {
+      // createExperiment rejects <2 variants, so set the definition directly to
+      // exercise the aggregation guard behind that gate.
+      const zeroVariantExperiment: ExperimentDefinition = {
+        ...validExperiment,
+        id: 'exp-zero-variants',
+        status: 'running',
+        variants: [],
+        startedAt: new Date().toISOString(),
+        endedAt: null,
+      };
+      (tracker as unknown as { experiments: Map<string, ExperimentDefinition> }).experiments.set(
+        zeroVariantExperiment.id,
+        zeroVariantExperiment
+      );
+
+      const summary = tracker.getSummary('exp-zero-variants');
+
+      expect(summary?.variantStats).toHaveLength(0);
+      expect(summary?.hasMinimumSampleSize).toBe(false);
+      expect(summary?.recommendation).toBe('continue');
     });
 
     it('should recommend continue when sample size not reached', () => {

--- a/packages/nexus-agents/src/learning/ab-test-tracker.ts
+++ b/packages/nexus-agents/src/learning/ab-test-tracker.ts
@@ -9,6 +9,7 @@
  */
 
 import { getTimeProvider } from '../core/index.js';
+import { allOf } from '../utils/verdict-aggregation.js';
 import type {
   ExperimentDefinition,
   ExperimentOutcome,
@@ -172,7 +173,14 @@ export class AbTestTracker implements IAbTestTracker {
 
     const outcomes = this.outcomes.get(experimentId) ?? [];
     const variantStats = this.calculateVariantStats(experiment, outcomes);
-    const hasMinimumSampleSize = variantStats.every((vs) => vs.n >= experiment.minSampleSize);
+    // No variants means no samples, not a powered experiment (#4581): `true`
+    // here would tell getRecommendation the experiment is statistically powered
+    // on zero observations. Empty must take the "not enough data" path.
+    const hasMinimumSampleSize = allOf(
+      variantStats,
+      (vs) => vs.n >= experiment.minSampleSize,
+      false
+    );
 
     const result = this.calculateExperimentResult(experiment, variantStats);
     const recommendation = this.getRecommendation(experiment, result, hasMinimumSampleSize);

--- a/packages/nexus-agents/src/testing/e2e/scenario-runner.test.ts
+++ b/packages/nexus-agents/src/testing/e2e/scenario-runner.test.ts
@@ -65,6 +65,15 @@ describe('ScenarioRunner', () => {
       expect(result.executedAt).toBeDefined();
     });
 
+    it('should not pass a scenario that asserted nothing (#4581)', async () => {
+      const emptyScenario: ScenarioFixture = { ...basicScenario, expectedOutputs: [] };
+
+      const result = await runner.run(emptyScenario);
+
+      expect(result.stepResults).toHaveLength(0);
+      expect(result.passed).toBe(false);
+    });
+
     it('should validate step status matches expectation', async () => {
       const result = await runner.run(basicScenario);
 

--- a/packages/nexus-agents/src/testing/e2e/scenario-runner.ts
+++ b/packages/nexus-agents/src/testing/e2e/scenario-runner.ts
@@ -15,6 +15,7 @@ import { getErrorMessage, getTimeProvider } from '../../core/index.js';
 
 import { WorkflowDefinitionSchema } from '../../workflows/workflow-types.js';
 import { logger } from '../../core/logger.js';
+import { allOf } from '../../utils/verdict-aggregation.js';
 import type {
   IScenarioRunner,
   ScenarioFixture,
@@ -110,7 +111,10 @@ export class ScenarioRunner implements IScenarioRunner {
       // Validate results against expectations
       const validations = this.validateResults(stepResults, scenario.expectedOutputs);
 
-      const passed = validations.every((v) => v.passed);
+      // A scenario that asserted nothing did not pass (#4581): with no
+      // expectations (or none surviving validation) `passed` would otherwise be
+      // vacuously true and a CI gate would read "nothing measured" as green.
+      const passed = allOf(validations, (v) => v.passed, false);
       const durationMs = getTimeProvider().now() - startTime;
 
       this.log.info('Scenario completed', { scenarioId: scenario.id, passed, durationMs });

--- a/packages/nexus-agents/src/workflows/parallel-executor-orchestration.test.ts
+++ b/packages/nexus-agents/src/workflows/parallel-executor-orchestration.test.ts
@@ -658,8 +658,10 @@ describe('ParallelExecutor', () => {
       expect(allSucceeded(results)).toBe(false);
     });
 
-    it('returns true for empty results', () => {
-      expect(allSucceeded([])).toBe(true);
+    // Previously pinned the vacuous pass (`[].every(p) === true`), which let a
+    // parallel branch that ran no steps report full success (#4581).
+    it('returns false for empty results', () => {
+      expect(allSucceeded([])).toBe(false);
     });
   });
 

--- a/packages/nexus-agents/src/workflows/parallel-executor.test.ts
+++ b/packages/nexus-agents/src/workflows/parallel-executor.test.ts
@@ -49,13 +49,25 @@ describe('allSucceeded', () => {
     expect(allSucceeded([successResult('a'), failResult('b')])).toBe(false);
   });
 
-  it('returns true for empty array', () => {
-    expect(allSucceeded([])).toBe(true);
+  // This assertion previously pinned the vacuous pass: `[].every(p)` is `true`,
+  // so a branch that produced zero step results was reported fully successful
+  // (#4581). Repointed, not deleted — the empty case is now "nothing measured".
+  it('returns false for empty array — zero results is not evidence of success', () => {
+    expect(allSucceeded([])).toBe(false);
   });
 
   it('returns false for skipped results', () => {
     const skipped: StepResult = { stepId: 'a', output: null, durationMs: 0, status: 'skipped' };
     expect(allSucceeded([skipped])).toBe(false);
+  });
+
+  // Regression for the shape in #4581: a caller that legitimately runs zero
+  // steps must decide that for itself (`steps.length === 0 || allSucceeded(r)`)
+  // rather than inheriting a pass from an aggregation that measured nothing.
+  it('does not report success for a branch that produced no step results', () => {
+    const noStepsRan: StepResult[] = [];
+    expect(allSucceeded(noStepsRan)).toBe(false);
+    expect(getFailedSteps(noStepsRan)).toHaveLength(0);
   });
 });
 

--- a/packages/nexus-agents/src/workflows/parallel-executor.ts
+++ b/packages/nexus-agents/src/workflows/parallel-executor.ts
@@ -11,6 +11,7 @@ import { getErrorMessage, ok, err, WorkflowError, getTimeProvider } from '../cor
 import type { WorkflowStep, StepResult } from '../core/index.js';
 import { TaskQueue } from './task-queue.js';
 import { WORKFLOW_TIMEOUTS } from '../config/timeouts.js';
+import { allOf } from '../utils/verdict-aggregation.js';
 
 /**
  * Options for parallel execution.
@@ -363,11 +364,19 @@ export function withRetries(baseExecutor: StepExecutor, defaultRetries = 0): Ste
 /**
  * Checks if all step results are successful.
  *
+ * Empty is `false` (#4581): zero step results is not evidence that a parallel
+ * branch succeeded, it is evidence that nothing was measured. The prior
+ * `results.every(...)` returned `true` for `[]`, so a branch whose steps never
+ * ran — cancelled, filtered to nothing, or lost — was reported fully
+ * successful. A caller that legitimately expects zero steps must say so at its
+ * own call site (`steps.length === 0 || allSucceeded(results)`) rather than
+ * inherit a pass from an aggregation over nothing.
+ *
  * @param results - Array of step results
- * @returns True if all steps succeeded
+ * @returns True if there is at least one result and every step succeeded
  */
 export function allSucceeded(results: StepResult[]): boolean {
-  return results.every((r) => r.status === 'success');
+  return allOf(results, (r) => r.status === 'success', false);
 }
 
 /**


### PR DESCRIPTION
Closes the `.every()` half of the vacuous-pass class measured for #4581. Nine of the ten confirmed sites; the tenth is on the governance path and is held for owner ratification under #4586.

## The class

`[].every(p)` is `true`. A verdict aggregated over an empty collection therefore reports **pass** having measured nothing — absence rendered as health, on exactly the code paths where that is most dangerous. #4580 shipped `allOf`/`anyOf`/`verdictOver`, whose required `whenEmpty` argument forces the author to say what empty means. This PR migrates the confirmed sites onto it.

## Measurement first

A census of every non-test `.every()` call site, so the fix is aimed at real instances rather than a shape:

| Class | Count |
| --- | --- |
| Array literal — cannot be empty | 7 |
| Guarded by an explicit length check | 27 |
| Unguarded but benign (type guards, filter predicates) | 24 |
| **Unguarded and verdict-shaped** | **10** |
| Total | 68 |

The 24 benign sites are deliberately untouched. `areAllStrings([])` narrowing an empty array to `string[]` is sound, and rewriting it would be churn.

## What was wrong

| Site | Empty input produced |
| --- | --- |
| `release-announce-command.ts` (×3) | `--channels=bogus` filtered to zero channels; `success: true`, the green "✓ All announcements generated" banner, and exit 0 for a release that announced nothing |
| `voting-protocol.ts` | an empty committee made `allVoted` true, finalizing a session as `completed` on zero ballots |
| `collaboration-session.ts` | a session with zero participants recorded `All experts failed` — a total expert failure attributed to nobody |
| `parallel-executor.ts` | `allSucceeded([])` reported a branch that produced no step results as fully successful |
| `scenario-runner.ts` | a scenario with no expectations reported `passed: true` having asserted nothing |
| `pr-reviewer-helpers.ts` | with zero reviews `allApproved` was true, so `hasHigh && !allApproved` could never fire — a HIGH-severity finding downgraded from `request_changes` to `comment` on an unreviewed PR |
| `ab-test-tracker.ts` | an experiment with zero variants reported `hasMinimumSampleSize: true`, so `getRecommendation` treated a zero-sample experiment as statistically powered |

Every fix names the empty verdict explicitly and carries a comment saying **why that value** at that site, not just that it was changed. `release-announce` additionally rejects an unrecognised channel at the CLI boundary instead of proceeding to announce nothing, and its printer distinguishes "no announcements were generated" from "some announcements failed".

## Three of these were pinned by passing tests

Worth stating plainly, because it changes what the class means. The vacuous pass was not merely unnoticed:

```ts
it('should handle empty channels array', async () => {
  const result = await runReleaseAnnounce({ version: '3.0.0', channels: [], ... });
  expect(result.success).toBe(true);   // ← asserted the defect as intended behaviour
});
```

Two more in `parallel-executor.test.ts` and `parallel-executor-orchestration.test.ts` did the same for `allSucceeded([])`. All three are **repointed, not deleted**, each with a comment recording what it previously pinned. A test suite that asserts the vacuous pass is worse than no test — it converts the defect into a documented contract, and the next author reading it has no reason to doubt.

## Reachability

Two sites looked hypothetical and are not. `createSession` stores the caller's committee array **by reference**, so a caller that clears its own array empties the session's committee. `getStatus()` returns a shallow copy sharing the live `participants` array, and `emitEvent` runs before `checkProgress`, so a registered listener can empty the roster mid-call.

`allSucceeded` genuinely has zero production callers today — it is exported from the barrel and deliberately not on the public surface. The fix is at the definition anyway: the risk is prospective, and a future caller should not inherit a pass from an aggregation over nothing.

## Not in this PR

- **#4586** — the governor-path cluster: `scripts/inject-governance.ts` (eight sites), `arch-lint.ts`, `check-registry-coverage.ts`, and `src/governance/claims-verify.ts`. Gates that report clean because their input directory was empty. Owner ratification required; an agent must not land changes to its own governor.
- **#4585** — the same defect in five other syntactic forms: negated `.some()` (4), `errors.length === 0` as a pass signal (9), loop-then-`return true` (11), `Math.min/max(...arr)` (2), `a.length === b.length` (1). 27 further confirmed instances.
- **#4581** — the durable mechanism. A 7-voter `higher_order` panel at the supermajority bar chose a verdict-position-scoped ESLint rule, 5 of 6 approvers (leading share 0.83).

## Verification

- `vitest run` — **1182 files, 28,064 tests, 0 failures**
- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `prettier --check` — clean
- Every fix was written Red first; each failing test was confirmed to fail for the right reason before the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
