### PR TITLE
feat(audit): stamp diff provenance on pr-review records (owner ratification)

### DIFF
--- a/.changeset/plenty-pugs-jam.md
+++ b/.changeset/plenty-pugs-jam.md
@@ -1,0 +1,33 @@
+---
+'nexus-agents': minor
+---
+
+feat(audit): record what a pr-review record was derived from (#4459)
+
+PR-review ledger records now carry an optional, **hash-covered** `diffProvenance`
+descriptor so a consumer can tell what the record was derived from:
+
+- `source: 'canonical-git' | 'caller-supplied'` — `canonical-git` when the reviewed
+  bytes are the pinned `git diff <base>..<head>` the CI gate itself recomputes
+  (`scripts/pr-review-local-ledger.ts`), `caller-supplied` when they arrived as
+  opaque `prDiff` input on a `pr_review` MCP call. Those are the only two producers,
+  so there are only two values: the `gh` v3.diff fallback skips the ledger entirely
+  and can never write a record.
+- `fileBoundaries: boolean` — whether the real `splitByFile` result attributed the
+  diff to files. `looksLikeUnifiedDiff` deliberately accepts plain `diff -u` output,
+  which has no `diff --git` headers, so this is the one signal a consumer cannot
+  re-derive from the record's other fields.
+
+`computePrReviewRecordHash` builds its canonical form from an explicit field
+allowlist, so the field is added **to the projection**, not just the schema — a
+provenance claim outside the self-hash could be upgraded from `caller-supplied` to
+`canonical-git` with no `hash_mismatch`. A record written without provenance still
+hashes exactly as before (the key is omitted, not emitted as `null`), pinned by a
+golden-hash test.
+
+Record `version` moves `'1.1'` → `'1.2'` as the pre/post-provenance boundary marker.
+No migration: `governance/pr-review-records.jsonl` holds 0 records.
+
+Also fixes a misleading log in `scripts/pr-review-local.ts` that printed
+`(canonical, ledger-excluded)` — it means the diff excludes the ledger _file_, not
+that the review is excluded from the ledger.

--- a/packages/nexus-agents/src/audit/index.ts
+++ b/packages/nexus-agents/src/audit/index.ts
@@ -91,6 +91,8 @@ export type { BuildVoteRecordInput, PersistVoteRecordOptions } from './vote-reco
 // SHA-BOUND record SET + monotonic sequence (mirrors the #3927 vote-record
 // model). Read by the warn-first governor-review gate.
 export {
+  PrReviewDiffProvenanceSchema,
+  PrReviewDiffSourceSchema,
   PrReviewRecordSchema,
   PrReviewVerdictSchema,
   PrReviewVoteCountsSchema,
@@ -98,6 +100,8 @@ export {
   verifyPrReviewRecordSet,
 } from './pr-review-record.js';
 export type {
+  PrReviewDiffProvenance,
+  PrReviewDiffSource,
   PrReviewRecord,
   PrReviewVerdict,
   PrReviewVoteCounts,

--- a/packages/nexus-agents/src/audit/pr-review-record-store.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.ts
@@ -30,7 +30,12 @@ import { findRepoRoot } from '../config/repo-root-detection.js';
 import type { ILogger } from '../core/index.js';
 import { createLogger, getErrorMessage } from '../core/index.js';
 
-import type { PrReviewRecord, PrReviewVerdict, PrReviewVoteCounts } from './pr-review-record.js';
+import type {
+  PrReviewDiffProvenance,
+  PrReviewRecord,
+  PrReviewVerdict,
+  PrReviewVoteCounts,
+} from './pr-review-record.js';
 import { PrReviewRecordSchema, computePrReviewRecordHash } from './pr-review-record.js';
 
 /** Repo-relative committable artifact path (read by the gate/CI). */
@@ -61,6 +66,14 @@ export interface BuildPrReviewRecordInput {
   readonly correlationId?: string | undefined;
   readonly recordedAt?: string | undefined;
   /**
+   * What the reviewed diff was DERIVED FROM (#4459). Optional here because the
+   * schema field is optional (a record written without it must still parse and
+   * still hash as it did pre-#4459). Producers that KNOW their provenance —
+   * both in-tree ones do — must pass it; omitting it is a record that declines
+   * to say, never a record that is `canonical-git`.
+   */
+  readonly diffProvenance?: PrReviewDiffProvenance | undefined;
+  /**
    * Monotonic sequence number for this record. Defaults to 0 (first record)
    * when omitted; the future producer supplies (max existing sequence)+1.
    */
@@ -85,7 +98,7 @@ export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRe
       ? input.summary.slice(0, MAX_SUMMARY_RECORD_CHARS) + '...'
       : input.summary;
   const payload: Omit<PrReviewRecord, 'hash'> = {
-    version: '1.1',
+    version: '1.2',
     sequence: input.sequence ?? 0,
     prNumber: input.prNumber,
     baseSha: input.baseSha,
@@ -101,6 +114,7 @@ export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRe
       total: input.voteCounts.total,
     },
     summary: summaryTruncated,
+    ...(input.diffProvenance !== undefined ? { diffProvenance: input.diffProvenance } : {}),
     ...(input.correlationId !== undefined ? { correlationId: input.correlationId } : {}),
     ...(input.previousHash !== undefined ? { previousHash: input.previousHash } : {}),
   };

--- a/packages/nexus-agents/src/audit/pr-review-record.test.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.test.ts
@@ -12,8 +12,12 @@
 
 import { describe, it, expect } from 'vitest';
 
-import type { PrReviewRecord } from './pr-review-record.js';
-import { computePrReviewRecordHash, verifyPrReviewRecordSet } from './pr-review-record.js';
+import type { PrReviewDiffProvenance, PrReviewRecord } from './pr-review-record.js';
+import {
+  PrReviewRecordSchema,
+  computePrReviewRecordHash,
+  verifyPrReviewRecordSet,
+} from './pr-review-record.js';
 import { buildPrReviewRecord } from './pr-review-record-store.js';
 
 const SHA_A = 'a'.repeat(40);
@@ -31,7 +35,7 @@ function makeRecord(
   overrides: Partial<Omit<PrReviewRecord, 'hash'>> = {}
 ): PrReviewRecord {
   const payload: Omit<PrReviewRecord, 'hash'> = {
-    version: '1.1',
+    version: '1.2',
     sequence,
     prNumber,
     baseSha: SHA_A,
@@ -147,5 +151,105 @@ describe('buildPrReviewRecord (#3831)', () => {
     expect(rec.summary.length).toBeLessThan(long.length);
     expect(rec.summary.endsWith('...')).toBe(true);
     expect(verifyPrReviewRecordSet([rec]).ok).toBe(true);
+  });
+});
+
+describe('diffProvenance (#4459)', () => {
+  const CALLER_SUPPLIED: PrReviewDiffProvenance = {
+    source: 'caller-supplied',
+    fileBoundaries: true,
+  };
+
+  /**
+   * THE load-bearing test. `computePrReviewRecordHash` builds its canonical form
+   * from an explicit field ALLOWLIST, not `JSON.stringify(record)` — so a field
+   * present in the schema but absent from the projection sits OUTSIDE
+   * tamper-evidence. If this passes with the projection unchanged, `source` could
+   * be edited from `caller-supplied` to `canonical-git` — upgrading a record's
+   * apparent provenance — with no `hash_mismatch`.
+   */
+  it('folds diffProvenance.source into the self-hash: flipping it is a hash_mismatch', () => {
+    const authentic = makeRecord(4459, 0, { diffProvenance: CALLER_SUPPLIED });
+    const forged: PrReviewRecord = {
+      ...authentic,
+      diffProvenance: { source: 'canonical-git', fileBoundaries: true },
+    };
+    expect(computePrReviewRecordHash(forged)).not.toBe(authentic.hash);
+    const verification = verifyPrReviewRecordSet([forged]);
+    expect(verification.ok).toBe(false);
+    if (!verification.ok) expect(verification.reason).toBe('hash_mismatch');
+  });
+
+  it('folds diffProvenance.fileBoundaries into the self-hash', () => {
+    const authentic = makeRecord(4459, 0, { diffProvenance: CALLER_SUPPLIED });
+    const forged: PrReviewRecord = {
+      ...authentic,
+      diffProvenance: { source: 'caller-supplied', fileBoundaries: false },
+    };
+    expect(computePrReviewRecordHash(forged)).not.toBe(authentic.hash);
+    expect(verifyPrReviewRecordSet([forged]).ok).toBe(false);
+  });
+
+  it('DETECTS deletion of the whole diffProvenance field as a hash_mismatch', () => {
+    const authentic = makeRecord(4459, 0, { diffProvenance: CALLER_SUPPLIED });
+    const stripped = { ...authentic };
+    Reflect.deleteProperty(stripped, 'diffProvenance');
+    expect(verifyPrReviewRecordSet([stripped]).ok).toBe(false);
+  });
+
+  /**
+   * BACKWARD COMPATIBILITY PIN. A record written WITHOUT `diffProvenance` must
+   * hash exactly as it did before the field existed — otherwise every previously
+   * written record flips to `hash_mismatch` on the next verification. The golden
+   * hex below was computed with the pre-#4459 projection; it must never change.
+   * (This is why the projection OMITS the key when absent rather than emitting
+   * `null`: `JSON.stringify` drops `undefined` values, so the canonical string is
+   * byte-identical to the pre-field one.)
+   */
+  it('hashes a record with NO diffProvenance identically to the pre-#4459 projection', () => {
+    const payload: Omit<PrReviewRecord, 'hash'> = {
+      version: '1.2',
+      sequence: 7,
+      prNumber: 4459,
+      baseSha: SHA_A,
+      reviewedDiffHash: DIFF_HASH_A,
+      recordedAt: '2026-06-15T00:00:00.000Z',
+      verdict: 'approve',
+      verified: true,
+      voteCounts: { approve: 5, request_changes: 0, abstain: 0, error: 0, total: 5 },
+      summary: 'looks good',
+    };
+    expect(computePrReviewRecordHash(payload)).toBe(
+      'ca8f09d59e628b2b9f7bf7be988dc796efe6b641df3f0b12fce49bfc76cb75a8'
+    );
+  });
+
+  it('is OPTIONAL: a record without it still parses under the .strict() schema', () => {
+    const rec = makeRecord(4459, 0);
+    expect(PrReviewRecordSchema.safeParse(rec).success).toBe(true);
+  });
+
+  it('parses a record that carries it', () => {
+    const parsed = PrReviewRecordSchema.safeParse(
+      makeRecord(4459, 0, { diffProvenance: { source: 'canonical-git', fileBoundaries: false } })
+    );
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.diffProvenance?.source).toBe('canonical-git');
+  });
+
+  it('rejects an unreachable source value (gh-api was measured to be unreachable)', () => {
+    const bad = {
+      ...makeRecord(4459, 0),
+      diffProvenance: { source: 'gh-api', fileBoundaries: true },
+    };
+    expect(PrReviewRecordSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe('record version (#4459)', () => {
+  it('pins the schema version at 1.2 — the pre/post diffProvenance boundary', () => {
+    expect(makeRecord(1, 0).version).toBe('1.2');
+    const stale = { ...makeRecord(1, 0), version: '1.1' };
+    expect(PrReviewRecordSchema.safeParse(stale).success).toBe(false);
   });
 });

--- a/packages/nexus-agents/src/audit/pr-review-record.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.ts
@@ -41,6 +41,14 @@
  * rejected `headSha` binding (a head pointer is mutable; the reviewed bytes are
  * what the voters actually saw).
  *
+ * DIFF PROVENANCE (#4459). The binding says WHICH bytes were reviewed; it does not
+ * say where those bytes CAME FROM. `diffProvenance` closes that gap: `canonical-git`
+ * means the diff is the pinned `git diff` the gate itself recomputes, while
+ * `caller-supplied` means an MCP caller handed over opaque bytes that merely passed
+ * the `looksLikeUnifiedDiff` shape gate (#4451). It is HASH-COVERED like every other
+ * authenticity field — a provenance claim outside the hash could be upgraded by
+ * editing one word.
+ *
  * WHY A DEDICATED PAYLOAD-COVERING HASH (and not the audit-event head hash).
  * As in #3897/#3927: the audit-event chain (`computeEventHash` in
  * audit-logger.ts) hashes only the stable HEAD fields and intentionally NOT
@@ -79,8 +87,57 @@ export const PrReviewVoteCountsSchema = z
 export type PrReviewVoteCounts = z.infer<typeof PrReviewVoteCountsSchema>;
 
 /**
+ * Where the bytes behind `reviewedDiffHash` came from (#4459). Only two values
+ * exist because only two non-test producers write records:
+ *  - `canonical-git` — the diff is the pinned `git diff <base>..<head>` output
+ *    (`audit/reviewed-diff-hash.ts`), the same invocation the CI gate recomputes.
+ *    Written by `scripts/pr-review-local-ledger.ts`.
+ *  - `caller-supplied` — the diff arrived as opaque `prDiff` input on the
+ *    `pr_review` MCP call. It PASSED the `looksLikeUnifiedDiff` shape gate
+ *    (#4451), but nothing establishes that it is the PR's actual diff. Written
+ *    by `mcp/tools/pr-review-tool.ts`.
+ *
+ * There is deliberately NO `gh-api` member: the `gh` v3.diff fallback in
+ * `scripts/pr-review-local.ts` skips the ledger entirely (it sets
+ * `canonicalDiff: undefined`, and the feeder writes no record), so a `gh-api`
+ * record cannot be produced. An enum member no producer can emit is a value a
+ * consumer would have to handle without ever meeting it.
+ */
+export const PrReviewDiffSourceSchema = z.enum(['canonical-git', 'caller-supplied']);
+export type PrReviewDiffSource = z.infer<typeof PrReviewDiffSourceSchema>;
+
+/**
+ * What the record was DERIVED FROM — the provenance descriptor a consumer reads
+ * to decide how much the record's diff-binding is worth (#4459).
+ *
+ * Both fields are HASH-COVERED (see {@link computePrReviewRecordHash}). That is
+ * the whole point: a provenance claim outside the self-hash could be upgraded
+ * from `caller-supplied` to `canonical-git` by editing one word in the ledger,
+ * with no `hash_mismatch` — the record would then assert a stronger derivation
+ * than it has, which is exactly the "record that misreports" failure mode.
+ */
+export const PrReviewDiffProvenanceSchema = z
+  .object({
+    /** How the reviewed diff was obtained. */
+    source: PrReviewDiffSourceSchema,
+    /**
+     * Whether the reviewed diff carried parseable `^diff --git` FILE BOUNDARIES
+     * (sourced from the real `splitByFile` result, not a second regex). The one
+     * signal a consumer genuinely CANNOT re-derive from the other record fields:
+     * `looksLikeUnifiedDiff` deliberately accepts plain `diff -u` output, which
+     * has no `diff --git` headers, so a record can be bound to a real diff whose
+     * per-file attribution is unavailable. `false` means "a diff, but the packer
+     * saw it as one undifferentiated blob".
+     */
+    fileBoundaries: z.boolean(),
+  })
+  .strict();
+export type PrReviewDiffProvenance = z.infer<typeof PrReviewDiffProvenanceSchema>;
+
+/**
  * One authentic, self-hashed pr-review record. The `hash` covers every
- * authenticity field INCLUDING `prNumber`, `baseSha`, `reviewedDiffHash`, `verdict`, and `sequence`
+ * authenticity field INCLUDING `prNumber`, `baseSha`, `reviewedDiffHash`, `verdict`,
+ * `diffProvenance`, and `sequence`
  * but EXCLUDING `previousHash`, so the record is tamper-EVIDENT and
  * POSITION-INDEPENDENT: any edit to a persisted line is detected by
  * {@link verifyPrReviewRecordSet} as a `hash_mismatch`, while reordering file
@@ -89,13 +146,17 @@ export type PrReviewVoteCounts = z.infer<typeof PrReviewVoteCountsSchema>;
 export const PrReviewRecordSchema = z
   .object({
     /**
-     * Schema version. '1.1' is the Option-C binding (#3831): the record binds to
+     * Schema version. '1.1' was the Option-C binding (#3831): the record binds to
      * `{prNumber, baseSha, reviewedDiffHash}` instead of the rejected `headSha`.
-     * Clean break — the committed `governance/pr-review-records.jsonl` ledger is
-     * empty on every install (no producer ever wrote a '1.0' record), so there is
-     * no '1.0' data to migrate.
+     * '1.2' (#4459) marks the boundary at which records began carrying
+     * {@link diffProvenance} — an honest pre/post marker so a reader can tell
+     * "this record predates provenance" from "this record's provenance was
+     * dropped". Clean break, as with '1.0'→'1.1': the committed
+     * `governance/pr-review-records.jsonl` ledger is EMPTY on every install (0
+     * records at the time of this bump), so there is no data to migrate and no
+     * reason to keep a tolerant version union.
      */
-    version: z.literal('1.1'),
+    version: z.literal('1.2'),
     /**
      * Monotonic sequence number (integer ≥ 0). Assigned as (max existing
      * sequence)+1 at write time. Sorted, the set of sequences must cover
@@ -139,6 +200,13 @@ export const PrReviewRecordSchema = z
     /** Optional correlation/decision id linking to the cost rollup / trace. */
     correlationId: z.string().min(1).optional(),
     /**
+     * What this record was DERIVED FROM (#4459). OPTIONAL by necessity: the
+     * schema is `.strict()`, so a required field would reject every record
+     * written before it existed. Absent ⇒ the producer did not state a
+     * provenance; a consumer must NOT read that as `canonical-git`.
+     */
+    diffProvenance: PrReviewDiffProvenanceSchema.optional(),
+    /**
      * ADVISORY hash of the tip record at write time (absent for the first).
      * Retained for audit texture but NOT covered by `hash` and NOT verified —
      * the record-set model is position-independent (mirrors #3927).
@@ -156,7 +224,8 @@ type PrReviewRecordPayload = Omit<PrReviewRecord, 'hash'>;
 /**
  * Compute the SHA-256 over the canonical payload projection. Folds in EVERY
  * authenticity-bearing field — crucially `prNumber`, `baseSha`, `reviewedDiffHash`, and `verdict`
- * (the diff-binding, Option-C) plus the monotonic `sequence` — but EXCLUDES
+ * (the diff-binding, Option-C), `diffProvenance` (#4459), plus the monotonic
+ * `sequence` — but EXCLUDES
  * `previousHash`, so the hash is position-independent and stable across
  * concurrent-branch merges and file reorders. Built field-by-field (not
  * `JSON.stringify(record)`) so key-order is deterministic regardless of how the
@@ -185,6 +254,25 @@ export function computePrReviewRecordHash(payload: PrReviewRecordPayload): strin
     },
     summary: payload.summary,
     correlationId: payload.correlationId ?? null,
+    // #4459 provenance, INSIDE the hash. This projection is an explicit
+    // allowlist, so a schema field omitted here would sit OUTSIDE
+    // tamper-evidence — `caller-supplied` could be edited to `canonical-git`
+    // with no `hash_mismatch`.
+    //
+    // Absent ⇒ the key is OMITTED entirely (not emitted as `null`, unlike
+    // `correlationId` which has always been in the projection). `JSON.stringify`
+    // drops `undefined` values, so a record written WITHOUT provenance produces
+    // a canonical string byte-identical to the pre-#4459 one and keeps its hash.
+    // Emitting `null` here would flip every such record to `hash_mismatch`.
+    // Rebuilt in schema order for the same reason `voteCounts` is (#3962).
+    ...(payload.diffProvenance !== undefined
+      ? {
+          diffProvenance: {
+            source: payload.diffProvenance.source,
+            fileBoundaries: payload.diffProvenance.fileBoundaries,
+          },
+        }
+      : {}),
   });
   return crypto.createHash('sha256').update(canonical).digest('hex');
 }

--- a/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   SENSITIVE_PATH_PATTERNS,
+  hasFileBoundaries,
   looksLikeUnifiedDiff,
   securityFirstPack,
   splitByFile,
@@ -277,5 +278,38 @@ describe('looksLikeUnifiedDiff', () => {
   it('requires the marker at the start of a line, not merely present', () => {
     // Prose that merely mentions the tokens must not pass.
     expect(looksLikeUnifiedDiff('I ran diff --git and saw @@ markers in the output.')).toBe(false);
+  });
+});
+
+describe('hasFileBoundaries (#4459)', () => {
+  it('is true for a git diff whose segments are real files', () => {
+    expect(hasFileBoundaries(fileDiff('src/a.ts', 2) + fileDiff('src/b.ts', 2))).toBe(true);
+  });
+
+  it('is true when a preamble precedes the first file header', () => {
+    expect(hasFileBoundaries('From 1234 Mon Sep 17\n\n' + fileDiff('src/a.ts', 1))).toBe(true);
+  });
+
+  /**
+   * The one genuinely non-derivable signal (#4459). `looksLikeUnifiedDiff`
+   * deliberately ACCEPTS plain `diff -u` output, which carries no `diff --git`
+   * headers — so a record can be bound to a real diff that `splitByFile` cannot
+   * attribute to files. The consumer needs to know that.
+   */
+  it('is false for plain `diff -u` output that passes the unified-diff gate', () => {
+    const plain = '--- a/x.ts\n+++ b/x.ts\n@@ -1 +1 @@\n-a\n+b\n';
+    expect(looksLikeUnifiedDiff(plain)).toBe(true);
+    expect(hasFileBoundaries(plain)).toBe(false);
+  });
+
+  it('is false for an empty diff', () => {
+    expect(hasFileBoundaries('')).toBe(false);
+  });
+
+  it('agrees with the real split result, not a re-derivation', () => {
+    const diff = fileDiff('src/a.ts', 1);
+    expect(hasFileBoundaries(diff)).toBe(
+      splitByFile(diff).every((f) => f.path !== '(unstructured)')
+    );
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
@@ -100,6 +100,15 @@ function extractPath(fileText: string): string {
 }
 
 /**
+ * Path label for the single segment {@link splitByFile} returns when the input
+ * carries NO `^diff --git ` header at all — i.e. the content could not be
+ * attributed to files. Exported so {@link hasFileBoundaries} (and the #4459
+ * provenance stamp it feeds) reads the split's own verdict instead of
+ * re-deriving one.
+ */
+export const UNSTRUCTURED_SEGMENT_PATH = '(unstructured)';
+
+/**
  * Split a unified diff into whole-file segments on `^diff --git ` boundaries
  * (multiline). Each returned {@link DiffFile} is a complete file segment — header
  * plus every hunk up to the next file header — so the packer can only ever include
@@ -125,7 +134,7 @@ export function splitByFile(diff: string): DiffFile[] {
   }
 
   if (starts.length === 0) {
-    return [{ path: '(unstructured)', text: diff, bytes: byteLen(diff) }];
+    return [{ path: UNSTRUCTURED_SEGMENT_PATH, text: diff, bytes: byteLen(diff) }];
   }
 
   const files: DiffFile[] = [];
@@ -141,6 +150,25 @@ export function splitByFile(diff: string): DiffFile[] {
     files.push({ path: extractPath(text), text, bytes: byteLen(text) });
   }
   return files;
+}
+
+/**
+ * Whether `diff` carries parseable per-file boundaries (#4459) — i.e. whether the
+ * REAL {@link splitByFile} result attributes content to files, rather than falling
+ * back to the single {@link UNSTRUCTURED_SEGMENT_PATH} segment.
+ *
+ * Answered from the split itself, deliberately NOT from a second `^diff --git`
+ * regex: a re-derivation can drift from what the packer actually sees, and this
+ * value is written into a hash-covered audit record. Lives beside `splitByFile` so
+ * there stays ONE place that knows what a file boundary is.
+ *
+ * Note this is genuinely independent of {@link looksLikeUnifiedDiff}: that gate
+ * ACCEPTS plain `diff -u` output (no `diff --git` headers), which lands here as
+ * `false`. Empty input is `false` — no boundaries were observed.
+ */
+export function hasFileBoundaries(diff: string): boolean {
+  const segments = splitByFile(diff);
+  return segments.length > 0 && segments.every((s) => s.path !== UNSTRUCTURED_SEGMENT_PATH);
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
@@ -106,7 +106,10 @@ function extractPath(fileText: string): string {
  * provenance stamp it feeds) reads the split's own verdict instead of
  * re-deriving one.
  */
-export const UNSTRUCTURED_SEGMENT_PATH = '(unstructured)';
+// Module-local by design: `splitByFile` and `hasFileBoundaries` are its only
+// readers, and the export ratchet (#4561) correctly flagged it as a producer
+// with no consumer when it was exported for a test that never imported it.
+const UNSTRUCTURED_SEGMENT_PATH = '(unstructured)';
 
 /**
  * Split a unified diff into whole-file segments on `^diff --git ` boundaries

--- a/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
@@ -20,7 +20,8 @@ import {
   reviewedDiffWasTruncated,
 } from '../../audit/reviewed-diff-hash.js';
 import { persistPrReviewRecord } from '../../audit/pr-review-record-store.js';
-import { looksLikeUnifiedDiff } from './pr-review-diff-budget.js';
+import type { PrReviewDiffProvenance, PrReviewDiffSource } from '../../audit/pr-review-record.js';
+import { hasFileBoundaries, looksLikeUnifiedDiff } from './pr-review-diff-budget.js';
 import type { PrReviewAggregate, PrReviewInput } from './pr-review-tool.js';
 
 /**
@@ -88,8 +89,42 @@ export interface PersistReviewRecordArgs {
   readonly counts: PrReviewCounts;
   readonly reviewCount: number;
   readonly logger: ILogger;
+  /**
+   * REQUIRED (#4459): where `input.prDiff` came from. Every door into the ledger
+   * must NAME its provenance — a default would let a caller that never thought
+   * about it emit a record asserting something about its own derivation. There
+   * are exactly two doors: the pr_review MCP tool (`caller-supplied`, the diff is
+   * opaque input) and `scripts/pr-review-local-ledger.ts` (`canonical-git`).
+   */
+  readonly diffSource: PrReviewDiffSource;
   /** #4140: large-diff coverage; stamped into the record summary when partial. */
   readonly coverage?: PrReviewCoverageStamp | undefined;
+}
+
+/**
+ * Diff-hash parity contract (#4031): the gate recomputes `reviewedDiffHash` over the
+ * first MAX_REVIEWED_DIFF_BYTES of the canonical `git diff`. If the reviewed diff
+ * exceeds that byte cap, content past it is UNBOUND, so a record can match a
+ * different tail than the voters saw. Warn so the silent truncation is observable
+ * (the diff-hash module documents this producer obligation).
+ */
+function warnIfDiffTruncated(diff: string, prNumber: number, logger: ILogger): void {
+  if (!reviewedDiffWasTruncated(diff)) return;
+  logger.warn(
+    'Reviewed diff exceeds the hash byte cap; content past it is unbound in reviewedDiffHash',
+    { prNumber }
+  );
+}
+
+/**
+ * The #4459 provenance descriptor for a reviewed diff: WHERE the bytes came from
+ * (asserted by the producer's door — see {@link PersistReviewRecordArgs.diffSource})
+ * and whether the REAL {@link hasFileBoundaries} split attributed them to files.
+ * Hash-covered downstream, so neither half can be upgraded after the fact. Computed
+ * over the SAME `input.prDiff` bytes the `reviewedDiffHash` binding covers.
+ */
+function diffProvenanceOf(source: PrReviewDiffSource, diff: string): PrReviewDiffProvenance {
+  return { source, fileBoundaries: hasFileBoundaries(diff) };
 }
 
 /**
@@ -103,7 +138,7 @@ function buildAndPersist(
   baseSha: string,
   args: PersistReviewRecordArgs
 ): PrReviewRecordOutcome {
-  const { input, aggregate, counts, reviewCount, logger, coverage } = args;
+  const { input, aggregate, counts, reviewCount, logger, coverage, diffSource } = args;
   // #4140: honest completeness — stamp partial coverage into the (hash-covered)
   // summary so an auditor reading the ledger sees the review was partial. Does NOT
   // touch reviewedDiffHash (the gate's binding), so gate parity is preserved.
@@ -111,21 +146,12 @@ function buildAndPersist(
     coverage?.partial === true
       ? ` [partial coverage: ${String(coverage.reviewedFiles)}/${String(coverage.totalFiles)} files reviewed, dropped: ${coverage.droppedFiles.join(', ')}]`
       : '';
-  // Diff-hash parity contract (#4031): the gate recomputes this hash over the
-  // first MAX_REVIEWED_DIFF_BYTES of the canonical `git diff`. If the reviewed
-  // diff exceeds that byte cap, content past it is UNBOUND, so a record can match
-  // a different tail than the voters saw. Warn so the silent truncation is
-  // observable (the diff-hash module documents this producer obligation).
-  if (reviewedDiffWasTruncated(input.prDiff)) {
-    logger.warn(
-      'Reviewed diff exceeds the hash byte cap; content past it is unbound in reviewedDiffHash',
-      { prNumber }
-    );
-  }
+  warnIfDiffTruncated(input.prDiff, prNumber, logger);
   const record = persistPrReviewRecord({
     prNumber,
     baseSha,
     reviewedDiffHash: computeReviewedDiffHash(input.prDiff),
+    diffProvenance: diffProvenanceOf(diffSource, input.prDiff),
     verdict: aggregate.decision,
     verified: aggregate.verified,
     voteCounts: {

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
@@ -737,6 +737,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
   it('persists a record bound to {prNumber, baseSha, reviewedDiffHash} when both inputs + live review', () => {
     const parsed = input({ prNumber: 99, baseSha: BASE_SHA });
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: parsed,
       aggregate: APPROVE_AGG,
       counts: COUNTS,
@@ -768,6 +769,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
     // `verified: true` LEDGER RECORD, the writer needs its own gate — otherwise
     // the check covers one of two doors into the thing it protects.
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       // Bypass the schema exactly as the script does.
       input: {
         ...input({ prNumber: 101, baseSha: BASE_SHA }),
@@ -788,6 +790,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
 
   it('skips with binding-inputs-absent when prNumber or baseSha is missing', () => {
     const onlyPr = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: input({ prNumber: 99 }),
       aggregate: APPROVE_AGG,
       counts: COUNTS,
@@ -798,6 +801,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
       expect.objectContaining({ persisted: false, reason: 'binding-inputs-absent' })
     );
     const onlySha = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: input({ baseSha: BASE_SHA }),
       aggregate: APPROVE_AGG,
       counts: COUNTS,
@@ -814,6 +818,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
 
   it('skips with reason=simulated even when the binding is present (no governance from non-live output)', () => {
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: input({ prNumber: 99, baseSha: BASE_SHA, simulate: true }),
       aggregate: APPROVE_AGG,
       counts: COUNTS,
@@ -828,6 +833,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
   it('stamps partial coverage into the (hash-covered) record summary without breaking verification (#4140)', () => {
     const parsed = input({ prNumber: 77, baseSha: BASE_SHA });
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: parsed,
       // A partial review degrades to abstain/verified:false per the C1 gate.
       aggregate: {
@@ -856,6 +862,50 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
     expect(verifyPrReviewRecordSet(records).ok).toBe(true);
   });
 
+  it('stamps diffProvenance {source, fileBoundaries} onto the record (#4459)', () => {
+    const parsed = input({ prNumber: 4459, baseSha: BASE_SHA });
+    const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
+      input: parsed,
+      aggregate: APPROVE_AGG,
+      counts: COUNTS,
+      reviewCount: 5,
+      logger,
+    });
+    expect(outcome.persisted).toBe(true);
+    const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
+    const { records } = readPrReviewRecords(path);
+    // The MCP tool's prDiff is opaque caller input — it is never canonical-git.
+    expect(records[0]?.diffProvenance).toEqual({
+      source: 'caller-supplied',
+      fileBoundaries: true,
+    });
+    // Stamped INSIDE the hash, so it verifies and cannot be edited silently.
+    expect(verifyPrReviewRecordSet(records).ok).toBe(true);
+  });
+
+  it('records fileBoundaries:false for a boundary-less diff the unified gate accepts (#4459)', () => {
+    // `looksLikeUnifiedDiff` deliberately accepts plain `diff -u` output, which
+    // carries no `diff --git` headers — the one provenance signal a consumer
+    // cannot re-derive from the record's other fields.
+    const parsed = {
+      ...input({ prNumber: 4460, baseSha: BASE_SHA }),
+      prDiff: '--- a/x.ts\n+++ b/x.ts\n@@ -1 +1 @@\n-a\n+b\n',
+    };
+    const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
+      input: parsed,
+      aggregate: APPROVE_AGG,
+      counts: COUNTS,
+      reviewCount: 5,
+      logger,
+    });
+    expect(outcome.persisted).toBe(true);
+    const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
+    const { records } = readPrReviewRecords(path);
+    expect(records[0]?.diffProvenance?.fileBoundaries).toBe(false);
+  });
+
   it('skips with reason=no-live-votes when every voter errored (no false gate pass)', () => {
     // An all-errored panel still aggregates to {abstain, verified:true}, but no
     // voter actually reviewed — persisting would write a gate-satisfying record
@@ -867,6 +917,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
       errorCount: 5,
     };
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: input({ prNumber: 99, baseSha: BASE_SHA }),
       aggregate: APPROVE_AGG,
       counts: allErrored,
@@ -949,6 +1000,7 @@ describe('pr_review repoPath input (#4278)', () => {
       });
 
       const outcome = persistReviewRecord({
+        diffSource: 'caller-supplied',
         input: parsed,
         aggregate: APPROVE_AGG,
         counts: COUNTS,
@@ -974,6 +1026,7 @@ describe('pr_review repoPath input (#4278)', () => {
       });
 
       const outcome = persistReviewRecord({
+        diffSource: 'caller-supplied',
         input: parsed,
         aggregate: APPROVE_AGG,
         counts: COUNTS,
@@ -999,6 +1052,7 @@ describe('pr_review repoPath input (#4278)', () => {
         });
 
         const outcome = persistReviewRecord({
+          diffSource: 'caller-supplied',
           input: parsed,
           aggregate: APPROVE_AGG,
           counts: COUNTS,

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -527,6 +527,9 @@ async function executePrReviewBody(
   // a structured outcome and never throws — an audit sink must not break the
   // review it observes.
   const recordOutcome = persistReviewRecord({
+    // #4459: `input.prDiff` is opaque MCP input — it passed the unified-diff
+    // shape gate (#4451), but nothing here establishes it is the PR's real diff.
+    diffSource: 'caller-supplied',
     input,
     aggregate,
     counts,

--- a/scripts/pr-review-local-ledger.ts
+++ b/scripts/pr-review-local-ledger.ts
@@ -252,6 +252,12 @@ export async function feedLedgerFromReview(
       : {}),
   };
   return persistReviewRecord({
+    // #4459: this feeder ALWAYS hashes the pinned `git diff base..head` output —
+    // either passed in from the review it just ran, or regenerated above by
+    // `generateCanonicalReviewDiff`. There is no path here that writes a record
+    // from a caller-supplied or gh-fetched diff (the gh fallback sets
+    // `canonicalDiff: undefined`, which returns before this call).
+    diffSource: 'canonical-git',
     input,
     aggregate: params.aggregate,
     counts: params.counts,

--- a/scripts/pr-review-local.test.ts
+++ b/scripts/pr-review-local.test.ts
@@ -150,6 +150,12 @@ describe('pr-review-local ledger feeder (#4229 Part 2 — real git)', () => {
     expect(records[0]?.reviewedDiffHash).toBe(gateHash);
     expect(records[0]?.prNumber).toBe(4229);
     expect(records[0]?.baseSha).toBe(baseSha);
+    // #4459: the feeder's diff is ALWAYS the canonical git diff, and this
+    // fixture is a real git diff, so both provenance signals are pinned here.
+    expect(records[0]?.diffProvenance).toEqual({
+      source: 'canonical-git',
+      fileBoundaries: true,
+    });
   });
 
   it('does NOT bypass the producer live-review guard (all-errored panel → no record)', async () => {

--- a/scripts/pr-review-local.ts
+++ b/scripts/pr-review-local.ts
@@ -267,7 +267,15 @@ async function runReview(prNumber: number): Promise<ReviewResult> {
   const { reviewDiff, canonicalDiff } = await resolveReviewDiff(prNumber, meta);
   console.log(`  ${meta.title}`);
   console.log(
-    `  diff size: ${String(reviewDiff.length)} chars${canonicalDiff !== undefined ? ' (canonical, ledger-excluded)' : ' (gh fallback)'}`
+    // #4459: the old wording was `(canonical, ledger-excluded)`, which reads as
+    // "this review is excluded from the ledger" — the opposite of the truth. It
+    // is the DIFF that excludes the ledger FILE, which is precisely what makes
+    // the review ledger-eligible.
+    `  diff size: ${String(reviewDiff.length)} chars${
+      canonicalDiff !== undefined
+        ? ' (canonical git diff, excluding the ledger file — feeds the ledger)'
+        : ' (gh fallback diff — no ledger record)'
+    }`
   );
 
   const proposal = buildPrReviewProposal({


### PR DESCRIPTION
Refs #4459. **`packages/nexus-agents/src/audit/` is on CLAUDE.md's never-auto-merge list — this is opened for your ratification, not to be merged by me.**

## What it does

A pr-review record binds itself to a diff via `reviewedDiffHash`. #4451 made sure the diff is *shaped* like a diff. Nothing said what it was *derived from* — whether the bytes were the canonical `git diff <base>..<head>` the CI gate recomputes, or an opaque `prDiff` a caller pasted into the MCP tool.

Records now carry `diffProvenance { source, fileBoundaries }`, and **it is inside `computePrReviewRecordHash`'s allowlist.**

That last part is the whole point. `computePrReviewRecordHash` builds its canonical form field by field, deliberately not `JSON.stringify`. A provenance claim in the schema but outside the projection could be upgraded from `caller-supplied` to `canonical-git` by editing one word in the ledger, with **no `hash_mismatch`** — a record asserting a stronger derivation than it has. That is a worse version of the problem this issue exists to solve, so it was the first thing built and the first thing tested.

**The hole was real.** With the field in the schema but not the projection, flipping `caller-supplied` → `canonical-git` produced an identical hash (`32eb3392…` both sides). Closed.

## Reshaped after measurement, not built to the issue body

Three of the five acceptance items rested on things that are not true:

| Issue said | Measured |
| --- | --- |
| `source: 'canonical-git' \| 'gh-api' \| 'caller-supplied'` | **`gh-api` is unreachable.** The gh fallback sets `canonicalDiff: undefined` and the feeder returns before writing (`pr-review-local-ledger.ts:296-300`). Only two producers exist. An enum member no producer can emit is a value consumers must handle without ever meeting it — omitted, with the reasoning in the JSDoc. |
| `shapeValidated: boolean` | **Would be a hardcoded `true`.** Both #4451 gates are unconditional. A constant is not a signal. Replaced by `version` `'1.1'` → `'1.2'` as the honest pre/post-gate boundary. |
| "records predating the field are distinguishable" | **Vacuous today** — the ledger is 0 records. Kept the version bump as the forward-looking marker and said so rather than writing a migration for nothing. |
| `fileBoundaries: boolean` | **Real and non-derivable.** `looksLikeUnifiedDiff` deliberately accepts plain `diff -u` output, which `splitByFile` then collapses into a single `(unstructured)` segment — a record can be bound to a genuine diff whose per-file coverage a reader would misjudge. Sourced from the real split result via a new `hasFileBoundaries()` beside `splitByFile`, not a second regex. |

I also had one thing wrong and the issue was right: I misread `(canonical, ledger-excluded)` as "canonical reviews skip the ledger". It means the *diff* excludes the ledger file, so committing the record onto the PR head stays hash-safe. The log now says `(canonical git diff, excluding the ledger file — feeds the ledger)`.

## My instruction was wrong and the implementation refuted it

I specified `payload.diffProvenance ?? null` in the projection. That would have **broken** the backward compatibility I was asking for: `JSON.stringify` keeps `null` but drops `undefined`, so emitting `null` changes the canonical string for every record lacking the field and flips all of them to `hash_mismatch`. Implemented as omit-when-absent instead.

## Verified independently, against the pre-change code

Not taking the report's word for it — I extracted `main`'s version of the module and hashed the same record with both:

```
pre-change  hash: 408e5b1a2217e05af05a0591
post-change hash: 408e5b1a2217e05af05a0591
IDENTICAL — old records keep their hashes
```

And every provenance value is hash-covered:

```
source flip changes hash?       YES (hash-covered)
fileBoundaries changes hash?    YES (hash-covered)
absent field != present field?  YES
```

`verifyPrReviewRecordSet` returns `hash_mismatch` on a flipped or deleted field.

## Also

`diffSource` is **required** on `PersistReviewRecordArgs` — each writer must name its provenance rather than inherit a default, so a new producer cannot silently claim the stronger value.

Deliberately not done: provenance is not surfaced in `check-governor-review.ts` or the `pr_review` response. Out of scope, and the governor path stays minimal for ratification.

## Gates

- Package suite **28,209 passed** / 1,184 files; root suite 667 / 44 files
- `pnpm typecheck`, `pnpm lint`, `prettier --check` clean
- No migration: the ledger is 0 records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHXwDm2C34XvS2it2L83Et
