### PR TITLE
chore(ops): drop two $schema refs pointing at the meta-schema

### DIFF
--- a/.changeset/remove-false-metaschema-refs.md
+++ b/.changeset/remove-false-metaschema-refs.md
@@ -1,0 +1,11 @@
+---
+'nexus-agents': patch
+---
+
+chore(ops): drop two `$schema` declarations that pointed at the JSON Schema meta-schema
+
+`docs/ops/docops-manifest.json` and `docs/architecture/wiring-graph.json` declared `"$schema": "https://json-schema.org/draft/2020-12/schema"`. Neither is a JSON Schema — both are plain data manifests (`version`, `description`, `pipeline_files`, `metadata`). That declaration tells an editor to validate the document _as a schema_, and since JSON Schema permits arbitrary keywords the editor silently accepts anything: validation reporting success having checked nothing.
+
+Found while sweeping #4612, which reported one dangling `$schema`. There are five broken declarations in total, all on files this repo owns; the other eleven, every one pointing at a third-party tool schema, are correct.
+
+Only these two are changed here. A 3-voter panel split 1-1-1 on what to do with the three _dangling_ relative references — write schemas, generate them from the TypeScript validators, or delete the lines — so that stays open on #4612 for a decision. All three options agreed these two references are wrong, and deletion is the safe intersection: if schema generation is chosen later, it adds a correct reference anyway.

--- a/docs/architecture/wiring-graph.json
+++ b/docs/architecture/wiring-graph.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "version": "1.0.0",
   "generated": "2026-01-29T00:00:00Z",
   "description": "Nexus-Agents System Wiring Graph - Machine-readable topology",

--- a/docs/ops/docops-manifest.json
+++ b/docs/ops/docops-manifest.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "version": "1.0.0",
   "description": "DocOps pipeline manifest for enforcement gates",
   "created": "2026-02-01",


### PR DESCRIPTION
Refs #4612. Deliberately partial: this lands only the part a deadlocked panel unanimously agreed on.

## What is wrong

`docs/ops/docops-manifest.json` and `docs/architecture/wiring-graph.json` both declared:

```json
"$schema": "https://json-schema.org/draft/2020-12/schema"
```

That is the JSON Schema **meta-schema**. Neither file is a schema — both are plain data manifests with `version`, `description`, `pipeline_files`, `metadata`. The declaration tells an editor "validate this document *as a JSON Schema*", and because JSON Schema permits arbitrary keywords, the editor silently accepts anything.

So it is not a dangling reference that fails loudly. It is validation that **reports success having checked nothing** — the shape this repo has spent the week removing, in the tooling layer rather than the code.

## The sweep: 5 broken, not 1

#4612 reported one dangling `$schema`. Sweeping all 16 non-vendored declarations:

- **11 correct** — every one pointing at a third-party tool schema over HTTPS (turbo, markdownlint, cspell, changesets, typedoc, tsconfig, MCP `server.json`, Claude hooks/marketplace).
- **3 dangling** — `orphan-allowlist.json`, `registry-coverage-manifest.json`, `schema-fanout-manifest.json` each point at a `./*.schema.json` that does not exist anywhere in the repo.
- **2 meta-schema** — the two fixed here.

Every wrong one is on a file we own. Every third-party one is right.

## Why only two of the five change

A 3-voter panel **deadlocked 1-1-1** on the three dangling references — `no_quorum`, leading option 33.3%:

- **Scope steward → delete all five.** A dangling or semantically false signal is worse than none; editor validation is not worth a second encoding.
- **Security → generate the schemas from the TypeScript validators.** Dual-maintained validation drifts, and a drifted schema means the editor approves what the gate will reject.
- **Architect → delete the two wrong refs, write only `orphan-allowlist.schema.json`** — the one file with a live invariant (#4583's exactly-one-of `expires`/`permanent`) and a demonstrated editing hazard.

Worth recording: **3 approve, 0 reject, and still `no_quorum`.** A plain approve/reject tally would have read as 3-0, 100% approved, and I could have claimed a mandate for whichever option I preferred. The option-gate from #4472 is what prevented that — the mechanism doing exactly its job.

All three positions agree these two meta-schema refs are wrong: two delete them, one replaces them with generated ones. **Deletion is the safe intersection** — if generation is chosen later it adds a correct reference anyway. The contested three are left untouched and escalated on the issue, because the disagreement is a real judgement about how much tooling this repo wants to carry.

## Verification

- Both files still parse as JSON.
- The DocOps gate (which reads `docops-manifest.json`) exits 0.
- Script suite: 41 files, 609 tests.
- `pnpm typecheck` clean.
- Nothing in the tree read either `$schema` value — checked before removing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
