### PR TITLE
fix(test): stop leaking a /tmp directory on every audit test run

### DIFF
--- a/.changeset/audit-test-tmp-leak.md
+++ b/.changeset/audit-test-tmp-leak.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+fix(test): stop leaking a `/tmp` directory on every audit test run
+
+`cli-server-audit.test.ts` allocated `/tmp/nexus-audit-test-<pid>`, hardcoded outside the managed `getNexusTmpDir()` tree, and never removed it. Closing the `AuditLogger` is not the same as deleting what it wrote into, and the pid meant runs never reused a path — so the directory count grew once per test run and never shrank. 73 had accumulated on the dev box, rising to 76 during the session that found it.
+
+The path now comes from `mkdtempSync`, unique by construction rather than by pid, and a `finally` removes it on every path including a failing assertion.
+
+Cleaning up exposed a second defect the leak had been hiding: `close()` was called as `void result.close()` and returned before the log stream had flushed, so deleting the directory underneath it raised an unhandled `AuditError: Failed to flush audit log`. It is awaited now. The test had never actually waited for the logger to finish; nothing noticed because the directory was never removed.
+
+Volume is trivial — nexus-attributable content in `/tmp` totals 300K against 16G in use, so this is unrelated to the tmpfs exhaustion in #4488. What made it worth fixing is that it was unbounded by construction, and an unbounded directory count exhausts inodes before it exhausts bytes.

--- a/packages/nexus-agents/src/cli-server-audit.test.ts
+++ b/packages/nexus-agents/src/cli-server-audit.test.ts
@@ -6,6 +6,9 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { initializeAuditLogger } from './cli-server-audit.js';
 import type { ILogger } from './core/index.js';
 
@@ -62,30 +65,45 @@ describe('initializeAuditLogger', () => {
     expect(result).toBeNull();
   });
 
