### PR TITLE
fix(adapters): thread Claude cache token figures through the direct-API path

### DIFF
--- a/.changeset/claude-api-cache-tokens.md
+++ b/.changeset/claude-api-cache-tokens.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+fix(adapters): the direct-API Claude path was dropping cache token figures
+
+`parsers/claude-parser.ts` has extracted `cache_read_input_tokens` and `cache_creation_input_tokens` since #4435, with a comment recording why: a panel's **first** call is the one that writes the cache, so dropping the figures loses its largest input measurement entirely. `adapters/claude-adapter.ts` — the direct-API path — never read them, building `TokenUsage` from `input_tokens` and `output_tokens` alone.
+
+The same one-arm-fixed shape as #4602, where the CLI arms reported a quota signal and the API arms could not. Here `observability/cache-token-threading.test.ts` already asserts these fields reach the decision-cost rollup, so the API path was silently supplying less than the rollup was written to consume.
+
+Both fields are declared `number | null` by the SDK, so this is a plain read, not a cast. Null stays **absent** rather than becoming `0` — a fabricated zero reads as "no cache write happened", which is a claim the API did not make. `totalTokens` deliberately remains uncached input + output, matching the CLI parser; folding the cache figures in would change semantics for every existing consumer.
+
+Also corrects a rename artifact from #4444: the docstring on `SessionTokenTotals` read "distinguish it from the per-call `SessionTokenTotals`", the rename having been applied to the wrong token. It now says `TokenUsage`, which is what it means.

--- a/packages/nexus-agents/src/adapters/claude-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.test.ts
@@ -205,6 +205,69 @@ describe('ClaudeAdapter', () => {
       }
     });
 
