### PR TITLE
fix(routing): let API arms report a provider-asserted quota signal

### DIFF
--- a/.changeset/api-arm-quota-signal.md
+++ b/.changeset/api-arm-quota-signal.md
@@ -1,0 +1,53 @@
+---
+'nexus-agents': patch
+---
+
+fix(routing): let the API/SDK arms report a provider-asserted quota signal
+
+`ModelToCliAdapter` — the bridge every direct-API and SDK arm is wrapped by —
+answered `getCapacity()` from hardcoded literals, including
+`quotaExhausted: false`. `assessCapacity` reaches `'exhausted'` only through
+`quotaExhausted`, so no API arm could ever be excluded for quota no matter
+what the provider said. A check that cannot fail is not a check.
+
+The two literals were not equally wrong. `observed: false` was honest —
+nothing had been observed. `quotaExhausted: false` asserted a measurement
+that never happened.
+
+`toCliError` supplied the other half of the defect: it classified
+`RATE_LIMITED` but never called `parseRetryAfterMs`, unlike the subprocess
+path's `createError`. The provider's stated horizon is the only input
+`CapacityTracker.recordProviderQuotaExhaustion` accepts, so it was discarded
+before anything could record it.
+
+The receiving machinery already worked; the API arms simply never fed it.
+This wires them onto it rather than building a second capacity system:
+
+- `toCliError` parses `retryAfterMs` off a retryable error, mirroring
+  `base-adapter.ts`. Not parsed on a non-retryable one — a wait hint inside a
+  500 body is not a rate-limit assertion.
+- The bridge holds a per-instance canonical `CapacityTracker`, records usage
+  on success and a quota signal on `RATE_LIMITED`, and reports `getCapacity()`
+  from it. One arm's exhaustion never speaks for another's.
+- `CapacityTracker.recordProviderQuotaExhaustion` now marks the tracker
+  observed when it records. Without that, `assessCapacity` short-circuits to
+  `unmeasured` and the strongest evidence available about an arm — the
+  provider stating its quota is gone — would be stored and then ignored on any
+  adapter whose first call rate-limits. A rejected assertion observed nothing
+  and still does not set the flag.
+
+The empty case stays named: an arm that has neither served a call nor been
+given a horizon reports `observed: false` and grades `unmeasured`, never
+`healthy`.
+
+Nothing starts being excluded. `CapacityStageConfig.enforceHardLimits` still
+defaults `false`, and a test pins both halves — an exhausted arm still routes
+under the shipped defaults, and is excluded only once a caller opts in.
+
+Partial by construction, and worth stating: `parseRetryAfterMs` matches the
+message text OpenAI-family 429s usually carry ("try again in 20s"), but not
+Anthropic's, whose body has no wait hint, nor Gemini's `"retryDelay":"33s"`.
+Neither adapter reads the HTTP `retry-after` header — it is discarded at
+`transformError`. Those arms therefore record no horizon and correctly report
+no quota exhaustion rather than a fabricated one. Capturing the header is
+sequenced separately (#4532).

--- a/packages/nexus-agents/src/cli-adapters/capacity-tracker.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/capacity-tracker.test.ts
@@ -414,6 +414,27 @@ describe('#4456: a local rate window is not provider-asserted quota', () => {
     expect(status.quotaResetAt?.getTime()).toBe(Date.now() + retryAfterMs);
   });
 
+  it('counts a recorded provider assertion as an observation (#4602)', () => {
+    // `assessCapacity` short-circuits to 'unmeasured' on `observed === false`,
+    // so a tracker that records a provider's quota assertion but still reports
+    // itself unobserved can never reach 'exhausted' — the assertion would be
+    // stored and then ignored. A provider telling us our quota is gone IS an
+    // observation about this arm; it is in fact the strongest one available.
+    // Matters most on a first call that rate-limits, where no success has run.
+    expect(tracker.getCapacity().observed).toBe(false);
+
+    tracker.recordProviderQuotaExhaustion(RATE_LIMIT_WINDOW_MS * 60);
+
+    expect(tracker.getCapacity().observed).toBe(true);
+  });
+
+  it('does not mark the tracker observed when the assertion is rejected', () => {
+    // A sub-window retry-after records nothing, so it observed nothing.
+    tracker.recordProviderQuotaExhaustion(RATE_LIMIT_WINDOW_MS - 1);
+
+    expect(tracker.getCapacity().observed).toBe(false);
+  });
+
   it('treats a short retry-after as a throttle, not quota exhaustion', () => {
     // Shorter than our own window means a per-minute limit, which rateLimited
     // already covers. Escalating it would empty the candidate pool for a

--- a/packages/nexus-agents/src/cli-adapters/capacity-tracker.ts
+++ b/packages/nexus-agents/src/cli-adapters/capacity-tracker.ts
@@ -241,6 +241,14 @@ export class CapacityTracker {
    */
   recordProviderQuotaExhaustion(retryAfterMs: number | undefined): boolean {
     if (retryAfterMs === undefined || retryAfterMs <= this.config.windowMs) return false;
+    // #4602: a recorded assertion is an observation. `assessCapacity`
+    // short-circuits to 'unmeasured' on `observed === false`, so without this
+    // the strongest evidence we can get about an arm — the provider stating
+    // its quota is gone — would be stored and then ignored on any adapter
+    // whose first call rate-limits (no success has run, so `recordUsage`
+    // never fired). Only set on a recorded assertion: a rejected one
+    // observed nothing.
+    this.hasObserved = true;
     this.quotaExhaustedUntil = getTimeProvider().now() + retryAfterMs;
     return true;
   }

--- a/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.test.ts
@@ -1,10 +1,22 @@
 /**
  * Tests for the Model→CLI adapter bridge (#3422).
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { createModelToCliAdapter } from './model-to-cli-adapter.js';
-import { ok, err, ModelError, type IModelAdapter, type CompletionResponse } from '../core/index.js';
+import { CapacityFilterStage, assessCapacity } from './routing/stages/capacity-stage.js';
+import { createRoutingContext, getRemainingCandidates } from './routing/router-stage.js';
+import type { RoutingArmId } from './types.js';
+import {
+  ok,
+  err,
+  ModelError,
+  FixedTimeProvider,
+  setTimeProvider,
+  resetTimeProvider,
+  type IModelAdapter,
+  type CompletionResponse,
+} from '../core/index.js';
 
 function makeModelAdapter(overrides: Partial<IModelAdapter> = {}): IModelAdapter {
   return {
@@ -97,10 +109,17 @@ describe('ModelToCliAdapter (#3422)', () => {
     expect(health.healthy).toBe(true);
   });
 
-  it('reports non-exhausted capacity (API rate limits surface via execute)', async () => {
+  it('reports an untouched arm as unmeasured, not as measured-healthy', async () => {
+    // Repointed (#4602). This previously read `cap.rateLimited === false`
+    // against a hardcoded literal, so it pinned a value the adapter asserted
+    // rather than measured. `rateLimited: false` is still correct on a fresh
+    // tracker, but the load-bearing claim is `observed: false` — nothing has
+    // been observed about this arm yet, and the reading must say so.
     const adapter = createModelToCliAdapter(makeModelAdapter(), { name: 'claude' });
     const cap = await adapter.getCapacity();
     expect(cap.rateLimited).toBe(false);
+    expect(cap.observed).toBe(false);
+    expect(assessCapacity(cap)).toBe('unmeasured');
   });
 
   it('delegates listModels to the model adapter when present', async () => {
@@ -115,5 +134,179 @@ describe('ModelToCliAdapter (#3422)', () => {
   it('returns an empty model list when the adapter has no listModels surface', async () => {
     const adapter = createModelToCliAdapter(makeModelAdapter(), { name: 'claude' });
     expect(await adapter.listModels()).toEqual([]);
+  });
+});
+
+/**
+ * Provider-asserted quota on the API/SDK arms (#4602).
+ *
+ * `getCapacity()` used to return `quotaExhausted: false` as a literal. Since
+ * `assessCapacity` reaches `'exhausted'` only through `quotaExhausted`, and
+ * every API/SDK arm is wrapped by this bridge, no API arm could ever be
+ * excluded for quota no matter what the provider said — a check that cannot
+ * fail. `toCliError` compounded it: it classified RATE_LIMITED but never
+ * called `parseRetryAfterMs`, so the provider's own horizon — the one piece of
+ * evidence `CapacityTracker.recordProviderQuotaExhaustion` requires — was
+ * discarded before anything could record it.
+ *
+ * The subprocess path already does all of this (`base-adapter.ts`
+ * `createError` → `recordQuotaSignal` → the tracker). These tests pin the
+ * bridge onto that same mechanism rather than a parallel one.
+ */
+describe('ModelToCliAdapter provider quota signal (#4602)', () => {
+  /** Longer than the tracker's own 60s window, so it means quota, not throttle. */
+  const DURABLE_RETRY_SECONDS = 3_600;
+
+  function rateLimitAdapter(message: string): ReturnType<typeof createModelToCliAdapter> {
+    const complete = vi.fn().mockResolvedValue(err(new ModelError(message)));
+    return createModelToCliAdapter(makeModelAdapter({ complete }), { name: 'claude' });
+  }
+
+  beforeEach(() => {
+    setTimeProvider(new FixedTimeProvider(1_700_000_000_000));
+  });
+
+  afterEach(() => {
+    resetTimeProvider();
+  });
+
+  it('parses the provider retry-after onto the CliError, as the subprocess path does', async () => {
+    const adapter = rateLimitAdapter('429 rate limit exceeded; retry after 3600 seconds');
+
+    const result = await adapter.execute({ content: 'hi' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('RATE_LIMITED');
+      expect(result.error.retryAfterMs).toBe(DURABLE_RETRY_SECONDS * 1_000);
+    }
+  });
+
+  it('omits retryAfterMs when the provider stated no horizon', async () => {
+    const adapter = rateLimitAdapter('429 too many requests');
+
+    const result = await adapter.execute({ content: 'hi' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.retryAfterMs).toBeUndefined();
+  });
+
+  it('never carries retryAfterMs on a non-retryable error', async () => {
+    // Mirrors base-adapter's `retryable ? parse : undefined` guard: a wait hint
+    // inside a 500 body is not a rate-limit assertion.
+    const adapter = rateLimitAdapter('upstream 500: try again in 30 seconds');
+
+    const result = await adapter.execute({ content: 'hi' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('EXECUTION_ERROR');
+      expect(result.error.retryAfterMs).toBeUndefined();
+    }
+  });
+
+  it('reports the arm exhausted after a durable provider assertion', async () => {
+    // The mutation check: an arm handed a real rate-limit error must be able to
+    // reach 'exhausted'. Pre-fix this was unreachable by construction.
+    const adapter = rateLimitAdapter('rate limit reached; retry after 3600 s');
+
+    await adapter.execute({ content: 'hi' });
+    const cap = await adapter.getCapacity();
+
+    expect(cap.quotaExhausted).toBe(true);
+    expect(cap.observed).toBe(true);
+    expect(assessCapacity(cap)).toBe('exhausted');
+  });
+
+  it('does not report quota exhaustion for a sub-window throttle', async () => {
+    // A 5s retry-after is an ordinary per-minute throttle. Escalating it would
+    // empty the candidate pool for a condition that clears within the minute.
+    const adapter = rateLimitAdapter('rate limit; retry after 5 seconds');
+
+    await adapter.execute({ content: 'hi' });
+
+    expect((await adapter.getCapacity()).quotaExhausted).toBe(false);
+  });
+
+  it('does not report quota exhaustion when the provider gave no horizon', async () => {
+    const adapter = rateLimitAdapter('429 too many requests');
+
+    await adapter.execute({ content: 'hi' });
+
+    expect((await adapter.getCapacity()).quotaExhausted).toBe(false);
+  });
+
+  it('marks the arm observed once a call succeeds, and records its usage', async () => {
+    const complete = vi.fn().mockResolvedValue(ok(COMPLETION));
+    const adapter = createModelToCliAdapter(makeModelAdapter({ complete }), { name: 'claude' });
+
+    await adapter.execute({ content: 'hi' });
+    const cap = await adapter.getCapacity();
+
+    expect(cap.observed).toBe(true);
+    expect(assessCapacity(cap)).toBe('healthy');
+    // 200 tokens off the claude 100k/min estimate.
+    expect(cap.remainingTokens).toBe(100_000 - COMPLETION.usage!.totalTokens);
+  });
+
+  it('lets a later success overturn a stale provider assertion', async () => {
+    const complete = vi
+      .fn()
+      .mockResolvedValueOnce(err(new ModelError('rate limit; retry after 3600 s')))
+      .mockResolvedValueOnce(ok(COMPLETION));
+    const adapter = createModelToCliAdapter(makeModelAdapter({ complete }), { name: 'claude' });
+
+    await adapter.execute({ content: 'hi' });
+    expect((await adapter.getCapacity()).quotaExhausted).toBe(true);
+
+    await adapter.execute({ content: 'hi again' });
+
+    expect((await adapter.getCapacity()).quotaExhausted).toBe(false);
+  });
+
+  it('keeps per-adapter isolation: one arm exhausted does not exhaust another', async () => {
+    const exhausted = rateLimitAdapter('rate limit; retry after 3600 s');
+    const fresh = createModelToCliAdapter(makeModelAdapter(), { name: 'claude' });
+
+    await exhausted.execute({ content: 'hi' });
+
+    expect((await exhausted.getCapacity()).quotaExhausted).toBe(true);
+    expect((await fresh.getCapacity()).quotaExhausted).toBe(false);
+  });
+
+  it('still routes an exhausted arm under the shipped defaults', async () => {
+    // Hard constraint on #4602: `enforceHardLimits` defaults false, so making
+    // the signal reportable must not start excluding anyone by default.
+    const adapter = rateLimitAdapter('rate limit; retry after 3600 s');
+    await adapter.execute({ content: 'hi' });
+
+    // `createRoutingContext` types its candidate list as CliName[], so the
+    // stage is exercised on the display slot; the api:* arm-id distinction is
+    // the router's Map key and is not what this test is about.
+    const armId: RoutingArmId = 'claude';
+    const stage = new CapacityFilterStage(new Map([[armId, adapter]]));
+    const result = await stage.route(createRoutingContext('x', ['claude']));
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(getRemainingCandidates(result.value.context)).toEqual([armId]);
+    }
+  });
+
+  it('excludes the exhausted arm once a caller opts into enforcement', async () => {
+    // The other half of the same guard: the signal is real, not inert.
+    const adapter = rateLimitAdapter('rate limit; retry after 3600 s');
+    await adapter.execute({ content: 'hi' });
+
+    const armId: RoutingArmId = 'claude';
+    const stage = new CapacityFilterStage(new Map([[armId, adapter]]), {
+      enforceHardLimits: true,
+    });
+    const result = await stage.route(createRoutingContext('x', ['claude']));
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(getRemainingCandidates(result.value.context)).toEqual([]);
+    }
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
@@ -20,7 +20,8 @@ import type {
 } from '../core/index.js';
 import { ok, err, ModelError } from '../core/index.js';
 import { FALLBACK_CONTEXT_WINDOW } from '../config/model-config-helpers.js';
-import { isRateLimitText } from '../adapters/rate-limit-detector.js';
+import { isRateLimitText, parseRetryAfterMs } from '../adapters/rate-limit-detector.js';
+import { CapacityTracker, createCapacityTracker } from './capacity-tracker.js';
 import type {
   ICliAdapter,
   CliTask,
@@ -78,10 +79,19 @@ export class ModelToCliAdapter implements ICliAdapter {
 
   private readonly modelAdapter: IModelAdapter;
 
+  /**
+   * Per-arm capacity state (#4602). The same canonical `CapacityTracker` the
+   * subprocess adapters use — this bridge previously answered `getCapacity()`
+   * from literals, so no API/SDK arm could report a quota signal at all.
+   * Per-instance, so one arm's exhaustion never speaks for another's.
+   */
+  private readonly capacityTracker: CapacityTracker;
+
   constructor(modelAdapter: IModelAdapter, config: ModelToCliAdapterConfig) {
     this.modelAdapter = modelAdapter;
     this.name = config.name;
     this.capabilities = config.capabilities ?? NEUTRAL_CAPABILITIES;
+    this.capacityTracker = createCapacityTracker(config.name);
   }
 
   /** Build a single-turn CompletionRequest from a CliTask. */
@@ -139,25 +149,54 @@ export class ModelToCliAdapter implements ICliAdapter {
    * Convert a ModelError to a CliError. Rate-limit text → RATE_LIMITED
    * (retryable); everything else → EXECUTION_ERROR (non-retryable) so the
    * routing/circuit layers see a real, typed failure.
+   *
+   * #4602: parses `retryAfterMs` off the message, mirroring
+   * `base-adapter.ts`'s `createError`. Pre-fix this bridge classified
+   * RATE_LIMITED and then threw the provider's stated horizon away — and that
+   * horizon is the sole input `CapacityTracker.recordProviderQuotaExhaustion`
+   * accepts, so the API/SDK arms could never assert quota exhaustion.
+   *
+   * Only parsed on a retryable error, as on the subprocess path: a wait hint
+   * inside a 500 body is not a rate-limit assertion.
    */
   private toCliError(error: ModelError): CliError {
     const rateLimited = isRateLimitText(error.message);
     const code: CliErrorCode = rateLimited ? 'RATE_LIMITED' : 'EXECUTION_ERROR';
+    const retryAfterMs = rateLimited ? parseRetryAfterMs(error.message) : undefined;
     const base: CliError = {
       code,
       message: error.message,
       cli: this.name,
       retryable: rateLimited,
+      ...(retryAfterMs !== undefined && { retryAfterMs }),
     };
     return error.cause instanceof Error ? { ...base, cause: error.cause } : base;
+  }
+
+  /**
+   * Feed a provider's own rate-limit assertion into capacity tracking (#4602).
+   *
+   * The API-side counterpart of `BaseCliAdapter.recordQuotaSignal`. The
+   * tracker — not this adapter — decides whether the stated wait is long
+   * enough to mean durable quota rather than a per-minute throttle.
+   */
+  private recordQuotaSignal(error: CliError): void {
+    if (error.code !== 'RATE_LIMITED') return;
+    this.capacityTracker.recordProviderQuotaExhaustion(error.retryAfterMs);
   }
 
   async execute(task: CliTask, options?: ExecutionOptions): Promise<Result<CliResponse, CliError>> {
     const result = await this.modelAdapter.complete(this.toCompletionRequest(task, options));
     if (!result.ok) {
-      return err(this.toCliError(result.error));
+      const cliError = this.toCliError(result.error);
+      this.recordQuotaSignal(cliError);
+      return err(cliError);
     }
-    return ok(this.toCliResponse(result.value));
+    const response = this.toCliResponse(result.value);
+    // A served request is direct evidence the provider is serving; the tracker
+    // uses it both to count the window and to retire a stale assertion.
+    this.capacityTracker.recordUsage(response.usage);
+    return ok(response);
   }
 
   /** Health is derived from the model adapter's config validation. */
@@ -173,25 +212,22 @@ export class ModelToCliAdapter implements ICliAdapter {
   }
 
   /**
-   * API adapters don't expose subprocess-style rate windows; report
-   * non-exhausted capacity. Real rate-limit signals surface via execute()'s
-   * RATE_LIMITED error, which the resilience layer acts on.
+   * Report this arm's capacity from its `CapacityTracker` (#4602).
    *
-   * #4374: `observed: false` — the infinities below are a stand-in for "this
-   * adapter has no rate window to report", not a measurement. Reporting them as
-   * observed would tell consumers we had checked and found unlimited capacity.
+   * Previously this returned literals: `POSITIVE_INFINITY` remaining,
+   * `quotaExhausted: false`, `observed: false`. The `observed: false` half was
+   * honest (#4374 — nothing had been observed), but `quotaExhausted: false`
+   * asserted a measurement that never happened, and since `assessCapacity`
+   * reaches `'exhausted'` only through `quotaExhausted`, it made every
+   * API/SDK arm unexcludable for quota by construction — a check that cannot
+   * fail, whatever the provider said.
+   *
+   * The tracker keeps the honest empty case: until this arm has served a call
+   * or a provider has asserted a horizon, it reports `observed: false` and the
+   * stage grades it `unmeasured`, never `healthy`.
    */
   getCapacity(): Promise<CapacityStatus> {
-    return Promise.resolve({
-      remainingTokens: Number.POSITIVE_INFINITY,
-      remainingRequests: Number.POSITIVE_INFINITY,
-      resetTime: new Date(0),
-      utilizationPercent: 0,
-      rateLimited: false,
-      exhausted: false,
-      quotaExhausted: false,
-      observed: false,
-    });
+    return Promise.resolve(this.capacityTracker.getCapacity());
   }
 
   getVersion(): Promise<string> {


### PR DESCRIPTION
Closes #4602. Found by the spike the #4532 panel required before implementing its own decision — and it turned out to be the cheaper fix that captures most of the same value.

## Three links in one broken chain

**1. `getCapacity()` hardcoded the answer.** `model-to-cli-adapter.ts:184-195` returned `quotaExhausted: false, observed: false` as literals. Every API/SDK arm is wrapped by this bridge, and `assessCapacity` (`capacity-stage.ts:127`) reaches `'exhausted'` only through `quotaExhausted` — so **no API arm could be excluded for quota by construction**, whatever the provider said. A check that cannot fail.

Worth separating the two literals: `observed: false` was *honest* (#4374 — nothing had been observed). The hardcoded `quotaExhausted: false` asserted a measurement that never happened.

**2. `toCliError` discarded the evidence.** It classified `RATE_LIMITED` and then never called `parseRetryAfterMs`, unlike `base-adapter.ts:413` on the subprocess path. The retry horizon is the *sole* input `recordProviderQuotaExhaustion` accepts, so the one thing that could have fed the tracker was thrown away at the boundary.

**3. A third link, found while wiring.** `recordProviderQuotaExhaustion` never set `hasObserved`. Since `assessCapacity` short-circuits to `'unmeasured'` on `observed === false`, a provider assertion on an arm with no prior success would be **stored and then ignored** — the strongest evidence obtainable about an arm, recorded and discarded. Fixed in `capacity-tracker.ts`, which also closes the same latent hole on the subprocess path. A *rejected* assertion still observes nothing.

Each link individually looks defensible. Together they made the exclusion path unreachable for half the fleet.

## The fix reuses the canonical mechanism

The bridge now holds a per-instance `CapacityTracker` — the same one the subprocess adapters use, not a second capacity system. It records usage on success (so a served request retires a stale assertion) and feeds a quota signal on `RATE_LIMITED`. `getCapacity()` delegates.

Tracker lifetime is correct: `collectApiRoutingArms` runs from the adapter factory at registry construction, not per request, so the tracker persists for the arm's life exactly as it does for subprocess arms.

**Defaults are unchanged.** `enforceHardLimits` still defaults `false`, and a test pins both halves — an exhausted arm still routes under shipped defaults, and is excluded only on explicit opt-in.

## Stated rather than under-delivered: the horizon only lands for some vendors

Classification works everywhere — `isRateLimitText` matches 429/rate_limit across all vendors. The *horizon* does not:

| Vendor | Wait hint in the error body | Parsed? |
| --- | --- | --- |
| OpenAI family | "Please try again in 20s" | yes (sub-second "632ms" is not) |
| Anthropic | none in the 429 body | no |
| Gemini | `"retryDelay":"33s"` | no — no pattern matches |

And **no code anywhere reads the HTTP `retry-after` header**: `transformError` (`adapters/base-adapter.ts:359`) discards it. So Anthropic and Gemini arms record no horizon and therefore honestly report no exhaustion — which is the correct behaviour for this PR (never assert what was not measured) but leaves real signal on the floor. Filed as a follow-up; it is a far cheaper win than the full header-monitor wiring in #4532, and it closes exactly the gap that motivated it.

## Verification

- `vitest run` — **1182 files, 28,134 tests, 0 failures**
- `pnpm typecheck`, `pnpm lint`, `prettier --check` — clean
- **Mutation-checked, five ways**: dropping `parseRetryAfterMs`, `recordQuotaSignal`, `recordUsage`, the `hasObserved` line, or restoring the literal `getCapacity` each failed 2–5 tests; restoring passed. The wiring is proven to fire rather than merely present.
- 13 tests added, 1 repointed with a comment recording what it pinned.

One correction to my own brief: I told the agent to expect several existing tests pinning the hardcoded values, on the strength of how often that has happened tonight. **Only one did.** The prediction was wrong and the report says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
