### PR TITLE
feat(testing): fail any unit test that spawns a real agent-CLI binary

### DIFF
--- a/.changeset/cli-spawn-guard.md
+++ b/.changeset/cli-spawn-guard.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+Fail any unit test that spawns a real agent-CLI binary (#4639)
+
+#4629 fixed four tests that shelled out to a real `opencode`. This stops the
+fifth. A vitest `setupFiles` interceptor blocks the five agent CLIs (`claude`,
+`gemini`, `codex`, `opencode`, `agy`) and records the attempt; anything else —
+`git`, `node`, `npm` — passes through untouched, because 16 test files spawn
+those legitimately and a blanket guard would be reverted within a day.
+
+Full-suite spawn count goes from 23 to 0.
+
+Two mechanisms that look right and are not, recorded in the module so they are
+not retried: mutating the `node:child_process` namespace throws
+`Cannot redefine property`, and a `Proxy` apply-trap misses
+`promisify(execFile)` entirely because promisify resolves via
+`util.promisify.custom` — that alone would have let 17 of the 23 spawns
+through while the guard reported success.
+
+Blocking is also not enough on its own. Every CLI probe catches the throw and
+reports "CLI unavailable", so the spawn stopped while the test still passed,
+silently, on a branch it never meant to take. Attempts are re-raised from an
+`afterEach` outside any production catch block.

--- a/packages/nexus-agents/src/testing/cli-spawn-guard.setup.ts
+++ b/packages/nexus-agents/src/testing/cli-spawn-guard.setup.ts
@@ -1,0 +1,109 @@
+/**
+ * Installs the CLI-spawn guard for every test file (#4639).
+ *
+ * Registered as a `setupFiles` entry, so `vi.mock` here applies to the whole
+ * module graph of each test file. See `cli-spawn-guard.ts` for why the guard
+ * intercepts at the module boundary rather than living in production code.
+ *
+ * ## Three mechanisms were tried against an isolated probe before this was written
+ *
+ * 1. **Mutating the `node:child_process` namespace** throws `Cannot redefine
+ *    property: execFile`, and already-bound named imports keep pointing at the
+ *    real function. It silently does nothing.
+ * 2. **A `Proxy` with an `apply` trap** blocks a direct `execFile(...)` call but
+ *    NOT `promisify(execFile)(...)`. `promisify` resolves through the
+ *    `util.promisify.custom` symbol, which returns Node's internal
+ *    implementation and never reaches the trap. This matters more than it
+ *    sounds: 13 modules in this tree use `promisify(execFile)`, including
+ *    `cli/cli-auth-probe.ts`, which accounted for 17 of the 23 spawns in #4629.
+ *    A proxy-only guard would have shipped green and blocked almost nothing.
+ *    Adding a `get` trap for the symbol does not work either — it is a
+ *    read-only, non-configurable data property, so the trap is forbidden by the
+ *    proxy invariants from returning anything else.
+ * 3. **A plain wrapper function** with its own `util.promisify.custom` defined
+ *    on it. This one works for both call shapes, and is what is below.
+ *
+ * @module testing/cli-spawn-guard.setup
+ */
+
+import { afterEach, vi } from 'vitest';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const { promisify } = await import('node:util');
+  const {
+    GUARDED_CLI_BINARIES,
+    binaryNameFrom,
+    guardedSpawnError,
+    realCliSpawnsAllowed,
+    recordSpawnViolation,
+  } = await import('./cli-spawn-guard.js');
+
+  const CUSTOM = promisify.custom as unknown as symbol;
+
+  const blocked = (args: readonly unknown[]): string | undefined => {
+    const binary = binaryNameFrom(args[0]);
+    return GUARDED_CLI_BINARIES.has(binary) && !realCliSpawnsAllowed() ? binary : undefined;
+  };
+
+  function guard<T>(fnName: string, fn: T): T {
+    const wrapper = function (this: unknown, ...args: unknown[]): unknown {
+      const binary = blocked(args);
+      if (binary !== undefined) {
+        recordSpawnViolation(binary, fnName);
+        throw guardedSpawnError(binary, fnName);
+      }
+      return (fn as (...a: unknown[]) => unknown).apply(this, args);
+    };
+
+    // The promisified form is a separate entry point, not a wrapper around the
+    // callback one — guard it explicitly or `promisify(execFile)` walks past.
+    const custom = (fn as Record<symbol, unknown>)[CUSTOM];
+    if (typeof custom === 'function') {
+      Object.defineProperty(wrapper, CUSTOM, {
+        value: (...args: unknown[]): unknown => {
+          const binary = blocked(args);
+          if (binary !== undefined) {
+            recordSpawnViolation(binary, fnName);
+            return Promise.reject(guardedSpawnError(binary, fnName));
+          }
+          return (custom as (...a: unknown[]) => unknown)(...args);
+        },
+        configurable: true,
+      });
+    }
+
+    return wrapper as unknown as T;
+  }
+
+  // Only the entry points this tree uses to reach a CLI. Everything else in the
+  // module passes through unwrapped.
+  return {
+    ...actual,
+    exec: guard('exec', actual.exec),
+    execFile: guard('execFile', actual.execFile),
+    execSync: guard('execSync', actual.execSync),
+    spawn: guard('spawn', actual.spawn),
+  };
+});
+
+/**
+ * Re-raise blocked attempts where production code cannot swallow them.
+ *
+ * The throw inside the wrapper stops the spawn, but every CLI probe catches it
+ * and reports "unavailable" — so without this hook the test passes silently on
+ * a branch it never meant to take. Failing here makes the guard visible.
+ */
+afterEach(async () => {
+  const { takeSpawnViolations } = await import('./cli-spawn-guard.js');
+  const violations = takeSpawnViolations();
+  if (violations.length === 0) return;
+  throw new Error(
+    `[cli-spawn-guard] This test attempted ${String(violations.length)} real CLI spawn(s):\n` +
+      violations.map((v) => `  - ${v}`).join('\n') +
+      `\nThe spawn was blocked, but the code under test caught the error and carried on as if\n` +
+      `the CLI were merely unavailable — so the test would otherwise have passed on a branch it\n` +
+      `never meant to exercise. Mock the module that reaches the binary (commonly\n` +
+      `'cli-adapters/factory.js' or 'cli/cli-auth-probe.js'), replacing it WHOLESALE.`
+  );
+});

