### PR TITLE
feat(adapters): read the Retry-After header for a provider quota horizon

### DIFF
--- a/.changeset/retry-after-header-capture.md
+++ b/.changeset/retry-after-header-capture.md
@@ -1,0 +1,54 @@
+---
+'nexus-agents': patch
+---
+
+fix(adapters): read the HTTP `Retry-After` header instead of guessing from prose
+
+`recordProviderQuotaExhaustion` accepts exactly one input — a retry horizon in
+milliseconds — and #4605 wired the API arms to feed it. But the horizon was
+parsed out of the error _message_, and `transformError` dropped the HTTP
+response before anyone could read the header that actually carries it. So the
+horizon only ever arrived for one vendor family:
+
+| vendor    | horizon in the body       | reached the tracker |
+| --------- | ------------------------- | ------------------- |
+| OpenAI    | "Please try again in 20s" | yes; "632ms" no     |
+| Anthropic | nothing at all            | no                  |
+| Gemini    | `"retryDelay":"33s"`      | no                  |
+
+Classification was never the problem — `isRateLimitText` matches a 429 on every
+vendor. Two of the three arms simply had no horizon to report, so they recorded
+nothing and graded `unmeasured` forever.
+
+Both SDKs hand the response headers straight to the thrown error
+(`@anthropic-ai/sdk` and `openai` as a `Headers` instance, the Vercel AI SDK as
+`responseHeaders`), so the boundary is reachable without holding the response
+open. `BaseAdapter.transformError` and `SdkAdapter.toErrorResult` now capture
+the horizon there and park it on the `ModelError` context, which
+`ModelToCliAdapter.toCliError` reads onto `CliError.retryAfterMs` — the very
+input #4605 already threads into the tracker. No new plumbing past the capture.
+
+`@google/genai` is the exception, and not by omission: its `ApiError` carries
+`{message, status}` and no headers at all. It does stringify the whole response
+body into the message, so Gemini's `google.rpc.RetryInfo` is added as a body
+fallback, alongside the sub-second `"try again in 632ms"` phrasing the
+second-granularity rule could never match. Body patterns are the fallback only;
+`Retry-After` wins where both are present, so an arm cannot under-report an
+hour-long outage because the prose mentioned 20 seconds.
+
+Both legal header forms are handled: delta-seconds and an HTTP-date, the latter
+resolved against the clock and clamped at 0 for a date already past. An absent
+or unreadable value is **absent**, never 0 — a 0 horizon reads as "retry
+immediately", which is a measurement, and substituting it for a field we could
+not parse would report a vacuous default as a provider assertion. `Date.parse`
+is lenient enough to turn `"12.5"` into a date in 2001, so the HTTP-date branch
+is gated on the day-of-week prefix all three legal spellings share.
+
+Only `retry-after` is ever read. `Authorization` and API keys ride in the same
+bag, so the named field is extracted to a number at the boundary and no header
+object travels inward, into a log, or onto an error.
+
+Defaults are unchanged. `CapacityStageConfig.enforceHardLimits` still defaults
+`false`, nothing starts excluding candidates, and per-vendor tests pin both
+halves of the check: a 429 stating a durable horizon reaches `exhausted`, and a
+429 stating nothing anywhere stays `unmeasured` — never `healthy`.

--- a/packages/nexus-agents/src/adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/adapters/base-adapter.ts
@@ -16,7 +16,11 @@ import type {
   ModelCapability,
 } from '../core/index.js';
 import { getErrorMessage } from '../core/index.js';
