### PR TITLE
fix(verdict): name the empty case in the vacuous-pass forms beyond .every()

### DIFF
--- a/.changeset/vacuous-other-forms.md
+++ b/.changeset/vacuous-other-forms.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix: name the empty case in the vacuous-pass forms beyond `.every()`
+
+`#4580`/`#4587` covered `.every()`. The same defect — a check reporting PASS because it had nothing to check — lives in five other shapes: `![].some(p)` is `true`, a `for` loop with an early failure return never runs its body on an empty collection, `errors.length === 0` holds when the producing loop iterated nothing, `Math.min(...[])` is `Infinity`, and `0 === 0`.
+
+Fixed:
+
+- **`shouldFinalize`** — `results.size === participants.length` and `votes.length === participants.length` are both `0 === 0`, so a session whose roster emptied transitioned to `finalizing` as though its work were complete. Reachable: `getStatus()` returns a shallow copy sharing the live `participants` array.
+- **`benchmark-runner` / `memory-benchmark-output`** — a run that recorded zero operations, and a run with zero configured thresholds, both certified the perf gate. `checkThreshold` returned `null` for "no threshold set" and for "check passed" alike; those are now distinct.
+- **`stpa-validation`** — a tool with no readable input schema, or with zero constraints evaluated, reported `valid: true`. An _empty_ property map is deliberately not that case: a parameterless tool has been inspected and found to have nothing to sanitize.
+- **`skill-composer`** — a composition with zero steps reported executable.
+- **`aflow` structure and completeness** — a zero-step workflow was reported acyclic, uniquely-identified, validly-roled and constraint-satisfying, all without a step being read.
+- **`workflow-evolver-helpers`** — two zero-step workflows reported crossover-compatible.
+- **`consensus-plan`** — when every CLI answered but none produced a parseable plan, the summary rendered as an ordinary consensus plan containing zero steps. It now says nothing was compared.
+- **`confidence-cascade-stage`** — escalation on zero candidates was emergent from `-Infinity < threshold`; it is now explicit, with a `confidence:no-candidates` signal separating "nothing scored" from "scored too low".
+
+Three sites on the original list were traced and left alone as false positives: `setup-command` and `workflow-run` aggregate over fixed or specification-derived lists, and `correlation-helpers` fails in the conservative direction — an unmeasured panel collapses to one subset, reducing effective vote count rather than inflating it.

--- a/packages/nexus-agents/src/agents/collaboration/session-helpers.test.ts
+++ b/packages/nexus-agents/src/agents/collaboration/session-helpers.test.ts
@@ -366,4 +366,20 @@ describe('shouldFinalize', () => {
     const votes = [{ decision: 'approve' } as VoteMessage];
     expect(shouldFinalize('consensus', participants, new Map(), votes, [])).toBe(true);
   });
+
+  // `results.size === participants.length` and `votes.length === participants.length`
+  // are both `0 === 0` for a session with no participants, so an empty session
+  // finalized as though its work were complete. The `review` branch already
+  // guarded with `> 0`; the other two did not (#4585).
+  it('does not finalize an empty parallel session (#4585)', () => {
+    expect(shouldFinalize('parallel', [], new Map(), [], [])).toBe(false);
+  });
+
+  it('does not finalize an empty sequential session (#4585)', () => {
+    expect(shouldFinalize('sequential', [], new Map(), [], [])).toBe(false);
+  });
+
+  it('does not finalize an empty consensus session (#4585)', () => {
+    expect(shouldFinalize('consensus', [], new Map(), [], [])).toBe(false);
+  });
 });

