### PR TITLE
fix(release): read the publish-race decision from the commit, not the tree

### DIFF
--- a/.changeset/release-fallback-reads-commit.md
+++ b/.changeset/release-fallback-reads-commit.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+fix(release): the publish-race fallback was reading an uncommitted version and force-publishing on every merge
+
+`release.yml`'s `#2382` fallback force-published an unmerged version on **17 of 17 runs** on 2026-08-23. In 6 of those, npm was briefly ahead of `main`.
+
+It was not `changesets/action` — v2 does not publish in PR mode, which the SBOM step (gated on `published == 'true'`, skipped on every version-PR run across all 38 runs) proves structurally. The fallback itself was the publisher.
+
+The `#2696` guard, `git checkout "$GITHUB_SHA"`, worked under changesets/action v1 because v1 checked out `changeset-release/main` locally, so the checkout was a real branch switch that restored `main`'s files. v2.0.0 pushes release commits via the GitHub API and never checks that branch out: HEAD is already on `main` at `$GITHUB_SHA` with the bump uncommitted, so the checkout is a bare detach that **preserves modified files**. The guard kept running, kept logging correctly, and did nothing.
+
+Two fixes, protecting different things. The **decision** now reads the commit object — `git show` for the version, `git ls-tree` for the pending-changeset count — so no tree state a future action version leaves behind can fool it. The **publish** gets `--force` on the checkout, so `pnpm release` ships the commit's content rather than an uncommitted bump the decision never approved.
+
+The fallback is kept, not removed: the `#2382` skipped-minor failure it guards against silently loses a published release, and nobody has established it is impossible under v2. Verifying that is tracked separately and gates any future removal, not this fix.
+
+Also closes the tag skew in #4624 at source. The fallback tagged `$GITHUB_SHA`, which on a feature merge held the _previous_ version — 14 of 14 tags checked were off by one. With the read fixed the fallback only fires when the commit genuinely holds the version, so the existing tag target becomes correct by construction. A post-publish assertion now fails the release if a tag ever again points at a commit whose `package.json` disagrees.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,16 +124,29 @@ jobs:
         # The third condition prevents publishing partial state when changesets
         # are still pending; in that case the next merge will close the loop.
         #
-        # CRITICAL (#2696, 2026-05-14): in PR-update mode the changesets/action
-        # runs `changeset version` on a `changeset-release/main` branch and
-        # LEAVES THE WORKING TREE CHECKED OUT THERE. Reading package.json or
-        # .changeset/ from the working tree would see the NEXT version already
-        # bumped and the changesets already consumed — making this step
-        # force-publish an unreleased version straight off the changeset-release
-        # branch on every changeset-bearing feature merge, with no git tag
-        # pushed and no GitHub Release created (2.68.0–2.76.0 all published this
-        # way). `git checkout "$GITHUB_SHA"` pins the whole step to the
-        # triggering main commit so the skew check only ever reasons about main.
+        # CRITICAL (#2696, 2026-05-14; corrected #4487, 2026-08-23): in PR-update
+        # mode the changesets/action bumps package.json and consumes .changeset/*.md
+        # WITHOUT COMMITTING. Reading either from the working tree sees the NEXT
+        # version already bumped and the changesets already gone — making this step
+        # force-publish an unreleased version on every changeset-bearing feature
+        # merge, with no git tag and no GitHub Release (2.68.0–2.76.0 published
+        # this way).
+        #
+        # The original guard was `git checkout "$GITHUB_SHA"`, which worked under
+        # changesets/action v1 because v1 checked out `changeset-release/main`
+        # locally, so the checkout was a real branch switch that restored main's
+        # files. v2.0.0 (#692) pushes release commits via the GitHub API and never
+        # checks that branch out: HEAD is ALREADY on main at $GITHUB_SHA with the
+        # bump uncommitted, so `git checkout <sha-at-HEAD>` is a bare detach that
+        # PRESERVES modified files. The guard kept running, kept logging correctly,
+        # and did nothing — 17 of 17 runs on 2026-08-23 force-published an unmerged
+        # version, and every release tag landed one commit early (#4624).
+        #
+        # Two independent fixes, because they protect different things:
+        #   * the DECISION reads the commit object (`git show`/`git ls-tree`), so no
+        #     tree state any future action version leaves behind can fool it;
+        #   * the PUBLISH gets `--force`, so `pnpm release` ships the commit's
+        #     content rather than an uncommitted bump the decision never approved.
         if: steps.changesets.outputs.published != 'true'
         shell: bash
         env:
@@ -144,11 +157,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Pin to the triggering main commit — never trust the working tree,
-          # which changesets/action may have left on changeset-release/main.
-          git checkout --quiet "$GITHUB_SHA"
+          # `--force` is load-bearing (#4487): HEAD is already at $GITHUB_SHA with
+          # the action's uncommitted bump in the tree, so a plain checkout is a
+          # no-op that leaves those files in place. This restores the commit's
+          # content for the `pnpm release` further down.
+          git checkout --quiet --force "$GITHUB_SHA"
 
-          local_version=$(jq -r '.version' packages/nexus-agents/package.json)
+          # Read the DECISION inputs from the commit object, not the tree. Even
+          # with --force above, deriving the verdict from an immutable artifact is
+          # what stops a future action version from silently voiding this guard
+          # again the way v2 did.
+          local_version=$(git show "$GITHUB_SHA:packages/nexus-agents/package.json" | jq -r '.version')
           published_version=$(npm view nexus-agents version 2>/dev/null || echo "0.0.0")
 
           # Use sort -V to pick the larger of the two versions.
@@ -158,7 +177,8 @@ jobs:
             exit 0
           fi
 
-          pending_changesets=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null | wc -l)
+          pending_changesets=$(git ls-tree --name-only "$GITHUB_SHA" .changeset/ \
+            | grep -E '\.md$' | grep -cv 'README\.md' || true)
           if [ "$pending_changesets" -gt 0 ]; then
             echo "::warning::package.json is at $local_version but npm has $published_version, AND $pending_changesets changeset(s) are still pending. The next release-PR merge should close the loop. Not force-publishing."
             exit 0
@@ -179,6 +199,20 @@ jobs:
             echo "::warning::changeset publish did not create tag $TAG — creating it now"
             git tag "$TAG" "$GITHUB_SHA"
             git push origin "refs/tags/$TAG"