-import { isRateLimitLikeError } from './rate-limit-detector.js';
+import {
+  isRateLimitLikeError,
+  resolveRetryAfterMs,
+  RETRY_AFTER_CONTEXT_KEY,
+} from './rate-limit-detector.js';
 import { recordWouldHaveSelfHealed } from './optional-params.js';
 
 import {
@@ -329,7 +333,18 @@ export abstract class BaseAdapter implements IModelAdapter {
       recordWouldHaveSelfHealed(this.modelId, param);
     }
 
-    const modelError = this.createModelError(errorMessage, errorCode, error, param);
+    // #4606: capture the provider's stated retry horizon HERE, while the
+    // thrown SDK error — the last place the HTTP response is reachable — is
+    // still in hand. Header first (RFC 9110 `Retry-After`), body prose second.
+    // Only on a rate limit: a wait hint inside a 500 body is not a rate-limit
+    // assertion, matching the subprocess path's `retryable ? parse : undefined`.
+    // `resolveRetryAfterMs` returns a NUMBER; no header object travels inward.
+    const retryAfterMs =
+      errorCode === ErrorCode.MODEL_RATE_LIMITED
+        ? resolveRetryAfterMs(error, errorMessage)
+        : undefined;
+
+    const modelError = this.createModelError(errorMessage, errorCode, error, param, retryAfterMs);
 
     this.logger.error('Model adapter error', modelError, {
       errorCode,
@@ -347,7 +362,8 @@ export abstract class BaseAdapter implements IModelAdapter {
     message: string,
     errorCode: (typeof ErrorCode)[keyof typeof ErrorCode],
     originalError: unknown,
-    param?: string
+    param?: string,
+    retryAfterMs?: number
   ): ModelError {
     const fullMessage = `${this.providerId}/${this.modelId}: ${message}`;
 
@@ -360,6 +376,13 @@ export abstract class BaseAdapter implements IModelAdapter {
     // and the reactive self-heal path (#4071) can read which param to retry without.
     if (param !== undefined) {
       context.param = param;
+    }
+    // #4606: the provider-stated retry horizon, in ms. Set only when a horizon
+    // was actually read — absent means "the provider said nothing", which is
+    // what `CapacityTracker.recordProviderQuotaExhaustion` needs to see rather
+    // than a substituted 0.
+    if (retryAfterMs !== undefined) {
+      context[RETRY_AFTER_CONTEXT_KEY] = retryAfterMs;
     }
     const options: NexusErrorOptions = {
       code: errorCode,

--- a/packages/nexus-agents/src/adapters/index.ts
+++ b/packages/nexus-agents/src/adapters/index.ts
@@ -49,6 +49,12 @@ export {
   isRateLimitText,
   RATE_LIMIT_PATTERNS,
   parseRetryAfterMs,
+  // HTTP `Retry-After` capture (#4606)
+  parseRetryAfterHeader,
+  extractRetryAfterMs,
+  resolveRetryAfterMs,
+  retryAfterMsFromContext,
+  RETRY_AFTER_CONTEXT_KEY,
   toRateLimitError,
   recordRateLimitEvent,
   getRateLimitStats,

--- a/packages/nexus-agents/src/adapters/openai-compat-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-compat-adapter.test.ts
@@ -11,16 +11,23 @@ import {
   createOpenAICompatAdapter,
   type OpenAICompatConfig,
 } from './openai-compat-adapter.js';
-import { ConfigError } from '../core/index.js';
+import { ConfigError, ErrorCode } from '../core/index.js';
 
-// Mock the OpenAI SDK so tests don't make real HTTP calls.
-const { mockList } = vi.hoisted(() => ({ mockList: vi.fn() }));
-vi.mock('openai', () => {
+// Mock the OpenAI SDK so tests don't make real HTTP calls. `mockChatCreate` is
+// hoisted so the #4606 delegation test can drive a 429 through the inner
+// OpenAIAdapter; keep the real `APIError`, which that adapter does
+// `instanceof` against.
+const { mockList, mockChatCreate } = vi.hoisted(() => ({
+  mockList: vi.fn(),
+  mockChatCreate: vi.fn(),
+}));
+vi.mock('openai', async () => {
+  const actual = await vi.importActual<typeof import('openai')>('openai');
   class MockOpenAI {
     models = { list: mockList };
-    chat = { completions: { create: vi.fn() } };
+    chat = { completions: { create: mockChatCreate } };
   }
-  return { default: MockOpenAI };
+  return { default: MockOpenAI, APIError: actual.APIError };
 });
 
 // #2503: stub the opencode-bridge so these tests stay focused on env-var
@@ -332,5 +339,37 @@ describe('buildOpenAICompatAdapters (#2468)', () => {
     mockList.mockRejectedValue(new Error('gateway down'));
     const result = await buildOpenAICompatAdapters();
     expect(result?.ok).toBe(false);
+  });
+});
+
+/**
+ * The gateway adapter delegates the actual request to an inner `OpenAIAdapter`
+ * and returns its `Result` untouched, so the #4606 header capture reaches this
+ * path for free. Pinned here so a future refactor that rebuilds the error on
+ * the way out cannot silently drop the horizon again.
+ */
+describe('openai-compat retry-after delegation (#4606)', () => {
+  it("passes the inner adapter's captured Retry-After straight through", async () => {
+    const { APIError } = await import('openai');
+    mockChatCreate.mockRejectedValueOnce(
+      new APIError(
+        429,
+        { error: { message: 'Rate limit reached', type: 'rate_limit_exceeded' } },
+        'Rate limit reached',
+        new Headers({ 'retry-after': '3600' })
+      )
+    );
+    const adapter = createOpenAICompatAdapter('gateway-model', {
+      baseUrl: 'https://gateway.example/v1',
+      apiKey: 'test-key',
+    });
+
+    const result = await adapter.complete({ messages: [{ role: 'user', content: 'hi' }] });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCode.MODEL_RATE_LIMITED);
+      expect(result.error.context?.['retryAfterMs']).toBe(3_600_000);
+    }
   });
 });

--- a/packages/nexus-agents/src/adapters/rate-limit-detector.test.ts
+++ b/packages/nexus-agents/src/adapters/rate-limit-detector.test.ts
@@ -4,18 +4,21 @@
  * (Source: Issue #996 — Rate limit error surfacing)
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   isRateLimitLikeError,
   isRateLimitText,
   RATE_LIMIT_PATTERNS,
   parseRetryAfterMs,
+  parseRetryAfterHeader,
+  extractRetryAfterMs,
   toRateLimitError,
   recordRateLimitEvent,
   getRateLimitStats,
   clearRateLimitEvents,
 } from './rate-limit-detector.js';
 import { RateLimitError } from '../core/errors.js';
+import { FixedTimeProvider, setTimeProvider, resetTimeProvider } from '../core/index.js';
 
 beforeEach(() => {
   clearRateLimitEvents();
@@ -211,5 +214,155 @@ describe('rate limit tracking', () => {
     // Should cap at 200
     const testStat = stats.find((s) => s.provider === 'test');
     expect(testStat?.totalHits).toBe(200);
+  });
+});
+
+// ============================================================================
+// Retry-After HEADER Capture Tests (#4606)
+// ============================================================================
+
+/**
+ * The horizon only ever arrived for the OpenAI family, because it was parsed
+ * out of prose and the HTTP `Retry-After` header was dropped with the
+ * response. Anthropic states nothing in its 429 body and Gemini states it as
+ * `"retryDelay":"33s"` — so neither arm could report a quota horizon at all.
+ */
+describe('parseRetryAfterHeader (#4606)', () => {
+  beforeEach(() => {
+    setTimeProvider(new FixedTimeProvider(Date.parse('Wed, 21 Oct 2015 07:28:00 GMT')));
+  });
+
+  afterEach(() => {
+    resetTimeProvider();
+  });
+
+  it('parses the delta-seconds form', () => {
+    expect(parseRetryAfterHeader('120')).toBe(120_000);
+  });
+
+  it('parses the HTTP-date form against the current clock', () => {
+    expect(parseRetryAfterHeader('Wed, 21 Oct 2015 07:29:00 GMT')).toBe(60_000);
+  });
+
+  it('clamps an HTTP-date already in the past to zero rather than negative', () => {
+    expect(parseRetryAfterHeader('Wed, 21 Oct 2015 07:27:00 GMT')).toBe(0);
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseRetryAfterHeader('  45  ')).toBe(45_000);
+  });
+
+  /**
+   * Names the empty case. A `0` horizon reads downstream as "retry
+   * immediately", which is a measurement; defaulting to it when the header
+   * could not be read would report a vacuous default as a provider assertion.
+   */
+  it('reports an UNPARSEABLE header as absent, never as a zero horizon', () => {
+    for (const bogus of ['soon', '', '   ', 'later today', '-30', '12.5', 'NaN']) {
+      const parsed = parseRetryAfterHeader(bogus);
+      expect(parsed, `"${bogus}" must be absent, not 0`).toBeUndefined();
+    }
+  });
+
+  it('reports an ABSENT header as absent, never as a zero horizon', () => {
+    expect(parseRetryAfterHeader(undefined)).toBeUndefined();
+    expect(parseRetryAfterHeader(null)).toBeUndefined();
+  });
+
+  it('keeps a literal "0" distinguishable from an absent header', () => {
+    // A server that really said 0 said "retry now"; that is a measurement and
+    // survives as one. Only the unreadable case collapses to undefined.
+    expect(parseRetryAfterHeader('0')).toBe(0);
+  });
+});
+
+describe('extractRetryAfterMs (#4606)', () => {
+  it('reads a Headers-style bag (Anthropic/OpenAI SDK APIError.headers)', () => {
+    const error = Object.assign(new Error('429 rate_limit_error'), {
+      status: 429,
+      headers: new Headers({ 'retry-after': '3600' }),
+    });
+    expect(extractRetryAfterMs(error)).toBe(3_600_000);
+  });
+
+  it('reads a plain record bag (Vercel AI SDK APICallError.responseHeaders)', () => {
+    const error = Object.assign(new Error('rate limit exceeded'), {
+      responseHeaders: { 'content-type': 'application/json', 'Retry-After': '90' },
+    });
+    expect(extractRetryAfterMs(error)).toBe(90_000);
+  });
+
+  it('follows the cause chain, so a re-classification probe keeps the horizon', () => {
+    // The OpenAI adapter classifies on a clean probe Error and sets
+    // `probe.cause = originalError`; the header lives on the original.
+    const original = Object.assign(new Error('429'), {
+      headers: new Headers({ 'retry-after': '75' }),
+    });
+    const probe = Object.assign(new Error('429'), { cause: original });
+    expect(extractRetryAfterMs(probe)).toBe(75_000);
+  });
+
+  it('returns absent for an error with no header bag at all', () => {
+    expect(extractRetryAfterMs(new Error('429 too many requests'))).toBeUndefined();
+    expect(extractRetryAfterMs('a string')).toBeUndefined();
+    expect(extractRetryAfterMs(undefined)).toBeUndefined();
+  });
+
+  it('returns absent — not zero — when the bag holds an unparseable value', () => {
+    const error = Object.assign(new Error('429'), {
+      headers: new Headers({ 'retry-after': 'whenever' }),
+    });
+    expect(extractRetryAfterMs(error)).toBeUndefined();
+  });
+
+  it('extracts ONLY retry-after and never returns the header bag itself', () => {
+    // Security constraint: Authorization and API keys ride in the same bag.
+    const error = Object.assign(new Error('429'), {
+      headers: new Headers({
+        authorization: 'Bearer sk-test-not-a-real-key',
+        'x-api-key': 'sk-test-also-not-real',
+        'retry-after': '30',
+      }),
+    });
+    const captured = extractRetryAfterMs(error);
+    expect(typeof captured).toBe('number');
+    expect(JSON.stringify(captured)).not.toContain('Bearer');
+    expect(JSON.stringify(captured)).not.toContain('sk-test');
+  });
+});
+
+describe('parseRetryAfterMs body fallbacks (#4606)', () => {
+  it('parses the Gemini RetryInfo shape stringified into the message', () => {
+    const body =
+      '{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","details":' +
+      '[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"33s"}]}}';
+    expect(parseRetryAfterMs(body)).toBe(33_000);
+  });
+
+  it('parses a fractional Gemini retryDelay', () => {
+    expect(parseRetryAfterMs('{"retryDelay":"1.5s"}')).toBe(1500);
+  });
+
+  it('parses the sub-second OpenAI phrasing that the second-granularity rule missed', () => {
+    expect(parseRetryAfterMs('Please try again in 632ms')).toBe(632);
+  });
+
+  it('still parses the whole-second OpenAI phrasing', () => {
+    expect(parseRetryAfterMs('Please try again in 20s')).toBe(20_000);
+  });
+
+  it('stays absent when the body states no horizon (Anthropic 429)', () => {
+    expect(
+      parseRetryAfterMs('{"type":"error","error":{"type":"rate_limit_error","message":"..."}}')
+    ).toBeUndefined();
+  });
+});
+
+describe('toRateLimitError header capture (#4606)', () => {
+  it('prefers the header horizon over the message prose', () => {
+    const error = Object.assign(new Error('rate limit; try again in 20s'), {
+      headers: new Headers({ 'retry-after': '600' }),
+    });
+    expect(toRateLimitError(error, 'openai').retryAfterMs).toBe(600_000);
   });
 });

--- a/packages/nexus-agents/src/adapters/rate-limit-detector.ts
+++ b/packages/nexus-agents/src/adapters/rate-limit-detector.ts
@@ -8,7 +8,7 @@
  * (Source: Issue #996 — Rate limit error surfacing)
  */
 
-import { RateLimitError, getErrorMessage } from '../core/index.js';
+import { RateLimitError, getErrorMessage, getTimeProvider } from '../core/index.js';
 
 // ============================================================================
 // Detection
@@ -49,33 +49,180 @@ export function isRateLimitLikeError(error: unknown): boolean {
 }
 
 /**
+ * Wait-hint patterns providers put in an error message, in precedence order.
+ * Each captures one number; `msPerUnit` converts it to milliseconds.
+ *
+ * The body is the FALLBACK for the HTTP `Retry-After` header — see
+ * {@link resolveRetryAfterMs}. It is the only channel for vendors that state
+ * the horizon nowhere else (#4606).
+ */
+const RETRY_HINT_PATTERNS: readonly { readonly pattern: RegExp; readonly msPerUnit: number }[] = [
+  // "retry after X seconds" / "retry-after: X sec"
+  { pattern: /retry[- ]?after[:\s]+(\d+(?:\.\d+)?)\s*(?:s|sec)/i, msPerUnit: 1000 },
+  // "retry after X ms" / "wait X milliseconds"
+  { pattern: /(?:retry[- ]?after|wait)[:\s]+(\d+)\s*(?:ms|millisecond)/i, msPerUnit: 1 },
+  // "try again in X seconds" — the OpenAI family's phrasing.
+  { pattern: /try again in (\d+(?:\.\d+)?)\s*(?:s|sec)/i, msPerUnit: 1000 },
+  // #4606: the sub-second variant. The rule above cannot match "try again in
+  // 632ms" — `632` is followed by `m`, not `s` — so the OpenAI family silently
+  // lost every horizon shorter than a second.
+  { pattern: /try again in (\d+(?:\.\d+)?)\s*ms\b/i, msPerUnit: 1 },
+  // #4606: Gemini states its horizon only as google.rpc.RetryInfo inside the
+  // response body, and `@google/genai` stringifies that whole body into the
+  // error message (its `ApiError` carries `{message, status}` and no headers),
+  // so this is the only place the horizon is reachable on that vendor.
+  { pattern: /"retrydelay"\s*:\s*"(\d+(?:\.\d+)?)s"/i, msPerUnit: 1000 },
+];
+
+/**
  * Parses retry-after metadata from an error message.
  * Providers often include timing hints in error messages.
  */
 export function parseRetryAfterMs(errorMessage: string): number | undefined {
   const lower = errorMessage.toLowerCase();
-
-  // Match "retry after X seconds" or "retry-after: X"
-  const secondsMatch = /retry[- ]?after[:\s]+(\d+(?:\.\d+)?)\s*(?:s|sec)/i.exec(lower);
-  if (secondsMatch !== null) {
-    const parsed = parseFloat(secondsMatch[1] ?? '0');
-    return Math.ceil(parsed * 1000);
+  for (const { pattern, msPerUnit } of RETRY_HINT_PATTERNS) {
+    const match = pattern.exec(lower);
+    const captured = match?.[1];
+    if (captured !== undefined) {
+      return Math.ceil(Number.parseFloat(captured) * msPerUnit);
+    }
   }
-
-  // Match "retry after X ms" or "wait X milliseconds"
-  const msMatch = /(?:retry[- ]?after|wait)[:\s]+(\d+)\s*(?:ms|millisecond)/i.exec(lower);
-  if (msMatch !== null) {
-    return parseInt(msMatch[1] ?? '0', 10);
-  }
-
-  // Match "try again in X seconds"
-  const againMatch = /try again in (\d+(?:\.\d+)?)\s*(?:s|sec)/i.exec(lower);
-  if (againMatch !== null) {
-    const parsed = parseFloat(againMatch[1] ?? '0');
-    return Math.ceil(parsed * 1000);
-  }
-
   return undefined;
+}
+
+// ============================================================================
+// HTTP Retry-After capture (#4606)
+// ============================================================================
+
+/**
+ * The ONLY header this module ever reads.
+ *
+ * A 429 response's header bag also carries `Authorization` / `x-api-key` and
+ * every other credential the request was made with. Nothing here accepts,
+ * returns, or stores a header object: the named field is read at the boundary
+ * and converted to a number before anything travels inward.
+ */
+const RETRY_AFTER_HEADER = 'retry-after';
+
+/** Error fields under which the SDKs hang their response header bag. */
+const HEADER_BAG_FIELDS = ['headers', 'responseHeaders'] as const;
+
+/** How far to follow `cause` looking for the originating provider error. */
+const MAX_CAUSE_DEPTH = 3;
+
+/** Day-of-week prefix shared by all three legal HTTP-date spellings. */
+const HTTP_DATE_PREFIX = /^(?:mon|tue|wed|thu|fri|sat|sun)/i;
+
+/**
+ * Parse an HTTP `Retry-After` header value (RFC 9110 §10.2.3).
+ *
+ * Both legal forms are accepted: delta-seconds (`"120"`) and an HTTP-date
+ * (`"Wed, 21 Oct 2015 07:28:00 GMT"`), resolved against the current clock. A
+ * date already past yields 0 — the server said "now", which is a real answer.
+ *
+ * An absent or unparseable value returns `undefined`, never 0. A 0 horizon
+ * reads downstream as "retry immediately"; substituting it for a value we
+ * could not read would report a vacuous default as a provider measurement,
+ * which is the shape `.rules/development-disciplines.md` prohibits. A literal
+ * `"0"` still parses to 0 and stays distinguishable from absence.
+ */
+export function parseRetryAfterHeader(value: string | null | undefined): number | undefined {
+  if (value === null || value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (trimmed === '') return undefined;
+
+  // delta-seconds — a non-negative integer, per the grammar. Anything else
+  // (fractions, negatives) is not this form and falls through to the date try.
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10) * 1000;
+  }
+
+  // HTTP-date. All three legal spellings (IMF-fixdate, the obsolete RFC 850
+  // form, and asctime) begin with a day-of-week name, so gate on that before
+  // handing anything to `Date.parse`. Ungated, `Date.parse` is lenient enough
+  // to turn junk like "12.5" into a date in 2001 — which then clamps to 0 and
+  // reports "retry immediately" for a header we could not actually read.
+  if (!HTTP_DATE_PREFIX.test(trimmed)) return undefined;
+  const at = Date.parse(trimmed);
+  if (Number.isNaN(at)) return undefined;
+  return Math.max(0, at - getTimeProvider().now());
+}
+
+/**
+ * Read `Retry-After` out of one header bag, whatever shape the SDK used.
+ *
+ * `@anthropic-ai/sdk` and `openai` hand back a `Headers` instance (a `.get()`
+ * surface); the Vercel AI SDK hands back a plain `Record<string, string>`.
+ * Header names are case-insensitive either way. Returns the raw string so the
+ * caller can decide; nothing else in the bag is read.
+ */
+function readRetryAfterField(bag: unknown): string | undefined {
+  if (bag === null || typeof bag !== 'object') return undefined;
+
+  const getter = (bag as { get?: unknown }).get;
+  if (typeof getter === 'function') {
+    const raw = (bag as { get(name: string): unknown }).get(RETRY_AFTER_HEADER);
+    return typeof raw === 'string' ? raw : undefined;
+  }
+
+  for (const [key, val] of Object.entries(bag as Record<string, unknown>)) {
+    if (key.toLowerCase() === RETRY_AFTER_HEADER && typeof val === 'string') return val;
+  }
+  return undefined;
+}
+
+/**
+ * Capture the provider's stated retry horizon from a thrown SDK error (#4606).
+ *
+ * `transformError` used to drop the HTTP response, so the horizon survived
+ * only when a vendor happened to repeat it in prose — which the OpenAI family
+ * does and Anthropic does not. Both SDKs attach the response headers directly
+ * to the thrown `APIError`, so the boundary is reachable without holding the
+ * response open.
+ *
+ * The `cause` chain is followed (bounded) because the OpenAI adapter
+ * re-classifies on a clean probe `Error` and hangs the original off `cause`.
+ *
+ * @returns Milliseconds until retry, or `undefined` when no readable header
+ *   was found. Never a header object, and never a substituted 0.
+ */
+export function extractRetryAfterMs(error: unknown): number | undefined {
+  let current: unknown = error;
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH; depth++) {
+    if (current === null || typeof current !== 'object') return undefined;
+    const obj = current as Record<string, unknown>;
+    for (const field of HEADER_BAG_FIELDS) {
+      const parsed = parseRetryAfterHeader(readRetryAfterField(obj[field]));
+      if (parsed !== undefined) return parsed;
+    }
+    current = obj['cause'];
+  }
+  return undefined;
+}
+
+/**
+ * Context key under which the adapters park a captured horizon on a
+ * `ModelError`. Single authoritative spelling — the bridge reads it back
+ * through {@link retryAfterMsFromContext}, never by hand.
+ */
+export const RETRY_AFTER_CONTEXT_KEY = 'retryAfterMs';
+
+/** Read a previously captured horizon back off a `ModelError`'s context. */
+export function retryAfterMsFromContext(
+  context: Record<string, unknown> | undefined
+): number | undefined {
+  const raw = context?.[RETRY_AFTER_CONTEXT_KEY];
+  return typeof raw === 'number' && Number.isFinite(raw) && raw >= 0 ? raw : undefined;
+}
+
+/**
+ * The horizon a provider stated, header first and body second (#4606).
+ *
+ * `Retry-After` is the authoritative field; the message patterns are the
+ * fallback for vendors that state the wait only in the response body.
+ */
+export function resolveRetryAfterMs(error: unknown, message: string): number | undefined {
+  return extractRetryAfterMs(error) ?? parseRetryAfterMs(message);
 }
 
 /**
@@ -83,7 +230,9 @@ export function parseRetryAfterMs(errorMessage: string): number | undefined {
  */
 export function toRateLimitError(error: unknown, provider?: string): RateLimitError {
   const message = getErrorMessage(error);
-  const retryAfterMs = parseRetryAfterMs(message);
+  // #4606: header first — the message prose is only a fallback for vendors
+  // that state the wait in the body instead of `Retry-After`.
+  const retryAfterMs = resolveRetryAfterMs(error, message);
   return new RateLimitError(message, {
     ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
     ...(provider !== undefined ? { provider } : {}),

--- a/packages/nexus-agents/src/adapters/retry-after-capture.test.ts
+++ b/packages/nexus-agents/src/adapters/retry-after-capture.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Per-vendor retry-horizon capture, end to end (#4606).
+ *
+ * `recordProviderQuotaExhaustion` accepts exactly one input — a retry horizon
+ * in milliseconds — and #4605 wired the API arms to feed it. But the horizon
+ * was parsed out of prose only, and `transformError` dropped the HTTP response
+ * before anyone could read `Retry-After`. Measured before this change:
+ *
+ * | vendor    | horizon in the body        | reached the tracker? |
+ * | --------- | -------------------------- | -------------------- |
+ * | OpenAI    | "Please try again in 20s"  | yes; "632ms" no      |
+ * | Anthropic | nothing at all             | NO                   |
+ * | Gemini    | `"retryDelay":"33s"`       | NO                   |
+ *
+ * So two of the three arms could not report a quota horizon by construction.
+ * Each vendor below gets both halves of the mutation check: a 429 that states
+ * a durable horizon must reach `exhausted`, and a 429 that states nothing
+ * anywhere must stay `unmeasured` — never `healthy`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  anthropicCreate: vi.fn(),
+  openaiCreate: vi.fn(),
+  geminiGenerate: vi.fn(),
+}));
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: mocks.anthropicCreate, stream: vi.fn() };
+  },
+}));
+
+// Keep the REAL `APIError`: the OpenAI adapter's #4047 re-messaging branch is
+// `instanceof APIError`, and that branch is exactly where the headers used to
+// be dropped on the floor.
+vi.mock('openai', async () => {
+  const actual = await vi.importActual<typeof import('openai')>('openai');
+  return {
+    default: class MockOpenAI {
+      chat = { completions: { create: mocks.openaiCreate } };
+    },
+    APIError: actual.APIError,
+  };
+});
+
+vi.mock('@google/genai', () => ({
+  GoogleGenAI: class MockGoogleGenAI {
+    models = { generateContent: mocks.geminiGenerate, generateContentStream: vi.fn() };
+  },
+}));
+
+import { APIError } from 'openai';
+import { ClaudeAdapter } from './claude-adapter.js';
+import { OpenAIAdapter } from './openai-adapter.js';
+import { GeminiAdapter } from './gemini-adapter.js';
+import { createModelToCliAdapter } from '../cli-adapters/model-to-cli-adapter.js';
+import { assessCapacity } from '../cli-adapters/routing/stages/capacity-stage.js';
+import { CapacityFilterStage } from '../cli-adapters/routing/stages/capacity-stage.js';
+import {
+  createRoutingContext,
+  getRemainingCandidates,
+} from '../cli-adapters/routing/router-stage.js';
+import type { IModelAdapter } from '../core/index.js';
+import { FixedTimeProvider, setTimeProvider, resetTimeProvider } from '../core/index.js';
+import type { CliName, RoutingArmId } from '../cli-adapters/types.js';
+
+/** Longer than the tracker's 60s window, so it means quota and not throttle. */
+const DURABLE_SECONDS = 3_600;
+const NOW = 1_700_000_000_000;
+
+/** Run one failing call through the bridge and report what the arm can say. */
+async function armAfterOneFailure(
+  modelAdapter: IModelAdapter,
+  name: CliName
+): Promise<{ retryAfterMs: number | undefined; grade: string; quotaExhausted: boolean }> {
+  const bridge = createModelToCliAdapter(modelAdapter, { name });
+  const result = await bridge.execute({ content: 'hi' });
+  expect(result.ok).toBe(false);
+  const capacity = await bridge.getCapacity();
+  return {
+    retryAfterMs: result.ok ? undefined : result.error.retryAfterMs,
+    grade: assessCapacity(capacity),
+    quotaExhausted: capacity.quotaExhausted,
+  };
+}
+
+/**
+ * The Anthropic SDK's thrown `APIError` shape: status, the JSON body, and the
+ * response headers hung straight off the error.
+ */
+function anthropicRateLimit(headers?: Record<string, string>): Error {
+  const body = { type: 'error', error: { type: 'rate_limit_error', message: 'rate limit' } };
+  return Object.assign(new Error(`429 ${JSON.stringify(body)}`), {
+    status: 429,
+    error: body,
+    ...(headers === undefined ? {} : { headers: new Headers(headers) }),
+  });
+}
+
+/** The `@google/genai` `ApiError`: `{message, status}` and NO headers at all. */
+function geminiRateLimit(body: unknown): Error {
+  return Object.assign(new Error(JSON.stringify(body)), { name: 'ApiError', status: 429 });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setTimeProvider(new FixedTimeProvider(NOW));
+});
+
+afterEach(() => {
+  resetTimeProvider();
+});
+
+describe('Anthropic arm — horizon lives ONLY in the header (#4606)', () => {
+  const config = { modelId: 'claude-sonnet-4', apiKey: 'test-api-key-12345' };
+
+  it('reaches exhausted from a Retry-After header its 429 body never mentions', async () => {
+    mocks.anthropicCreate.mockRejectedValue(
+      anthropicRateLimit({ 'retry-after': String(DURABLE_SECONDS) })
+    );
+
+    const arm = await armAfterOneFailure(new ClaudeAdapter(config), 'claude');
+
+    expect(arm.retryAfterMs).toBe(DURABLE_SECONDS * 1000);
+    expect(arm.quotaExhausted).toBe(true);
+    expect(arm.grade).toBe('exhausted');
+  });
+
+  it('stays unmeasured — never healthy — with neither header nor prose', async () => {
+    mocks.anthropicCreate.mockRejectedValue(anthropicRateLimit());
+
+    const arm = await armAfterOneFailure(new ClaudeAdapter(config), 'claude');
+
+    expect(arm.retryAfterMs).toBeUndefined();
+    expect(arm.quotaExhausted).toBe(false);
+    expect(arm.grade).toBe('unmeasured');
+  });
+
+  it('accepts the HTTP-date form of Retry-After', async () => {
+    mocks.anthropicCreate.mockRejectedValue(
+      anthropicRateLimit({ 'retry-after': new Date(NOW + DURABLE_SECONDS * 1000).toUTCString() })
+    );
+
+    const arm = await armAfterOneFailure(new ClaudeAdapter(config), 'claude');
+
+    expect(arm.retryAfterMs).toBe(DURABLE_SECONDS * 1000);
+    expect(arm.grade).toBe('exhausted');
+  });
+
+  it('treats an unreadable Retry-After as absent, not as a zero horizon', async () => {
+    mocks.anthropicCreate.mockRejectedValue(anthropicRateLimit({ 'retry-after': 'soon' }));
+
+    const arm = await armAfterOneFailure(new ClaudeAdapter(config), 'claude');
+
+    expect(arm.retryAfterMs).toBeUndefined();
+    expect(arm.grade).toBe('unmeasured');
+  });
+
+  it('never lets the rest of the header bag out of the boundary', async () => {
+    mocks.anthropicCreate.mockRejectedValue(
+      anthropicRateLimit({
+        authorization: 'Bearer sk-ant-test-not-a-real-key',
+        'x-api-key': 'sk-ant-test-also-not-real',
+        'retry-after': String(DURABLE_SECONDS),
+      })
+    );
+
+    const bridge = createModelToCliAdapter(new ClaudeAdapter(config), { name: 'claude' });
+    const result = await bridge.execute({ content: 'hi' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Everything the bridge exposes — message, cause chain, the whole error —
+      // must be free of the credentials that rode in the same bag.
+      const exposed = JSON.stringify({
+        error: result.error,
+        message: result.error.message,
+        cause: result.error.cause?.message,
+      });
+      expect(exposed).not.toContain('sk-ant-test');
+      expect(exposed).not.toContain('Bearer');
+      expect(exposed).not.toContain('authorization');
+      expect(result.error.retryAfterMs).toBe(DURABLE_SECONDS * 1000);
+    }
+  });
+});
+
+describe('OpenAI arm — header beats prose, and sub-second prose now parses (#4606)', () => {
+  const config = { modelId: 'gpt-4o', apiKey: 'test-api-key-12345' };
+
+  function openaiRateLimit(message: string, headers?: Record<string, string>): APIError {
+    return new APIError(
+      429,
+      { error: { message, type: 'rate_limit_exceeded' } },
+      message,
+      headers === undefined ? undefined : new Headers(headers)
+    );
+  }
+
+  it('prefers the Retry-After header over the shorter horizon stated in prose', async () => {
+    // The prose says 20s (a throttle); the header says an hour (quota). The
+    // authoritative field must win, or the arm under-reports its outage.
+    mocks.openaiCreate.mockRejectedValue(
+      openaiRateLimit('Rate limit reached. Please try again in 20s', {
+        'retry-after': String(DURABLE_SECONDS),
+      })
+    );
+
+    const arm = await armAfterOneFailure(new OpenAIAdapter(config), 'codex');
+
+    expect(arm.retryAfterMs).toBe(DURABLE_SECONDS * 1000);
+    expect(arm.grade).toBe('exhausted');
+  });
+
+  it('keeps the prose path working when the gateway sends no header', async () => {
+    mocks.openaiCreate.mockRejectedValue(
+      openaiRateLimit(`Rate limit reached. Please try again in ${String(DURABLE_SECONDS)}s`)
+    );
+
+    const arm = await armAfterOneFailure(new OpenAIAdapter(config), 'codex');
+
+    expect(arm.retryAfterMs).toBe(DURABLE_SECONDS * 1000);
+    expect(arm.grade).toBe('exhausted');
+  });
+
+  it('parses the sub-second phrasing the second-granularity rule used to miss', async () => {
+    mocks.openaiCreate.mockRejectedValue(
+      openaiRateLimit('Rate limit reached. Please try again in 632ms')
+    );
+
+    const bridge = createModelToCliAdapter(new OpenAIAdapter(config), { name: 'codex' });
+    const result = await bridge.execute({ content: 'hi' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.retryAfterMs).toBe(632);
+  });
+
+  it('does NOT escalate a sub-window horizon to quota exhaustion', async () => {
+    mocks.openaiCreate.mockRejectedValue(
+      openaiRateLimit('Rate limit reached', { 'retry-after': '5' })
+    );
+
+    const arm = await armAfterOneFailure(new OpenAIAdapter(config), 'codex');
+
+    expect(arm.retryAfterMs).toBe(5_000);
+    expect(arm.quotaExhausted).toBe(false);
+  });
+
+  it('stays unmeasured — never healthy — with neither header nor prose', async () => {
+    mocks.openaiCreate.mockRejectedValue(openaiRateLimit('Rate limit reached for gpt-4o'));
+
+    const arm = await armAfterOneFailure(new OpenAIAdapter(config), 'codex');
+
+    expect(arm.retryAfterMs).toBeUndefined();
+    expect(arm.grade).toBe('unmeasured');
+  });
+});
+
+describe('Gemini arm — no headers on the SDK error, horizon only in RetryInfo (#4606)', () => {
+  const config = { modelId: 'gemini-2.5-flash', apiKey: 'test-api-key-12345' };
+
+  it('reaches exhausted from the RetryInfo the SDK stringifies into the message', async () => {
+    mocks.geminiGenerate.mockRejectedValue(
+      geminiRateLimit({
+        error: {
+          code: 429,
+          status: 'RESOURCE_EXHAUSTED',
+          message: 'You exceeded your current quota',
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+              retryDelay: `${String(DURABLE_SECONDS)}s`,
+            },
+          ],
+        },
+      })
+    );
+
+    const arm = await armAfterOneFailure(new GeminiAdapter(config), 'gemini');
+
+    expect(arm.retryAfterMs).toBe(DURABLE_SECONDS * 1000);
+    expect(arm.grade).toBe('exhausted');
+  });
+
+  it('does NOT escalate the common 33s RetryInfo to quota exhaustion', async () => {
+    mocks.geminiGenerate.mockRejectedValue(
+      geminiRateLimit({
+        error: {
+          code: 429,
+          status: 'RESOURCE_EXHAUSTED',
+          details: [{ '@type': 'google.rpc.RetryInfo', retryDelay: '33s' }],
+        },
+      })
+    );
+
+    const arm = await armAfterOneFailure(new GeminiAdapter(config), 'gemini');
+
+    expect(arm.retryAfterMs).toBe(33_000);
+    expect(arm.quotaExhausted).toBe(false);
+  });
+
+  it('stays unmeasured — never healthy — when the body carries no RetryInfo', async () => {
+    mocks.geminiGenerate.mockRejectedValue(
+      geminiRateLimit({ error: { code: 429, status: 'RESOURCE_EXHAUSTED', message: 'quota' } })
+    );
+
+    const arm = await armAfterOneFailure(new GeminiAdapter(config), 'gemini');
+
+    expect(arm.retryAfterMs).toBeUndefined();
+    expect(arm.grade).toBe('unmeasured');
+  });
+});
+
+describe('routing defaults are untouched by a reportable horizon (#4606)', () => {
+  it('still routes an exhausted arm, because enforceHardLimits stays false', async () => {
+    mocks.anthropicCreate.mockRejectedValue(
+      anthropicRateLimit({ 'retry-after': String(DURABLE_SECONDS) })
+    );
+    const bridge = createModelToCliAdapter(
+      new ClaudeAdapter({ modelId: 'claude-sonnet-4', apiKey: 'test-api-key-12345' }),
+      { name: 'claude' }
+    );
+    await bridge.execute({ content: 'hi' });
+    expect((await bridge.getCapacity()).quotaExhausted).toBe(true);
+
+    const armId: RoutingArmId = 'claude';
+    const stage = new CapacityFilterStage(new Map([[armId, bridge]]));
+    const routed = await stage.route(createRoutingContext('x', ['claude']));
+
+    expect(routed.ok).toBe(true);
+    if (routed.ok) expect(getRemainingCandidates(routed.value.context)).toEqual([armId]);
+  });
+});

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
@@ -6,7 +6,10 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SdkAdapter, extractAiSdkFunctions } from './sdk-adapter.js';
-import type { CompletionRequest } from '../../core/index.js';
+import type { CompletionRequest, ModelError } from '../../core/index.js';
+import { ErrorCode } from '../../core/index.js';
+import { createModelToCliAdapter } from '../../cli-adapters/model-to-cli-adapter.js';
+import { assessCapacity } from '../../cli-adapters/routing/stages/capacity-stage.js';
 // Mock the AI SDK modules. The full `ai` mock stays installed for the whole
 // suite — the "missing export" cases (#3433) are unit-tested directly against
 // `extractAiSdkFunctions` (#3449) rather than swapping the global mock, so no