--- a/packages/nexus-agents/src/agents/collaboration/session-helpers.ts
+++ b/packages/nexus-agents/src/agents/collaboration/session-helpers.ts
@@ -359,9 +359,15 @@ export function shouldFinalize(
   reviews: ReviewResponseMessage[]
 ): boolean {
   // A session with no participants has nothing to finalize. Both equality
-  // comparisons below are `0 === 0` on an empty roster, so an empty session
-  // used to transition to `finalizing` as though its work were complete — the
-  // `review` branch already guarded with `> 0`, the other two did not (#4585).
+  // comparisons below are `0 === 0` on an empty roster, so a session whose
+  // roster emptied transitioned to `finalizing` as though its work were
+  // complete — the `review` branch already guarded with `> 0`, the other two
+  // did not (#4585).
+  //
+  // Reachable despite `CollaborationConfigSchema` requiring at least one
+  // expert: `getStatus()` returns `{ ...this.state }`, a shallow copy that
+  // shares the live `participants` array, so any holder can empty it between
+  // construction and the next `checkProgress`.
   if (participants.length === 0) return false;
 
   switch (pattern) {

--- a/packages/nexus-agents/src/agents/collaboration/session-helpers.ts
+++ b/packages/nexus-agents/src/agents/collaboration/session-helpers.ts
@@ -358,6 +358,12 @@ export function shouldFinalize(
   votes: VoteMessage[],
   reviews: ReviewResponseMessage[]
 ): boolean {
+  // A session with no participants has nothing to finalize. Both equality
+  // comparisons below are `0 === 0` on an empty roster, so an empty session
+  // used to transition to `finalizing` as though its work were complete — the
+  // `review` branch already guarded with `> 0`, the other two did not (#4585).
+  if (participants.length === 0) return false;
+
   switch (pattern) {
     case 'sequential':
     case 'parallel':

--- a/packages/nexus-agents/src/agents/skills/skill-composer.test.ts
+++ b/packages/nexus-agents/src/agents/skills/skill-composer.test.ts
@@ -161,6 +161,20 @@ describe('SkillComposer', () => {
         expect(validation.errors.length).toBeGreaterThan(0);
       }
     });
+
+    it('does not report an empty composition as valid (#4585)', () => {
+      // A composition with zero steps executes nothing; the step loop never
+      // runs, so `errors.length === 0` used to render absence as validity.
+      const validation = composer.validateComposition({
+        steps: [],
+        description: 'Empty composition',
+        estimatedComplexity: 'primitive',
+        confidence: 1,
+      });
+
+      expect(validation.valid).toBe(false);
+      expect(validation.errors.some((e) => e.includes('no steps'))).toBe(true);
+    });
   });
 
   describe('configuration', () => {

--- a/packages/nexus-agents/src/agents/skills/skill-composer.ts
+++ b/packages/nexus-agents/src/agents/skills/skill-composer.ts
@@ -94,11 +94,24 @@ export class SkillComposer {
 
   /**
    * Validates that a composition is executable.
+   *
+   * A zero-step composition is reported invalid rather than valid: the step
+   * loop below never runs, so `errors.length === 0` would report "executable"
+   * having checked nothing, and executing it would do nothing (#4585).
    */
   validateComposition(composition: SkillComposition): CompositionValidation {
     const errors: string[] = [];
     const warnings: string[] = [];
     const seenSkills = new Set<string>();
+
+    // Name the empty case (#4585): nothing to execute is not a passing check.
+    if (composition.steps.length === 0) {
+      return {
+        valid: false,
+        errors: ['Composition has no steps; there is nothing to execute or validate'],
+        warnings,
+      };
+    }
 
     for (const step of composition.steps) {
       const skill = this.library.getSkill(step.skillId);

--- a/packages/nexus-agents/src/benchmarks/benchmark-runner.test.ts
+++ b/packages/nexus-agents/src/benchmarks/benchmark-runner.test.ts
@@ -463,6 +463,25 @@ describe('createBenchmarkSummary', () => {
     expect(summary.failures).toHaveLength(0);
   });
 
+  // #4585: `passed` was `failures.length === 0` over a loop that never ran for
+  // an empty suite, so a run that benchmarked nothing certified the perf gate.
+  it('should not pass when zero operations were benchmarked', () => {
+    const summary = createBenchmarkSummary([]);
+
+    expect(summary.passed).toBe(false);
+    expect(summary.failures).toHaveLength(1);
+    expect(summary.failures[0]).toContain('No operations were benchmarked');
+  });
+
+  it('should report zero rather than NaN aggregates for an empty suite', () => {
+    const summary = createBenchmarkSummary([]);
+
+    expect(summary.totalOperations).toBe(0);
+    expect(summary.totalDurationMs).toBe(0);
+    expect(summary.overallThroughput).toBe(0);
+    expect(summary.avgP95Latency).toBe(0);
+  });
+
   it('should fail when p95 latency exceeds threshold', () => {
     const operations = [
       createMockOperation({

--- a/packages/nexus-agents/src/benchmarks/benchmark-runner.ts
+++ b/packages/nexus-agents/src/benchmarks/benchmark-runner.ts
@@ -229,6 +229,24 @@ export function createBenchmarkSummary(
   config: Partial<BenchmarkConfig> = {}
 ): BenchmarkSummary {
   const cfg = { ...DEFAULT_BENCHMARK_CONFIG, ...config };
+
+  // A suite that benchmarked nothing measured nothing: every threshold check
+  // below is inside a loop over `operations`, so an empty run left `failures`
+  // empty and reported the perf gate as passed (#4585). `passed` is a plain
+  // boolean and cannot say "unmeasured", so report the honest `false` and name
+  // the reason in `failures`. The aggregates are 0 rather than NaN (0/0) for
+  // the same reason: an unmeasured run should not print as a metric.
+  if (operations.length === 0) {
+    return {
+      totalDurationMs: 0,
+      totalOperations: 0,
+      overallThroughput: 0,
+      avgP95Latency: 0,
+      passed: false,
+      failures: ['No operations were benchmarked - thresholds unmeasured'],
+    };
+  }
+
   const failures: string[] = [];
 
   // Calculate aggregates

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/confidence-cascade-stage.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/confidence-cascade-stage.test.ts
@@ -128,6 +128,32 @@ describe('ConfidenceCascadeStage', () => {
       }
     });
 
+    it('escalates for zero candidates and says why (#4585)', async () => {
+      // `Math.max(...[])` is -Infinity, so escalation for a task with no
+      // candidate models was an emergent side effect of an empty spread.
+      // Escalating is the right call — no candidates means no confidence
+      // evidence — but the record must name the reason, not imply that a
+      // measured confidence score fell below the threshold.
+      const ctx = createContext('design a distributed architecture with security review', []);
+      const result = await stage.route(ctx);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.context.signals).toContain('confidence:should-escalate');
+        expect(result.value.context.signals).toContain('confidence:no-candidates');
+      }
+    });
+
+    it('does not claim no-candidates when candidates were scored (#4585)', async () => {
+      const ctx = createContext('design a distributed architecture with security review');
+      const result = await stage.route(ctx);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.context.signals).not.toContain('confidence:no-candidates');
+      }
+    });
+
     it('updates scores for all candidates', async () => {
       const ctx = createContext('test task');
       const result = await stage.route(ctx);

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/confidence-cascade-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/confidence-cascade-stage.ts
@@ -187,12 +187,22 @@ export class ConfidenceCascadeStage implements IRouterStage {
 
   /**
    * Check if task should escalate to more capable model.
+   *
+   * Zero candidates escalate, deliberately (#4585). That was already the
+   * behaviour, but only as an accident of `Math.max(...[]) === -Infinity`
+   * landing below any threshold. Keeping it is correct — with no candidate
+   * models there is no confidence evidence, and for a non-simple task the
+   * fail-safe direction is to escalate rather than to accept a model nobody
+   * scored — so state it instead of leaving it emergent. `buildSignals`
+   * records `confidence:no-candidates` so the trace does not imply that a
+   * measured score fell short.
    */
   private checkEscalation(
     scores: Array<{ cli: CliName; score: number }>,
     complexity: TaskComplexity
   ): boolean {
     if (complexity === 'simple') return false;
+    if (scores.length === 0) return true;
 
     const maxScore = Math.max(...scores.map((s) => s.score));
     return maxScore < this.config.escalationThreshold;
@@ -210,6 +220,12 @@ export class ConfidenceCascadeStage implements IRouterStage {
     const signals = [...existing];
 
     signals.push(`confidence:complexity-${complexity}`);
+
+    // Distinguish "nothing was scored" from "the best score was too low"
+    // (#4585) — both escalate, but only one of them is a measurement.
+    if (scores.length === 0) {
+      signals.push('confidence:no-candidates');
+    }
 
     if (shouldEscalate) {
       signals.push('confidence:should-escalate');

--- a/packages/nexus-agents/src/mcp/safety/stpa-analyzer.test.ts
+++ b/packages/nexus-agents/src/mcp/safety/stpa-analyzer.test.ts
@@ -567,8 +567,14 @@ describe('validateToolAgainstConstraints', () => {
     ];
 
     const result = validateToolAgainstConstraints(safeTool, constraints);
-    expect(result.valid).toBe(true);
+    // Previously pinned the vacuous pass: `safeTool` declares no input
+    // properties, so every schema-driven check is a no-op and "no violations"
+    // is evidence of nothing. Unmeasured is now reported as not-valid (#4585);
+    // the empty `violations` list plus the NO_INPUT_SCHEMA warning is what
+    // distinguishes it from a real violation.
+    expect(result.valid).toBe(false);
     expect(result.violations).toHaveLength(0);
+    expect(result.warnings.some((w) => w.code === 'NO_INPUT_SCHEMA')).toBe(true);
   });
 
   it('should detect missing input validation for path parameters', () => {

--- a/packages/nexus-agents/src/mcp/safety/stpa-analyzer.test.ts
+++ b/packages/nexus-agents/src/mcp/safety/stpa-analyzer.test.ts
@@ -555,7 +555,7 @@ describe('generateSafetyConstraints', () => {
 // =============================================================================
 
 describe('validateToolAgainstConstraints', () => {
-  it('should return valid when no violations found', () => {
+  it('should return valid for a parameterless tool with no violations', () => {
     const constraints: SafetyConstraint[] = [
       {
         id: 'SC-001',
@@ -567,12 +567,12 @@ describe('validateToolAgainstConstraints', () => {
     ];
 
     const result = validateToolAgainstConstraints(safeTool, constraints);
-    // Previously pinned the vacuous pass: `safeTool` declares no input
-    // properties, so every schema-driven check is a no-op and "no violations"
-    // is evidence of nothing. Unmeasured is now reported as not-valid (#4585);
-    // the empty `violations` list plus the NO_INPUT_SCHEMA warning is what
-    // distinguishes it from a real violation.
-    expect(result.valid).toBe(false);
+    // `get_time` is genuinely parameterless: its empty `properties` map is a
+    // measurement (nothing to sanitize), not an absent schema, so a constraint
+    // that finds nothing wrong yields a real pass (#4585). Only an
+    // absent/unreadable schema is unmeasured — covered separately in
+    // stpa-validation.test.ts.
+    expect(result.valid).toBe(true);
     expect(result.violations).toHaveLength(0);
     expect(result.warnings.some((w) => w.code === 'NO_INPUT_SCHEMA')).toBe(true);
   });

--- a/packages/nexus-agents/src/mcp/safety/stpa-validation-boundaries.test.ts
+++ b/packages/nexus-agents/src/mcp/safety/stpa-validation-boundaries.test.ts
@@ -104,7 +104,9 @@ describe('STPA Validation - Input Validation', () => {
       const constraints: SafetyConstraint[] = [];
 
       const result = validateToolAgainstConstraints(tool, constraints);
-      expect(result.valid).toBe(true);
+      // Previously pinned the vacuous pass: zero constraints and no declared
+      // input properties means nothing was measured (#4585).
+      expect(result.valid).toBe(false);
     });
 
     it('should handle tool with empty description', () => {
@@ -112,7 +114,8 @@ describe('STPA Validation - Input Validation', () => {
       const constraints: SafetyConstraint[] = [];
 
       const result = validateToolAgainstConstraints(tool, constraints);
-      expect(result.valid).toBe(true);
+      // Previously pinned the vacuous pass (see above) — unmeasured, not valid (#4585).
+      expect(result.valid).toBe(false);
     });
   });
 
@@ -144,7 +147,10 @@ describe('STPA Validation - Input Validation', () => {
       const constraints: SafetyConstraint[] = [];
 
       const result = validateToolAgainstConstraints(tool, constraints);
-      expect(result.valid).toBe(true);
+      // Previously pinned the vacuous pass: the properties are rich, but zero
+      // constraints were evaluated, so no verdict was earned (#4585).
+      expect(result.valid).toBe(false);
+      expect(result.warnings.some((w) => w.code === 'NO_CONSTRAINTS_EVALUATED')).toBe(true);
     });
 
     it('should detect path parameters without validation', () => {
@@ -671,11 +677,14 @@ describe('STPA Validation - Result Structure', () => {
     expect(result.validatedAt.getTime()).toBeLessThanOrEqual(Date.now());
   });
 
-  it('should set valid=true when no violations', () => {
+  it('should set valid=false when nothing could be measured', () => {
     const tool = createTool('safe_tool', 'A safe tool', {});
     const result = validateToolAgainstConstraints(tool, []);
 
-    expect(result.valid).toBe(true);
+    // Previously pinned the vacuous pass (`valid=true when no violations`) for
+    // a tool with no declared inputs checked against zero constraints (#4585).
+    expect(result.valid).toBe(false);
+    expect(result.violations).toHaveLength(0);
   });
 
   it('should set valid=false when violations exist', () => {

--- a/packages/nexus-agents/src/mcp/safety/stpa-validation.test.ts
+++ b/packages/nexus-agents/src/mcp/safety/stpa-validation.test.ts
@@ -52,12 +52,14 @@ afterEach(() => {
 // -- Happy Path ---------------------------------------------------------------
 
 describe('validateToolAgainstConstraints - happy path', () => {
-  it('returns valid=true with no constraints', () => {
+  it('returns valid=false with no constraints (nothing was evaluated)', () => {
     const result = validateToolAgainstConstraints(
       makeTool('my_tool', 'Does something', { data: { type: 'string' } }),
       []
     );
-    expect(result.valid).toBe(true);
+    // Previously pinned the vacuous pass (`valid: true` over an empty
+    // constraint loop). Zero constraints means the tool was not measured (#4585).
+    expect(result.valid).toBe(false);
     expect(result.toolName).toBe('my_tool');
     expect(result.violations).toHaveLength(0);
     expect(result.passed).toHaveLength(0);
@@ -383,5 +385,65 @@ describe('edge cases', () => {
       [makeConstraint('F1', 'Sanitize to prevent injection', ConstraintEnforcement.SANITIZE)]
     );
     expect(result.violations.filter((v) => v.constraintId === 'F1')).toHaveLength(1);
+  });
+});
+
+// -- Vacuous validity (#4585) -------------------------------------------------
+
+describe('vacuous validity (#4585)', () => {
+  it('does not report a tool with no input schema as valid', () => {
+    const tool: ToolDefinition = {
+      name: 'bare_tool',
+      description: 'Takes no declared parameters',
+      inputSchema: { type: 'object' },
+    };
+    const result = validateToolAgainstConstraints(tool, [
+      makeConstraint('U1', 'Sanitize to prevent injection', ConstraintEnforcement.SANITIZE),
+    ]);
+    // Inputs could not be inspected at all, so "passes all constraints" is
+    // unmeasured, not true.
+    expect(result.valid).toBe(false);
+    expect(result.warnings.some((w) => w.code === 'NO_INPUT_SCHEMA')).toBe(true);
+  });
+
+  it('does not report a tool with an empty properties map as valid', () => {
+    const result = validateToolAgainstConstraints(makeTool('bare2', 'No params', {}), [
+      makeConstraint('U2', 'Sanitize to prevent injection', ConstraintEnforcement.SANITIZE),
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  it('does not report validity when zero constraints were evaluated', () => {
+    const result = validateToolAgainstConstraints(
+      makeTool('my_tool', 'Does something', { data: { type: 'string' } }),
+      []
+    );
+    expect(result.valid).toBe(false);
+    expect(result.warnings.some((w) => w.code === 'NO_CONSTRAINTS_EVALUATED')).toBe(true);
+  });
+
+  it('omits NO_CONSTRAINTS_EVALUATED when at least one constraint was evaluated', () => {
+    const result = validateToolAgainstConstraints(
+      makeTool('my_tool', 'Does something', { data: { type: 'string' } }),
+      [makeConstraint('U3', 'Alert on cosmic rays', ConstraintEnforcement.ALERT)]
+    );
+    expect(result.warnings.every((w) => w.code !== 'NO_CONSTRAINTS_EVALUATED')).toBe(true);
+  });
+
+  it('still reports valid for a measured tool with no violations', () => {
+    const result = validateToolAgainstConstraints(
+      makeTool('calculator', 'Math', { x: { type: 'number' } }),
+      [makeConstraint('U4', 'Prevent random stuff', ConstraintEnforcement.PREVENT)]
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('reports invalid (not unmeasured) when a real violation exists', () => {
+    const result = validateToolAgainstConstraints(
+      makeTool('bash', 'Shell', { command: { type: 'string' } }),
+      [makeConstraint('U5', 'Prevent injection', ConstraintEnforcement.PREVENT)]
+    );
+    expect(result.valid).toBe(false);
+    expect(result.violations.length).toBeGreaterThan(0);
   });
 });

--- a/packages/nexus-agents/src/mcp/safety/stpa-validation.test.ts
+++ b/packages/nexus-agents/src/mcp/safety/stpa-validation.test.ts
@@ -406,11 +406,27 @@ describe('vacuous validity (#4585)', () => {
     expect(result.warnings.some((w) => w.code === 'NO_INPUT_SCHEMA')).toBe(true);
   });
 
-  it('does not report a tool with an empty properties map as valid', () => {
-    const result = validateToolAgainstConstraints(makeTool('bare2', 'No params', {}), [
-      makeConstraint('U2', 'Sanitize to prevent injection', ConstraintEnforcement.SANITIZE),
-    ]);
-    expect(result.valid).toBe(false);
+  it('reports a parameterless tool as valid when an applicable constraint passes', () => {
+    // An empty `properties` map is a *measurement*, not a missing one: this
+    // tool genuinely takes no parameters, so there is nothing to sanitize and
+    // the sanitization constraint below genuinely passes. Treating the empty
+    // map as unmeasured made `valid: true` unreachable for every parameterless
+    // tool — a permanent false alarm (#4585 follow-up).
+    const result = validateToolAgainstConstraints(
+      makeTool('list_workspace_files', 'List every file in the workspace root', {}),
+      // Applies via the ('path' in constraint, 'file' in tool) description
+      // pattern in doesConstraintApply, so this constraint is really evaluated.
+      [
+        makeConstraint(
+          'U2',
+          'Sanitize path input to prevent traversal',
+          ConstraintEnforcement.SANITIZE
+        ),
+      ]
+    );
+    expect(result.valid).toBe(true);
+    expect(result.violations).toHaveLength(0);
+    expect(result.passed).toContain('U2');
   });
 
   it('does not report validity when zero constraints were evaluated', () => {
@@ -430,12 +446,39 @@ describe('vacuous validity (#4585)', () => {
     expect(result.warnings.every((w) => w.code !== 'NO_CONSTRAINTS_EVALUATED')).toBe(true);
   });
 
-  it('still reports valid for a measured tool with no violations', () => {
+  it('still reports valid when an applicable constraint is evaluated and passes', () => {
+    // Positive control. The constraint must genuinely APPLY to the tool,
+    // otherwise checkConstraint returns null and the id lands in `passed`
+    // without being evaluated — which would certify "measured" on zero
+    // applicable constraints, the same defect this suite exists to catch.
+    // Applicability here comes from doesConstraintApply's ('path', 'file')
+    // description pattern; the second assertion block proves the check is live
+    // by removing the property pattern and getting a violation.
+    const constraints = [
+      makeConstraint(
+        'U4',
+        'Sanitize path input to prevent traversal',
+        ConstraintEnforcement.SANITIZE
+      ),
+    ];
+
     const result = validateToolAgainstConstraints(
-      makeTool('calculator', 'Math', { x: { type: 'number' } }),
-      [makeConstraint('U4', 'Prevent random stuff', ConstraintEnforcement.PREVENT)]
+      makeTool('read_file', 'Read a file from disk', {
+        path: { type: 'string', pattern: '^[\\w./-]+$' },
+      }),
+      constraints
     );
     expect(result.valid).toBe(true);
+    expect(result.violations).toHaveLength(0);
+    expect(result.passed).toContain('U4');
+
+    // Same tool, same constraint, no validation pattern: the constraint fires,
+    // so the pass above was earned rather than skipped.
+    const unpatterned = validateToolAgainstConstraints(
+      makeTool('read_file', 'Read a file from disk', { path: { type: 'string' } }),
+      constraints
+    );
+    expect(unpatterned.violations.map((v) => v.constraintId)).toContain('U4');
   });
 
   it('reports invalid (not unmeasured) when a real violation exists', () => {

--- a/packages/nexus-agents/src/mcp/safety/stpa-validation.ts
+++ b/packages/nexus-agents/src/mcp/safety/stpa-validation.ts
@@ -31,6 +31,13 @@ import { classifyTool, ToolCategory } from './hazard-catalog.js';
  *  - no input schema — inputs cannot be inspected, so no input-shaped
  *    constraint can be judged (the code already said as much in a warning)
  *
+ * "No input schema" means the `properties` map is *absent or unreadable*. An
+ * empty `properties` map is not that case: a parameterless tool has been
+ * inspected and found to have nothing to sanitize, which is a measurement.
+ * Conflating the two made `valid: true` unreachable for every parameterless
+ * tool — a check that can only ever fail is as useless as one that can only
+ * ever pass.
+ *
  * Callers distinguish "unmeasured" from "violated" with the existing fields:
  * `violations` is non-empty for a real violation, while an unmeasured result
  * carries the `NO_CONSTRAINTS_EVALUATED` / `NO_INPUT_SCHEMA` warning codes.
@@ -73,9 +80,8 @@ export function validateToolAgainstConstraints(
   }
 
   // Add warnings for tools without schema validation
-  const inputsUnvalidatable =
-    !tool.inputSchema.properties || Object.keys(tool.inputSchema.properties).length === 0;
-  if (inputsUnvalidatable) {
+  const inputs = inspectInputSchema(tool);
+  if (inputs.noParameters) {
     warnings.push({
       code: 'NO_INPUT_SCHEMA',
       message: 'Tool has no input schema defined; cannot validate inputs',
@@ -94,7 +100,7 @@ export function validateToolAgainstConstraints(
 
   // Name the empty case instead of letting `violations.length === 0` speak for
   // it: an unmeasured tool is not a passing tool (#4585).
-  const measured = !noConstraintsEvaluated && !inputsUnvalidatable;
+  const measured = !noConstraintsEvaluated && !inputs.uninspectable;
 
   return {
     valid: measured && violations.length === 0,
@@ -103,6 +109,34 @@ export function validateToolAgainstConstraints(
     passed,
     warnings,
     validatedAt: new Date(getTimeProvider().now()),
+  };
+}
+
+/** What the tool's declared input schema does and does not tell us (#4585). */
+interface InputSchemaInspection {
+  /**
+   * The property map is absent or is not a readable object, so the inputs
+   * could not be inspected at all — no input-shaped constraint can be judged.
+   */
+  readonly uninspectable: boolean;
+  /**
+   * The tool exposes no parameters — either because the map was unreadable or
+   * because it is present and empty. An empty map is a measurement (there is
+   * nothing to sanitize), which is why it is tracked separately from
+   * `uninspectable`.
+   */
+  readonly noParameters: boolean;
+}
+
+/**
+ * Separates "inputs could not be inspected" from "tool declares no parameters".
+ */
+function inspectInputSchema(tool: ToolDefinition): InputSchemaInspection {
+  const declaredProperties = tool.inputSchema.properties;
+  const uninspectable = declaredProperties === undefined || typeof declaredProperties !== 'object';
+  return {
+    uninspectable,
+    noParameters: uninspectable || Object.keys(declaredProperties).length === 0,
   };
 }
 

--- a/packages/nexus-agents/src/mcp/safety/stpa-validation.ts
+++ b/packages/nexus-agents/src/mcp/safety/stpa-validation.ts
@@ -22,6 +22,22 @@ import { classifyTool, ToolCategory } from './hazard-catalog.js';
 /**
  * Validates a tool against a set of safety constraints.
  *
+ * `valid` is an assertion that the tool was *measured* and passed. It is true
+ * only when at least one constraint was evaluated, the tool's inputs were
+ * inspectable, and nothing was violated. Two vacuous-pass cases used to report
+ * `valid: true` because `violations.length === 0` (#4585):
+ *
+ *  - zero constraints — the check loop never ran, so nothing was measured
+ *  - no input schema — inputs cannot be inspected, so no input-shaped
+ *    constraint can be judged (the code already said as much in a warning)
+ *
+ * Callers distinguish "unmeasured" from "violated" with the existing fields:
+ * `violations` is non-empty for a real violation, while an unmeasured result
+ * carries the `NO_CONSTRAINTS_EVALUATED` / `NO_INPUT_SCHEMA` warning codes.
+ * `ValidationResult.valid` is a boolean in the shared type, so the honest value
+ * for "could not be measured" is `false` — fail closed rather than launder an
+ * uninspected tool as safe.
+ *
  * @param tool - Tool definition to validate
  * @param constraints - Safety constraints to check against
  * @returns Validation result with violations and warnings
@@ -46,8 +62,20 @@ export function validateToolAgainstConstraints(
     }
   }
 
+  // Nothing was checked: the constraint loop above iterated zero times (#4585).
+  const noConstraintsEvaluated = constraints.length === 0;
+  if (noConstraintsEvaluated) {
+    warnings.push({
+      code: 'NO_CONSTRAINTS_EVALUATED',
+      message: 'No safety constraints were supplied; the tool was not measured',
+      affected: 'constraints',
+    });
+  }
+
   // Add warnings for tools without schema validation
-  if (!tool.inputSchema.properties || Object.keys(tool.inputSchema.properties).length === 0) {
+  const inputsUnvalidatable =
+    !tool.inputSchema.properties || Object.keys(tool.inputSchema.properties).length === 0;
+  if (inputsUnvalidatable) {
     warnings.push({
       code: 'NO_INPUT_SCHEMA',
       message: 'Tool has no input schema defined; cannot validate inputs',
@@ -64,8 +92,12 @@ export function validateToolAgainstConstraints(
     });
   }
 
+  // Name the empty case instead of letting `violations.length === 0` speak for
+  // it: an unmeasured tool is not a passing tool (#4585).
+  const measured = !noConstraintsEvaluated && !inputsUnvalidatable;
+
   return {
-    valid: violations.length === 0,
+    valid: measured && violations.length === 0,
     toolName: tool.name,
     violations,
     passed,

--- a/packages/nexus-agents/src/orchestration/consensus-plan.test.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan.test.ts
@@ -6,8 +6,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ok, err } from '../core/index.js';
 import type { ICliAdapter, CliName, CliResponse, CliError } from '../cli-adapters/types.js';
-import { executeConsensusPlan } from './consensus-plan.js';
+import { executeConsensusPlan, findDivergences } from './consensus-plan.js';
 import { createDefaultPlanConfig } from './consensus-plan-types.js';
+import type { CliPlan, CliPlanPartition } from './consensus-plan-types.js';
 import { resetOutcomeStore, getOutcomeStore } from './outcomes/index.js';
 
 // Force in-memory outcome store (avoid hydrating from disk in tests)
@@ -440,5 +441,75 @@ describe('executeConsensusPlan', () => {
     if (!result.ok) return;
     expect(result.value.partitions[0]?.model).toBe('claude');
     expect(getOutcomeStore().query({})[0]?.model).toBe('claude');
+  });
+});
+
+// ============================================================================
+// findDivergences — empty-collection verdicts (#4585)
+// ============================================================================
+
+function makePartition(cli: CliName, plan: CliPlan | null): CliPlanPartition {
+  return {
+    cli,
+    success: plan !== null,
+    plan,
+    rawOutput: '',
+    durationMs: 1,
+    model: `${cli}-model`,
+  };
+}
+
+function makePlan(stepCount: number, riskCount: number): CliPlan {
+  return {
+    steps: Array.from({ length: stepCount }, (_, i) => ({
+      description: `step ${String(i)}`,
+      complexity: 'medium' as const,
+      dependencies: [],
+    })),
+    risks: Array.from({ length: riskCount }, (_, i) => ({
+      description: `risk ${String(i)}`,
+      impact: 'medium' as const,
+      mitigation: '',
+    })),
+    alternatives: [],
+    summary: '',
+  };
+}
+
+describe('findDivergences', () => {
+  it('reports comparison as unmeasured when no plan parsed (#4585)', () => {
+    // Math.min(...[]) is Infinity and Math.max(...[]) is -Infinity, so every
+    // threshold below evaluated false and synthesis reported a clean sheet
+    // over zero plans.
+    const divergences = findDivergences([
+      makePartition('claude', null),
+      makePartition('codex', null),
+    ]);
+
+    expect(divergences).toHaveLength(1);
+    expect(divergences[0]?.topic).toContain('unmeasured');
+    expect(divergences[0]?.positions.get('claude')).toBeDefined();
+  });
+
+  it('reports comparison as unmeasured for an empty plan list (#4585)', () => {
+    const divergences = findDivergences([]);
+    expect(divergences).toHaveLength(1);
+    expect(divergences[0]?.topic).toContain('unmeasured');
+  });
+
+  it('still detects real step-count divergence', () => {
+    const divergences = findDivergences([
+      makePartition('claude', makePlan(2, 0)),
+      makePartition('codex', makePlan(10, 0)),
+    ]);
+    expect(divergences.some((d) => d.topic === 'Plan granularity')).toBe(true);
+  });
+
+  it('reports no divergence when plans agree', () => {
+    const divergences = findDivergences([
+      makePartition('claude', makePlan(3, 1)),
+      makePartition('codex', makePlan(3, 1)),
+    ]);
+    expect(divergences).toHaveLength(0);
   });
 });

--- a/packages/nexus-agents/src/orchestration/consensus-plan.test.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan.test.ts
@@ -6,9 +6,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ok, err } from '../core/index.js';
 import type { ICliAdapter, CliName, CliResponse, CliError } from '../cli-adapters/types.js';
-import { executeConsensusPlan, findDivergences } from './consensus-plan.js';
+import { executeConsensusPlan } from './consensus-plan.js';
 import { createDefaultPlanConfig } from './consensus-plan-types.js';
-import type { CliPlan, CliPlanPartition } from './consensus-plan-types.js';
 import { resetOutcomeStore, getOutcomeStore } from './outcomes/index.js';
 
 // Force in-memory outcome store (avoid hydrating from disk in tests)
@@ -131,6 +130,24 @@ describe('executeConsensusPlan', () => {
     ],
     alternatives: ['Use monorepo structure'],
     summary: 'Four-phase iterative development with TDD',
+  });
+
+  it('says so when every CLI answered but none produced a parseable plan (#4585)', async () => {
+    // Both CLIs succeed, so `clisUsed` is non-empty, but neither output parses,
+    // so `successPlans` is empty. The summary used to render as an ordinary
+    // consensus plan that happened to have zero steps — a clean sheet over zero
+    // evidence — rather than saying nothing was comparable.
+    const adapters = buildAdapters(
+      ['claude', createPlanAdapter('claude', 'I would start by thinking about it.')],
+      ['codex', createPlanAdapter('codex', 'Here are some thoughts, no structure.')]
+    );
+
+    const result = await executeConsensusPlan('Plan something', adapters);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.summary).toContain('No parseable plan');
+    expect(result.value.summary).not.toMatch(/\*\*0 steps\*\*/);
   });
 
   it('dispatches plan to multiple CLIs', async () => {
@@ -441,75 +458,5 @@ describe('executeConsensusPlan', () => {
     if (!result.ok) return;
     expect(result.value.partitions[0]?.model).toBe('claude');
     expect(getOutcomeStore().query({})[0]?.model).toBe('claude');
-  });
-});
-
-// ============================================================================
-// findDivergences — empty-collection verdicts (#4585)
-// ============================================================================
-
-function makePartition(cli: CliName, plan: CliPlan | null): CliPlanPartition {
-  return {
-    cli,
-    success: plan !== null,
-    plan,
-    rawOutput: '',
-    durationMs: 1,
-    model: `${cli}-model`,
-  };
-}
-
-function makePlan(stepCount: number, riskCount: number): CliPlan {
-  return {
-    steps: Array.from({ length: stepCount }, (_, i) => ({
-      description: `step ${String(i)}`,
-      complexity: 'medium' as const,
-      dependencies: [],
-    })),
-    risks: Array.from({ length: riskCount }, (_, i) => ({
-      description: `risk ${String(i)}`,
-      impact: 'medium' as const,
-      mitigation: '',
-    })),
-    alternatives: [],
-    summary: '',
-  };
-}
-
-describe('findDivergences', () => {
-  it('reports comparison as unmeasured when no plan parsed (#4585)', () => {
-    // Math.min(...[]) is Infinity and Math.max(...[]) is -Infinity, so every
-    // threshold below evaluated false and synthesis reported a clean sheet
-    // over zero plans.
-    const divergences = findDivergences([
-      makePartition('claude', null),
-      makePartition('codex', null),
-    ]);
-
-    expect(divergences).toHaveLength(1);
-    expect(divergences[0]?.topic).toContain('unmeasured');
-    expect(divergences[0]?.positions.get('claude')).toBeDefined();
-  });
-
-  it('reports comparison as unmeasured for an empty plan list (#4585)', () => {
-    const divergences = findDivergences([]);
-    expect(divergences).toHaveLength(1);
-    expect(divergences[0]?.topic).toContain('unmeasured');
-  });
-
-  it('still detects real step-count divergence', () => {
-    const divergences = findDivergences([
-      makePartition('claude', makePlan(2, 0)),
-      makePartition('codex', makePlan(10, 0)),
-    ]);
-    expect(divergences.some((d) => d.topic === 'Plan granularity')).toBe(true);
-  });
-
-  it('reports no divergence when plans agree', () => {
-    const divergences = findDivergences([
-      makePartition('claude', makePlan(3, 1)),
-      makePartition('codex', makePlan(3, 1)),
-    ]);
-    expect(divergences).toHaveLength(0);
   });
 });

--- a/packages/nexus-agents/src/orchestration/consensus-plan.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan.ts
@@ -367,14 +367,34 @@ function stepsOverlap(a: string, b: string): boolean {
   return overlap / smaller > STEP_OVERLAP_THRESHOLD;
 }
 
-/** Finds divergence points between plans. */
-function findDivergences(plans: readonly CliPlanPartition[]): Divergence[] {
+/**
+ * Finds divergence points between plans.
+ *
+ * Exported for direct testing of the zero-plan contract below (#4585); the
+ * production caller is `synthesize`.
+ */
+export function findDivergences(plans: readonly CliPlanPartition[]): Divergence[] {
   const divergences: Divergence[] = [];
 
+  const comparable = plans.filter((p) => p.plan !== null);
+
+  // Zero comparable plans is not agreement (#4585). `Math.min(...[])` is
+  // `Infinity` and `Math.max(...[])` is `-Infinity`, so the granularity test
+  // below evaluated false and the risk test found neither side — and the
+  // synthesis reported "no divergences" over nothing at all, which reads in
+  // the record as "the CLIs agreed". Name the empty case: comparison was
+  // unmeasured, and say so instead of emitting a clean sheet.
+  if (comparable.length === 0) {
+    const positions = new Map<CliName, string>();
+    for (const p of plans) {
+      positions.set(p.cli, 'No parsed plan');
+    }
+    divergences.push({ topic: 'Plan comparison unmeasured (no parsed plans)', positions });
+    return divergences;
+  }
+
   // Compare step counts
-  const stepCounts = plans
-    .filter((p) => p.plan !== null)
-    .map((p) => ({ cli: p.cli, count: p.plan?.steps.length ?? 0 }));
+  const stepCounts = comparable.map((p) => ({ cli: p.cli, count: p.plan?.steps.length ?? 0 }));
 
   const counts = stepCounts.map((s) => s.count);
   const minSteps = Math.min(...counts);
@@ -389,9 +409,7 @@ function findDivergences(plans: readonly CliPlanPartition[]): Divergence[] {
   }
 
   // Compare risk assessments
-  const riskCounts = plans
-    .filter((p) => p.plan !== null)
-    .map((p) => ({ cli: p.cli, count: p.plan?.risks.length ?? 0 }));
+  const riskCounts = comparable.map((p) => ({ cli: p.cli, count: p.plan?.risks.length ?? 0 }));
 
   const highRiskClis = riskCounts.filter((r) => r.count > 0);
   const noRiskClis = riskCounts.filter((r) => r.count === 0);

--- a/packages/nexus-agents/src/orchestration/consensus-plan.ts
+++ b/packages/nexus-agents/src/orchestration/consensus-plan.ts
@@ -87,7 +87,7 @@ export async function executeConsensusPlan(
       const { agreedSteps, divergences } = synthesize(successPlans);
       const risks = collectRisks(successPlans);
       const alternatives = collectAlternatives(successPlans);
-      const summary = buildPlanSummary(agreedSteps, divergences, clisUsed);
+      const summary = buildPlanSummary(agreedSteps, divergences, clisUsed, successPlans.length);
 
       recordPlanOutcomes(partitions);
 
@@ -370,28 +370,14 @@ function stepsOverlap(a: string, b: string): boolean {
 /**
  * Finds divergence points between plans.
  *
- * Exported for direct testing of the zero-plan contract below (#4585); the
- * production caller is `synthesize`.
+ * `synthesize` only reaches this with two or more parsed plans, so the
+ * `Math.min(...[])`/`Math.max(...[])` empty case cannot occur here. The
+ * unmeasured-comparison verdict belongs at the summary instead (#4585).
  */
-export function findDivergences(plans: readonly CliPlanPartition[]): Divergence[] {
+function findDivergences(plans: readonly CliPlanPartition[]): Divergence[] {
   const divergences: Divergence[] = [];
 
   const comparable = plans.filter((p) => p.plan !== null);
-
-  // Zero comparable plans is not agreement (#4585). `Math.min(...[])` is
-  // `Infinity` and `Math.max(...[])` is `-Infinity`, so the granularity test
-  // below evaluated false and the risk test found neither side — and the
-  // synthesis reported "no divergences" over nothing at all, which reads in
-  // the record as "the CLIs agreed". Name the empty case: comparison was
-  // unmeasured, and say so instead of emitting a clean sheet.
-  if (comparable.length === 0) {
-    const positions = new Map<CliName, string>();
-    for (const p of plans) {
-      positions.set(p.cli, 'No parsed plan');
-    }
-    divergences.push({ topic: 'Plan comparison unmeasured (no parsed plans)', positions });
-    return divergences;
-  }
 
   // Compare step counts
   const stepCounts = comparable.map((p) => ({ cli: p.cli, count: p.plan?.steps.length ?? 0 }));
@@ -462,10 +448,19 @@ function collectAlternatives(plans: readonly CliPlanPartition[]): string[] {
 function buildPlanSummary(
   agreedSteps: readonly AgreedStep[],
   divergences: readonly Divergence[],
-  clisUsed: readonly CliName[]
+  clisUsed: readonly CliName[],
+  parsedPlanCount: number
 ): string {
   if (clisUsed.length === 0) {
     return 'All planning CLIs failed. No plan to synthesize.';
+  }
+
+  // Every CLI answered, none of them parseably (#4585). Without this the
+  // summary rendered as an ordinary consensus plan that happened to contain
+  // zero steps and zero divergences — a clean sheet over zero evidence, which
+  // reads in the record as agreement rather than as nothing to compare.
+  if (parsedPlanCount === 0) {
+    return `No parseable plan from any of ${String(clisUsed.length)} CLI(s): ${clisUsed.join(', ')}. Nothing was compared.`;
   }
 
   const multiAgreed = agreedSteps.filter((s) => s.proposedBy.length > 1).length;

--- a/packages/nexus-agents/src/testing/memory-benchmark-output.ts
+++ b/packages/nexus-agents/src/testing/memory-benchmark-output.ts
@@ -96,6 +96,17 @@ const formatters = {
   bytes: (v: number): string => `${v.toFixed(0)}B/op`,
 };
 
+/**
+ * Outcome of one threshold check.
+ *
+ * `applied: false` (no threshold configured) is deliberately distinct from a
+ * clean `failure: null`: without that distinction an unconfigured check and a
+ * passing check are indistinguishable, which is what let a benchmark with zero
+ * thresholds report `pass` (#4585).
+ */
+type AppliedThresholdCheck = { readonly applied: true; readonly failure: string | null };
+type ThresholdCheck = { readonly applied: false } | AppliedThresholdCheck;
+
 /** Helper to check a single threshold condition. */
 function checkThreshold(
   value: number,
@@ -103,15 +114,18 @@ function checkThreshold(
   comparison: 'min' | 'max',
   label: string,
   format: (v: number) => string
-): string | null {
-  if (threshold === undefined) return null;
+): ThresholdCheck {
+  if (threshold === undefined) return { applied: false };
   const failed = comparison === 'min' ? value < threshold : value > threshold;
-  if (!failed) return null;
-  return `${label} ${format(value)} ${comparison === 'min' ? '<' : '>'} ${format(threshold)}`;
+  if (!failed) return { applied: true, failure: null };
+  return {
+    applied: true,
+    failure: `${label} ${format(value)} ${comparison === 'min' ? '<' : '>'} ${format(threshold)}`,
+  };
 }
 
 /** Build array of threshold checks for validation. */
-function buildThresholdChecks(r: MemoryBenchmarkResult, t: BenchmarkThresholds): (string | null)[] {
+function buildThresholdChecks(r: MemoryBenchmarkResult, t: BenchmarkThresholds): ThresholdCheck[] {
   const { pct, dec, ms, bytes } = formatters;
   return [
     checkThreshold(r.recallAtK[5] ?? 0, t.minRecallAt5, 'min', 'Recall@5', pct),
@@ -143,7 +157,17 @@ export function validateBenchmarkResults(
   result: MemoryBenchmarkResult,
   thresholds: BenchmarkThresholds
 ): { pass: boolean; failures: string[] } {
-  const checks = buildThresholdChecks(result, thresholds);
-  const failures = checks.filter((c): c is string => c !== null);
+  const applied = buildThresholdChecks(result, thresholds).filter(
+    (c): c is AppliedThresholdCheck => c.applied
+  );
+
+  // No configured threshold means no check ran, and `failures.length === 0`
+  // would certify a benchmark nobody measured (#4585). `pass` is a plain
+  // boolean with no way to say "unmeasured", so report `false` and name why.
+  if (applied.length === 0) {
+    return { pass: false, failures: ['No thresholds configured - benchmark unmeasured'] };
+  }
+
+  const failures = applied.map((c) => c.failure).filter((f): f is string => f !== null);
   return { pass: failures.length === 0, failures };
 }

--- a/packages/nexus-agents/src/testing/memory-benchmark.test.ts
+++ b/packages/nexus-agents/src/testing/memory-benchmark.test.ts
@@ -368,8 +368,19 @@ describe('memory-benchmark', () => {
       expect(validation.failures.length).toBeGreaterThanOrEqual(2);
     });
 
-    it('should pass with empty thresholds', () => {
+    // Previously pinned the vacuous pass: with no thresholds configured every
+    // check is skipped, so `failures.length === 0` reported an unmeasured
+    // benchmark as green. A gate that checked nothing has not passed (#4585).
+    it('should not pass with empty thresholds - nothing was measured', () => {
       const validation = validateBenchmarkResults(baseResult, {});
+
+      expect(validation.pass).toBe(false);
+      expect(validation.failures).toHaveLength(1);
+      expect(validation.failures[0]).toContain('No thresholds configured');
+    });
+
+    it('should pass when the one configured threshold is met', () => {
+      const validation = validateBenchmarkResults(baseResult, { minMrr: 0.8 });
 
       expect(validation.pass).toBe(true);
       expect(validation.failures).toEqual([]);

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-completeness.test.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-completeness.test.ts
@@ -177,6 +177,18 @@ describe('calculateConstraintScore', () => {
     expect(calculateConstraintScore(wf, constraints)).toBe(1);
   });
 
+  it('does not credit a zero-step workflow with forbidden-agent compliance (#4585)', () => {
+    const constraints: TaskConstraints = { forbiddenAgents: ['code_expert'] };
+    // `![].some(isForbidden)` is true: an empty workflow used to score a
+    // perfect 1 on a constraint it was never measured against.
+    expect(calculateConstraintScore(makeWorkflow({ steps: [] }), constraints)).toBe(0);
+  });
+
+  it('does not credit a zero-step workflow on step-derived constraints (#4585)', () => {
+    const constraints: TaskConstraints = { maxRetriesPerStep: 3, requireParallel: false };
+    expect(calculateConstraintScore(makeWorkflow({ steps: [] }), constraints)).toBe(0);
+  });
+
   it('averages multiple constraint checks', () => {
     const constraints: TaskConstraints = {
       forbiddenAgents: ['security_expert'], // passes
@@ -234,6 +246,12 @@ describe('generateFeedback', () => {
     });
     const feedback = generateFeedback(wf, makeTask());
     expect(feedback.some((f) => f.includes('no dependencies'))).toBe(true);
+  });
+
+  it('reports a zero-step workflow as empty, not as cyclic (#4585)', () => {
+    const feedback = generateFeedback(makeWorkflow({ steps: [] }), makeTask());
+    expect(feedback.some((f) => f.includes('no steps'))).toBe(true);
+    expect(feedback.some((f) => f.includes('cycle'))).toBe(false);
   });
 
   it('returns "looks good" when no issues', () => {

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-completeness.test.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-completeness.test.ts
@@ -189,6 +189,21 @@ describe('calculateConstraintScore', () => {
     expect(calculateConstraintScore(makeWorkflow({ steps: [] }), constraints)).toBe(0);
   });
 
+  it('returns 1 when constraints declare nothing this score measures (#4585)', () => {
+    // Deliberate: unlike the zero-step cases above, this is absence of
+    // criteria, not absence of evidence. `requiredAgents` is scored by
+    // calculateAgentCoverageScore and `maxTotalTimeout` by the efficiency
+    // score, so no step-derived check is applicable here and nothing can be
+    // violated. Holds for an empty workflow too - emptiness is penalised by
+    // evaluateStructure, not by inventing a constraint failure.
+    const constraints: TaskConstraints = {
+      requiredAgents: ['code_expert'],
+      maxTotalTimeout: 60000,
+    };
+    expect(calculateConstraintScore(makeWorkflow(), constraints)).toBe(1);
+    expect(calculateConstraintScore(makeWorkflow({ steps: [] }), constraints)).toBe(1);
+  });
+
   it('averages multiple constraint checks', () => {
     const constraints: TaskConstraints = {
       forbiddenAgents: ['security_expert'], // passes

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-completeness.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-completeness.ts
@@ -105,6 +105,17 @@ export function calculateConstraintScore(
     checks.push(hasSteps && hasParallel === constraints.requireParallel);
   }
 
+  // `checks.length === 0` is absence of *criteria*, not absence of *evidence*,
+  // and 1 is the honest answer (#4585). The `hasSteps` guard above covers the
+  // vacuous case: a declared constraint that no step was read to verify.
+  // Here the task declared no step-derived constraint at all, so the ratio's
+  // denominator is genuinely zero and nothing can be violated - the same
+  // convention as `!constraints` above and as the two coverage scores, which
+  // both return 1 when nothing is required. Returning 0 instead would depress
+  // completeness by a constant that depends only on the task's constraint
+  // shape, identically for every candidate workflow, so it could never
+  // discriminate between workflows - it would only make the weighted score
+  // report "unconstrained task" as "bad workflow".
   if (checks.length === 0) return 1;
   return checks.filter(Boolean).length / checks.length;
 }

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-completeness.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-completeness.ts
@@ -79,26 +79,51 @@ export function calculateConstraintScore(
 
   const checks: boolean[] = [];
 
+  // Every check below reads its evidence off `workflow.steps`. With zero steps
+  // `![].some(isForbidden)` and `[].every(withinRetries)` are both vacuously
+  // true, so an empty workflow used to score a perfect 1 on constraints it was
+  // never measured against (#4585). Name the empty case once: no steps, no
+  // evidence of satisfaction — consistent with `hasValidSteps`, which already
+  // treats a zero-step workflow as invalid.
+  const hasSteps = workflow.steps.length > 0;
+
   // Check forbidden agents
   if (constraints.forbiddenAgents && constraints.forbiddenAgents.length > 0) {
     const forbidden = new Set<AgentRole>(constraints.forbiddenAgents);
-    checks.push(!workflow.steps.some((s) => forbidden.has(s.agent)));
+    checks.push(hasSteps && !workflow.steps.some((s) => forbidden.has(s.agent)));
   }
 
   // Check max retries
   if (constraints.maxRetriesPerStep !== undefined) {
     const maxRetries = constraints.maxRetriesPerStep;
-    checks.push(workflow.steps.every((s) => (s.retries ?? 0) <= maxRetries));
+    checks.push(hasSteps && workflow.steps.every((s) => (s.retries ?? 0) <= maxRetries));
   }
 
   // Check parallel requirement
   if (constraints.requireParallel !== undefined) {
     const hasParallel = workflow.steps.some((s) => s.parallel === true);
-    checks.push(hasParallel === constraints.requireParallel);
+    checks.push(hasSteps && hasParallel === constraints.requireParallel);
   }
 
   if (checks.length === 0) return 1;
   return checks.filter(Boolean).length / checks.length;
+}
+
+/**
+ * Structural complaint about the workflow shape, or null if it is well-formed.
+ *
+ * `hasNoCycles` now reports a zero-step workflow as unverifiable rather than
+ * vacuously acyclic (#4585), so the two failures are named separately — an
+ * empty workflow has no cycle to report.
+ */
+function structuralFeedback(workflow: WorkflowDefinition): string | null {
+  if (workflow.steps.length === 0) {
+    return 'Workflow has no steps - nothing to execute or verify';
+  }
+  if (!hasNoCycles(workflow)) {
+    return 'Workflow contains dependency cycles - invalid structure';
+  }
+  return null;
 }
 
 /**
@@ -136,8 +161,9 @@ export function generateFeedback(
   }
 
   // Check for valid structure
-  if (!hasNoCycles(workflow)) {
-    feedback.push('Workflow contains dependency cycles - invalid structure');
+  const structural = structuralFeedback(workflow);
+  if (structural !== null) {
+    feedback.push(structural);
   }
 
   if (feedback.length === 0) {

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-structure.test.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-structure.test.ts
@@ -85,6 +85,12 @@ describe('evaluateStructure', () => {
     });
     expect(evaluateStructure(wf)).toBeLessThan(1.0);
   });
+
+  it('does not score a zero-step workflow as mostly sound (#4585)', () => {
+    // Four of the five structural checks pass vacuously on an empty workflow,
+    // which used to score 0.8 for a workflow `hasValidSteps` calls invalid.
+    expect(evaluateStructure(makeWorkflow({ steps: [] }))).toBeLessThanOrEqual(0.6);
+  });
 });
 
 // ============================================================================
@@ -135,6 +141,12 @@ describe('hasNoCycles', () => {
       ],
     });
     expect(hasNoCycles(wf)).toBe(true);
+  });
+
+  it('returns false for a zero-step workflow instead of a vacuous pass (#4585)', () => {
+    // `[].some()` is false, so the old `!steps.some(hasCycle)` certified a
+    // workflow with nothing in it as acyclic. There is no DAG to verify.
+    expect(hasNoCycles(makeWorkflow({ steps: [] }))).toBe(false);
   });
 });
 

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-structure.test.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-structure.test.ts
@@ -86,10 +86,13 @@ describe('evaluateStructure', () => {
     expect(evaluateStructure(wf)).toBeLessThan(1.0);
   });
 
-  it('does not score a zero-step workflow as mostly sound (#4585)', () => {
-    // Four of the five structural checks pass vacuously on an empty workflow,
-    // which used to score 0.8 for a workflow `hasValidSteps` calls invalid.
-    expect(evaluateStructure(makeWorkflow({ steps: [] }))).toBeLessThanOrEqual(0.6);
+  it('scores a zero-step workflow at zero, not on vacuous passes (#4585)', () => {
+    // Previously asserted `toBeLessThanOrEqual(0.6)`, which encoded the
+    // half-fixed state: only `hasValidSteps` and `hasNoCycles` named the empty
+    // case, so `hasValidDependencies` / `hasUniqueStepIds` /
+    // `hasValidAgentRoles` still passed vacuously and handed an empty workflow
+    // 3 of 5. A workflow with zero steps satisfies no structural property.
+    expect(evaluateStructure(makeWorkflow({ steps: [] }))).toBe(0);
   });
 });
 
@@ -165,6 +168,12 @@ describe('hasValidDependencies', () => {
     });
     expect(hasValidDependencies(wf)).toBe(false);
   });
+
+  it('returns false for a zero-step workflow instead of a vacuous pass (#4585)', () => {
+    // `[].every()` is true, so an empty workflow used to certify that all of
+    // its (nonexistent) dependencies resolve. There is nothing to resolve.
+    expect(hasValidDependencies(makeWorkflow({ steps: [] }))).toBe(false);
+  });
 });
 
 // ============================================================================
@@ -185,6 +194,12 @@ describe('hasUniqueStepIds', () => {
     });
     expect(hasUniqueStepIds(wf)).toBe(false);
   });
+
+  it('returns false for a zero-step workflow instead of a vacuous pass (#4585)', () => {
+    // `0 === new Set([]).size` is true, so an empty workflow used to certify
+    // uniqueness over an empty id list. No ids means no uniqueness observed.
+    expect(hasUniqueStepIds(makeWorkflow({ steps: [] }))).toBe(false);
+  });
 });
 
 // ============================================================================
@@ -202,6 +217,12 @@ describe('hasValidAgentRoles', () => {
     });
     expect(hasValidAgentRoles(wf)).toBe(false);
   });
+
+  it('returns false for a zero-step workflow instead of a vacuous pass (#4585)', () => {
+    // `[].every()` is true, so an empty workflow used to certify that every
+    // agent role is valid without ever reading a role.
+    expect(hasValidAgentRoles(makeWorkflow({ steps: [] }))).toBe(false);
+  });
 });
 
 // ============================================================================
@@ -215,6 +236,14 @@ describe('isViableWorkflow', () => {
 
   it('returns false for workflow below min steps', () => {
     expect(isViableWorkflow(makeWorkflow(), 5)).toBe(false);
+  });
+
+  it('rejects a zero-step workflow even when minSteps is 0 (#4585)', () => {
+    // `minSteps: 0` makes the length guard vacuous, so viability rests
+    // entirely on the structural checks. This was already false before the
+    // #4585 empty-case work (`hasValidSteps` requires >= 1 step) - the change
+    // to `hasNoCycles` did not flip it - but nothing pinned it, so pin it.
+    expect(isViableWorkflow(makeWorkflow({ steps: [] }), 0)).toBe(false);
   });
 });
 

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-structure.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-structure.ts
@@ -14,6 +14,9 @@ import { VALID_AGENT_ROLES } from './evaluation-types.js';
 /**
  * Evaluate workflow structural validity.
  * Returns a score between 0 and 1 based on structural checks.
+ *
+ * A zero-step workflow scores 0: every check below names the empty case
+ * explicitly (#4585) rather than passing vacuously over an empty step list.
  */
 export function evaluateStructure(workflow: WorkflowDefinition): number {
   const checks = [
@@ -77,24 +80,44 @@ export function hasNoCycles(workflow: WorkflowDefinition): boolean {
 
 /**
  * Check if all dependencies reference valid steps.
+ *
+ * A zero-step workflow is reported as invalid for the same reason as
+ * `hasNoCycles` (#4585): `[].every()` is true, so an empty workflow used to
+ * certify that all of its dependencies resolve without a single reference
+ * being read. No steps means no dependencies were verified, not that they all
+ * check out.
  */
 export function hasValidDependencies(workflow: WorkflowDefinition): boolean {
+  if (workflow.steps.length === 0) return false;
+
   const stepIds = new Set(workflow.steps.map((s) => s.id));
   return workflow.steps.every((s) => (s.dependsOn ?? []).every((dep) => stepIds.has(dep)));
 }
 
 /**
  * Check if all step IDs are unique.
+ *
+ * A zero-step workflow is reported as invalid (#4585): `0 === new Set([]).size`
+ * holds, so an empty id list used to pass as "all ids unique". Uniqueness over
+ * nothing is not uniqueness observed.
  */
 export function hasUniqueStepIds(workflow: WorkflowDefinition): boolean {
+  if (workflow.steps.length === 0) return false;
+
   const ids = workflow.steps.map((s) => s.id);
   return ids.length === new Set(ids).size;
 }
 
 /**
  * Check if all agent roles are valid.
+ *
+ * A zero-step workflow is reported as invalid (#4585): `[].every()` is true,
+ * so an empty workflow used to certify every agent role as valid without ever
+ * consulting `VALID_AGENT_ROLES`.
  */
 export function hasValidAgentRoles(workflow: WorkflowDefinition): boolean {
+  if (workflow.steps.length === 0) return false;
+
   return workflow.steps.every((s) => VALID_AGENT_ROLES.has(s.agent));
 }
 

--- a/packages/nexus-agents/src/workflows/aflow/evaluation-structure.ts
+++ b/packages/nexus-agents/src/workflows/aflow/evaluation-structure.ts
@@ -42,8 +42,17 @@ export function hasValidSteps(workflow: WorkflowDefinition): boolean {
 /**
  * Check if workflow has no dependency cycles.
  * Uses DFS with recursion stack to detect cycles.
+ *
+ * A zero-step workflow is reported as NOT acyclic (#4585): `[].some()` is
+ * `false`, so `!steps.some(hasCycle)` used to certify an empty workflow as
+ * structurally sound purely because there was nothing to walk. That vacuous
+ * pass handed an empty workflow 4 of the 5 checks in `evaluateStructure`
+ * (0.8), even though `hasValidSteps` in this same module already declares a
+ * zero-step workflow invalid. Empty means "no DAG to verify", not "verified".
  */
 export function hasNoCycles(workflow: WorkflowDefinition): boolean {
+  if (workflow.steps.length === 0) return false;
+
   const visited = new Set<string>();
   const recursionStack = new Set<string>();
 

--- a/packages/nexus-agents/src/workflows/self-evolving/workflow-evolver-helpers.test.ts
+++ b/packages/nexus-agents/src/workflows/self-evolving/workflow-evolver-helpers.test.ts
@@ -72,8 +72,11 @@ describe('areWorkflowsCompatible', () => {
     expect(areWorkflowsCompatible(steps1, steps2)).toBe(false);
   });
 
-  it('returns true for empty arrays', () => {
-    expect(areWorkflowsCompatible([], [])).toBe(true);
+  // Previously asserted `true` — that assertion pinned the vacuous pass: two
+  // zero-step parents share no genes, so "compatible for crossover" was a
+  // verdict reached by having nothing to compare (#4585).
+  it('returns false for empty arrays — no genes to exchange (#4585)', () => {
+    expect(areWorkflowsCompatible([], [])).toBe(false);
   });
 });
 

--- a/packages/nexus-agents/src/workflows/self-evolving/workflow-evolver-helpers.ts
+++ b/packages/nexus-agents/src/workflows/self-evolving/workflow-evolver-helpers.ts
@@ -53,11 +53,19 @@ export function tournamentSelect(
 
 /**
  * Check if two workflows are compatible for crossover (same structure).
+ *
+ * Two zero-step parents are reported INCOMPATIBLE (#4585): the loop below
+ * never runs on empty inputs, so the trailing `return true` used to declare
+ * "compatible" from a comparison that never happened. Crossover of two empty
+ * parents can only produce an empty child, so `performCrossover` returning
+ * `null` (skip this pair) is the honest outcome rather than a wasted
+ * generation of empty offspring.
  */
 export function areWorkflowsCompatible(
   p1Steps: readonly WorkflowStep[],
   p2Steps: readonly WorkflowStep[]
 ): boolean {
+  if (p1Steps.length === 0 || p2Steps.length === 0) return false;
   if (p1Steps.length !== p2Steps.length) return false;
   for (let i = 0; i < p1Steps.length; i++) {
     if (p1Steps[i]?.id !== p2Steps[i]?.id) return false;


### PR DESCRIPTION
Closes #4585. The same defect class as #4580/#4587/#4590 — a check reporting PASS because it had nothing to check — in the five syntactic shapes that are not `.every()`.

`![].some(p)` is `true`. A `for` loop with an early failure return never runs its body on an empty collection, so it falls through to the pass. `errors.length === 0` holds when the producing loop iterated nothing. `Math.min(...[])` is `Infinity`. And `0 === 0`.

## Fixed

| Site | Empty input produced |
| --- | --- |
| `session-helpers.ts` `shouldFinalize` | `results.size === participants.length` and `votes.length === participants.length` are both `0 === 0`, so a session whose roster emptied transitioned to `finalizing` as though its work were complete. The `review` branch already guarded with `> 0`; the other two did not |
| `benchmark-runner.ts` | every threshold check lives inside the loop, so a run that recorded zero operations certified the perf gate |
| `memory-benchmark-output.ts` | `checkThreshold` returned `null` for "no threshold configured" and for "check passed" alike, so a benchmark with zero thresholds was indistinguishable from a clean one |
| `stpa-validation.ts` | a tool with no readable input schema, or with zero constraints evaluated, reported `valid: true` |
| `skill-composer.ts` | a composition with zero steps reported executable |
| `evaluation-structure.ts` | a zero-step workflow was reported acyclic, uniquely-identified, and validly-roled — three properties certified without a step being read |
| `evaluation-completeness.ts` | a zero-step workflow scored a perfect 1 on constraints it was never measured against |
| `workflow-evolver-helpers.ts` | two zero-step workflows reported crossover-compatible |
| `consensus-plan.ts` | when every CLI answered but none produced a parseable plan, the summary rendered as an ordinary consensus plan containing zero steps |
| `confidence-cascade-stage.ts` | escalation on zero candidates was emergent from `-Infinity < threshold`, and the trace implied a measured score had fallen short |

## Three sites traced and left alone

Reported as candidates, dropped after tracing — the four-point gate doing its job:

- **`setup-command.ts`** aggregates over a fixed 11-element array literal built by its only caller; no path produces an empty list, and no step is left pending.
- **`workflow-run.ts`** iterates `workflow.inputs` — the *specification*, not results. An empty array means the workflow declares no input requirements, and blocking that would be wrong.
- **`correlation-helpers.ts`** fails in the *conservative* direction, which I had it backwards on. With no correlation data every agent joins one subset, so `effectiveVoteCount` becomes 1 rather than N and the ISP path does not run at all. An unmeasured panel is treated as one correlated bloc. Retracted on the issue.

## The adversarial review is the interesting part

I ran a `code-reviewer` pass over the whole diff instructed to **refute** each change rather than confirm it, and told it two problems had already been caught so it should assume more. It found six. **Three of them were the same defect reappearing inside the fix for it:**

- **A guard that cannot fire.** I added an unmeasured-comparison verdict to `findDivergences` and exported the function to test it. `synthesize` short-circuits below two parsed plans and the caller pre-filters nulls, so the guard was unreachable and both new tests exercised input shapes production cannot produce — coverage of dead code, reported as a fix. Reverted. The reviewer also found where the defect actually lives, which I then reproduced by driving the real entry point:

  ```
  ## Consensus Plan (2 CLIs)

  **0 steps** (0 agreed by multiple CLIs)
  ```

  `buildPlanSummary` had a branch for "all CLIs failed" and none for "all CLIs answered, none parseably". It does now.

- **A control test that certifies without measuring.** The positive control added to prove the STPA fix does not over-fire used a constraint that fails `doesConstraintApply`, so `checkConstraint` returned `null` and the id landed in `passed` unevaluated — the test certified "measured" on zero applicable constraints. Rewritten to use a genuinely applicable constraint, and it now proves the check is live by removing the property pattern and requiring a violation.

- **An assertion that pins the half-fixed number.** `hasNoCycles` was fixed; the three neighbouring checks were not, so `evaluateStructure([])` scored 0.6 — and the new test asserted `toBeLessThanOrEqual(0.6)`, encoding the survivors as the expected answer. All three named, test repointed to `toBe(0)`.

The STPA fix had also introduced a **permanent false alarm**: it treated an empty `properties` map as unmeasured, pinning every parameterless tool at `valid: false` however many constraints passed. An empty property map is a measurement — the tool was inspected and has nothing to sanitize. Only an absent or unreadable schema is unmeasured. A check that can only ever fail is as useless as one that can only ever pass.

**Two findings were refuted, with evidence rather than assertion:**

- The reviewer called `shouldFinalize`'s new guard dead because `CollaborationConfigSchema` requires at least one expert. That traces construction, not mutation: `getStatus()` returns `{ ...this.state }`, a shallow copy **sharing the live `participants` array**, so any holder can empty it before the next `checkProgress`. Guard kept, comment corrected to state that path.
- The reviewer wanted `calculateConstraintScore`'s `if (checks.length === 0) return 1` changed. Absence of *criteria* is not absence of *evidence* — the `hasSteps` guards above already cover the vacuous case. A counterfactual run flipping it to `0` broke two existing tests and, because `checks.length` depends only on the task, would have applied a constant offset across every candidate: it could never discriminate, only relabel "unconstrained task" as "bad workflow". Left unchanged, with the reasoning recorded in the code.

**What this says about the lint rule shipped in #4590:** it would not have caught any of the three self-inflicted instances. Reachability, applicability, and whether an assertion pins the right number are not expressible in an AST pattern. The rule catches the syntactic shape; the adversarial pass and the empty-input test catch the rest, and the rule's own header says as much.

## CODEOWNERS

`packages/nexus-agents/src/mcp/` is a CODEOWNERS path (`stpa-validation.ts`). Not on CLAUDE.md's never-auto-merge list, but flagging it for review rather than leaving the call in the merge log. The broader problem in that file — non-applicable constraints counted in `passed`, and `checkRateLimitViolation` that can never fail — is deliberately untouched and tracked at #4592.

## Verification

- `vitest run` — **1182 files, 28,097 tests, 0 failures**
- `pnpm lint` — clean; `nexus/no-vacuous-verdict` reports 0 errors and the single tracked `src/governance/claims-verify.ts` warning held for #4586
- `pnpm typecheck`, `prettier --check` — clean
- Every fix written Red first, each failing test confirmed to fail for the right reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