-  it('should return AuditLogger when audit is enabled', () => {
+  // The directory was previously `/tmp/nexus-audit-test-<pid>`, hardcoded and
+  // never removed. Closing the logger is not the same as deleting what it
+  // wrote into, and the pid meant runs never reused a path — so the directory
+  // count grew once per test run, forever. 73 had accumulated on the dev box
+  // before anyone noticed (#4603). `mkdtempSync` makes the path unique by
+  // construction rather than by pid, and the `finally` removes it on every
+  // path including a failing assertion.
+  it('should return AuditLogger when audit is enabled', async () => {
     const logger = createMockLogger();
-    const tmpDir = '/tmp/nexus-audit-test-' + String(process.pid);
-    const result = initializeAuditLogger(
-      {
-        allowedPaths: ['./'],
-        blockedPatterns: [],
-        rateLimit: { enabled: true, requestsPerMinute: 60 },
-        audit: {
-          enabled: true,
-          logDir: tmpDir,
-          minSeverity: 'info',
-          enableHashChain: false,
-          maxFileSizeBytes: 10 * 1024 * 1024,
-          maxFiles: 10,
+    const tmpDir = mkdtempSync(join(tmpdir(), 'nexus-audit-test-'));
+    try {
+      const result = initializeAuditLogger(
+        {
+          allowedPaths: ['./'],
+          blockedPatterns: [],
+          rateLimit: { enabled: true, requestsPerMinute: 60 },
+          audit: {
+            enabled: true,
+            logDir: tmpDir,
+            minSeverity: 'info',
+            enableHashChain: false,
+            maxFileSizeBytes: 10 * 1024 * 1024,
+            maxFiles: 10,
+          },
         },
-      },
-      logger
-    );
-    expect(result).not.toBeNull();
+        logger
+      );
+      expect(result).not.toBeNull();
 
-    // Clean up
-    if (result !== null) {
-      void result.close();
+      // Awaited, not fire-and-forget. `void result.close()` returned before
+      // the log stream had flushed; removing the directory underneath it then
+      // surfaced as an unhandled `AuditError: Failed to flush audit log`. The
+      // old code never deleted the directory, so this race was invisible —
+      // the leak was hiding a second defect (#4603).
+      if (result !== null) {
+        await result.close();
+      }
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
Closes #4603. Small, but it demonstrated its own bug twice while being fixed.

## The leak

`cli-server-audit.test.ts:67` allocated `/tmp/nexus-audit-test-<pid>`, hardcoded outside the managed `getNexusTmpDir()` tree, and never removed it. Three things compounded:

1. it bypassed the scratch root that `doctor-scratch-space.ts` measures, so it was invisible to our own instrument;
2. closing the `AuditLogger` is not the same as deleting what it wrote into — there was no `afterEach`, no `finally`, no `rmSync`;
3. the pid meant runs never reused a path, so the count only ever grew.

**73 orphaned directories** when found. **76 by the time it was fixed** — my own three verification runs during this session, which is the leak demonstrating itself.

The path now comes from `mkdtempSync`, unique by construction rather than by pid, removed in a `finally` so a failing assertion cleans up too.

## Removing the directory exposed a second defect it had been hiding

First green run after adding cleanup:

```
Unhandled Rejection
AuditError: Failed to flush audit log
Caused by: ENOENT: no such file or directory, open '.../nexus-audit-test-4sfKgj/audit-....jsonl'
```

`void result.close()` was fire-and-forget: it returned before the log stream had flushed, so deleting the directory underneath it raced the write. The test had **never actually waited for the logger to finish** — nothing surfaced it because the directory was never removed. Now awaited.

That is the more interesting half. The leak was load-bearing: it was masking a real async bug in the same test.

## The gate question, answered with a measurement rather than a change

#4603 asked why `scripts/arch-lint.ts`'s `checkTempDirCleanup` (#4489) missed this. Two blind spots:

- it **excludes test files outright** (`relPath.includes('.test.')`), on the stated assumption that "tests tear down via their own fixtures" — false here;
- it only triggers on `nexusMkdtemp(Sync)`, so a hardcoded `'/tmp/…'` string never matches it at all, test or not.

So I measured what widening it would cost before proposing it. Across the tree, 198 hardcoded `/tmp` references; a file-level heuristic (`has "/tmp" literal` AND `has mkdir/mkdtemp` AND `lacks a teardown idiom`) flags **five** files:

| File | Reality |
| --- | --- |
| `pipeline/expert-bridge.ts` | the `/tmp` hit is inside a **comment** |
| `context/memory-markdown.test.ts` | `fs` is **mocked** — `mkdirSync: vi.fn()` |
| `cli/session-commands.test.ts` | mocked `mkdirSync`; the path is an assertion argument |
| `cli/index-command.test.ts` | mocked fs; assertion argument |
| `audit/audit-storage.test.ts` | `vi.mocked(fs.mkdirSync)`; assertion strings |

**0 of 5 are real. 100% false positives.** A precise rule would have to know whether `fs` is mocked, which is real static analysis, and this defect class has exactly one confirmed instance. So **I am not widening the gate** — a noisy gate is how people learn to reach for exemptions, and that lesson is already recorded in `.rules/development-disciplines.md` from the `no-vacuous-verdict` scoping work.

The honest conclusion is that this was found by `ls /tmp`, not by a gate, and the durable control already exists: `doctor-scratch-space.ts` reports occupancy of both scratch roots and drops an unresolvable one rather than assuming it healthy.

I also swept for siblings. `cli/index-command-link-validator.test.ts:177` has the identical pid-suffixed shape — but it cleans up properly in an `afterEach`, and there are **0** orphaned directories from it on disk, so it is fine and untouched.

## Not done

The 76 pre-existing orphans are still on the dev box. They are 300K of unambiguous test detritus, but they live outside the repo and deleting files on your filesystem is not something I will do unasked — say the word and they're gone.

## Verification

- `vitest run src/cli-server-audit.test.ts` — 4 passed, **no unhandled errors**
- Directory count before and after the run: **76 → 76**, so the run created and removed its own
- `pnpm typecheck`, `eslint`, `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