@@ -580,5 +583,105 @@ describe('SdkAdapter', () => {
       await adapter.complete(TEST_REQUEST);
       expect(dnsLookupMock).not.toHaveBeenCalled();
     });
+  });
+});
+
+/**
+ * Retry-horizon capture on the AI-SDK arm (#4606).
+ *
+ * `toErrorResult` builds its `ModelError` directly instead of going through
+ * `BaseAdapter.transformError`, so it needed the capture wired separately or
+ * this whole arm would keep reporting `unmeasured` on a 429 that named its own
+ * horizon. The Vercel AI SDK exposes it as `APICallError.responseHeaders` — a
+ * plain record, not a `Headers` instance.
+ */
+describe('SdkAdapter retry-after capture (#4606)', () => {
+  /** Longer than the CapacityTracker's 60s window: quota, not throttle. */
+  const DURABLE_MS = 3_600_000;
+
+  async function failWith(error: unknown): Promise<ModelError | undefined> {
+    const { generateText } = await import('ai');
+    vi.mocked(generateText).mockRejectedValueOnce(error);
+    const adapter = new SdkAdapter({
+      providerId: 'anthropic',
+      modelId: 'claude-sonnet-4-6',
+      apiKey: 'test-key',
+    });
+    const result = await adapter.complete(TEST_REQUEST);
+    expect(result.ok).toBe(false);
+    return result.ok ? undefined : result.error;
+  }
+
+  it('captures Retry-After from the SDK error responseHeaders record', async () => {
+    const error = await failWith(
+      Object.assign(new Error('rate limit exceeded'), {
+        statusCode: 429,
+        responseHeaders: { 'content-type': 'application/json', 'retry-after': '3600' },
+      })
+    );
+
+    expect(error?.code).toBe(ErrorCode.MODEL_RATE_LIMITED);
+    expect(error?.context?.['retryAfterMs']).toBe(DURABLE_MS);
+  });
+
+  it('leaves the horizon ABSENT — never 0 — when the 429 states none anywhere', async () => {
+    const error = await failWith(
+      Object.assign(new Error('429 too many requests'), { statusCode: 429 })
+    );
+
+    expect(error?.code).toBe(ErrorCode.MODEL_RATE_LIMITED);
+    expect(error?.context?.['retryAfterMs']).toBeUndefined();
+  });
+
+  it('never parks anything but the horizon from the header bag', async () => {
+    const error = await failWith(
+      Object.assign(new Error('rate limit exceeded'), {
+        statusCode: 429,
+        responseHeaders: {
+          authorization: 'Bearer sk-test-not-a-real-key',
+          'retry-after': '3600',
+        },
+      })
+    );
+
+    expect(error?.context).toEqual({ retryAfterMs: DURABLE_MS });
+  });
+
+  it('does not capture a horizon off a non-rate-limit failure', async () => {
+    // A wait hint inside a 500 body is not a rate-limit assertion.
+    const error = await failWith(
+      Object.assign(new Error('upstream 500'), {
+        statusCode: 500,
+        responseHeaders: { 'retry-after': '3600' },
+      })
+    );
+
+    expect(error?.code).not.toBe(ErrorCode.MODEL_RATE_LIMITED);
+    expect(error?.context?.['retryAfterMs']).toBeUndefined();
+  });
+
+  it('reaches exhausted through the bridge, and stays unmeasured without a horizon', async () => {
+    const { generateText } = await import('ai');
+    const makeAdapter = (): SdkAdapter =>
+      new SdkAdapter({ providerId: 'anthropic', modelId: 'claude-sonnet-4-6', apiKey: 'test-key' });
+
+    vi.mocked(generateText).mockRejectedValueOnce(
+      Object.assign(new Error('rate limit exceeded'), {
+        statusCode: 429,
+        responseHeaders: { 'retry-after': '3600' },
+      })
+    );
+    const stated = createModelToCliAdapter(makeAdapter(), { name: 'claude' });
+    await stated.execute({ content: 'hi' });
+    const statedCapacity = await stated.getCapacity();
+    expect(statedCapacity.quotaExhausted).toBe(true);
+    expect(assessCapacity(statedCapacity)).toBe('exhausted');
+
+    vi.mocked(generateText).mockRejectedValueOnce(new Error('429 too many requests'));
+    const silent = createModelToCliAdapter(makeAdapter(), { name: 'claude' });
+    await silent.execute({ content: 'hi' });
+    const silentCapacity = await silent.getCapacity();
+    expect(silentCapacity.quotaExhausted).toBe(false);
+    expect(assessCapacity(silentCapacity)).toBe('unmeasured');
   });
 });

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -26,7 +26,11 @@ import {
 } from '../../core/index.js';
 import { BaseAdapter, AdapterModelError } from '../base-adapter.js';
 import { ErrorCode } from '../../core/index.js';
