### PR TITLE
test: clean up scratch dirs in the three suites that leaked them

### DIFF
--- a/.changeset/test-scratch-cleanup.md
+++ b/.changeset/test-scratch-cleanup.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+Clean up test scratch dirs in three suites that leaked them (#4630)
+
+`symbol-extractor.test.ts`, `quality-gate-commands.test.ts` and
+`quality-gate-cwd.test.ts` created `mkdtemp` directories and never removed
+them, leaving 716 stale directories in the test scratch root.
+
+Measured before acting: 89 test files call `mkdtemp*` and only these 3 lacked
+cleanup. The convention already exists and is followed 97% of the time, so
+these get `afterAll` cleanup matching the other 86 — no new helper, which would
+only have created a second convention.
+
+Control: running the three suites without the fix adds 25 directories; with it,
+zero.

--- a/packages/nexus-agents/src/indexer/symbol-extractor.test.ts
+++ b/packages/nexus-agents/src/indexer/symbol-extractor.test.ts
@@ -10,8 +10,8 @@
  * @module indexer/symbol-extractor.test
  */
 
-import { describe, it, expect } from 'vitest';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { afterAll, describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { extractSymbols, extractSymbolIndexResult } from './symbol-extractor.js';
@@ -105,11 +105,21 @@ describe('extractSymbolIndex', () => {
 });
 
 describe('#4517: an unparsed file is not an empty file', () => {
+  /** Scratch roots created here, removed in afterAll — this suite does not leak (#4630). */
+  const scratch: string[] = [];
+
   const tmp = (name: string, body: string): string => {
-    const p = join(mkdtempSync(join(tmpdir(), 'symext-')), name);
+    const dir = mkdtempSync(join(tmpdir(), 'symext-'));
+    scratch.push(dir);
+    const p = join(dir, name);
     writeFileSync(p, body, 'utf-8');
     return p;
   };
+
+  afterAll(() => {
+    for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+    scratch.length = 0;
+  });
 
   it('marks an unsupported extension as not parsed', async () => {
     const result = await extractSymbols(tmp('service.py', 'def handler():\n    return 1\n'));

--- a/packages/nexus-agents/src/security/quality-gate-commands.test.ts
+++ b/packages/nexus-agents/src/security/quality-gate-commands.test.ts
@@ -1,13 +1,22 @@
-import { describe, expect, it } from 'vitest';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { afterAll, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { detectPackageManager, resolveCheckCommand } from './quality-gate-commands.js';
 
+/** Scratch dirs created here, removed in afterAll — this suite does not leak (#4630). */
+const scratch: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+  scratch.length = 0;
+});
+
 /** A throwaway project dir with the given files. */
 function project(files: Record<string, string>): string {
   const dir = mkdtempSync(join(tmpdir(), 'qgate-'));
+  scratch.push(dir);
   for (const [name, body] of Object.entries(files)) {
     writeFileSync(join(dir, name), body, 'utf-8');
   }

--- a/packages/nexus-agents/src/security/quality-gate-cwd.test.ts
+++ b/packages/nexus-agents/src/security/quality-gate-cwd.test.ts
@@ -13,8 +13,8 @@
  * @module security/quality-gate-cwd.test
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { afterAll, describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -38,8 +38,17 @@ vi.mock('node:child_process', () => ({
  * directory with no package.json resolves to `unconfigured` and never execs —
  * correctly. These tests are about cwd, so they need a real project.
  */
+/** Scratch dirs created here, removed in afterAll — this suite does not leak (#4630). */
+const scratch: string[] = [];
+
+afterAll(() => {
+  for (const dir of scratch) rmSync(dir, { recursive: true, force: true });
+  scratch.length = 0;
+});
+
 function fixtureProject(): string {
   const dir = mkdtempSync(join(tmpdir(), 'qgate-cwd-'));
+  scratch.push(dir);
   writeFileSync(
     join(dir, 'package.json'),
     JSON.stringify({
@@ -110,6 +119,7 @@ describe('quality-gate checks run in projectDir (#4355)', () => {
     // an unpinned ESLint and failed a project whose own lint was green.
     const { checkLint } = await import('./quality-gate.js');
     const bare = mkdtempSync(join(tmpdir(), 'qgate-bare-'));
+    scratch.push(bare);
 
     const result = await checkLint(bare)();
 


### PR DESCRIPTION
Closes #4630.

Three test suites created `mkdtemp` directories and never removed them, leaving **716 stale directories** in the test scratch root:

| Prefix | Leaked | Source |
| --- | --- | --- |
| `qgate-` | 377 | `quality-gate-commands.test.ts:10` |
| `qgate-cwd-` | 162 | `quality-gate-cwd.test.ts:42` |
| `symext-` | 150 | `symbol-extractor.test.ts:109` |
| `qgate-bare-` | 27 | `quality-gate-cwd.test.ts:112` |

## What I did not build, and why

The issue body — which I wrote — ended with "a shared `mkdtempForTest()` helper … clears the DRY bar, by the repo's own extract-at-3+ rule." I measured before acting on it:

```
test files calling mkdtemp*:            89
of those, with NO cleanup:               3
```

**86 of 89 already clean up.** The convention exists and is followed 97% of the time; these three skipped it. A helper now would mean either migrating 89 files or running two conventions side by side. The extract-at-3+ rule is about duplicated logic with no home — this logic has one, `afterAll`, and nearly everything uses it. Suggestion withdrawn on the issue.

So: three files get the same `afterAll` cleanup the other 86 use. No new abstraction.

## Control

A fix verified by "the number didn't go up" needs proof the number would have gone up. Same three suites, same run:

```
WITHOUT fix: 610 -> 635   (delta +25)
WITH fix:    635 -> 635   (delta  0)
```

31 tests pass, eslint and tsc clean.

## Note on the 716 already there

The reaper from #4632 removes them on age, so they will clear on their own. This stops new ones. The larger producer — `opencode` spawns dropping 8.2 MB each — is #4629, now attributed to four specific test files.
