### PR TITLE
test: stop four unit tests from spawning the real opencode binary

### DIFF
--- a/.changeset/no-real-cli-spawn-in-tests.md
+++ b/.changeset/no-real-cli-spawn-in-tests.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+Stop four unit tests from spawning the real `opencode` binary (#4629)
+
+Measured with a `PATH` shim over the full 1,185-file suite: 23 real `opencode`
+spawns, all from four test files, none of them an opt-in integration test.
+
+The disk cost was visible (each spawn unpacks an 8.2 MB `libopentui.so` into
+`$TMPDIR` and never removes it). The determinism cost was not: a unit test that
+shells out to an installed binary makes the suite's result depend on what is on
+the machine. On a box without `opencode` these four exercised a different branch
+and nothing reported which branch had run.
+
+`verify-command.test.ts` mocks the auth probe with a deliberately mixed panel —
+one authenticated, three not — so both sides of the availability check stay
+exercised rather than collapsing to a uniform all-authed shape.
+
+The three MCP tests needed a **wholesale** module mock of the CLI factory. The
+narrow `vi.mock(path, async (importOriginal) => ({ ...actual, stub }))` form does
+not stop the spawn: the test file's own import is mocked, but other importers
+still reach the real `getAvailableClis`. Each mock carries a comment saying so.

--- a/packages/nexus-agents/src/cli/verify-command.test.ts
+++ b/packages/nexus-agents/src/cli/verify-command.test.ts
@@ -4,8 +4,33 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+
 import { runVerify, printVerifyResult, verifyCommand } from './verify-command.js';
 import type { VerifyResult, VerifyCheck } from './verify-command.js';
+
+/**
+ * Stub the CLI auth probe (#4629).
+ *
+ * `runVerify()` calls `checkAdapterAvailability()` → `probeAllClis()`, which
+ * spawns each CLI binary for real. This file has 17 `runVerify`/`verifyCommand`
+ * calls, so an unmocked run produced 17 real `opencode auth list` subprocesses
+ * — 8.2 MB of leaked scratch each, and, worse, a suite whose result depended on
+ * which CLIs happened to be installed on the machine. On a box without
+ * `opencode` these tests exercised a different branch, and nothing reported
+ * which branch had run.
+ *
+ * The canned panel is deliberately mixed — one authenticated, one not — so the
+ * assertions below exercise both sides of the availability check rather than a
+ * uniform all-authed shape that would hide a branch.
+ */
+vi.mock('./cli-auth-probe.js', () => ({
+  probeAllClis: vi.fn().mockResolvedValue([
+    { cli: 'claude', state: 'authenticated', via: 'cli-credentials' },
+    { cli: 'gemini', state: 'needs-login', reason: 'stubbed', fixCommand: 'gemini auth login' },
+    { cli: 'codex', state: 'needs-login', reason: 'stubbed', fixCommand: 'codex login' },
+    { cli: 'opencode', state: 'needs-login', reason: 'stubbed', fixCommand: 'opencode auth login' },
+  ]),
+}));
 
 describe('verify-command', () => {
   describe('runVerify', () => {

--- a/packages/nexus-agents/src/mcp/mcp-expert-tools.test.ts
+++ b/packages/nexus-agents/src/mcp/mcp-expert-tools.test.ts
@@ -19,6 +19,20 @@ import {
 import { createDefaultRateLimiter } from './middleware/rate-limiter.js';
 import type { Expert } from '../agents/index.js';
 
+// #4629: this test reached a real CLI binary through the CLI-detection layer.
+// The expert tools call checkAdapterAvailability(), which probes every CLI for
+// a usable adapter, so `opencode --version` and `opencode auth list` were
+// actually spawned. Stub the factory so detection answers "nothing available";
+// the availability middleware and the tools under test stay real. Keep this a
+// full module replacement — with an `importOriginal` spread the real module
+// still wins for the middleware's own import and the spawns come back.
+vi.mock('../cli-adapters/factory.js', () => ({
+  createCliAdapter: vi.fn(),
+  createAllAdapters: vi.fn(() => new Map()),
+  isCliAvailable: vi.fn().mockResolvedValue(false),
+  getAvailableClis: vi.fn().mockResolvedValue([]),
+}));
+
 // ============================================================================
 // Test Infrastructure
 // ============================================================================

--- a/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
+++ b/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
@@ -7,7 +7,7 @@
  *
  * @module mcp/mcp-standalone-tools.test
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 
@@ -31,6 +31,21 @@ import {
   registerRunWorkflowTool,
 } from './tools/index.js';
 import type { IWorkflowEngine } from '../core/index.js';
+
+// #4629: this test reached a real CLI binary through the CLI-detection layer.
+// The memory_query call below runs reflective retrieval, which asks the
+// registry for a default adapter, and the auto-adapter probes every CLI to
+// find one, so `opencode --version` and `opencode auth list` were actually
+// spawned. Stub the factory so detection answers "nothing available"; every
+// tool under test stays real. Keep this a full module replacement — with an
+// `importOriginal` spread the real module still wins for auto-adapter's own
+// import and the spawns come back.
+vi.mock('../cli-adapters/factory.js', () => ({
+  createCliAdapter: vi.fn(),
+  createAllAdapters: vi.fn(() => new Map()),
+  isCliAvailable: vi.fn().mockResolvedValue(false),
+  getAvailableClis: vi.fn().mockResolvedValue([]),
+}));
 
 // ============================================================================
 // Test Infrastructure

--- a/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
@@ -14,6 +14,21 @@ import {
   type MemoryQueryInput,
 } from './memory-query.js';
 
+// #4629: this test reached a real CLI binary through the CLI-detection layer.
+// resolveReflection() asks the registry for a default adapter, and the
+// auto-adapter probes every CLI to find one, so `opencode --version` and
+// `opencode auth list` were actually spawned. Stub the factory so detection
+// answers "nothing available"; the registry, retriever, and keyword-fallback
+// path under test stay real. Keep this a full module replacement — with an
+// `importOriginal` spread the real module still wins for auto-adapter's own
+// import and the spawns come back.
+vi.mock('../../cli-adapters/factory.js', () => ({
+  createCliAdapter: vi.fn(),
+  createAllAdapters: vi.fn(() => new Map()),
+  isCliAvailable: vi.fn().mockResolvedValue(false),
+  getAvailableClis: vi.fn().mockResolvedValue([]),
+}));
+
 // Mock getToolMemory at module level
 const mockQueryAll = vi.fn();
 const mockQueryBySource = vi.fn();


### PR DESCRIPTION
Closes #4629.

## Measured, not guessed

A `PATH` shim over `opencode` across the full 1,185-file suite: **23 real spawns, four files, all accidental.** No opt-in integration test was involved — `opencode-adapter.e2e.test.ts` stayed correctly gated behind `OPENCODE_E2E` throughout.

| File | Spawns | Route |
| --- | --- | --- |
| `src/cli/verify-command.test.ts` | 17 | `verify-command.ts:267 probeAllClis()` → `cli-auth-probe.ts:233 execFileAsync('opencode', ['auth','list'])` |
| `src/mcp/tools/memory-query.test.ts` | 2 | `resolveReflection` → `auto-adapter` → `factory.ts:161 isCliAvailable` |
| `src/mcp/mcp-standalone-tools.test.ts` | 2 | same, via `ResilientAdapter` |
| `src/mcp/mcp-expert-tools.test.ts` | 2 | via `middleware/adapter-availability.ts` |

## Why this is a correctness fix, not housekeeping

The 8.2 MB of leaked scratch per spawn is the visible half and the least important. The real problem: **a unit test that shells out to an installed binary makes the suite's result depend on what is on the machine.** On a box without `opencode`, these four tests exercised a different branch — and neither run reported which branch it had taken. That is a test suite reporting a pass it cannot account for.

## What changed

`verify-command.test.ts` had **no `vi.mock` at all**. It now stubs `./cli-auth-probe.js` with a deliberately **mixed** panel — one authenticated, three needing login — so both sides of the availability check stay exercised. A uniform all-authed stub would have hidden a branch while looking tidier.

The three MCP tests get a wholesale `vi.mock` of the CLI factory.

## The finding worth keeping

The narrow mock form **does not stop the spawn**:

```ts
vi.mock('../../cli-adapters/factory.js', async (importOriginal) => ({
  ...(await importOriginal()), isCliAvailable: vi.fn(),   // still spawns
}));
```

Traced with a temporary `child_process` wrapper: the test file's own import is mocked (`vi.isMockFunction` returns true), yet `auto-adapter.ts:120` still reaches the real `getAvailableClis` → `isCliAvailable` → `opencode --version`. Only replacing the module wholesale intercepts every importer. Each mock carries a comment saying this, so the next reader doesn't "simplify" it back into a spawning test.

Also confirmed: `restoreMocks: true` does not strip `vi.fn().mockResolvedValue(...)` implementations in Vitest 4, so the stubs survive between tests.

## Verification

```
WITHOUT mocks: +23 opencode .so     (17 / 2 / 2 / 2, matching the attribution exactly)
WITH mocks:      0
```

57 tests pass across the four files. Prettier, eslint, `tsc` clean.

Checked the thing that would make this a false fix: **none of the three MCP tests assert on adapter availability**, so stubbing detection to empty masks no coverage. `verify-command`'s mixed panel preserves the branch it does assert on.

## Scope

Fixes the four instances. The chokepoint guard from the #4629 vote is **not** here — verifying the two dissents showed the proposed placement was wrong in two independent ways (a production-side env guard cannot tell a mocked `child_process` from a real one, and `isCliAvailable` would have covered only 6 of 23 spawns). That work is #4639, where the allowlist question has since been settled by measurement.