-import { isRateLimitLikeError } from '../rate-limit-detector.js';
+import {
+  isRateLimitLikeError,
+  resolveRetryAfterMs,
+  RETRY_AFTER_CONTEXT_KEY,
+} from '../rate-limit-detector.js';
 import { sanitizeOutput } from '../../security/output-sanitizer.js';
 import type { SdkAdapterConfig, SdkProviderId } from './types.js';
 import { PROVIDER_ENV_KEYS, CUSTOM_API_BASE_URL_ENV } from './types.js';
@@ -568,9 +572,20 @@ export class SdkAdapter extends BaseAdapter {
     const safeMessage = sanitizeOutput(message);
     const errorObj = error instanceof Error ? error : new Error(safeMessage);
     this.logger.error(`SDK adapter error (${this.sdkProviderId})`, errorObj);
+    // #4606: this path builds the ModelError itself rather than going through
+    // `BaseAdapter.transformError`, so it has to capture the horizon too. The
+    // AI SDK's `APICallError` carries `responseHeaders` as a plain record;
+    // `resolveRetryAfterMs` reads only `retry-after` out of it and returns a
+    // number, so no header bag reaches the error or the logs. Parsed off the
+    // SANITIZED message, so a scrubbed credential can't be re-read from it.
+    const retryAfterMs =
+      code === ErrorCode.MODEL_RATE_LIMITED ? resolveRetryAfterMs(error, safeMessage) : undefined;
     // AdapterModelError extends ModelError — no cast needed
     const modelError = new AdapterModelError(`${this.sdkProviderId} SDK error: ${safeMessage}`, {
       code,
+      ...(retryAfterMs !== undefined
+        ? { context: { [RETRY_AFTER_CONTEXT_KEY]: retryAfterMs } }
+        : {}),
     });
     return { ok: false, error: modelError };
   }

