### PR TITLE
fix(indexer): take the supported-extension list from one place

### DIFF
--- a/.changeset/single-extension-list.md
+++ b/.changeset/single-extension-list.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+Take the supported-extension list from one place (#4640)
+
+`codebase-search.ts` hardcoded its own copy of `['.ts','.tsx','.js','.jsx']`
+while `symbol-extractor.ts` exports `SUPPORTED_EXTENSIONS` — whose JSDoc says it
+is exported to be the single source.
+
+The copies were not merely redundant: they sat on opposite sides of the same
+decision. `extract_symbols` reaches the extension gate at
+`symbol-extractor.ts:162`, while the `search_codebase` sweep filters _before_ it.
+So adding a language to `SUPPORTED_EXTENSIONS` taught `extract_symbols` to parse
+it while `search_codebase` silently indexed none of it — no error, just an index
+quietly missing a language.
+
+Adds a test that fails when the lists diverge, since a shared constant alone
+cannot prevent someone reintroducing a local copy. Verified red/green: with a
+fifth extension added to the canonical list the test fails before the fix and
+passes after.

--- a/packages/nexus-agents/src/indexer/codebase-search.test.ts
+++ b/packages/nexus-agents/src/indexer/codebase-search.test.ts
@@ -10,7 +10,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { resolve, join } from 'node:path';
 import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { CodebaseIndex, MAX_INDEX_MAX_DEPTH } from './codebase-search.js';
+import { CodebaseIndex, MAX_INDEX_MAX_DEPTH, findSourceFiles } from './codebase-search.js';
+import { SUPPORTED_EXTENSIONS } from './symbol-extractor.js';
 
 const SRC_DIR = resolve(import.meta.dirname ?? '.', '..');
 
@@ -170,5 +171,44 @@ describe('CodebaseIndex maxDepth (#4243)', () => {
     const zeroIndex = new CodebaseIndex(tmpRoot);
     const stats = await zeroIndex.index(0);
     expect(stats.skippedDirs).toBeGreaterThan(0);
+  });
+});
+
+describe('supported extensions are a single list (#4640)', () => {
+  let root: string;
+
+  beforeAll(async () => {
+    root = await mkdtemp(join(tmpdir(), 'ext-agreement-'));
+    for (const ext of SUPPORTED_EXTENSIONS) {
+      await writeFile(join(root, `sample${ext}`), 'export const x = 1;\n', 'utf-8');
+    }
+    await writeFile(join(root, 'sample.py'), 'def f():\n    return 1\n', 'utf-8');
+  });
+
+  afterAll(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('walks every extension the extractor claims to support', async () => {
+    // `codebase-search` used to hardcode its own copy of this list, so the two
+    // sat on opposite sides of the same decision: `extract_symbols` reaches the
+    // extension gate, while this sweep pre-filters *before* it. Adding a
+    // language to SUPPORTED_EXTENSIONS therefore taught extract_symbols to parse
+    // it while search_codebase silently indexed none of it — no error, just an
+    // index quietly missing a language. This test fails if the lists diverge
+    // again, which a shared constant alone cannot guarantee.
+    const { files } = await findSourceFiles(root, 1);
+    const found = files.map((f) => f.slice(f.lastIndexOf('.')));
+
+    for (const ext of SUPPORTED_EXTENSIONS) {
+      expect(found).toContain(ext);
+    }
+  });
+
+  it('still excludes an extension the extractor does not support', async () => {
+    // Guards the other direction: agreement must not be achieved by walking
+    // everything.
+    const { files } = await findSourceFiles(root, 1);
+    expect(files.some((f) => f.endsWith('.py'))).toBe(false);
   });
 });

--- a/packages/nexus-agents/src/indexer/codebase-search.ts
+++ b/packages/nexus-agents/src/indexer/codebase-search.ts
@@ -14,6 +14,7 @@ import { readdir } from 'node:fs/promises';
 import { resolve, extname, relative } from 'node:path';
 import {
   extractSymbols,
+  SUPPORTED_EXTENSIONS,
   type CodeSymbol,
   type SymbolExtractionResult,
 } from './symbol-extractor.js';
@@ -66,7 +67,12 @@ const SCORE_EXPORTED_BONUS = 3;
 function isSourceFile(name: string): boolean {
   const ext = extname(name).toLowerCase();
   return (
-    ['.ts', '.tsx', '.js', '.jsx'].includes(ext) &&
+    // #4640: take the list from the extractor rather than keeping a copy. The
+    // two sat on opposite sides of the same decision — `extract_symbols` reaches
+    // the extension gate at symbol-extractor.ts:162, while this sweep filters
+    // *before* it — so a language added to SUPPORTED_EXTENSIONS was parsed by
+    // one tool and silently never indexed by the other.
+    SUPPORTED_EXTENSIONS.includes(ext) &&
     !name.endsWith('.test.ts') &&
     !name.endsWith('.test.tsx') &&
     !name.endsWith('.d.ts')


### PR DESCRIPTION
Closes #4640.

## Two copies of one list, on opposite sides of the same gate

`symbol-extractor.ts:40` exports the canonical list, and its JSDoc says it is exported *to be* the single source:

```ts
export const SUPPORTED_EXTENSIONS: readonly string[] = ['.ts', '.tsx', '.js', '.jsx'];
```

`codebase-search.ts:69` hardcoded the same four values — while already importing from `./symbol-extractor.js` on line 15, so this was a copy, not an access problem.

What makes it more than redundancy is *where* each copy sits:

| Consumer | Reaches the extension gate? |
| --- | --- |
| `extract_symbols` (single deliberate path) | yes — `symbol-extractor.ts:162` |
| `search_codebase` (`index()` sweep) | **no** — pre-filtered at `codebase-search.ts:69` |

Add a language to `SUPPORTED_EXTENSIONS` and `extract_symbols` starts parsing it while `search_codebase` silently indexes none of it. No error, no warning — an index quietly missing a language, which reads to the caller as "no symbols here."

That is the first thing #4517's tree-sitter proposal would have hit: half the feature ships, the other half returns an empty result that looks like a legitimate measured zero.

## The test matters more than the one-line fix

Importing the shared constant fixes today. It does not stop someone reintroducing a local copy tomorrow — which is how the copy got there in the first place. So there is a test that fails when the lists diverge.

It goes through `findSourceFiles` rather than exporting `isSourceFile`, for two reasons: exporting a function solely for a test would trip the producer/consumer ratchet from #4561, and walking a real fixture directory asserts the behaviour that actually matters rather than a helper's return value.

Both directions are covered — every supported extension is walked, and an unsupported one (`.py`) is still excluded, so agreement cannot be achieved by walking everything.

## Red/green verified

Temporarily added a fifth extension (`.mts`) to the canonical list:

```
divergence introduced, before fix:  FAIL — expected [ '.js', '.jsx', '.ts', '.tsx' ] to include '.mts'
divergence still present, after fix: PASS (19/19)
```

So the test detects the class, and the fix is what resolves it. Control change reverted; `SUPPORTED_EXTENSIONS` is back to its four entries.

## Verification

- 363 tests pass across `src/indexer/` and `extract-symbols-tool.test.ts` (20 files)
- eslint, prettier, `tsc` clean

## Incidental finding for #4517

Because the sweep pre-filters, **only** `extract_symbols` reaches the extension gate. The rejection counter I recommended on #4517 before building tree-sitter therefore measures agent-chosen paths only — a deliberate ask about a `.py` file — and is not inflated by directory sweeps skipping hundreds of non-source files. That demand signal is clean by construction, which makes the counter worth more than it seemed when proposed.
