### PR TITLE
fix(testing): reap stale test scratch before each run

### DIFF
--- a/.changeset/plenty-pugs-jam.md
+++ b/.changeset/plenty-pugs-jam.md
@@ -1,0 +1,33 @@
+---
+'nexus-agents': minor
+---
+
+feat(audit): record what a pr-review record was derived from (#4459)
+
+PR-review ledger records now carry an optional, **hash-covered** `diffProvenance`
+descriptor so a consumer can tell what the record was derived from:
+
+- `source: 'canonical-git' | 'caller-supplied'` — `canonical-git` when the reviewed
+  bytes are the pinned `git diff <base>..<head>` the CI gate itself recomputes
+  (`scripts/pr-review-local-ledger.ts`), `caller-supplied` when they arrived as
+  opaque `prDiff` input on a `pr_review` MCP call. Those are the only two producers,
+  so there are only two values: the `gh` v3.diff fallback skips the ledger entirely
+  and can never write a record.
+- `fileBoundaries: boolean` — whether the real `splitByFile` result attributed the
+  diff to files. `looksLikeUnifiedDiff` deliberately accepts plain `diff -u` output,
+  which has no `diff --git` headers, so this is the one signal a consumer cannot
+  re-derive from the record's other fields.
+
+`computePrReviewRecordHash` builds its canonical form from an explicit field
+allowlist, so the field is added **to the projection**, not just the schema — a
+provenance claim outside the self-hash could be upgraded from `caller-supplied` to
+`canonical-git` with no `hash_mismatch`. A record written without provenance still
+hashes exactly as before (the key is omitted, not emitted as `null`), pinned by a
+golden-hash test.
+
+Record `version` moves `'1.1'` → `'1.2'` as the pre/post-provenance boundary marker.
+No migration: `governance/pr-review-records.jsonl` holds 0 records.
+
+Also fixes a misleading log in `scripts/pr-review-local.ts` that printed
+`(canonical, ledger-excluded)` — it means the diff excludes the ledger _file_, not
+that the review is excluded from the ledger.

--- a/.changeset/scratch-reaper.md
+++ b/.changeset/scratch-reaper.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+Reap stale test scratch before each vitest run (#4413)
+
+`vitest.config.ts` now runs a `globalSetup` hook that removes entries older than
+24 hours from the suite's scratch root, and logs what it removed.
+
+#4412 moved that scratch off the shared `/tmp` tmpfs, because the tmpfs filled
+and the suite failed to _collect_ ~1,100 test files while reporting zero
+assertion failures. That fixed the contention but removed the one property the
+tmpfs had — it cleared on reboot. On real disk the same leak accumulated
+permanently: the root reached 9.7 GB across 1,987 entries before anything
+measured it. The sweep is the other half of that trade.
+
+The reaper reports rather than tidies silently. `ReapReport` distinguishes four
+outcomes a naive implementation collapses into one cheerful "cleaned up" — root
+absent, root empty, swept-but-nothing-stale, and reaped-N — because a reaper
+pointed at the wrong directory otherwise looks exactly like a working one. A
+rising reap count each run is the leak detector; a silent net would just hide
+the next 9.7 GB.
+
+Ties are retained, not reaped, so a clock skew of a millisecond cannot delete a
+concurrent run's scratch, and stale symlinks are removed as links rather than
+followed.

--- a/packages/nexus-agents/src/audit/index.ts
+++ b/packages/nexus-agents/src/audit/index.ts
@@ -91,6 +91,8 @@ export type { BuildVoteRecordInput, PersistVoteRecordOptions } from './vote-reco
 // SHA-BOUND record SET + monotonic sequence (mirrors the #3927 vote-record
 // model). Read by the warn-first governor-review gate.
 export {
+  PrReviewDiffProvenanceSchema,
+  PrReviewDiffSourceSchema,
   PrReviewRecordSchema,
   PrReviewVerdictSchema,
   PrReviewVoteCountsSchema,
@@ -98,6 +100,8 @@ export {
   verifyPrReviewRecordSet,
 } from './pr-review-record.js';
 export type {
+  PrReviewDiffProvenance,
+  PrReviewDiffSource,
   PrReviewRecord,
   PrReviewVerdict,
   PrReviewVoteCounts,

--- a/packages/nexus-agents/src/audit/pr-review-record-store.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record-store.ts
@@ -30,7 +30,12 @@ import { findRepoRoot } from '../config/repo-root-detection.js';
 import type { ILogger } from '../core/index.js';
 import { createLogger, getErrorMessage } from '../core/index.js';
 
-import type { PrReviewRecord, PrReviewVerdict, PrReviewVoteCounts } from './pr-review-record.js';
+import type {
+  PrReviewDiffProvenance,
+  PrReviewRecord,
+  PrReviewVerdict,
+  PrReviewVoteCounts,
+} from './pr-review-record.js';
 import { PrReviewRecordSchema, computePrReviewRecordHash } from './pr-review-record.js';
 
 /** Repo-relative committable artifact path (read by the gate/CI). */
@@ -61,6 +66,14 @@ export interface BuildPrReviewRecordInput {
   readonly correlationId?: string | undefined;
   readonly recordedAt?: string | undefined;
   /**
+   * What the reviewed diff was DERIVED FROM (#4459). Optional here because the
+   * schema field is optional (a record written without it must still parse and
+   * still hash as it did pre-#4459). Producers that KNOW their provenance —
+   * both in-tree ones do — must pass it; omitting it is a record that declines
+   * to say, never a record that is `canonical-git`.
+   */
+  readonly diffProvenance?: PrReviewDiffProvenance | undefined;
+  /**
    * Monotonic sequence number for this record. Defaults to 0 (first record)
    * when omitted; the future producer supplies (max existing sequence)+1.
    */
@@ -85,7 +98,7 @@ export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRe
       ? input.summary.slice(0, MAX_SUMMARY_RECORD_CHARS) + '...'
       : input.summary;
   const payload: Omit<PrReviewRecord, 'hash'> = {
-    version: '1.1',
+    version: '1.2',
     sequence: input.sequence ?? 0,
     prNumber: input.prNumber,
     baseSha: input.baseSha,
@@ -101,6 +114,7 @@ export function buildPrReviewRecord(input: BuildPrReviewRecordInput): PrReviewRe
       total: input.voteCounts.total,
     },
     summary: summaryTruncated,
+    ...(input.diffProvenance !== undefined ? { diffProvenance: input.diffProvenance } : {}),
     ...(input.correlationId !== undefined ? { correlationId: input.correlationId } : {}),
     ...(input.previousHash !== undefined ? { previousHash: input.previousHash } : {}),
   };

--- a/packages/nexus-agents/src/audit/pr-review-record.test.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.test.ts
@@ -12,8 +12,12 @@
 
 import { describe, it, expect } from 'vitest';
 
-import type { PrReviewRecord } from './pr-review-record.js';
-import { computePrReviewRecordHash, verifyPrReviewRecordSet } from './pr-review-record.js';
+import type { PrReviewDiffProvenance, PrReviewRecord } from './pr-review-record.js';
+import {
+  PrReviewRecordSchema,
+  computePrReviewRecordHash,
+  verifyPrReviewRecordSet,
+} from './pr-review-record.js';
 import { buildPrReviewRecord } from './pr-review-record-store.js';
 
 const SHA_A = 'a'.repeat(40);
@@ -31,7 +35,7 @@ function makeRecord(
   overrides: Partial<Omit<PrReviewRecord, 'hash'>> = {}
 ): PrReviewRecord {
   const payload: Omit<PrReviewRecord, 'hash'> = {
-    version: '1.1',
+    version: '1.2',
     sequence,
     prNumber,
     baseSha: SHA_A,
@@ -147,5 +151,105 @@ describe('buildPrReviewRecord (#3831)', () => {
     expect(rec.summary.length).toBeLessThan(long.length);
     expect(rec.summary.endsWith('...')).toBe(true);
     expect(verifyPrReviewRecordSet([rec]).ok).toBe(true);
+  });
+});
+
+describe('diffProvenance (#4459)', () => {
+  const CALLER_SUPPLIED: PrReviewDiffProvenance = {
+    source: 'caller-supplied',
+    fileBoundaries: true,
+  };
+
+  /**
+   * THE load-bearing test. `computePrReviewRecordHash` builds its canonical form
+   * from an explicit field ALLOWLIST, not `JSON.stringify(record)` — so a field
+   * present in the schema but absent from the projection sits OUTSIDE
+   * tamper-evidence. If this passes with the projection unchanged, `source` could
+   * be edited from `caller-supplied` to `canonical-git` — upgrading a record's
+   * apparent provenance — with no `hash_mismatch`.
+   */
+  it('folds diffProvenance.source into the self-hash: flipping it is a hash_mismatch', () => {
+    const authentic = makeRecord(4459, 0, { diffProvenance: CALLER_SUPPLIED });
+    const forged: PrReviewRecord = {
+      ...authentic,
+      diffProvenance: { source: 'canonical-git', fileBoundaries: true },
+    };
+    expect(computePrReviewRecordHash(forged)).not.toBe(authentic.hash);
+    const verification = verifyPrReviewRecordSet([forged]);
+    expect(verification.ok).toBe(false);
+    if (!verification.ok) expect(verification.reason).toBe('hash_mismatch');
+  });
+
+  it('folds diffProvenance.fileBoundaries into the self-hash', () => {
+    const authentic = makeRecord(4459, 0, { diffProvenance: CALLER_SUPPLIED });
+    const forged: PrReviewRecord = {
+      ...authentic,
+      diffProvenance: { source: 'caller-supplied', fileBoundaries: false },
+    };
+    expect(computePrReviewRecordHash(forged)).not.toBe(authentic.hash);
+    expect(verifyPrReviewRecordSet([forged]).ok).toBe(false);
+  });
+
+  it('DETECTS deletion of the whole diffProvenance field as a hash_mismatch', () => {
+    const authentic = makeRecord(4459, 0, { diffProvenance: CALLER_SUPPLIED });
+    const stripped = { ...authentic };
+    Reflect.deleteProperty(stripped, 'diffProvenance');
+    expect(verifyPrReviewRecordSet([stripped]).ok).toBe(false);
+  });
+
+  /**
+   * BACKWARD COMPATIBILITY PIN. A record written WITHOUT `diffProvenance` must
+   * hash exactly as it did before the field existed — otherwise every previously
+   * written record flips to `hash_mismatch` on the next verification. The golden
+   * hex below was computed with the pre-#4459 projection; it must never change.
+   * (This is why the projection OMITS the key when absent rather than emitting
+   * `null`: `JSON.stringify` drops `undefined` values, so the canonical string is
+   * byte-identical to the pre-field one.)
+   */
+  it('hashes a record with NO diffProvenance identically to the pre-#4459 projection', () => {
+    const payload: Omit<PrReviewRecord, 'hash'> = {
+      version: '1.2',
+      sequence: 7,
+      prNumber: 4459,
+      baseSha: SHA_A,
+      reviewedDiffHash: DIFF_HASH_A,
+      recordedAt: '2026-06-15T00:00:00.000Z',
+      verdict: 'approve',
+      verified: true,
+      voteCounts: { approve: 5, request_changes: 0, abstain: 0, error: 0, total: 5 },
+      summary: 'looks good',
+    };
+    expect(computePrReviewRecordHash(payload)).toBe(
+      'ca8f09d59e628b2b9f7bf7be988dc796efe6b641df3f0b12fce49bfc76cb75a8'
+    );
+  });
+
+  it('is OPTIONAL: a record without it still parses under the .strict() schema', () => {
+    const rec = makeRecord(4459, 0);
+    expect(PrReviewRecordSchema.safeParse(rec).success).toBe(true);
+  });
+
+  it('parses a record that carries it', () => {
+    const parsed = PrReviewRecordSchema.safeParse(
+      makeRecord(4459, 0, { diffProvenance: { source: 'canonical-git', fileBoundaries: false } })
+    );
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data.diffProvenance?.source).toBe('canonical-git');
+  });
+
+  it('rejects an unreachable source value (gh-api was measured to be unreachable)', () => {
+    const bad = {
+      ...makeRecord(4459, 0),
+      diffProvenance: { source: 'gh-api', fileBoundaries: true },
+    };
+    expect(PrReviewRecordSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe('record version (#4459)', () => {
+  it('pins the schema version at 1.2 — the pre/post diffProvenance boundary', () => {
+    expect(makeRecord(1, 0).version).toBe('1.2');
+    const stale = { ...makeRecord(1, 0), version: '1.1' };
+    expect(PrReviewRecordSchema.safeParse(stale).success).toBe(false);
   });
 });

--- a/packages/nexus-agents/src/audit/pr-review-record.ts
+++ b/packages/nexus-agents/src/audit/pr-review-record.ts
@@ -41,6 +41,14 @@
  * rejected `headSha` binding (a head pointer is mutable; the reviewed bytes are
  * what the voters actually saw).
  *
+ * DIFF PROVENANCE (#4459). The binding says WHICH bytes were reviewed; it does not
+ * say where those bytes CAME FROM. `diffProvenance` closes that gap: `canonical-git`
+ * means the diff is the pinned `git diff` the gate itself recomputes, while
+ * `caller-supplied` means an MCP caller handed over opaque bytes that merely passed
+ * the `looksLikeUnifiedDiff` shape gate (#4451). It is HASH-COVERED like every other
+ * authenticity field — a provenance claim outside the hash could be upgraded by
+ * editing one word.
+ *
  * WHY A DEDICATED PAYLOAD-COVERING HASH (and not the audit-event head hash).
  * As in #3897/#3927: the audit-event chain (`computeEventHash` in
  * audit-logger.ts) hashes only the stable HEAD fields and intentionally NOT
@@ -79,8 +87,57 @@ export const PrReviewVoteCountsSchema = z
 export type PrReviewVoteCounts = z.infer<typeof PrReviewVoteCountsSchema>;
 
 /**
+ * Where the bytes behind `reviewedDiffHash` came from (#4459). Only two values
+ * exist because only two non-test producers write records:
+ *  - `canonical-git` — the diff is the pinned `git diff <base>..<head>` output
+ *    (`audit/reviewed-diff-hash.ts`), the same invocation the CI gate recomputes.
+ *    Written by `scripts/pr-review-local-ledger.ts`.
+ *  - `caller-supplied` — the diff arrived as opaque `prDiff` input on the
+ *    `pr_review` MCP call. It PASSED the `looksLikeUnifiedDiff` shape gate
+ *    (#4451), but nothing establishes that it is the PR's actual diff. Written
+ *    by `mcp/tools/pr-review-tool.ts`.
+ *
+ * There is deliberately NO `gh-api` member: the `gh` v3.diff fallback in
+ * `scripts/pr-review-local.ts` skips the ledger entirely (it sets
+ * `canonicalDiff: undefined`, and the feeder writes no record), so a `gh-api`
+ * record cannot be produced. An enum member no producer can emit is a value a
+ * consumer would have to handle without ever meeting it.
+ */
+export const PrReviewDiffSourceSchema = z.enum(['canonical-git', 'caller-supplied']);
+export type PrReviewDiffSource = z.infer<typeof PrReviewDiffSourceSchema>;
+
+/**
+ * What the record was DERIVED FROM — the provenance descriptor a consumer reads
+ * to decide how much the record's diff-binding is worth (#4459).
+ *
+ * Both fields are HASH-COVERED (see {@link computePrReviewRecordHash}). That is
+ * the whole point: a provenance claim outside the self-hash could be upgraded
+ * from `caller-supplied` to `canonical-git` by editing one word in the ledger,
+ * with no `hash_mismatch` — the record would then assert a stronger derivation
+ * than it has, which is exactly the "record that misreports" failure mode.
+ */
+export const PrReviewDiffProvenanceSchema = z
+  .object({
+    /** How the reviewed diff was obtained. */
+    source: PrReviewDiffSourceSchema,
+    /**
+     * Whether the reviewed diff carried parseable `^diff --git` FILE BOUNDARIES
+     * (sourced from the real `splitByFile` result, not a second regex). The one
+     * signal a consumer genuinely CANNOT re-derive from the other record fields:
+     * `looksLikeUnifiedDiff` deliberately accepts plain `diff -u` output, which
+     * has no `diff --git` headers, so a record can be bound to a real diff whose
+     * per-file attribution is unavailable. `false` means "a diff, but the packer
+     * saw it as one undifferentiated blob".
+     */
+    fileBoundaries: z.boolean(),
+  })
+  .strict();
+export type PrReviewDiffProvenance = z.infer<typeof PrReviewDiffProvenanceSchema>;
+
+/**
  * One authentic, self-hashed pr-review record. The `hash` covers every
- * authenticity field INCLUDING `prNumber`, `baseSha`, `reviewedDiffHash`, `verdict`, and `sequence`
+ * authenticity field INCLUDING `prNumber`, `baseSha`, `reviewedDiffHash`, `verdict`,
+ * `diffProvenance`, and `sequence`
  * but EXCLUDING `previousHash`, so the record is tamper-EVIDENT and
  * POSITION-INDEPENDENT: any edit to a persisted line is detected by
  * {@link verifyPrReviewRecordSet} as a `hash_mismatch`, while reordering file
@@ -89,13 +146,17 @@ export type PrReviewVoteCounts = z.infer<typeof PrReviewVoteCountsSchema>;
 export const PrReviewRecordSchema = z
   .object({
     /**
-     * Schema version. '1.1' is the Option-C binding (#3831): the record binds to
+     * Schema version. '1.1' was the Option-C binding (#3831): the record binds to
      * `{prNumber, baseSha, reviewedDiffHash}` instead of the rejected `headSha`.
-     * Clean break — the committed `governance/pr-review-records.jsonl` ledger is
-     * empty on every install (no producer ever wrote a '1.0' record), so there is
-     * no '1.0' data to migrate.
+     * '1.2' (#4459) marks the boundary at which records began carrying
+     * {@link diffProvenance} — an honest pre/post marker so a reader can tell
+     * "this record predates provenance" from "this record's provenance was
+     * dropped". Clean break, as with '1.0'→'1.1': the committed
+     * `governance/pr-review-records.jsonl` ledger is EMPTY on every install (0
+     * records at the time of this bump), so there is no data to migrate and no
+     * reason to keep a tolerant version union.
      */
-    version: z.literal('1.1'),
+    version: z.literal('1.2'),
     /**
      * Monotonic sequence number (integer ≥ 0). Assigned as (max existing
      * sequence)+1 at write time. Sorted, the set of sequences must cover
@@ -139,6 +200,13 @@ export const PrReviewRecordSchema = z
     /** Optional correlation/decision id linking to the cost rollup / trace. */
     correlationId: z.string().min(1).optional(),
     /**
+     * What this record was DERIVED FROM (#4459). OPTIONAL by necessity: the
+     * schema is `.strict()`, so a required field would reject every record
+     * written before it existed. Absent ⇒ the producer did not state a
+     * provenance; a consumer must NOT read that as `canonical-git`.
+     */
+    diffProvenance: PrReviewDiffProvenanceSchema.optional(),
+    /**
      * ADVISORY hash of the tip record at write time (absent for the first).
      * Retained for audit texture but NOT covered by `hash` and NOT verified —
      * the record-set model is position-independent (mirrors #3927).
@@ -156,7 +224,8 @@ type PrReviewRecordPayload = Omit<PrReviewRecord, 'hash'>;
 /**
  * Compute the SHA-256 over the canonical payload projection. Folds in EVERY
  * authenticity-bearing field — crucially `prNumber`, `baseSha`, `reviewedDiffHash`, and `verdict`
- * (the diff-binding, Option-C) plus the monotonic `sequence` — but EXCLUDES
+ * (the diff-binding, Option-C), `diffProvenance` (#4459), plus the monotonic
+ * `sequence` — but EXCLUDES
  * `previousHash`, so the hash is position-independent and stable across
  * concurrent-branch merges and file reorders. Built field-by-field (not
  * `JSON.stringify(record)`) so key-order is deterministic regardless of how the
@@ -185,6 +254,25 @@ export function computePrReviewRecordHash(payload: PrReviewRecordPayload): strin
     },
     summary: payload.summary,
     correlationId: payload.correlationId ?? null,
+    // #4459 provenance, INSIDE the hash. This projection is an explicit
+    // allowlist, so a schema field omitted here would sit OUTSIDE
+    // tamper-evidence — `caller-supplied` could be edited to `canonical-git`
+    // with no `hash_mismatch`.
+    //
+    // Absent ⇒ the key is OMITTED entirely (not emitted as `null`, unlike
+    // `correlationId` which has always been in the projection). `JSON.stringify`
+    // drops `undefined` values, so a record written WITHOUT provenance produces
+    // a canonical string byte-identical to the pre-#4459 one and keeps its hash.
+    // Emitting `null` here would flip every such record to `hash_mismatch`.
+    // Rebuilt in schema order for the same reason `voteCounts` is (#3962).
+    ...(payload.diffProvenance !== undefined
+      ? {
+          diffProvenance: {
+            source: payload.diffProvenance.source,
+            fileBoundaries: payload.diffProvenance.fileBoundaries,
+          },
+        }
+      : {}),
   });
   return crypto.createHash('sha256').update(canonical).digest('hex');
 }

--- a/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   SENSITIVE_PATH_PATTERNS,
+  hasFileBoundaries,
   looksLikeUnifiedDiff,
   securityFirstPack,
   splitByFile,
@@ -277,5 +278,38 @@ describe('looksLikeUnifiedDiff', () => {
   it('requires the marker at the start of a line, not merely present', () => {
     // Prose that merely mentions the tokens must not pass.
     expect(looksLikeUnifiedDiff('I ran diff --git and saw @@ markers in the output.')).toBe(false);
+  });
+});
+
+describe('hasFileBoundaries (#4459)', () => {
+  it('is true for a git diff whose segments are real files', () => {
+    expect(hasFileBoundaries(fileDiff('src/a.ts', 2) + fileDiff('src/b.ts', 2))).toBe(true);
+  });
+
+  it('is true when a preamble precedes the first file header', () => {
+    expect(hasFileBoundaries('From 1234 Mon Sep 17\n\n' + fileDiff('src/a.ts', 1))).toBe(true);
+  });
+
+  /**
+   * The one genuinely non-derivable signal (#4459). `looksLikeUnifiedDiff`
+   * deliberately ACCEPTS plain `diff -u` output, which carries no `diff --git`
+   * headers — so a record can be bound to a real diff that `splitByFile` cannot
+   * attribute to files. The consumer needs to know that.
+   */
+  it('is false for plain `diff -u` output that passes the unified-diff gate', () => {
+    const plain = '--- a/x.ts\n+++ b/x.ts\n@@ -1 +1 @@\n-a\n+b\n';
+    expect(looksLikeUnifiedDiff(plain)).toBe(true);
+    expect(hasFileBoundaries(plain)).toBe(false);
+  });
+
+  it('is false for an empty diff', () => {
+    expect(hasFileBoundaries('')).toBe(false);
+  });
+
+  it('agrees with the real split result, not a re-derivation', () => {
+    const diff = fileDiff('src/a.ts', 1);
+    expect(hasFileBoundaries(diff)).toBe(
+      splitByFile(diff).every((f) => f.path !== '(unstructured)')
+    );
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
@@ -100,6 +100,15 @@ function extractPath(fileText: string): string {
 }
 
 /**
+ * Path label for the single segment {@link splitByFile} returns when the input
+ * carries NO `^diff --git ` header at all — i.e. the content could not be
+ * attributed to files. Exported so {@link hasFileBoundaries} (and the #4459
+ * provenance stamp it feeds) reads the split's own verdict instead of
+ * re-deriving one.
+ */
+export const UNSTRUCTURED_SEGMENT_PATH = '(unstructured)';
+
+/**
  * Split a unified diff into whole-file segments on `^diff --git ` boundaries
  * (multiline). Each returned {@link DiffFile} is a complete file segment — header
  * plus every hunk up to the next file header — so the packer can only ever include
@@ -125,7 +134,7 @@ export function splitByFile(diff: string): DiffFile[] {
   }
 
   if (starts.length === 0) {
-    return [{ path: '(unstructured)', text: diff, bytes: byteLen(diff) }];
+    return [{ path: UNSTRUCTURED_SEGMENT_PATH, text: diff, bytes: byteLen(diff) }];
   }
 
   const files: DiffFile[] = [];
@@ -141,6 +150,25 @@ export function splitByFile(diff: string): DiffFile[] {
     files.push({ path: extractPath(text), text, bytes: byteLen(text) });
   }
   return files;
+}
+
+/**
+ * Whether `diff` carries parseable per-file boundaries (#4459) — i.e. whether the
+ * REAL {@link splitByFile} result attributes content to files, rather than falling
+ * back to the single {@link UNSTRUCTURED_SEGMENT_PATH} segment.
+ *
+ * Answered from the split itself, deliberately NOT from a second `^diff --git`
+ * regex: a re-derivation can drift from what the packer actually sees, and this
+ * value is written into a hash-covered audit record. Lives beside `splitByFile` so
+ * there stays ONE place that knows what a file boundary is.
+ *
+ * Note this is genuinely independent of {@link looksLikeUnifiedDiff}: that gate
+ * ACCEPTS plain `diff -u` output (no `diff --git` headers), which lands here as
+ * `false`. Empty input is `false` — no boundaries were observed.
+ */
+export function hasFileBoundaries(diff: string): boolean {
+  const segments = splitByFile(diff);
+  return segments.length > 0 && segments.every((s) => s.path !== UNSTRUCTURED_SEGMENT_PATH);
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-diff-budget.ts
@@ -106,7 +106,10 @@ function extractPath(fileText: string): string {
  * provenance stamp it feeds) reads the split's own verdict instead of
  * re-deriving one.
  */
-export const UNSTRUCTURED_SEGMENT_PATH = '(unstructured)';
+// Module-local by design: `splitByFile` and `hasFileBoundaries` are its only
+// readers, and the export ratchet (#4561) correctly flagged it as a producer
+// with no consumer when it was exported for a test that never imported it.
+const UNSTRUCTURED_SEGMENT_PATH = '(unstructured)';
 
 /**
  * Split a unified diff into whole-file segments on `^diff --git ` boundaries

--- a/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-record-producer.ts
@@ -20,7 +20,8 @@ import {
   reviewedDiffWasTruncated,
 } from '../../audit/reviewed-diff-hash.js';
 import { persistPrReviewRecord } from '../../audit/pr-review-record-store.js';
-import { looksLikeUnifiedDiff } from './pr-review-diff-budget.js';
+import type { PrReviewDiffProvenance, PrReviewDiffSource } from '../../audit/pr-review-record.js';
+import { hasFileBoundaries, looksLikeUnifiedDiff } from './pr-review-diff-budget.js';
 import type { PrReviewAggregate, PrReviewInput } from './pr-review-tool.js';
 
 /**
@@ -88,8 +89,42 @@ export interface PersistReviewRecordArgs {
   readonly counts: PrReviewCounts;
   readonly reviewCount: number;
   readonly logger: ILogger;
+  /**
+   * REQUIRED (#4459): where `input.prDiff` came from. Every door into the ledger
+   * must NAME its provenance — a default would let a caller that never thought
+   * about it emit a record asserting something about its own derivation. There
+   * are exactly two doors: the pr_review MCP tool (`caller-supplied`, the diff is
+   * opaque input) and `scripts/pr-review-local-ledger.ts` (`canonical-git`).
+   */
+  readonly diffSource: PrReviewDiffSource;
   /** #4140: large-diff coverage; stamped into the record summary when partial. */
   readonly coverage?: PrReviewCoverageStamp | undefined;
+}
+
+/**
+ * Diff-hash parity contract (#4031): the gate recomputes `reviewedDiffHash` over the
+ * first MAX_REVIEWED_DIFF_BYTES of the canonical `git diff`. If the reviewed diff
+ * exceeds that byte cap, content past it is UNBOUND, so a record can match a
+ * different tail than the voters saw. Warn so the silent truncation is observable
+ * (the diff-hash module documents this producer obligation).
+ */
+function warnIfDiffTruncated(diff: string, prNumber: number, logger: ILogger): void {
+  if (!reviewedDiffWasTruncated(diff)) return;
+  logger.warn(
+    'Reviewed diff exceeds the hash byte cap; content past it is unbound in reviewedDiffHash',
+    { prNumber }
+  );
+}
+
+/**
+ * The #4459 provenance descriptor for a reviewed diff: WHERE the bytes came from
+ * (asserted by the producer's door — see {@link PersistReviewRecordArgs.diffSource})
+ * and whether the REAL {@link hasFileBoundaries} split attributed them to files.
+ * Hash-covered downstream, so neither half can be upgraded after the fact. Computed
+ * over the SAME `input.prDiff` bytes the `reviewedDiffHash` binding covers.
+ */
+function diffProvenanceOf(source: PrReviewDiffSource, diff: string): PrReviewDiffProvenance {
+  return { source, fileBoundaries: hasFileBoundaries(diff) };
 }
 
 /**
@@ -103,7 +138,7 @@ function buildAndPersist(
   baseSha: string,
   args: PersistReviewRecordArgs
 ): PrReviewRecordOutcome {
-  const { input, aggregate, counts, reviewCount, logger, coverage } = args;
+  const { input, aggregate, counts, reviewCount, logger, coverage, diffSource } = args;
   // #4140: honest completeness — stamp partial coverage into the (hash-covered)
   // summary so an auditor reading the ledger sees the review was partial. Does NOT
   // touch reviewedDiffHash (the gate's binding), so gate parity is preserved.
@@ -111,21 +146,12 @@ function buildAndPersist(
     coverage?.partial === true
       ? ` [partial coverage: ${String(coverage.reviewedFiles)}/${String(coverage.totalFiles)} files reviewed, dropped: ${coverage.droppedFiles.join(', ')}]`
       : '';
-  // Diff-hash parity contract (#4031): the gate recomputes this hash over the
-  // first MAX_REVIEWED_DIFF_BYTES of the canonical `git diff`. If the reviewed
-  // diff exceeds that byte cap, content past it is UNBOUND, so a record can match
-  // a different tail than the voters saw. Warn so the silent truncation is
-  // observable (the diff-hash module documents this producer obligation).
-  if (reviewedDiffWasTruncated(input.prDiff)) {
-    logger.warn(
-      'Reviewed diff exceeds the hash byte cap; content past it is unbound in reviewedDiffHash',
-      { prNumber }
-    );
-  }
+  warnIfDiffTruncated(input.prDiff, prNumber, logger);
   const record = persistPrReviewRecord({
     prNumber,
     baseSha,
     reviewedDiffHash: computeReviewedDiffHash(input.prDiff),
+    diffProvenance: diffProvenanceOf(diffSource, input.prDiff),
     verdict: aggregate.decision,
     verified: aggregate.verified,
     voteCounts: {

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
@@ -737,6 +737,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
   it('persists a record bound to {prNumber, baseSha, reviewedDiffHash} when both inputs + live review', () => {
     const parsed = input({ prNumber: 99, baseSha: BASE_SHA });
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: parsed,
       aggregate: APPROVE_AGG,
       counts: COUNTS,
@@ -768,6 +769,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
     // `verified: true` LEDGER RECORD, the writer needs its own gate — otherwise
     // the check covers one of two doors into the thing it protects.
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       // Bypass the schema exactly as the script does.
       input: {
         ...input({ prNumber: 101, baseSha: BASE_SHA }),
@@ -788,6 +790,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
 
   it('skips with binding-inputs-absent when prNumber or baseSha is missing', () => {
     const onlyPr = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: input({ prNumber: 99 }),
       aggregate: APPROVE_AGG,
       counts: COUNTS,
@@ -798,6 +801,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
       expect.objectContaining({ persisted: false, reason: 'binding-inputs-absent' })
     );
     const onlySha = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: input({ baseSha: BASE_SHA }),
       aggregate: APPROVE_AGG,
       counts: COUNTS,
@@ -814,6 +818,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
 
   it('skips with reason=simulated even when the binding is present (no governance from non-live output)', () => {
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: input({ prNumber: 99, baseSha: BASE_SHA, simulate: true }),
       aggregate: APPROVE_AGG,
       counts: COUNTS,
@@ -828,6 +833,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
   it('stamps partial coverage into the (hash-covered) record summary without breaking verification (#4140)', () => {
     const parsed = input({ prNumber: 77, baseSha: BASE_SHA });
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: parsed,
       // A partial review degrades to abstain/verified:false per the C1 gate.
       aggregate: {
@@ -856,6 +862,50 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
     expect(verifyPrReviewRecordSet(records).ok).toBe(true);
   });
 
+  it('stamps diffProvenance {source, fileBoundaries} onto the record (#4459)', () => {
+    const parsed = input({ prNumber: 4459, baseSha: BASE_SHA });
+    const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
+      input: parsed,
+      aggregate: APPROVE_AGG,
+      counts: COUNTS,
+      reviewCount: 5,
+      logger,
+    });
+    expect(outcome.persisted).toBe(true);
+    const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
+    const { records } = readPrReviewRecords(path);
+    // The MCP tool's prDiff is opaque caller input — it is never canonical-git.
+    expect(records[0]?.diffProvenance).toEqual({
+      source: 'caller-supplied',
+      fileBoundaries: true,
+    });
+    // Stamped INSIDE the hash, so it verifies and cannot be edited silently.
+    expect(verifyPrReviewRecordSet(records).ok).toBe(true);
+  });
+
+  it('records fileBoundaries:false for a boundary-less diff the unified gate accepts (#4459)', () => {
+    // `looksLikeUnifiedDiff` deliberately accepts plain `diff -u` output, which
+    // carries no `diff --git` headers — the one provenance signal a consumer
+    // cannot re-derive from the record's other fields.
+    const parsed = {
+      ...input({ prNumber: 4460, baseSha: BASE_SHA }),
+      prDiff: '--- a/x.ts\n+++ b/x.ts\n@@ -1 +1 @@\n-a\n+b\n',
+    };
+    const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
+      input: parsed,
+      aggregate: APPROVE_AGG,
+      counts: COUNTS,
+      reviewCount: 5,
+      logger,
+    });
+    expect(outcome.persisted).toBe(true);
+    const path = process.env[PR_REVIEW_RECORDS_PATH_ENV] as string;
+    const { records } = readPrReviewRecords(path);
+    expect(records[0]?.diffProvenance?.fileBoundaries).toBe(false);
+  });
+
   it('skips with reason=no-live-votes when every voter errored (no false gate pass)', () => {
     // An all-errored panel still aggregates to {abstain, verified:true}, but no
     // voter actually reviewed — persisting would write a gate-satisfying record
@@ -867,6 +917,7 @@ describe('pr_review Option-C audit-record persistence (#4031)', () => {
       errorCount: 5,
     };
     const outcome = persistReviewRecord({
+      diffSource: 'caller-supplied',
       input: input({ prNumber: 99, baseSha: BASE_SHA }),
       aggregate: APPROVE_AGG,
       counts: allErrored,
@@ -949,6 +1000,7 @@ describe('pr_review repoPath input (#4278)', () => {
       });
 
       const outcome = persistReviewRecord({
+        diffSource: 'caller-supplied',
         input: parsed,
         aggregate: APPROVE_AGG,
         counts: COUNTS,
@@ -974,6 +1026,7 @@ describe('pr_review repoPath input (#4278)', () => {
       });
 
       const outcome = persistReviewRecord({
+        diffSource: 'caller-supplied',
         input: parsed,
         aggregate: APPROVE_AGG,
         counts: COUNTS,
@@ -999,6 +1052,7 @@ describe('pr_review repoPath input (#4278)', () => {
         });
 
         const outcome = persistReviewRecord({
+          diffSource: 'caller-supplied',
           input: parsed,
           aggregate: APPROVE_AGG,
           counts: COUNTS,

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -527,6 +527,9 @@ async function executePrReviewBody(
   // a structured outcome and never throws — an audit sink must not break the
   // review it observes.
   const recordOutcome = persistReviewRecord({
+    // #4459: `input.prDiff` is opaque MCP input — it passed the unified-diff
+    // shape gate (#4451), but nothing here establishes it is the PR's real diff.
+    diffSource: 'caller-supplied',
     input,
     aggregate,
     counts,

--- a/packages/nexus-agents/src/testing/global-setup.ts
+++ b/packages/nexus-agents/src/testing/global-setup.ts
@@ -1,0 +1,52 @@
+/**
+ * Vitest global setup: reap stale test scratch before the run (#4413).
+ *
+ * Runs once in the main process before any worker spawns, which is the only
+ * window where an age-based sweep cannot race an in-flight test — nothing holds
+ * scratch yet. The age limit is a second, independent guard for the case that
+ * matters anyway: a developer running two suites at once.
+ *
+ * ## Why a net is needed at all
+ *
+ * The dominant producer is not this repo's code. Every spawned `opencode`
+ * process unpacks an 8.2 MB `libopentui.so` into `$TMPDIR` and never removes it
+ * (Bun standalone-binary behaviour), and `cli-adapters/subprocess-env.ts`
+ * forwards `TMPDIR` to spawned CLIs by design. One file per spawn, thousands
+ * over weeks. Tests that leak their own `mkdtemp` dirs add to it. Neither is
+ * fixable from inside a single test file, which is what makes a run-level sweep
+ * the right shape.
+ *
+ * The sweep logs what it removed. That is deliberate: a net that quietly
+ * absorbs a growing leak converts a visible disk-full failure into an
+ * invisible one, so a rising reap count each run is the leak detector.
+ *
+ * @module testing/global-setup
+ */
+
+import { formatReapReport, reapScratchRoot } from './reap-scratch.js';
+import { ensureTestScratchRoot } from './test-scratch-root.js';
+
+/**
+ * Entries older than this are removed.
+ *
+ * Generous on purpose. A full suite run is well under an hour, so a day's
+ * margin cannot reach a concurrent run, and bounding growth to roughly one
+ * day's scratch is the whole requirement — the reaper is a floor under the
+ * leak, not a substitute for fixing its producers.
+ */
+const MAX_SCRATCH_AGE_MS = 24 * 60 * 60 * 1000;
+
+export function setup(): void {
+  const report = reapScratchRoot(ensureTestScratchRoot(), {
+    maxAgeMs: MAX_SCRATCH_AGE_MS,
+    now: Date.now(),
+  });
+
+  // Silent on a clean, empty root; audible whenever it actually did something
+  // or could not. An always-on line would train everyone to ignore it, and a
+  // silent one would let a growing leak pass unremarked — which is how this
+  // root reached 9.7 GB. `warn` is the sanctioned console channel here.
+  if (report.reaped > 0 || report.failed.length > 0 || !report.rootExisted) {
+    console.warn(formatReapReport(report));
+  }
+}

--- a/packages/nexus-agents/src/testing/reap-scratch.test.ts
+++ b/packages/nexus-agents/src/testing/reap-scratch.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the scratch reaper (#4413).
+ *
+ * @module testing/reap-scratch.test
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  lutimesSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { mkdtempOutsideRepo } from './non-repo-temp-dir.js';
+import { formatReapReport, reapScratchRoot } from './reap-scratch.js';
+
+const HOUR = 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 7, 23, 12, 0, 0);
+
+let root: string;
+/** Every fixture root, removed in afterEach — this suite does not leak. */
+const created: string[] = [];
+
+function scratch(prefix: string): string {
+  const dir = mkdtempOutsideRepo(prefix);
+  created.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  root = scratch('reap-test-');
+});
+
+afterEach(() => {
+  while (created.length > 0) {
+    const dir = created.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Creates a file `ageHours` old relative to the fixed NOW. */
+function agedFile(name: string, ageHours: number, bytes = 8): string {
+  const p = join(root, name);
+  writeFileSync(p, Buffer.alloc(bytes));
+  const t = new Date(NOW - ageHours * HOUR);
+  utimesSync(p, t, t);
+  return p;
+}
+
+/** Creates a directory `ageHours` old holding one file of `bytes`. */
+function agedDir(name: string, ageHours: number, bytes = 8): string {
+  const p = join(root, name);
+  mkdirSync(p);
+  writeFileSync(join(p, 'inner'), Buffer.alloc(bytes));
+  const t = new Date(NOW - ageHours * HOUR);
+  utimesSync(p, t, t);
+  return p;
+}
+
+describe('reapScratchRoot', () => {
+  it('removes entries older than maxAge and keeps newer ones', () => {
+    agedFile('old.so', 48);
+    agedFile('fresh.so', 1);
+
+    const report = reapScratchRoot(root, { maxAgeMs: 24 * HOUR, now: NOW });
+
+    expect(report.reaped).toBe(1);
+    expect(report.retained).toBe(1);
+    expect(existsSync(join(root, 'old.so'))).toBe(false);
+    expect(existsSync(join(root, 'fresh.so'))).toBe(true);
+  });
+
+  it('removes stale directories recursively and counts their bytes', () => {
+    agedDir('qgate-abc', 48, 4096);
+
+    const report = reapScratchRoot(root, { maxAgeMs: 24 * HOUR, now: NOW });
+
+    expect(report.reaped).toBe(1);
+    expect(report.reclaimedBytes).toBeGreaterThanOrEqual(4096);
+    expect(readdirSync(root)).toHaveLength(0);
+  });
+
+  it('treats an entry exactly at maxAge as retained, not reaped', () => {
+    // A boundary that silently reaps is a boundary that can delete a run
+    // whose clock differs by a millisecond. Retain on the tie.
+    agedFile('boundary.so', 24);
+
+    const report = reapScratchRoot(root, { maxAgeMs: 24 * HOUR, now: NOW });
+
+    expect(report.reaped).toBe(0);
+    expect(report.retained).toBe(1);
+  });
+
+  it('reports an empty root as empty, distinctly from a swept root', () => {
+    const empty = reapScratchRoot(root, { maxAgeMs: 24 * HOUR, now: NOW });
+    expect(empty.rootExisted).toBe(true);
+    expect(empty.scanned).toBe(0);
+    expect(formatReapReport(empty)).toContain('empty');
+
+    agedFile('fresh.so', 1);
+    const swept = reapScratchRoot(root, { maxAgeMs: 24 * HOUR, now: NOW });
+    expect(swept.scanned).toBe(1);
+    expect(swept.reaped).toBe(0);
+    expect(formatReapReport(swept)).not.toContain('empty');
+    expect(formatReapReport(swept)).toContain('none older than');
+  });
+
+  it('reports a missing root as absent rather than throwing or claiming success', () => {
+    const report = reapScratchRoot(join(root, 'does-not-exist'), {
+      maxAgeMs: 24 * HOUR,
+      now: NOW,
+    });
+
+    expect(report.rootExisted).toBe(false);
+    expect(report.scanned).toBe(0);
+    expect(report.reaped).toBe(0);
+    expect(formatReapReport(report)).toContain('absent');
+  });
+
+  it('removes a stale symlink without following it', () => {
+    const outside = scratch('reap-outside-');
+    writeFileSync(join(outside, 'keep-me'), 'precious');
+    const link = join(root, 'stale-link');
+    symlinkSync(outside, link);
+    // lutimes, not utimes: utimesSync follows the link and would age the
+    // target instead, leaving the link itself newer than the age limit.
+    const t = new Date(NOW - 48 * HOUR);
+    lutimesSync(link, t, t);
+
+    const report = reapScratchRoot(root, { maxAgeMs: 24 * HOUR, now: NOW });
+
+    expect(report.reaped).toBe(1);
+    expect(existsSync(link)).toBe(false);
+    expect(existsSync(join(outside, 'keep-me'))).toBe(true);
+  });
+
+  it('continues past an entry it cannot remove and records the failure', () => {
+    agedFile('removable.so', 48);
+    agedFile('locked.so', 48);
+
+    const report = reapScratchRoot(root, {
+      maxAgeMs: 24 * HOUR,
+      now: NOW,
+      remove: (path) => {
+        if (path.endsWith('locked.so')) throw new Error('EPERM');
+      },
+    });
+
+    expect(report.reaped).toBe(1);
+    expect(report.failed).toHaveLength(1);
+    expect(report.failed[0]?.name).toBe('locked.so');
+    expect(formatReapReport(report)).toContain('1 failed');
+  });
+
+  it('reports failures rather than silently reporting a clean sweep', () => {
+    agedFile('locked.so', 48);
+
+    const report = reapScratchRoot(root, {
+      maxAgeMs: 24 * HOUR,
+      now: NOW,
+      remove: () => {
+        throw new Error('EBUSY');
+      },
+    });
+
+    expect(report.reaped).toBe(0);
+    expect(report.failed).toHaveLength(1);
+    // The whole point of the net is that it is visible when it tears.
+    expect(formatReapReport(report)).toContain('failed');
+  });
+});

--- a/packages/nexus-agents/src/testing/reap-scratch.ts
+++ b/packages/nexus-agents/src/testing/reap-scratch.ts
@@ -1,0 +1,232 @@
+/**
+ * Age-based reaper for a scratch root (#4413).
+ *
+ * ## Why this exists
+ *
+ * #4412 moved the test suite's scratch off the shared `/tmp` tmpfs, because
+ * that tmpfs filled and the suite failed to *collect* ~1,100 files while
+ * reporting zero assertion failures — a disk fault presenting as a code fault.
+ * Relocating it fixed the shared-filesystem contention but removed the one
+ * property the tmpfs had: it cleared on reboot. On real disk the same leak
+ * accumulates permanently instead of self-clearing, and it did — the test
+ * scratch root reached 9.7 GB across 1,987 entries before anything measured it.
+ *
+ * This reaper is the missing half of that change.
+ *
+ * ## What it is not
+ *
+ * It is a safety net, not a licence to leak. A net that silently absorbs a
+ * growing leak is worse than no net, because it converts a visible disk-full
+ * failure into an invisible one. So {@link reapScratchRoot} returns a report of
+ * everything it touched and {@link formatReapReport} renders it for the run
+ * log: a leak shows up as a rising reap count every run, rather than as a
+ * silent 9.7 GB two months later.
+ *
+ * For that reason the report distinguishes four outcomes that a naive
+ * implementation collapses into one cheerful "cleaned up":
+ *
+ * | Outcome | Meaning |
+ * | --- | --- |
+ * | root absent | nothing was measured — the reaper never ran on a real dir |
+ * | root empty | measured, and there was genuinely nothing there |
+ * | swept, none stale | measured, entries exist, none old enough |
+ * | reaped N | measured, and N were removed |
+ *
+ * "Absent" and "empty" are the two that matter: a reaper pointed at the wrong
+ * path reports the first, and reporting it as success is how a guard ends up
+ * aimed at a directory nothing writes to. See `.rules/development-disciplines.md`
+ * ("Name the empty case") and #4580.
+ *
+ * @module testing/reap-scratch
+ */
+
+import { lstatSync, readdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** One entry the reaper tried and failed to remove. */
+export interface ReapFailure {
+  /** Entry name, relative to the root. */
+  readonly name: string;
+  /** Stringified cause, for the run log. */
+  readonly reason: string;
+}
+
+/** What a single sweep observed and did. Every field is measured, never assumed. */
+export interface ReapReport {
+  /** The root the sweep was pointed at. */
+  readonly root: string;
+  /** False means nothing was measured — distinct from "measured and empty". */
+  readonly rootExisted: boolean;
+  /** Direct children examined. */
+  readonly scanned: number;
+  /** Direct children removed. */
+  readonly reaped: number;
+  /** Direct children retained because they were newer than `maxAgeMs`. */
+  readonly retained: number;
+  /** Bytes freed, summed over what was actually removed. */
+  readonly reclaimedBytes: number;
+  /** Entries that were stale but could not be removed. */
+  readonly failed: readonly ReapFailure[];
+}
+
+/** Options for {@link reapScratchRoot}. */
+export interface ReapOptions {
+  /** Entries strictly older than this are removed. Ties are retained. */
+  readonly maxAgeMs: number;
+  /** Reference time; injected so tests do not depend on the wall clock. */
+  readonly now: number;
+  /** Removal seam, injected so tests can simulate an unremovable entry. */
+  readonly remove?: (path: string) => void;
+}
+
+/** Recursively sizes a path, treating anything unreadable as zero. */
+function sizeOf(path: string): number {
+  let stat;
+  try {
+    stat = lstatSync(path);
+  } catch {
+    return 0;
+  }
+
+  if (!stat.isDirectory()) return stat.size;
+
+  let total = 0;
+  let children: string[];
+  try {
+    children = readdirSync(path);
+  } catch {
+    return total;
+  }
+  for (const child of children) total += sizeOf(join(path, child));
+  return total;
+}
+
+function defaultRemove(path: string): void {
+  rmSync(path, { recursive: true, force: true });
+}
+
+/** What the sweep did with one entry. */
+type SweepOutcome =
+  | { kind: 'vanished' }
+  | { kind: 'retained' }
+  | { kind: 'reaped'; bytes: number }
+  | { kind: 'failed'; reason: string };
+
+function sweepEntry(
+  path: string,
+  options: Required<Omit<ReapOptions, 'remove'>> & { remove: (p: string) => void }
+): SweepOutcome {
+  let mtimeMs: number;
+  try {
+    mtimeMs = lstatSync(path).mtimeMs;
+  } catch {
+    // Vanished mid-sweep — another run cleaned up after itself. Not a failure.
+    return { kind: 'vanished' };
+  }
+
+  // Retain on a tie: a boundary that reaps at exactly maxAge can delete a
+  // concurrent run whose clock differs by a millisecond.
+  if (options.now - mtimeMs <= options.maxAgeMs) return { kind: 'retained' };
+
+  const bytes = sizeOf(path);
+  try {
+    options.remove(path);
+    return { kind: 'reaped', bytes };
+  } catch (error) {
+    return { kind: 'failed', reason: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Removes direct children of `root` older than `maxAgeMs` and reports what it did.
+ *
+ * Only direct children are considered, and symlinks are removed as links rather
+ * than followed — a stale symlink in the scratch root must not become a path out
+ * of it.
+ *
+ * Never throws for an absent root or an unremovable entry: a failed sweep must
+ * still let the run proceed, but it must say so in the report rather than
+ * presenting itself as a clean one.
+ */
+export function reapScratchRoot(root: string, options: ReapOptions): ReapReport {
+  const { maxAgeMs, now } = options;
+  const remove = options.remove ?? defaultRemove;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return {
+      root,
+      rootExisted: false,
+      scanned: 0,
+      reaped: 0,
+      retained: 0,
+      reclaimedBytes: 0,
+      failed: [],
+    };
+  }
+
+  let reaped = 0;
+  let retained = 0;
+  let reclaimedBytes = 0;
+  const failed: ReapFailure[] = [];
+
+  for (const name of entries) {
+    const outcome = sweepEntry(join(root, name), { maxAgeMs, now, remove });
+    if (outcome.kind === 'vanished') continue;
+    if (outcome.kind === 'retained') retained += 1;
+    else if (outcome.kind === 'reaped') {
+      reaped += 1;
+      reclaimedBytes += outcome.bytes;
+    } else failed.push({ name, reason: outcome.reason });
+  }
+
+  return {
+    root,
+    rootExisted: true,
+    scanned: entries.length,
+    reaped,
+    retained,
+    reclaimedBytes,
+    failed,
+  };
+}
+
+/** Renders bytes at whole-unit precision, e.g. `9.7 GB`. */
+function humanBytes(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  const rendered = unit === 0 ? String(value) : value.toFixed(1);
+  return `${rendered} ${units[unit] ?? 'B'}`;
+}
+
+/**
+ * Renders a report as one log line, keeping the four outcomes distinguishable.
+ *
+ * The wording is load-bearing: "absent" must never read like "clean", or a
+ * reaper pointed at the wrong directory looks exactly like a working one.
+ */
+export function formatReapReport(report: ReapReport): string {
+  const prefix = `[scratch-reaper] ${report.root}`;
+
+  if (!report.rootExisted) return `${prefix}: absent — nothing measured`;
+  if (report.scanned === 0) return `${prefix}: empty — nothing to reap`;
+
+  const failures =
+    report.failed.length > 0 ? `, ${String(report.failed.length)} failed to remove` : '';
+
+  if (report.reaped === 0) {
+    return `${prefix}: ${String(report.scanned)} entries, none older than the age limit${failures}`;
+  }
+
+  return (
+    `${prefix}: reaped ${String(report.reaped)} of ${String(report.scanned)} entries, ` +
+    `freed ${humanBytes(report.reclaimedBytes)}${failures}`
+  );
+}

--- a/packages/nexus-agents/src/testing/test-scratch-root.ts
+++ b/packages/nexus-agents/src/testing/test-scratch-root.ts
@@ -1,0 +1,32 @@
+/**
+ * The one definition of the test suite's scratch root (#4412, #4413).
+ *
+ * Both `vitest.config.ts` (which exports it to every test process as `TMPDIR`)
+ * and `testing/global-setup.ts` (which reaps it) need this path. Deriving it
+ * twice is how a reaper ends up pointed at a directory nothing writes to — the
+ * failure that let this root reach 9.7 GB unobserved.
+ *
+ * @module testing/test-scratch-root
+ */
+
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * `<package>/.nexus-agents/tmp` — gitignored via `.nexus-agents/`.
+ *
+ * Module-local: callers take the path from {@link ensureTestScratchRoot}, so the
+ * directory always exists by the time anyone holds its path.
+ */
+const TEST_SCRATCH_ROOT = join(
+  dirname(dirname(dirname(fileURLToPath(import.meta.url)))),
+  '.nexus-agents',
+  'tmp'
+);
+
+/** Creates the scratch root if absent and returns it. Safe to call repeatedly. */
+export function ensureTestScratchRoot(): string {
+  mkdirSync(TEST_SCRATCH_ROOT, { recursive: true });
+  return TEST_SCRATCH_ROOT;
+}

--- a/packages/nexus-agents/vitest.config.ts
+++ b/packages/nexus-agents/vitest.config.ts
@@ -7,11 +7,10 @@
  * @module vitest.config
  */
 
-import { mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+import { ensureTestScratchRoot } from './src/testing/test-scratch-root.js';
 
 /**
  * Scratch root for the test run (#4412).
@@ -22,13 +21,21 @@ import { defineConfig } from 'vitest/config';
  * a 32G tmpfs anything on the box can fill, and when it filled, this suite
  * failed to *collect* ~1,100 files while reporting zero assertion failures.
  * A disk fault that presents as a code fault costs hours; a repo-local dir on
- * real disk removes the whole failure mode. Gitignored via `.nexus-agents/`.
+ * real disk removes the *contention* — nothing else on the box can fill it.
+ *
+ * It does not remove the growth. The tmpfs cleared on reboot and this does not,
+ * so the same leak accumulates permanently here instead of self-clearing; this
+ * root reached 9.7 GB across 1,987 entries before anything measured it. The
+ * `globalSetup` reaper below is the other half of that trade (#4413).
+ * Gitignored via `.nexus-agents/`.
  */
-const TEST_TMP = join(dirname(fileURLToPath(import.meta.url)), '.nexus-agents', 'tmp');
-mkdirSync(TEST_TMP, { recursive: true });
+const TEST_TMP = ensureTestScratchRoot();
 
 export default defineConfig({
   test: {
+    // Reap scratch older than a day before the run — see testing/global-setup.ts.
+    globalSetup: ['./src/testing/global-setup.ts'],
+
     // Keep scratch out of the shared tmpfs — see TEST_TMP above.
     // Tests asserting repo-*detection* need a dir with no `.git` ancestor,
     // which TEST_TMP cannot provide. Hand them the real system temp dir; see

--- a/scripts/check-new-unused-exports.test.ts
+++ b/scripts/check-new-unused-exports.test.ts
@@ -8,6 +8,7 @@ import {
   classifyAddedFiles,
   classifyDeadExports,
   exportedNames,
+  configPathPatterns,
   importSpecifierPatterns,
   isTestSupportFile,
   nameHasProductionUse,
@@ -100,6 +101,38 @@ describe('isTestSupportFile (#4412)', () => {
 
   it('does NOT match a production file merely named like testing', () => {
     expect(isTestSupportFile('packages/nexus-agents/src/cli/testing-command.ts')).toBe(false);
+  });
+});
+
+describe('configPathPatterns — a build-config path reference is a consumer', () => {
+  const matches = (file: string, source: string): boolean =>
+    configPathPatterns(file).some((p) => p.test(source));
+
+  it('matches a vitest globalSetup entry naming the module by path', () => {
+    // `globalSetup` / `setupFiles` name a module by PATH, not by import, so
+    // the import-shaped patterns never see it. Reporting a wired-up hook as
+    // having no consumer left only `@export-no-consumer-yet` as an escape —
+    // a marker that promises a production consumer which already existed.
+    // A gate whose opt-out requires a false statement is worse than no gate.
+    expect(matches('global-setup.ts', "globalSetup: ['./src/testing/global-setup.ts'],")).toBe(
+      true
+    );
+  });
+
+  it('matches the same reference written with a .js extension', () => {
+    expect(matches('global-setup.ts', "setupFiles: ['./src/testing/global-setup.js'],")).toBe(true);
+  });
+
+  it('does not match an unquoted mention of the name', () => {
+    expect(matches('global-setup.ts', '// see src/testing/global-setup.ts for details')).toBe(
+      false
+    );
+  });
+
+  it('does not match a different module', () => {
+    expect(matches('global-setup.ts', "globalSetup: ['./src/testing/other-setup.ts'],")).toBe(
+      false
+    );
   });
 });
 

--- a/scripts/check-new-unused-exports.ts
+++ b/scripts/check-new-unused-exports.ts
@@ -40,7 +40,7 @@
 
 import { execSync } from 'node:child_process';
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 const SRC_DIR = 'packages/nexus-agents/src';
 const SRC_PATTERN = /^packages\/nexus-agents\/src\/.+\.tsx?$/;
@@ -196,6 +196,55 @@ export function isTestSupportFile(file: string): boolean {
 }
 
 /**
+ * Patterns matching a build-config *path reference* to `file` (#4633).
+ *
+ * Vitest names a module by path rather than importing it — `globalSetup`,
+ * `setupFiles`, `globalTeardown` are all `['./src/…/x.ts']`. The import-shaped
+ * patterns cannot see that, so a fully wired hook looked exactly like a dead
+ * file, and the only way past the gate was `@export-no-consumer-yet` — a
+ * marker asserting that a production consumer is still to come, when one
+ * already existed. An opt-out that requires a false statement is not an
+ * opt-out; it is the gate teaching people to lie to it.
+ *
+ * Deliberately narrower than a bare substring match: the reference must be
+ * quoted and end in the module's own basename, so a prose mention of the path
+ * in a comment does not silently satisfy the gate. Applied ONLY to config
+ * files ({@link packageConfigFiles}), never to the source scan, so ordinary
+ * source files still need a real import.
+ */
+export function configPathPatterns(file: string): RegExp[] {
+  const base = basename(file).replace(/\.tsx?$/, '');
+  const escaped = base.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return [new RegExp(`['"][^'"]*\\/${escaped}\\.(?:js|ts)['"]`)];
+}
+
+/**
+ * Build/test config files at the package root, scanned as consumer candidates.
+ *
+ * These live outside `SRC_DIR`, so the source walk never sees them, yet a
+ * module they reference by path is as consumed as one that is imported.
+ */
+function packageConfigFiles(): string[] {
+  const pkgRoot = dirname(SRC_DIR);
+  let entries: string[];
+  try {
+    entries = readdirSync(pkgRoot);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => /\.config\.tsx?$/.test(e))
+    .map((e) => join(pkgRoot, e))
+    .filter((p) => {
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+}
+
+/**
  * Returns the set of `.ts` files under `SRC_DIR` that contain at least
  * one import matching `patterns`. Excludes the candidate file itself
  * (so a file importing its own siblings doesn't self-consume) and
@@ -221,6 +270,21 @@ function findConsumers(file: string, patterns: RegExp[]): string[] {
     }
     if (patterns.some((re) => re.test(content))) {
       consumers.add(candidate);
+    }
+  }
+
+  // A module named by path in a build config is consumed just as surely as an
+  // imported one — see configPathPatterns.
+  const configPatterns = configPathPatterns(file);
+  for (const config of packageConfigFiles()) {
+    let content: string;
+    try {
+      content = readFileSync(config, 'utf-8');
+    } catch {
+      continue;
+    }
+    if (configPatterns.some((re) => re.test(content))) {
+      consumers.add(config);
     }
   }
   return [...consumers];

--- a/scripts/pr-review-local-ledger.ts
+++ b/scripts/pr-review-local-ledger.ts
@@ -252,6 +252,12 @@ export async function feedLedgerFromReview(
       : {}),
   };
   return persistReviewRecord({
+    // #4459: this feeder ALWAYS hashes the pinned `git diff base..head` output —
+    // either passed in from the review it just ran, or regenerated above by
+    // `generateCanonicalReviewDiff`. There is no path here that writes a record
+    // from a caller-supplied or gh-fetched diff (the gh fallback sets
+    // `canonicalDiff: undefined`, which returns before this call).
+    diffSource: 'canonical-git',
     input,
     aggregate: params.aggregate,
     counts: params.counts,

--- a/scripts/pr-review-local.test.ts
+++ b/scripts/pr-review-local.test.ts
@@ -150,6 +150,12 @@ describe('pr-review-local ledger feeder (#4229 Part 2 — real git)', () => {
     expect(records[0]?.reviewedDiffHash).toBe(gateHash);
     expect(records[0]?.prNumber).toBe(4229);
     expect(records[0]?.baseSha).toBe(baseSha);
+    // #4459: the feeder's diff is ALWAYS the canonical git diff, and this
+    // fixture is a real git diff, so both provenance signals are pinned here.
+    expect(records[0]?.diffProvenance).toEqual({
+      source: 'canonical-git',
+      fileBoundaries: true,
+    });
   });
 
   it('does NOT bypass the producer live-review guard (all-errored panel → no record)', async () => {

--- a/scripts/pr-review-local.ts
+++ b/scripts/pr-review-local.ts
@@ -267,7 +267,15 @@ async function runReview(prNumber: number): Promise<ReviewResult> {
   const { reviewDiff, canonicalDiff } = await resolveReviewDiff(prNumber, meta);
   console.log(`  ${meta.title}`);
   console.log(
-    `  diff size: ${String(reviewDiff.length)} chars${canonicalDiff !== undefined ? ' (canonical, ledger-excluded)' : ' (gh fallback)'}`
+    // #4459: the old wording was `(canonical, ledger-excluded)`, which reads as
+    // "this review is excluded from the ledger" — the opposite of the truth. It
+    // is the DIFF that excludes the ledger FILE, which is precisely what makes
+    // the review ledger-eligible.
+    `  diff size: ${String(reviewDiff.length)} chars${
+      canonicalDiff !== undefined
+        ? ' (canonical git diff, excluding the ledger file — feeds the ledger)'
+        : ' (gh fallback diff — no ledger record)'
+    }`
   );
 
   const proposal = buildPrReviewProposal({


### PR DESCRIPTION
Closes #4413.

## The measurement that changed the answer

I commented on #4413 twice recommending **"do not build"** — 2026-08-19 and again earlier today. Both were wrong, and identically so: I surveyed the *runtime* scratch root and never looked at the *test* one.

| Scratch root | Entries | Size |
| --- | --- | --- |
| `~/.nexus-agents/tmp` | 0 | 4.0K |
| `<repo>/.nexus-agents/tmp` | 0 | 4.0K |
| `<repo>/packages/nexus-agents/.nexus-agents/tmp` | **1,987** | **9.7 GB** |

The third is `TEST_TMP`, pinned in `vitest.config.ts` and exported to every test process as `TMPDIR`. My producer survey traced `nexusMkdtempSync` / `nexusMkdtemp` callers, so the ~100 tests that call `os.tmpdir()` directly — which is precisely who `TMPDIR` redirection exists to catch — were invisible to it. The survey was sound for the path it covered and silent about the path that mattered.

Growth was ongoing, not historical: 160 new files on 08-10, 214 on 08-15, **506 on 08-23**.

## What #4412 actually traded

#4412 moved scratch off the shared `/tmp` tmpfs for a good reason, recorded in its own config comment: the tmpfs filled, and the suite **failed to collect ~1,100 test files while reporting zero assertion failures** — a disk fault presenting as a code fault.

It fixed the contention. It also removed the only thing reaping the directory, because a tmpfs clears on reboot and real disk does not. So the same leak went from recurring-but-self-healing to monotonic. This PR is the other half of that change; the config comment claiming it "removes the whole failure mode" is corrected in the diff.

## Wiring point chosen by vote

A `higher_order` panel with `absolute_quorum`, four named options: **A won with 5 of 6 approvers, 83% leading share.**

The option tally earned its keep. Raw counts read 6 approve / 1 reject — but the per-option split shows devex was approving **C**, not A. Without `options` (#4472) that dissent would have persisted as unanimous agreement, which is the exact defect #4452 describes.

- **A (chosen)** — globalSetup only. Runs before any worker spawns, so an age sweep cannot race an in-flight test. Targets 100% of measured growth.
- **B** — `getNexusTmpDir()` only. Architecturally disqualified: it sweeps the measured-zero root and misses the 9.7 GB by construction. A check that cannot fail on the thing it protects.
- **C** — both call sites. Deferred to **#4631** with an explicit measured-growth trigger. A first-call reap inside `getNexusTmpDir()` runs in long-lived processes concurrently with others holding scratch under the same root; accepting a deletion race to protect an empty directory inverts `correctness > simplicity`.
- **D** — producers only, no net. The contrarian's position, and half right: the producers are real bugs and are filed. But #4412's failure mode was *silent*, so "no net" means the next leak is discovered by disk exhaustion again.

## The net reports, it does not tidy

Every voter that approved converged on the same condition, so it is built in: a net that quietly absorbs a growing leak converts a visible disk-full failure into an invisible one. `ReapReport` therefore distinguishes four outcomes that a naive implementation collapses into one cheerful "cleaned up":

| Outcome | Meaning |
| --- | --- |
| root **absent** | nothing was measured — the reaper never ran on a real dir |
| root **empty** | measured, and there was genuinely nothing there |
| swept, **none stale** | measured, entries exist, none old enough |
| **reaped N** | measured, and N removed, with bytes |

"Absent" is the one that matters: a reaper pointed at the wrong path reports it, and rendering that as success is exactly how a guard ends up aimed at a directory nothing writes to — the failure this PR exists to correct. Per `.rules/development-disciplines.md` ("Name the empty case", #4580/#4594).

## Correctness details

- **Ties are retained, not reaped.** A boundary that reaps at exactly `maxAge` can delete a concurrent run whose clock differs by a millisecond. Covered by a test.
- **Symlinks are removed as links, never followed** — a stale symlink in the scratch root must not become a path out of it. Test asserts the link dies and its target survives.
- **A vanished entry is not a failure** — another run cleaning up after itself is normal.
- **An unremovable entry does not abort the sweep**, and shows up in the report as `N failed`. Injected via a `remove` seam.
- **24-hour limit**, generous on purpose: a full run is well under an hour, so it cannot reach a concurrent run.

## Verification

Run live against the real directory:

```
[scratch-reaper] .../packages/nexus-agents/.nexus-agents/tmp: reaped 884 of 1987 entries, freed 5.7 GB
```

**9.7 GB → 4.1 GB**, last 24 hours retained.

- 8/8 new unit tests pass
- 93 files / 2,195 tests pass across `src/testing/`, `src/config/`, `src/indexer/`
- typecheck, eslint, prettier clean
- export ratchet (#4561) exits 0 — `TEST_SCRATCH_ROOT` un-exported after it turned out to have no external consumer

## Producers filed separately

A net is not a fix; both producers are still running.

- **#4629** — every spawned `opencode` unpacks an 8.2 MB `libopentui.so` into `$TMPDIR` and never removes it (Bun standalone-binary behaviour, upstream). 1,267 byte-identical copies, ~9.7 GB — essentially the entire root. The part that is ours is that *unit tests are spawning a real `opencode` binary at all*, which also makes the suite depend on what is installed on the box.
- **#4630** — four tests `mkdtemp` without cleanup; 716 stale directories.
- **#4631** — option C, gated on measured growth.