--- a/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
@@ -20,7 +20,11 @@ import type {
 } from '../core/index.js';
 import { ok, err, ModelError } from '../core/index.js';
 import { FALLBACK_CONTEXT_WINDOW } from '../config/model-config-helpers.js';
-import { isRateLimitText, parseRetryAfterMs } from '../adapters/rate-limit-detector.js';
+import {
+  isRateLimitText,
+  parseRetryAfterMs,
+  retryAfterMsFromContext,
+} from '../adapters/rate-limit-detector.js';
 import { CapacityTracker, createCapacityTracker } from './capacity-tracker.js';
 import type {
   ICliAdapter,
@@ -158,11 +162,18 @@ export class ModelToCliAdapter implements ICliAdapter {
    *
    * Only parsed on a retryable error, as on the subprocess path: a wait hint
    * inside a 500 body is not a rate-limit assertion.
+   *
+   * #4606: the adapter that raised this error already captured the HTTP
+   * `Retry-After` header, which the message never carries — Anthropic states
+   * no horizon in its 429 body at all. That captured value wins; the message
+   * parse remains the fallback for a `ModelError` raised outside `BaseAdapter`.
    */
   private toCliError(error: ModelError): CliError {
     const rateLimited = isRateLimitText(error.message);
     const code: CliErrorCode = rateLimited ? 'RATE_LIMITED' : 'EXECUTION_ERROR';
-    const retryAfterMs = rateLimited ? parseRetryAfterMs(error.message) : undefined;
+    const retryAfterMs = rateLimited
+      ? (retryAfterMsFromContext(error.context) ?? parseRetryAfterMs(error.message))
+      : undefined;
     const base: CliError = {
       code,
       message: error.message,


### PR DESCRIPTION
Closes #4606. Completes the chain #4602/#4605 started, and — measured below — likely removes the remaining justification for #4532.

## The gap

`recordProviderQuotaExhaustion` accepts exactly one input: a retry horizon in milliseconds. #4605 wired the API arms to feed it. But the horizon was parsed out of **error message prose only**, and `transformError` dropped the HTTP response before anyone could read `Retry-After`:

| Vendor | Horizon in the body | Reached the tracker? |
| --- | --- | --- |
| OpenAI | "Please try again in 20s" | yes — but "632ms" did not |
| Anthropic | **nothing at all** | no |
| Gemini | `"retryDelay":"33s"` | no — matched no pattern |

Two of three arms could not report a quota horizon **by construction**, even after #4605 wired the path end to end.

## Reachability, verified per adapter — and the earlier spike was wrong about Gemini

| Adapter | Reachable | Evidence |
| --- | --- | --- |
| Anthropic | **yes** | `APIError.headers` hangs off the *thrown error* — no `withResponse()` needed |
| OpenAI | **yes** | same shape |
| openai-compat | **yes**, inherited | returns the inner `OpenAIAdapter` result untouched |
| Vercel AI SDK | **yes** | `APICallError.responseHeaders` |
| **Gemini** | **no** | `ApiError` is `{message, status}` only. `sdkHttpResponse` exists on *success* types, never on the error |

The #4532 spike listed Gemini as header-reachable via `sdkHttpResponse.headers`. That was true of the success path and not of the error path, which is the only one that matters here. Recorded rather than quietly worked around: Gemini's body fallback is its **only** channel, so a `retryDelay` pattern was added for it.

Two adapters also turned out *easier* than the spike thought — Anthropic and OpenAI expose headers directly on the thrown error.

## Correctness details worth stating

- **Both legal `Retry-After` forms**: delta-seconds, and HTTP-date resolved against `getTimeProvider()` and clamped at 0 for a past date.
- **Unparseable or absent stays absent, never 0.** A zero horizon reads as "retry immediately" — the vacuous-default shape `.rules/development-disciplines.md` now covers. Pinned by `reports an UNPARSEABLE header as absent, never as a zero horizon`.
- **A real red found during development**: `Date.parse("12.5")` yields a 2001 date, which clamps to 0 — so a malformed numeric header would have become "retry immediately". The date branch is now gated on the day-of-week prefix all three legal spellings share. A literal `"0"` still parses to 0 and stays distinguishable from absence.
- Header first, prose second. Body fallbacks are used **only** when no header is present.

## Security constraint held

Only `retry-after` is read, **by name**, and converted to a number at the boundary — no header object travels inward. A test seeds `authorization` and `x-api-key` into the header bag and asserts that nothing containing `Bearer`, `sk-ant-test`, or `authorization` reaches the error, its message, or its cause chain. This was the constraint the #4532 security voter raised.

## Proven end to end, per vendor

`retry-after-capture.test.ts` drives real adapters with mocked SDK clients through the whole chain — 429 → `CliError` → `CapacityTracker` → `assessCapacity` → `CapacityFilterStage`:

| Arm | 429 + durable horizon | 429 with neither header nor prose |
| --- | --- | --- |
| Anthropic (header only) | `exhausted` | `unmeasured` |
| OpenAI (header beats the 20s prose) | `exhausted` | `unmeasured` |
| Gemini (RetryInfo body) | `exhausted` | `unmeasured` |
| AI SDK (`responseHeaders`) | `exhausted` | `unmeasured` |

Also pinned: a 5s horizon does **not** escalate to durable quota, and an unreadable header grades `unmeasured` rather than exhausted. Red-verified by reverting each capture point — 6 failures on the `BaseAdapter` path, 3 on `SdkAdapter`, 17 on the detector, all `expected undefined to be 3600000` and none by import error.

## What this means for #4532

The panel there chose to wire the provider-header `CapacityMonitor` into the live path. The spike then showed the exclusion path already worked without it, shrinking its claim to "react before the first local failure". This PR now delivers the provider-asserted horizon for **every** vendor that can supply one, through the canonical tracker, with no new subsystem and no TTL design needed — a retry horizon is already an absolute wait and `CapacityTracker` self-expires, where `CapacityMonitor` has no expiry at all.

I'd re-measure before doing any of that work. Comment to follow on #4532.

## Verification

- `vitest run` — **1183 files, 28,192 tests, 0 failures**
- `pnpm typecheck`, `pnpm lint`, `prettier --check` — clean
- No routing file touched; `enforceHardLimits` still defaults `false`, with a test confirming an exhausted arm still routes
- No existing test needed repointing — the full suite went green without it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
