### PR TITLE
fix(ci): enforce owner ratification on governor paths (owner ratification required)

### DIFF
--- a/.changeset/governor-ratification-gate.md
+++ b/.changeset/governor-ratification-gate.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+Enforce owner ratification on governance-of-the-governor paths (#4634)
+
+CODEOWNERS and CLAUDE.md both state that the governor's own paths — the audit
+hash chain, governance source, drift machinery, `CLAUDE.md`/`AGENTS.md`,
+`CODEOWNERS` — are never auto-merged. Nothing enforced it. `governor-review.yml`
+checked whether a change was _reviewed_, which is a different question from
+whether the owner _ratified_ it, and it warns rather than blocks.
+
+Adds `scripts/check-governor-ratification.ts` and wires it as two jobs: a
+pre-merge check, and a post-merge backstop on `main`. The backstop exists
+because `gh pr merge --admin` bypasses required status checks, so a pre-merge
+check alone cannot stop the merge it is meant to stop.
+
+The gate's own machinery is now itself a governor path. A gate an agent can
+weaken without tripping it is not a gate.
+
+Four verdicts stay distinct — `not-applicable`, `ratified`, `unratified`,
+`indeterminate`. "No governor path touched" must never render as "ratified", and
+an unreadable CODEOWNERS must never render as "unratified" and blame the PR for
+a broken gate.

--- a/.changeset/governor-ratification-gate.md
+++ b/.changeset/governor-ratification-gate.md
@@ -2,7 +2,7 @@
 'nexus-agents': patch
 ---
 
-Enforce owner ratification on governance-of-the-governor paths (#4634)
+Enforce owner ratification on governance-of-the-governor paths (#4635)
 
 CODEOWNERS and CLAUDE.md both state that the governor's own paths — the audit
 hash chain, governance source, drift machinery, `CLAUDE.md`/`AGENTS.md`,

--- a/.github/workflows/governor-review.yml
+++ b/.github/workflows/governor-review.yml
@@ -99,7 +99,7 @@ jobs:
         run: npx tsx scripts/check-governor-review.ts
 
   # ---------------------------------------------------------------------------
-  # RATIFICATION gate (#4634).
+  # RATIFICATION gate (#4635).
   #
   # Distinct from the audit gate above, which asks whether the change was
   # REVIEWED. This asks whether the owner RATIFIED it — the requirement

--- a/.github/workflows/governor-review.yml
+++ b/.github/workflows/governor-review.yml
@@ -25,7 +25,7 @@ name: Governor Review Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - 'packages/nexus-agents/src/audit/**'
       - 'packages/nexus-agents/src/governance/**'
@@ -34,6 +34,22 @@ on:
       - 'CLAUDE.md'
       - 'AGENTS.md'
       - 'CODEOWNERS'
+      - '.github/workflows/governor-review.yml'
+      - 'scripts/check-governor-review.ts'
+      - 'scripts/check-governor-ratification.ts'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/nexus-agents/src/audit/**'
+      - 'packages/nexus-agents/src/governance/**'
+      - 'scripts/inject-governance.ts'
+      - 'governance/**'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - 'CODEOWNERS'
+      - '.github/workflows/governor-review.yml'
+      - 'scripts/check-governor-review.ts'
+      - 'scripts/check-governor-ratification.ts'
 
 permissions:
   contents: read
@@ -41,6 +57,7 @@ permissions:
 jobs:
   governor-review:
     name: Governor-path pr_review audit gate
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -80,3 +97,117 @@ jobs:
         # integrity break (exit 1) in its exit code. A non-zero exit here is a
         # tampered ledger and SHOULD surface as a job failure.
         run: npx tsx scripts/check-governor-review.ts
+
+  # ---------------------------------------------------------------------------
+  # RATIFICATION gate (#4634).
+  #
+  # Distinct from the audit gate above, which asks whether the change was
+  # REVIEWED. This asks whether the owner RATIFIED it — the requirement
+  # CODEOWNERS and CLAUDE.md both state and nothing enforced until now.
+  # ---------------------------------------------------------------------------
+  governor-ratification:
+    name: Governor-path ratification gate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: ./.github/actions/setup-node
+
+      - name: Collect ratification evidence
+        id: evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          FILES=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+          APPROVALS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+            --paginate --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u | tr '\n' ' ')
+          LABELS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --jq '.labels[].name' | tr '\n' ',')
+          {
+            echo 'files<<FILES_EOF'
+            echo "${FILES}"
+            echo 'FILES_EOF'
+            echo "approvals=${APPROVALS}"
+            echo "labels=${LABELS}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Run ratification gate
+        env:
+          CHANGED_FILES: ${{ steps.evidence.outputs.files }}
+          APPROVALS: ${{ steps.evidence.outputs.approvals }}
+          PR_LABELS: ${{ steps.evidence.outputs.labels }}
+        run: npx tsx scripts/check-governor-ratification.ts
+
+  # ---------------------------------------------------------------------------
+  # BACKSTOP: the same question, asked after the merge.
+  #
+  # `gh pr merge --admin` bypasses required status checks, so the pre-merge job
+  # above cannot actually stop the merge it is meant to stop — which is exactly
+  # how a48aa881d8 landed. This job runs on push to main and turns an unratified
+  # governor-path merge into a red X on main that nobody can bypass, because by
+  # then there is nothing left to bypass.
+  # ---------------------------------------------------------------------------
+  governor-ratification-backstop:
+    name: Governor-path ratification backstop (post-merge)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-node
+
+      - name: Collect ratification evidence for the merged PR
+        id: evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          FILES=$(git diff --name-only "${SHA}~1" "${SHA}")
+          PR_NUMBER=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/pulls" \
+            --jq '.[0].number // empty')
+          if [ -z "${PR_NUMBER}" ]; then
+            # A direct push to main touching governor paths is never ratified
+            # by construction — there is no PR to carry the evidence.
+            APPROVALS=""
+            LABELS=""
+          else
+            APPROVALS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+              --paginate --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u | tr '\n' ' ')
+            LABELS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+              --jq '.labels[].name' | tr '\n' ',')
+          fi
+          {
+            echo 'files<<FILES_EOF'
+            echo "${FILES}"
+            echo 'FILES_EOF'
+            echo "approvals=${APPROVALS}"
+            echo "labels=${LABELS}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Run ratification gate against what actually landed
+        env:
+          CHANGED_FILES: ${{ steps.evidence.outputs.files }}
+          APPROVALS: ${{ steps.evidence.outputs.approvals }}
+          PR_LABELS: ${{ steps.evidence.outputs.labels }}
+        run: npx tsx scripts/check-governor-ratification.ts

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,7 +39,7 @@
 /governance/ @williamzujkowski
 /governance/claims-registry.* @williamzujkowski
 
-# The governor's own gates (#4634). A gate an agent can quietly weaken without
+# The governor's own gates (#4635). A gate an agent can quietly weaken without
 # tripping it is not a gate — these must route through ratification like the
 # paths they protect.
 /.github/workflows/governor-review.yml @williamzujkowski

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,6 +39,13 @@
 /governance/ @williamzujkowski
 /governance/claims-registry.* @williamzujkowski
 
+# The governor's own gates (#4634). A gate an agent can quietly weaken without
+# tripping it is not a gate — these must route through ratification like the
+# paths they protect.
+/.github/workflows/governor-review.yml @williamzujkowski
+/scripts/check-governor-review.ts @williamzujkowski
+/scripts/check-governor-ratification.ts @williamzujkowski
+
 # Project governance
 /CLAUDE.md @williamzujkowski
 /AGENTS.md @williamzujkowski

--- a/scripts/check-governor-ratification.test.ts
+++ b/scripts/check-governor-ratification.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the governor-path ratification gate (#4634).
+ * Tests for the governor-path ratification gate (#4635).
  *
  * @module scripts/check-governor-ratification.test
  */

--- a/scripts/check-governor-ratification.test.ts
+++ b/scripts/check-governor-ratification.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the governor-path ratification gate (#4634).
+ *
+ * @module scripts/check-governor-ratification.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  evaluateRatification,
+  governorOwnersFromCodeowners,
+} from './check-governor-ratification.js';
+
+const OWNERS = ['williamzujkowski'];
+
+describe('governorOwnersFromCodeowners', () => {
+  const CODEOWNERS = [
+    '# Security modules',
+    '/packages/nexus-agents/src/security/ @someone-else',
+    '',
+    "# Governor's own core — never auto-merged",
+    '/packages/nexus-agents/src/audit/ @williamzujkowski',
+    '/CODEOWNERS @williamzujkowski @second-owner',
+  ].join('\n');
+
+  it('reads ratifiers from the governor section only', () => {
+    const owners = governorOwnersFromCodeowners(CODEOWNERS);
+    expect(owners).toContain('williamzujkowski');
+    expect(owners).toContain('second-owner');
+    // Owners of non-governor paths cannot ratify a governor change.
+    expect(owners).not.toContain('someone-else');
+  });
+
+  it('deduplicates a ratifier listed on several paths', () => {
+    expect(
+      governorOwnersFromCodeowners(CODEOWNERS).filter((o) => o === 'williamzujkowski')
+    ).toHaveLength(1);
+  });
+});
+
+describe('evaluateRatification', () => {
+  it('reports not-applicable when no governor path is touched — not "ratified"', () => {
+    // The distinction is the whole point: "nothing to ratify" and "ratified"
+    // are different measurements, and collapsing them is how a gate starts
+    // reporting a pass it never made.
+    const verdict = evaluateRatification({
+      touchedGovernorFiles: [],
+      approvals: [],
+      labels: [],
+      owners: OWNERS,
+    });
+    expect(verdict.kind).toBe('not-applicable');
+  });
+
+  it('ratifies on an approving review from a governor-path owner', () => {
+    const verdict = evaluateRatification({
+      touchedGovernorFiles: ['packages/nexus-agents/src/audit/pr-review-record.ts'],
+      approvals: ['williamzujkowski'],
+      labels: [],
+      owners: OWNERS,
+    });
+    expect(verdict.kind).toBe('ratified');
+    if (verdict.kind === 'ratified') expect(verdict.via).toBe('owner-approval');
+  });
+
+  it('ratifies on the explicit ratification label', () => {
+    const verdict = evaluateRatification({
+      touchedGovernorFiles: ['CLAUDE.md'],
+      approvals: [],
+      labels: ['owner-ratified'],
+      owners: OWNERS,
+    });
+    expect(verdict.kind).toBe('ratified');
+    if (verdict.kind === 'ratified') expect(verdict.via).toBe('ratification-label');
+  });
+
+  it('does NOT ratify on an approval from a non-owner', () => {
+    const verdict = evaluateRatification({
+      touchedGovernorFiles: ['packages/nexus-agents/src/audit/x.ts'],
+      approvals: ['a-bot', 'some-contributor'],
+      labels: [],
+      owners: OWNERS,
+    });
+    expect(verdict.kind).toBe('unratified');
+  });
+
+  it('does NOT ratify on an unrelated label', () => {
+    const verdict = evaluateRatification({
+      touchedGovernorFiles: ['CODEOWNERS'],
+      approvals: [],
+      labels: ['bug', 'ready-to-merge'],
+      owners: OWNERS,
+    });
+    expect(verdict.kind).toBe('unratified');
+  });
+
+  it('is indeterminate — never "unratified" — when no ratifier can be resolved', () => {
+    // An empty owner list means CODEOWNERS could not be read or parsed. That is
+    // an absence of measurement, and reporting it as a normal unratified verdict
+    // would blame the PR for a broken gate.
+    const verdict = evaluateRatification({
+      touchedGovernorFiles: ['packages/nexus-agents/src/audit/x.ts'],
+      approvals: ['williamzujkowski'],
+      labels: [],
+      owners: [],
+    });
+    expect(verdict.kind).toBe('indeterminate');
+  });
+
+  it('carries the touched files on an unratified verdict so the message can name them', () => {
+    const verdict = evaluateRatification({
+      touchedGovernorFiles: ['CLAUDE.md', 'packages/nexus-agents/src/audit/x.ts'],
+      approvals: [],
+      labels: [],
+      owners: OWNERS,
+    });
+    expect(verdict.kind).toBe('unratified');
+    if (verdict.kind === 'unratified') expect(verdict.touched).toHaveLength(2);
+  });
+});

--- a/scripts/check-governor-ratification.ts
+++ b/scripts/check-governor-ratification.ts
@@ -1,5 +1,5 @@
 /**
- * Governor-path RATIFICATION gate (#4634).
+ * Governor-path RATIFICATION gate (#4635).
  *
  * ## Why this exists
  *

--- a/scripts/check-governor-ratification.ts
+++ b/scripts/check-governor-ratification.ts
@@ -1,0 +1,199 @@
+/**
+ * Governor-path RATIFICATION gate (#4634).
+ *
+ * ## Why this exists
+ *
+ * CODEOWNERS and CLAUDE.md both say the governance-of-the-governor paths are
+ * *never auto-merged* — human ratification is required. Until now nothing
+ * enforced that. `governor-review.yml` checks whether a sha-bound pr_review
+ * audit record exists (warn-first), which is a different question: it asks
+ * whether the change was *reviewed*, not whether the owner *ratified* it.
+ *
+ * On 2026-08-23 `src/audit/` reached `main` in commit `a48aa881d8` without
+ * ratification. The proximate cause was a branch created off a feature branch
+ * instead of `main`, so an unrelated PR carried the audit commits along. But
+ * the reason it *landed* is that the only thing standing between an agent and
+ * the audit hash chain was that agent reading its own PR's file list. A
+ * control that depends on the diligence of the party it constrains is not a
+ * control.
+ *
+ * ## What counts as ratification
+ *
+ * Either an approving review from an owner of a governor path (per the
+ * governance-of-the-governor section of CODEOWNERS — the same single source
+ * `check-governor-review.ts` parses), or the explicit `owner-ratified` label.
+ * The label exists because ratification sometimes happens out of band; it is
+ * deliberately narrow and named for exactly what it asserts.
+ *
+ * ## The verdict names its empty cases
+ *
+ * Four outcomes, kept distinct on purpose:
+ *
+ * | Verdict | Meaning |
+ * | --- | --- |
+ * | `not-applicable` | no governor path touched — nothing to ratify |
+ * | `ratified` | governor paths touched, and ratification evidence found |
+ * | `unratified` | governor paths touched, and none found — the blocking case |
+ * | `indeterminate` | no ratifier could be resolved: the gate itself is broken |
+ *
+ * `not-applicable` must never render as `ratified`, or every ordinary PR would
+ * report a ratification it never received. `indeterminate` must never render as
+ * `unratified`, or a broken CODEOWNERS parse would blame the PR. Both are the
+ * empty-case discipline from `.rules/development-disciplines.md` (#4580).
+ *
+ * @module scripts/check-governor-ratification
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { governorFilesTouched, governorPathsFromCodeowners } from './check-governor-review.js';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const CODEOWNERS_FILE = join(ROOT, 'CODEOWNERS');
+
+/** The marker heading for the governance-of-the-governor CODEOWNERS section. */
+const GOVERNOR_SECTION_MARKER = "Governor's own core";
+
+/** The one label that asserts out-of-band owner ratification. */
+export const RATIFICATION_LABEL = 'owner-ratified';
+
+/** The outcome of a ratification check. */
+export type RatificationVerdict =
+  | { kind: 'not-applicable' }
+  | { kind: 'ratified'; via: 'owner-approval' | 'ratification-label'; detail: string }
+  | { kind: 'unratified'; touched: readonly string[] }
+  | { kind: 'indeterminate'; reason: string };
+
+/** Everything the verdict is computed from. */
+export interface RatificationInputs {
+  /** Changed files that matched a governor path. */
+  readonly touchedGovernorFiles: readonly string[];
+  /** Logins that submitted an APPROVED review. */
+  readonly approvals: readonly string[];
+  /** Labels currently on the PR. */
+  readonly labels: readonly string[];
+  /** Logins permitted to ratify, from the CODEOWNERS governor section. */
+  readonly owners: readonly string[];
+}
+
+/**
+ * Extract the logins that may ratify a governor-path change.
+ *
+ * Reads the same governance-of-the-governor section as
+ * {@link governorPathsFromCodeowners}, taking every `@login` token after the
+ * path pattern. Owners of *other* CODEOWNERS sections cannot ratify a governor
+ * change — being trusted with `src/security/` is not being trusted with the
+ * audit hash chain.
+ */
+export function governorOwnersFromCodeowners(codeownersText: string): string[] {
+  const owners = new Set<string>();
+  let inSection = false;
+  for (const raw of codeownersText.split('\n')) {
+    if (raw.includes(GOVERNOR_SECTION_MARKER)) {
+      inSection = true;
+      continue;
+    }
+    if (!inSection) continue;
+    const line = raw.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    for (const token of line.split(/\s+/).slice(1)) {
+      if (token.startsWith('@')) owners.add(token.slice(1).toLowerCase());
+    }
+  }
+  return [...owners];
+}
+
+/** Computes the ratification verdict. Pure — all evidence is passed in. */
+export function evaluateRatification(inputs: RatificationInputs): RatificationVerdict {
+  if (inputs.touchedGovernorFiles.length === 0) return { kind: 'not-applicable' };
+
+  if (inputs.owners.length === 0) {
+    return {
+      kind: 'indeterminate',
+      reason:
+        'no ratifier could be resolved from the CODEOWNERS governor section — ' +
+        'the gate cannot answer the question it was asked',
+    };
+  }
+
+  const ownerSet = new Set(inputs.owners.map((o) => o.toLowerCase()));
+  const approver = inputs.approvals.find((a) => ownerSet.has(a.toLowerCase()));
+  if (approver !== undefined) {
+    return { kind: 'ratified', via: 'owner-approval', detail: `approved by @${approver}` };
+  }
+
+  if (inputs.labels.some((l) => l.toLowerCase() === RATIFICATION_LABEL)) {
+    return {
+      kind: 'ratified',
+      via: 'ratification-label',
+      detail: `carries the \`${RATIFICATION_LABEL}\` label`,
+    };
+  }
+
+  return { kind: 'unratified', touched: inputs.touchedGovernorFiles };
+}
+
+/** Renders a verdict for the CI log / job summary. */
+export function formatVerdict(verdict: RatificationVerdict): string {
+  switch (verdict.kind) {
+    case 'not-applicable':
+      return 'No governance-of-the-governor path touched — ratification not required.';
+    case 'ratified':
+      return `Governor paths touched and ratified (${verdict.detail}).`;
+    case 'indeterminate':
+      return `::error::Ratification gate is broken: ${verdict.reason}`;
+    case 'unratified': {
+      const list = verdict.touched.map((f) => `  - ${f}`).join('\n');
+      return (
+        '::error::This PR modifies governance-of-the-governor paths without ratification.\n' +
+        `${list}\n` +
+        'These are NEVER auto-merged (CODEOWNERS, CLAUDE.md). To proceed, either\n' +
+        `obtain an approving review from a governor-path owner, or apply the \`${RATIFICATION_LABEL}\` label.\n` +
+        'If these files are here by accident, the usual cause is a branch created\n' +
+        'off another feature branch instead of main — check `git log --oneline main..HEAD`.'
+      );
+    }
+  }
+}
+
+/** Reads evidence from the environment and returns a process exit code. */
+export function runRatificationGate(env: NodeJS.ProcessEnv): number {
+  const changed = (env['CHANGED_FILES'] ?? '')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l !== '');
+  const approvals = (env['APPROVALS'] ?? '')
+    .split(/[\s,]+/)
+    .map((l) => l.trim())
+    .filter((l) => l !== '');
+  const labels = (env['PR_LABELS'] ?? '')
+    .split(/[\n,]+/)
+    .map((l) => l.trim())
+    .filter((l) => l !== '');
+
+  let codeowners = '';
+  try {
+    codeowners = readFileSync(CODEOWNERS_FILE, 'utf-8');
+  } catch {
+    console.error(formatVerdict({ kind: 'indeterminate', reason: 'CODEOWNERS is unreadable' }));
+    return 1;
+  }
+
+  const verdict = evaluateRatification({
+    touchedGovernorFiles: governorFilesTouched(changed, governorPathsFromCodeowners(codeowners)),
+    approvals,
+    labels,
+    owners: governorOwnersFromCodeowners(codeowners),
+  });
+
+  // stderr for every verdict, matching check-governor-review.ts — CI annotations
+  // and the human-readable line belong on the same stream.
+  console.error(formatVerdict(verdict));
+  return verdict.kind === 'unratified' || verdict.kind === 'indeterminate' ? 1 : 0;
+}
+
+if (process.argv[1]?.endsWith('check-governor-ratification.ts') === true) {
+  process.exit(runRatificationGate(process.env));
+}


### PR DESCRIPTION
Closes #4635. **Requires owner ratification — I am not merging this one.**

## Context

Earlier today `packages/nexus-agents/src/audit/` reached `main` in `a48aa881d8` without ratification. Ratified retroactively by @williamzujkowski after the fact; the full breach record is on #4628. This is the approved follow-up guard.

## What was actually broken

`governor-review.yml` already exists, already triggers on exactly these paths, and **ran green on the offending PR**. It is not broken — it answers a different question:

| Gate | Question |
| --- | --- |
| `governor-review` (existing) | was this change **reviewed** — is there a sha-bound `pr_review` audit record? |
| ratification (this PR) | did the **owner ratify** it? |

It is also warn-first and not a required check, so even its own question cannot block.

## Why "be more careful" was not an acceptable fix

The proximate cause was mundane — `git checkout -b` from a feature branch instead of `main`, so #4632 carried #4628's audit commits and squash-merged them.

What stood between an agent and the audit hash chain was **that agent reading its own PR's file list**. The list was printed in the same command as the merge and not read. A control that depends on the diligence of the party it constrains is not a control.

## Design

**Evidence** is an approving review from an owner of a governor path — parsed from the same governance-of-the-governor CODEOWNERS section the existing gate uses, so there is no divergent copy — or the explicit `owner-ratified` label for out-of-band ratification.

**Two wirings, and the second is the honest one.** `gh pr merge --admin` bypasses required status checks, so a pre-merge check cannot stop the merge it exists to stop; that is exactly how `a48aa881d8` landed. So there is also a post-merge backstop on `main`, which turns an unratified governor merge into a red X nobody can bypass — because by then there is nothing left to bypass.

A backstop detects rather than prevents, and that is worth stating plainly rather than dressing up. Preventing an `--admin` merge is not something a workflow can do. If you want prevention, the lever is branch protection with admin enforcement, which is your call and outside a PR.

**The gate's own machinery is now a governor path.** `governor-review.yml`, `check-governor-review.ts`, and `check-governor-ratification.ts` are added to the CODEOWNERS governor section and both `paths:` filters. A gate an agent can weaken without tripping it is not a gate.

## Four verdicts, kept distinct

| Verdict | Meaning |
| --- | --- |
| `not-applicable` | no governor path touched — nothing to ratify |
| `ratified` | touched, evidence found |
| `unratified` | touched, none found — the blocking case |
| `indeterminate` | no ratifier resolvable: the gate itself is broken |

`not-applicable` must never render as `ratified`, or every ordinary PR reports a ratification it never received. `indeterminate` must never render as `unratified`, or an unreadable CODEOWNERS blames the PR for a broken gate. Same discipline as #4580 and `.rules/development-disciplines.md`.

## Verified against the real breach, not a fixture

Replaying `a48aa881d8`'s actual file list through the gate:

```
no approval, no label   -> exit 1, names all four src/audit/ files
owner approval          -> exit 0, "approved by @williamzujkowski"
owner-ratified label    -> exit 0, "carries the `owner-ratified` label"
no governor path        -> exit 0, "ratification not required"
```

The unratified message names the usual cause and the command to check it (`git log --oneline main..HEAD`), because that is the failure that actually happened.

9 unit tests on the pure verdict logic; the 20 existing `check-governor-review` tests still pass; eslint, prettier and the YAML parse clean. The two `tsc` errors in the repo (`check-harness-alignment.ts`, `website/src/content.config.ts`) are pre-existing on `main` — confirmed by stashing.

## Self-consistency

Running the new gate against this branch exits 1 and names `CODEOWNERS`, `governor-review.yml`, and `check-governor-ratification.ts`.

That is correct, and it is why this PR sits until you ratify it. Merging it myself would mean using the breach to land the fix for the breach.

To land: approve, or apply the `owner-ratified` label.
