### PR TITLE
docs: list the empty-case discipline in AGENTS.md (owner ratification)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Non-negotiable across all building, reviewing, architecture work:
 - **YAGNI (bounded by capability-bias — see Mission)** — Implement what a named consumer or near-term mission loop will measurably use; no speculative abstractions, unused parameters, or "just in case" code with no named consumer. For nexus-agents the bar is "a named loop within the current epic/vector will use it, and it's instrumented to measure" — not "build everything that might help." Build ahead of demand only under that bar.
 - **DRY** — Every piece of knowledge must have a single, unambiguous, authoritative representation. Extract when you see the same logic in three places (two is a coincidence).
 - **Zero `any` policy** — ESLint enforces `@typescript-eslint/no-explicit-any: 'error'`. Use `unknown` + type guards or Zod at boundaries. See `.rules/typescript.md` for the full rule.
+- **Name the empty case** — when a check aggregates a verdict over a collection, state what empty means; never let a language default answer it. `[].every(p)`, `![].some(p)`, a loop that never runs its body, `errors.length === 0`, `Math.min(...[])` and `0 === 0` all render absence as health. Use `allOf`/`anyOf`/`verdictOver` from `utils/verdict-aggregation` (their `whenEmpty` is required) or an explicit guard, and write the empty-input test — that, not the type system and not `nexus/no-vacuous-verdict`, is what actually catches the class. See `.rules/development-disciplines.md`.
 
 ## Default working mode
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ Non-negotiable across all building, reviewing, architecture work:
 - **YAGNI (bounded by capability-bias — see Mission)** — Implement what a named consumer or near-term mission loop will measurably use; no speculative abstractions, unused parameters, or "just in case" code with no named consumer. For nexus-agents the bar is "a named loop within the current epic/vector will use it, and it's instrumented to measure" — not "build everything that might help." Build ahead of demand only under that bar.
 - **DRY** — Every piece of knowledge must have a single, unambiguous, authoritative representation. Extract when you see the same logic in three places (two is a coincidence).
 - **Zero `any` policy** — ESLint enforces `@typescript-eslint/no-explicit-any: 'error'`. Use `unknown` + type guards or Zod at boundaries. See `.rules/typescript.md` for the full rule.
+- **Name the empty case** — when a check aggregates a verdict over a collection, state what empty means; never let a language default answer it. `[].every(p)`, `![].some(p)`, a loop that never runs its body, `errors.length === 0`, `Math.min(...[])` and `0 === 0` all render absence as health. Use `allOf`/`anyOf`/`verdictOver` from `utils/verdict-aggregation` (their `whenEmpty` is required) or an explicit guard, and write the empty-input test — that, not the type system and not `nexus/no-vacuous-verdict`, is what actually catches the class. See `.rules/development-disciplines.md`.
 
 ## Default working mode
 


### PR DESCRIPTION
**Governance path — requires owner ratification. Do not auto-merge.** Touches `AGENTS.md` and `CLAUDE.md`, both on CLAUDE.md's never-auto-merge list and in `CODEOWNERS`.

One line. #4594 added `## Name the empty case` to `.rules/development-disciplines.md`, but the `## Development disciplines` list in `AGENTS.md` still enumerates four — TDD, YAGNI, DRY, zero-`any`. That list is what a non-Claude harness reads first, and Codex / Gemini CLI / OpenCode only see a `.rules` file through the index table, not its contents. A discipline that agents do not see is not applied, which would make the doctrine half of this work as vacuous as the defect it describes.

The `CLAUDE.md` hunk is generated: `scripts/inject-governance.ts` derives the agnostic body from `AGENTS.md` (#3446). I ran it rather than hand-editing. `check-harness-alignment` reports 6 aligned / 0 absent, and markdownlint is clean.

Text added:

> **Name the empty case** — when a check aggregates a verdict over a collection, state what empty means; never let a language default answer it. `[].every(p)`, `![].some(p)`, a loop that never runs its body, `errors.length === 0`, `Math.min(...[])` and `0 === 0` all render absence as health. Use `allOf`/`anyOf`/`verdictOver` from `utils/verdict-aggregation` (their `whenEmpty` is required) or an explicit guard, and write the empty-input test — that, not the type system and not `nexus/no-vacuous-verdict`, is what actually catches the class.

The last clause is deliberate. The lint rule shipped in #4590 has measured recall of 7 of 10 on the known corpus and caught none of the three cases where the defect reappeared inside its own fix. Stating that in the discipline keeps the rule from being read as coverage it does not provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