--- a/packages/nexus-agents/src/testing/cli-spawn-guard.test.ts
+++ b/packages/nexus-agents/src/testing/cli-spawn-guard.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the CLI-spawn guard's pure logic (#4639).
+ *
+ * The interception itself is verified end-to-end by the PATH-shim harness, not
+ * here — a unit test cannot meaningfully assert that a mock it installed is
+ * installed.
+ *
+ * @module testing/cli-spawn-guard.test
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  GUARDED_CLI_BINARIES,
+  binaryNameFrom,
+  guardedSpawnError,
+  realCliSpawnsAllowed,
+  takeSpawnViolations,
+} from './cli-spawn-guard.js';
+
+describe('binaryNameFrom', () => {
+  it('reads a bare binary, the execFile shape', () => {
+    expect(binaryNameFrom('opencode')).toBe('opencode');
+  });
+
+  it('reads the FIRST token of a command line, the exec shape', () => {
+    // `base-adapter.ts:294` uses exec('opencode --version'). Taking the last
+    // token yields '--version', which is not a guarded name — the guard would
+    // then pass its own tests while letting that spawn straight through.
+    expect(binaryNameFrom('opencode --version')).toBe('opencode');
+  });
+
+  it('strips a directory prefix', () => {
+    expect(binaryNameFrom('/usr/local/bin/opencode')).toBe('opencode');
+  });
+
+  it('strips a Windows executable suffix', () => {
+    expect(binaryNameFrom('opencode.exe')).toBe('opencode');
+  });
+
+  it('returns empty for absent or non-string input rather than throwing', () => {
+    expect(binaryNameFrom(undefined)).toBe('');
+    expect(binaryNameFrom('')).toBe('');
+    // A URL or fd is never a guarded binary; stringifying it would yield
+    // '[object Object]' and could never match, but silently.
+    expect(binaryNameFrom({ toString: () => 'opencode' })).toBe('');
+  });
+
+  it('does not mistake a non-CLI binary for a guarded one', () => {
+    expect(GUARDED_CLI_BINARIES.has(binaryNameFrom('git rev-parse HEAD'))).toBe(false);
+    expect(GUARDED_CLI_BINARIES.has(binaryNameFrom('node --version'))).toBe(false);
+  });
+});
+
+describe('GUARDED_CLI_BINARIES', () => {
+  it('covers every routing-arm CLI', () => {
+    for (const cli of ['claude', 'gemini', 'codex', 'opencode']) {
+      expect(GUARDED_CLI_BINARIES.has(cli)).toBe(true);
+    }
+  });
+
+  it('covers agy, which is probed as a binary but is not a routing arm', () => {
+    expect(GUARDED_CLI_BINARIES.has('agy')).toBe(true);
+  });
+
+  it('does not block ordinary tooling', () => {
+    for (const bin of ['git', 'node', 'npm', 'pnpm', 'sh']) {
+      expect(GUARDED_CLI_BINARIES.has(bin)).toBe(false);
+    }
+  });
+});
+
+describe('realCliSpawnsAllowed', () => {
+  it('is false with no opt-in — the default must fail closed', () => {
+    expect(realCliSpawnsAllowed({})).toBe(false);
+  });
+
+  it('is true when a *_E2E flag is set', () => {
+    expect(realCliSpawnsAllowed({ OPENCODE_E2E: 'true' })).toBe(true);
+  });
+
+  it('accepts a future gated suite without a code change', () => {
+    expect(realCliSpawnsAllowed({ CLAUDE_E2E: '1' })).toBe(true);
+  });
+
+  it('treats an empty or false-valued flag as not opted in', () => {
+    expect(realCliSpawnsAllowed({ OPENCODE_E2E: '' })).toBe(false);
+    expect(realCliSpawnsAllowed({ OPENCODE_E2E: 'false' })).toBe(false);
+  });
+
+  it('ignores an unrelated env var that merely contains E2E', () => {
+    expect(realCliSpawnsAllowed({ E2E_REPORT_DIR: '/tmp/x' })).toBe(false);
+  });
+});
+
+describe('guardedSpawnError', () => {
+  it('names the binary and the function that spawned it', () => {
+    const message = guardedSpawnError('opencode', 'execFile').message;
+    expect(message).toContain("'opencode'");
+    expect(message).toContain('execFile()');
+  });
+
+  it('tells the reader how to fix it, including the wholesale-mock trap', () => {
+    const message = guardedSpawnError('opencode', 'exec').message;
+    expect(message).toContain('WHOLESALE');
+    expect(message).toContain('_E2E');
+  });
+});
+
+describe('the installed guard (integration — the setup file is active here)', () => {
+  // These tests trigger the guard on purpose, so they must consume the
+  // violation record; otherwise the setup file's afterEach re-raises it and
+  // fails the very tests proving the guard works. Consuming it here is also an
+  // assertion in its own right — it proves the attempt WAS recorded, which is
+  // what makes the guard un-swallowable.
+  afterEach(() => {
+    takeSpawnViolations();
+  });
+
+  it('blocks a direct execFile call', async () => {
+    const { execFile } = await import('node:child_process');
+    expect(() => execFile('opencode', ['--version'], () => undefined)).toThrow(/cli-spawn-guard/);
+    expect(takeSpawnViolations()).toEqual(['opencode (via execFile)']);
+  });
+
+  it('blocks the promisified form, which bypasses a Proxy apply trap', async () => {
+    // The mechanism that made the first implementation useless: promisify()
+    // resolves via util.promisify.custom, so a proxy-only guard let every
+    // `promisify(execFile)` caller straight through — 13 modules, including the
+    // one responsible for 17 of the 23 spawns in #4629.
+    const { execFile } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    await expect(promisify(execFile)('opencode', ['--version'])).rejects.toThrow(/cli-spawn-guard/);
+  });
+
+  it('blocks the exec command-line form', async () => {
+    const { exec } = await import('node:child_process');
+    expect(() => exec('opencode --version', () => undefined)).toThrow(/cli-spawn-guard/);
+  });
+
+  it('lets ordinary tooling through untouched', async () => {
+    const { execFile } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const { stdout } = await promisify(execFile)('node', ['--version']);
+    expect(stdout).toMatch(/^v\d+/);
+  });
+});