+          fi
+
+          # Assert the tag points at a commit that actually holds this version
+          # (#4624). Before #4487 the fallback fired on feature merges and tagged
+          # $GITHUB_SHA, whose package.json was the PREVIOUS version — 14 of 14
+          # tags checked were off by one, and nothing noticed for weeks. Now that
+          # the decision reads the commit object, a legitimate firing means
+          # $GITHUB_SHA genuinely holds $local_version, so this assertion should
+          # never fire; it exists so that if that stops being true, a release
+          # fails loudly instead of quietly mislabelling its own provenance.
+          tagged_version=$(git show "$TAG:packages/nexus-agents/package.json" | jq -r '.version')
+          if [ "$tagged_version" != "$local_version" ]; then
+            echo "::error::Tag $TAG points at a commit whose package.json is $tagged_version, not $local_version (#4624)."
+            exit 1
           fi
           # Release notes = this version's section of the changesets CHANGELOG.
           notes=$(awk -v v="## $local_version" '


### PR DESCRIPTION
Refs #4487, closes #4624 at source. **`.github/workflows/release.yml` — CODEOWNERS, and the release pipeline itself.** Flagging for review rather than treating this as routine.

## What was happening

The `#2382` publish-race fallback force-published an unmerged version on **17 of 17 runs** on 2026-08-23. In **6 of 17** the npm registry write landed before the version PR merged, i.e. npm was genuinely ahead of `main`; in the rest auto-merge happened to win the ~80-second publish. The ordering was a coin flip, not a safeguard.

**It was not `changesets/action`.** #4487 assumed v2 publishes in PR mode. It does not, and the proof is structural rather than inferential: the SBOM step is gated on `published == 'true'` and is `success` on every feature run, `skipped` on every version-PR run, across all 38 runs. `steps.changesets.outputs.published` was never `'true'`. The fallback was the publisher.

## Root cause: a guard that ran, logged correctly, and did nothing

```yaml
git checkout --quiet "$GITHUB_SHA"
local_version=$(jq -r '.version' packages/nexus-agents/package.json)
```

Under v1 this worked because the action checked out `changeset-release/main` locally, so the checkout was a real branch switch that restored `main`'s files. **v2.0.0 (#692) pushes release commits via the GitHub API and never checks that branch out** — HEAD is already on `main` at `$GITHUB_SHA` with the bump *uncommitted*, so `git checkout <sha-already-at-HEAD>` is a bare detach that **preserves modified files**.

So the step read `package.json=3.6.14, 0 pending` when the commit held `3.6.13, 2 pending`, concluded there was a skew, and published. This is **#2696 regressed**, not a v2 behaviour change.

Reproduced locally before writing the fix:

```
--- what the OLD code reads (working tree) ---
  jq package.json      = 9.9.9
--- what the NEW code reads (commit object) ---
  git show $SHA:...    = 3.8.8
--- and with --force the tree is restored too ---
  jq after --force     = 3.8.8
```

## The fix, and why it is two changes rather than one

A 7-voter panel chose **option B — read from the commit object** (4 of 6 approvers, leading share 0.667, supermajority).

But **four voters independently flagged that B alone is unsafe**, and they were right. The decision would read the commit while `pnpm release` still published from the working tree — so a legitimate firing could ship 3.6.14's tree content under a decision made about 3.6.13's commit. Subtly worse than the bug being fixed. So:

- **the decision** reads the commit object — `git show` for the version, `git ls-tree` for the pending-changeset count — so no tree state any future action version leaves behind can fool it;
- **the publish** gets `--force` on the checkout, so it ships the commit's content rather than a bump the decision never approved.

Option A (`--force` alone) restores today's behaviour but re-encodes the assumption that broke: correctness derived from what a third-party action happens to leave behind. Option C (remove it) was rejected on evidence — the `#2382` skipped-minor failure silently loses a published release (2.64.0 → 2.67.0 actually happened), and nobody has shown it is impossible under v2. Option D (drop the tag block) was rejected because it reintroduces the #2696 untagged-publish symptom in exactly the rare legitimate-fire case the fallback exists for.

## #4624 is fixed at source, not patched

The fallback tagged `$GITHUB_SHA`, which on a feature merge holds the *previous* version — **14 of 14 tags checked were off by one**. With the read fixed, the fallback only fires when the commit genuinely holds the version, so `git tag "$TAG" "$GITHUB_SHA"` becomes correct by construction.

Added a post-publish assertion anyway: if a tag ever again points at a commit whose `package.json` disagrees, the release **fails loudly**. That skew went unnoticed across 14 releases; it should not be able to again.

## Verification

Stub-executed both branches against fixture repos:

| Case | Result |
| --- | --- |
| dirty tree, commit has 1 pending changeset | reads `1.0.0 / 1` — **declines to publish** (old code read `1.0.1 / 0` and published) |
| genuine skew: commit holds the bump, 0 changesets | reads `1.0.1 / 0` — **publishes**, and `$GITHUB_SHA` holds 1.0.1 so the tag is correct |

YAML re-parses. `actionlint` is **not installed** — not claiming a pass.

## What is not done, deliberately

Whether the `#2382` skipped-minor race can still occur under v2 is **unverified**. Five voters said that should not gate this fix — the current behaviour mispublishes on every merge — but it must gate any future removal of the fallback. Tracking separately.

**This change cannot be fully verified until a real release runs.** The next feature merge is the test: the fallback should log no-skew and skip, and the version-PR run should publish and tag. Worth watching rather than assuming.

Existing mistagged tags are untouched — retagging moves published refs and is an owner call (#4624).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