+    // The CLI-side parser has extracted these since #4435, with a comment
+    // recording why: a panel's FIRST call is the one that writes the cache, so
+    // dropping the figures loses its largest input measurement entirely. The
+    // direct-API path was never updated — same defect as #4602, where the CLI
+    // arm worked and the API arm did not (#4440).
+    it('threads Anthropic cache token fields through to usage', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Hello!' }],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_read_input_tokens: 900,
+          cache_creation_input_tokens: 1200,
+        },
+        stop_reason: 'end_turn',
+        model: CLAUDE_MODELS.SONNET_4,
+      });
+
+      const adapter = new ClaudeAdapter(validConfig);
+      const result = await adapter.complete({
+        messages: [{ role: 'user', content: 'Hi!' }],
+        maxTokens: 1024,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.usage?.cachedInputTokens).toBe(900);
+        expect(result.value.usage?.cacheCreationInputTokens).toBe(1200);
+        // totalTokens deliberately stays uncached input + output, matching
+        // parsers/claude-parser.ts — folding the cache figures in would change
+        // semantics for every existing consumer of totalTokens.
+        expect(result.value.usage?.totalTokens).toBe(15);
+      }
+    });
+
+    it('leaves cache fields absent when the API reports null, never 0', async () => {
+      // A fabricated 0 reads as "no cache write happened", which is a claim.
+      // Absence is the honest report when the API states nothing.
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Hello!' }],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_read_input_tokens: null,
+          cache_creation_input_tokens: null,
+        },
+        stop_reason: 'end_turn',
+        model: CLAUDE_MODELS.SONNET_4,
+      });
+
+      const adapter = new ClaudeAdapter(validConfig);
+      const result = await adapter.complete({
+        messages: [{ role: 'user', content: 'Hi!' }],
+        maxTokens: 1024,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.usage).not.toHaveProperty('cachedInputTokens');
+        expect(result.value.usage).not.toHaveProperty('cacheCreationInputTokens');
+      }
+    });
+
     it('should include system prompt when provided', async () => {
       mockCreate.mockResolvedValueOnce({
         content: [{ type: 'text', text: 'Response' }],

--- a/packages/nexus-agents/src/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.ts
@@ -322,10 +322,26 @@ export class ClaudeAdapter extends BaseAdapter {
       ? mapResponseWithRespondTool(response.content)
       : response.content.map(mapContentBlock);
 
+    // Cache figures come through in full (#4440). The CLI-side
+    // `parsers/claude-parser.ts` has extracted these since #4435 — a panel's
+    // FIRST call is the one that writes the cache, so dropping them loses its
+    // largest input measurement — but this direct-API path was never updated,
+    // the same one-arm-fixed shape as #4602.
+    //
+    // The SDK types both as `number | null` — never undefined, which is why a
+    // null check alone suffices here. Null stays absent rather than
+    // becoming 0: a fabricated 0 reads as "no cache write happened", which is
+    // a claim the API did not make. `totalTokens` deliberately remains
+    // uncached input + output, matching the CLI parser — folding the cache
+    // figures in would change semantics for every existing consumer.
+    const cachedInputTokens = response.usage.cache_read_input_tokens;
+    const cacheCreationInputTokens = response.usage.cache_creation_input_tokens;
     const usage: TokenUsage = {
       inputTokens: response.usage.input_tokens,
       outputTokens: response.usage.output_tokens,
       totalTokens: response.usage.input_tokens + response.usage.output_tokens,
+      ...(cachedInputTokens !== null && { cachedInputTokens }),
+      ...(cacheCreationInputTokens !== null && { cacheCreationInputTokens }),
     };
 
     return {

--- a/packages/nexus-agents/src/agents/observability/orchestration-observer-types.ts
+++ b/packages/nexus-agents/src/agents/observability/orchestration-observer-types.ts
@@ -66,7 +66,7 @@ export interface RoutingDecision {
 /**
  * Running token totals for an observability SESSION, aggregated across calls.
  *
- * Named to distinguish it from the per-call `SessionTokenTotals` in
+ * Named to distinguish it from the per-call `TokenUsage` in
  * `core/types/model.ts` (#4440). The two shared a name and a shape while
  * modelling different things — session aggregate vs. one call's usage — and
  * `exports/observability.ts` already had to alias this one as


### PR DESCRIPTION
Refs #4440. What that issue described is mostly already done; measuring it turned up a live defect underneath, which is what this fixes.

## Re-measuring #4440 first — most of it no longer applies

The issue was filed 2026-08-13, blocked on #4439. That blocker closed the same day (along with #4436 and #4435) and nobody picked this up — ten days. Re-measured before planning, because issue bodies here have repeatedly turned out stale:

| Claim in #4440 | Today |
| --- | --- |
| Three same-named `TokenUsage` types | **Two.** The session aggregate was renamed to `SessionTokenTotals` in #4444 |
| Rename the session aggregate (part 2) | **Already done**, and non-breakingly — `exports/observability.ts` keeps the public name via `as ObserverTokenUsage` |
| The two per-call types "model the same fact at different widths" | **Largely converged.** #4439 widened the response side; both now carry the same five field names. Only `totalTokens` required-vs-optional and `readonly`-vs-mutable differ |
| "Every crossing silently narrows" | **No.** Both bridges thread cache fields through in full and preserve absence |

So the refactor the issue asks for is smaller than it sounds, and the part described as most valuable is finished.

## The defect that was actually there

`parsers/claude-parser.ts` has extracted `cache_read_input_tokens` and `cache_creation_input_tokens` since #4435, with a comment recording exactly why it matters:

> a panel's FIRST call, which writes the cache, lost its largest input measurement entirely

`adapters/claude-adapter.ts` — the **direct-API** path — never read them. It built `TokenUsage` from `input_tokens` and `output_tokens` alone.

This is the same one-arm-fixed shape as #4602, where CLI arms could report a quota signal and API arms could not: a fix landed on one path and its sibling was left behind. And it is not theoretical — `observability/cache-token-threading.test.ts` already asserts these fields reach the decision-cost rollup, so the API path was silently supplying less than the rollup was written to consume.

Verified against the installed SDK rather than assumed: `Usage` at `@anthropic-ai/sdk@0.117.1` declares both as `number | null`. A plain read, no cast.

## Semantics, matched to the CLI parser rather than invented

- **Null stays absent, never `0`.** A fabricated zero reads as "no cache write happened" — a claim the API did not make. Pinned by a test.
- **`totalTokens` stays uncached input + output.** Folding the cache figures in would change semantics for every existing consumer; the CLI parser made that call deliberately and this matches it.

## One redundancy the linter caught, worth keeping

My first version guarded `!== null && !== undefined`. `@typescript-eslint/no-unnecessary-condition` rejected it: the SDK types are `number | null`, never undefined, so the second check was dead. Simplified, and the comment now records why a null check alone suffices — the kind of detail that otherwise gets re-litigated later.

## Also fixed: a rename artifact from #4444

The docstring on `SessionTokenTotals` read *"Named to distinguish it from the per-call `SessionTokenTotals` in core/types/model.ts"* — the rename had been applied to the wrong token, so the sentence distinguished the type from itself. It now says `TokenUsage`. This is republished in `docs/api/observability.md`, so it was misleading readers of the generated docs too.

## What remains on #4440

Only the small structural difference between the two per-call types (`totalTokens` optionality, `readonly`), and no evidence yet that it causes a real narrowing. I would leave that until something measurably breaks rather than refactor two nearly-identical types for symmetry. Comment to that effect on the issue.

## Verification

- `vitest run` — **1183 files, 28,194 tests, 0 failures**; root suite 656
- `pnpm typecheck`, `eslint`, `prettier` — clean
- Both new tests failed first for the right reason (`expected undefined to be 900`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