--- a/packages/nexus-agents/src/testing/cli-spawn-guard.ts
+++ b/packages/nexus-agents/src/testing/cli-spawn-guard.ts
@@ -1,0 +1,121 @@
+/**
+ * Fails any unit test that spawns a real agent-CLI binary (#4639).
+ *
+ * ## Why
+ *
+ * #4629 found 23 real `opencode` spawns across four test files, none of them an
+ * opt-in integration test. The visible cost was disk — each spawn unpacks an
+ * 8.2 MB `libopentui.so` into `$TMPDIR` and never removes it. The cost that
+ * matters is determinism: a unit test that shells out to an installed binary
+ * makes the suite's result depend on what is on the machine. On a box without
+ * `opencode` those four tests took a different branch, and nothing reported
+ * which branch had run.
+ *
+ * Fixing the four instances does not stop the fifth. This does.
+ *
+ * ## Why it lives here and not in production code
+ *
+ * A guard inside `isCliAvailable` was the obvious placement and is wrong twice:
+ *
+ * 1. It would have covered 6 of the 23 spawns. `verify-command` reaches the
+ *    binary through `probeAllClis` → `probeCli` → `execFileAsync`, never
+ *    touching `isCliAvailable`.
+ * 2. Production code cannot tell a mocked `child_process` from a real one. An
+ *    `if (isTestRunner()) throw` runs whether or not the test mocked the
+ *    subprocess layer, so it would fire on correctly-mocked tests. Intercepting
+ *    at the module boundary gets that distinction for free: a test that mocks
+ *    `node:child_process` itself replaces this wrapper along with it, which is
+ *    exactly the right behaviour.
+ *
+ * ## Why a named set rather than "no subprocesses"
+ *
+ * 16 test files spawn `git` or `node` legitimately. A blanket throw would break
+ * tests doing nothing wrong and would be reverted within a day. This blocks only
+ * the agent CLIs this repo drives; everything else passes through untouched.
+ *
+ * @module testing/cli-spawn-guard
+ */
+
+import { CLI_NAMES } from '../config/model-capabilities-types.js';
+
+/**
+ * Binaries a unit test must not spawn for real.
+ *
+ * `CLI_NAMES` is the canonical routing-arm list. `agy` is probed as a binary at
+ * `cli/cli-auth-probe.ts:209` but is deliberately not a routing arm, so it is
+ * absent from `CLI_NAMES` and named here explicitly rather than silently missed.
+ */
+export const GUARDED_CLI_BINARIES: ReadonlySet<string> = new Set<string>([...CLI_NAMES, 'agy']);
+
+/**
+ * Extracts the binary name from the first argument of a `child_process` call.
+ *
+ * Handles both call shapes in this tree: `execFile('opencode', ['--version'])`
+ * passes a bare binary, while `exec('opencode --version')` passes a whole
+ * command line. Taking the last token instead of the first resolves the latter
+ * to `--version` and lets the spawn through — the guard would then pass its own
+ * tests while missing `base-adapter.ts:294`, which uses the `exec` form.
+ */
+export function binaryNameFrom(command: unknown): string {
+  // Non-string first arguments (a URL, a file descriptor) are never a guarded
+  // binary name, and stringifying one would yield '[object Object]' — which
+  // could never match, but would do so silently.
+  if (typeof command !== 'string') return '';
+  const first = command.trim().split(/\s+/)[0] ?? '';
+  const withoutPath = first.split('/').pop() ?? '';
+  return withoutPath.replace(/\.(exe|cmd|bat)$/i, '');
+}
+
+/**
+ * True when this run has explicitly opted into real CLI spawns.
+ *
+ * Keyed on the `*_E2E` convention the gated suites already use — `OPENCODE_E2E`
+ * is the only one in the default suite today, and a future gated suite needs no
+ * change here. A path allowlist was the alternative and would be a one-row
+ * registry duplicating a signal the file already carries.
+ */
+export function realCliSpawnsAllowed(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Object.entries(env).some(
+    ([key, value]) =>
+      key.endsWith('_E2E') && value !== undefined && value !== '' && value !== 'false'
+  );
+}
+
+/** The error a guarded spawn raises. Exported so the guard's own tests can match it. */
+export function guardedSpawnError(binary: string, fnName: string): Error {
+  return new Error(
+    `[cli-spawn-guard] This test spawned the real '${binary}' binary via ${fnName}().\n` +
+      `Unit tests must not shell out to an agent CLI — the result then depends on what is\n` +
+      `installed on the machine, and the spawn leaks scratch that nothing cleans up.\n` +
+      `Mock the module that reaches it (commonly 'cli-adapters/factory.js' or\n` +
+      `'cli/cli-auth-probe.js'), replacing it WHOLESALE rather than spreading importOriginal —\n` +
+      `a module's internal calls to its own siblings bypass a partial stub.\n` +
+      `For a genuine integration test, gate the file behind a '*_E2E' env var.`
+  );
+}
+
+/**
+ * Blocked spawn attempts since the last {@link takeSpawnViolations} call.
+ *
+ * Throwing alone is not enough. Every CLI probe in this tree wraps its spawn in
+ * a try/catch that converts any failure into "this CLI is unavailable" — which
+ * is correct production behaviour and fatal for a guard. Measured: with the
+ * guard installed and the mock removed, `verify-command.test.ts` went from 51
+ * real spawns to 0 while still reporting 25 passing tests and no error. The
+ * spawn was prevented and nobody was told.
+ *
+ * A guard whose failure is swallowed by the code it guards is a check that
+ * cannot fail. So attempts are recorded here and re-raised from an `afterEach`
+ * hook, outside any production catch block.
+ */
+const spawnViolations: string[] = [];
+
+/** Records a blocked attempt. Called by the setup file before it throws. */
+export function recordSpawnViolation(binary: string, fnName: string): void {
+  spawnViolations.push(`${binary} (via ${fnName})`);
+}
+
+/** Returns and clears the recorded attempts. */
+export function takeSpawnViolations(): string[] {
+  return spawnViolations.splice(0, spawnViolations.length);
+}

--- a/packages/nexus-agents/vitest.config.ts
+++ b/packages/nexus-agents/vitest.config.ts
@@ -36,6 +36,10 @@ export default defineConfig({
     // Reap scratch older than a day before the run — see testing/global-setup.ts.
     globalSetup: ['./src/testing/global-setup.ts'],
 
+    // Fail any test that spawns a real agent-CLI binary (#4639). Blocks only
+    // the named CLIs; git/node/npm pass through. See testing/cli-spawn-guard.ts.
+    setupFiles: ['./src/testing/cli-spawn-guard.setup.ts'],
+
     // Keep scratch out of the shared tmpfs — see TEST_TMP above.
     // Tests asserting repo-*detection* need a dir with no `.git` ancestor,
     // which TEST_TMP cannot provide. Hand them the real system temp dir; see


### PR DESCRIPTION
Closes #4639.

#4629 fixed four tests that shelled out to a real `opencode`. This stops the fifth.

**Full-suite CLI spawn count: 23 → 0.**

## Scope is a named set, not a category

The issue said "wrap `child_process` and throw." Measuring showed that would be wrong: **16 test files spawn `git` or `node` legitimately.** A blanket throw breaks tests doing nothing wrong and gets reverted within a day.

So the guard blocks five names — `claude`, `gemini`, `codex`, `opencode`, `agy` — taken from `CLI_NAMES` plus `agy`, which is probed as a binary at `cli-auth-probe.ts:209` but deliberately is not a routing arm, so it is named explicitly rather than silently missed. Everything else passes through.

## Four mechanisms, three of which look right and are not

Recorded in the module so nobody retries them:

| Mechanism | Result |
| --- | --- |
| Mutate the `node:child_process` namespace | Throws `Cannot redefine property: execFile`; already-bound named imports keep pointing at the real function. Silently does nothing. |
| `Proxy` with an `apply` trap | Blocks `execFile('opencode')` but **not** `promisify(execFile)('opencode')` — promisify resolves through `util.promisify.custom`, which returns Node's internal implementation. |
| `Proxy` `get` trap for that symbol | Illegal: read-only, non-configurable data property, so proxy invariants forbid returning anything else. |
| **Plain wrapper with its own `promisify.custom`** | Works for both shapes. |

The second is the one worth dwelling on. **13 modules use `promisify(execFile)`, including `cli/cli-auth-probe.ts`, which accounted for 17 of the 23 spawns.** A proxy-only guard would have passed its own tests, shipped green, and blocked almost nothing.

## Blocking was still not enough

With the guard installed and #4641's mock removed, spawns fell from 51 to 0 — and **25 tests still passed with no error**. Every CLI probe wraps its spawn in a try/catch that converts failure into "this CLI is unavailable." That is correct production behaviour and fatal for a guard: the spawn stopped, the test passed, and nobody learned the test needed a mock. A guard whose failure is swallowed by the code it guards is a check that cannot fail.

Attempts are therefore recorded and re-raised from an `afterEach` registered in the setup file, outside any production catch block. The guard's own tests consume that record deliberately — which doubles as an assertion that the attempt *was* recorded.

## Why test-side rather than in production code

Two independent reasons, both from verifying the #4629 vote's dissents:

1. `isCliAvailable` would have covered 6 of 23 spawns — `verify-command` reaches the binary via `probeAllClis` → `probeCli` → `execFileAsync`, never touching it.
2. Production code cannot tell a mocked `child_process` from a real one. An `if (isTestRunner()) throw` runs regardless, so it fires on correctly-mocked tests. Intercepting at the module boundary gets that distinction free: a test that mocks `node:child_process` replaces this wrapper along with it, which is the correct behaviour.

## Controls

| Control | Result |
| --- | --- |
| `verify-command` mock removed | 51 → **0** spawns, and **16 loud failures** |
| mock present | 25 pass, 0 spawns |
| the 16 `git`/`node`-spawning files | **all pass**, 383 tests, 0 CLI spawns |
| full suite | 1186 files, 28,255 tests, **0 CLI spawns** |

The third is the control that matters — it is the one that would have caught a blanket guard.

The full-suite run also showed 7 failures in `env-schema.test.ts`. Those were **my harness, not the guard**: I passed `NEXUS_SHIM_LOG` to the run, and that test correctly flags unknown `NEXUS_*` vars. Without it, 30/30 pass. Verified both ways before reporting.

## Note

The producer/consumer gate accepted `cli-spawn-guard.setup.ts` on the strength of its `setupFiles` path reference — the #4633 fix from #4632 working on its first real case rather than a synthetic one.
