### PR TITLE
fix(release): count non-empty changesets, matching the action's own predicate

### DIFF
--- a/.changeset/empty-changeset-stall.md
+++ b/.changeset/empty-changeset-stall.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+Count non-empty changesets in the publish-race fallback (#4646)
+
+The `#2382` fallback counted `.changeset/*.md` **files**. `changesets/action`
+counts **releases**. An empty changeset — one file, zero releases, and what
+`pnpm changeset --empty` produces — meant the two disagreed about the same
+directory.
+
+Consequence: when a version PR merged while an empty changeset sat on `main`,
+the action published nothing _and opened no PR_ (its `All changesets are empty;
+not creating PR` branch), while the fallback stood down logging "the next
+release-PR merge should close the loop." No such PR existed. The release stalled
+silently with both components exiting 0.
+
+`scripts/count-pending-changesets.ts` now supplies the count via
+`@changesets/read` — the same library the action uses — so the predicate cannot
+drift. It materialises the ref's `.changeset/` from the commit object rather
+than reading the working tree, preserving the #4625 hardening that keeps an
+uncommitted version bump from swaying the verdict.
+
+Also corrects `docs/ops/release-changeset-race.md`, which described two action
+modes; v2 has four, and the third is the one that stalls.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,10 +177,16 @@ jobs:
             exit 0
           fi
 
-          pending_changesets=$(git ls-tree --name-only "$GITHUB_SHA" .changeset/ \
-            | grep -E '\.md$' | grep -cv 'README\.md' || true)
+          # Count NON-EMPTY changesets, matching changesets/action's own
+          # `hasNonEmptyChangesets` predicate via the same @changesets/read
+          # library (#4646). Counting FILES here was a real hole: an empty
+          # changeset (`pnpm changeset --empty`, which CLAUDE.md prescribes) is
+          # one file and zero releases, so the action published nothing AND
+          # opened no PR, while this step stood down waiting for a release-PR
+          # merge that was never going to happen. Both green, release stalled.
+          pending_changesets=$(npx tsx scripts/count-pending-changesets.ts "$GITHUB_SHA")
           if [ "$pending_changesets" -gt 0 ]; then
-            echo "::warning::package.json is at $local_version but npm has $published_version, AND $pending_changesets changeset(s) are still pending. The next release-PR merge should close the loop. Not force-publishing."
+            echo "::warning::package.json is at $local_version but npm has $published_version, AND $pending_changesets non-empty changeset(s) are still pending, so changesets/action will open a version PR. That merge closes the loop. Not force-publishing."
             exit 0
           fi
 

--- a/docs/ops/release-changeset-race.md
+++ b/docs/ops/release-changeset-race.md
@@ -36,10 +36,18 @@ If `LOCAL > PUBLISHED`, the publish step did not run on the merge of the most re
 
 ## Root cause
 
-`changesets/action` runs in one of two modes per push to `main`:
+`changesets/action` v2 selects one of four cases per push to `main`, on a plain
+switch over what `@changesets/read` finds in `.changeset/` (verified against the
+pinned source in #4626):
 
-1. **Publish mode** — when `pnpm changeset:version` finds **no** pending changesets in `.changeset/` → runs `pnpm release` and publishes to npm.
-2. **PR-update mode** — when `.changeset/*.md` files exist → consumes them on the side branch, force-pushes `changeset-release/main`, updates the open release PR.
+1. **Publish mode** — **no** pending changesets → runs `pnpm release` and publishes to npm. This is the _only_ branch that publishes.
+2. **PR-update mode** — non-empty changesets exist → consumes them on the side branch, force-pushes `changeset-release/main`, updates the open release PR.
+3. **All-empty** — changesets exist but every one declares zero releases → logs `All changesets are empty; not creating PR` and returns. **No publish and no PR.**
+4. **No changesets, no publish script** — returns.
+
+Case 3 is easy to miss and is the one behind the stall in #4646: an empty
+changeset (`pnpm changeset --empty`) is a file with no releases, so it suppresses
+publishing without producing a release PR to clear it.
 
 The race: between the moment a release PR is opened and the moment it merges, **other PRs on `main` add new changesets**. When the release PR squash-merges, only the changesets it knew about are deleted from `main`. The new changesets are still there. The post-merge release run sees them, enters PR-update mode, creates a _new_ release PR for the _next_ version, and **skips publishing the just-bumped version**.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexus-agents",
   "version": "2.8.0",
-  "description": "Intelligent orchestration platform for AI coding tools \u2014 routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus",
+  "description": "Intelligent orchestration platform for AI coding tools — routes tasks to the best model, learns from outcomes, and enforces quality through multi-model consensus",
   "private": true,
   "type": "module",
   "license": "MIT",
@@ -79,6 +79,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^1.0.0",
     "@changesets/cli": "^3.0.0",
+    "@changesets/read": "1.0.0",
     "@commitlint/cli": "^21.2.2",
     "@commitlint/config-conventional": "^21.2.2",
     "@commitlint/types": "^21.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@changesets/cli':
         specifier: ^3.0.0
         version: 3.0.0
+      '@changesets/read':
+        specifier: 1.0.0
+        version: 1.0.0
       '@commitlint/cli':
         specifier: ^21.2.2
         version: 21.2.2(@types/node@25.9.5)(conventional-commits-parser@7.1.2)(typescript@6.0.3)

--- a/scripts/count-pending-changesets.test.ts
+++ b/scripts/count-pending-changesets.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the non-empty changeset counter (#4646).
+ *
+ * @module scripts/count-pending-changesets.test
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { countNonEmptyChangesetsAt } from './count-pending-changesets.js';
+
+const created: string[] = [];
+
+afterEach(() => {
+  while (created.length > 0) {
+    const dir = created.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** A throwaway git repo whose HEAD commit holds the given changeset files. */
+function repoWithChangesets(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cs-count-'));
+  created.push(dir);
+  const git = (...args: string[]): void => {
+    execFileSync('git', ['-C', dir, ...args], { stdio: 'pipe' });
+  };
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+  mkdirSync(join(dir, '.changeset'), { recursive: true });
+  writeFileSync(join(dir, '.changeset', 'config.json'), JSON.stringify({ changelog: false }));
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(join(dir, '.changeset', name), body, 'utf-8');
+  }
+  git('add', '-A');
+  git('commit', '-qm', 'fixture');
+  return dir;
+}
+
+const REAL = "---\n'nexus-agents': patch\n---\n\nA real change\n";
+// Exactly what `pnpm changeset --empty` writes — verified against the generator.
+const EMPTY = '---\n---\n';
+
+describe('countNonEmptyChangesetsAt', () => {
+  it('counts a changeset that declares a release', async () => {
+    const dir = repoWithChangesets({ 'real.md': REAL });
+    await expect(countNonEmptyChangesetsAt(dir, 'HEAD')).resolves.toBe(1);
+  });
+
+  it('does NOT count an empty changeset', async () => {
+    // The whole bug: the old file-count treated this as pending, so the
+    // fallback stood down waiting for a release PR the action never created.
+    const dir = repoWithChangesets({ 'empty.md': EMPTY });
+    await expect(countNonEmptyChangesetsAt(dir, 'HEAD')).resolves.toBe(0);
+  });
+
+  it('counts only the non-empty ones in a mixed directory', async () => {
+    const dir = repoWithChangesets({ 'real.md': REAL, 'empty.md': EMPTY });
+    await expect(countNonEmptyChangesetsAt(dir, 'HEAD')).resolves.toBe(1);
+  });
+
+  it('ignores README.md and config.json', async () => {
+    const dir = repoWithChangesets({ 'README.md': '# Changesets\n' });
+    await expect(countNonEmptyChangesetsAt(dir, 'HEAD')).resolves.toBe(0);
+  });
+
+  it('reports zero for a directory with no changesets at all', async () => {
+    // Distinct from "only empty ones" in cause, identical in consequence —
+    // both mean nothing is pending, so the fallback may publish.
+    const dir = repoWithChangesets({});
+    await expect(countNonEmptyChangesetsAt(dir, 'HEAD')).resolves.toBe(0);
+  });
+
+  it('reads the named commit, not the working tree', async () => {
+    // #4625's hardening: the decision must come from the immutable commit, so
+    // an uncommitted bump left in the tree by changesets/action cannot sway it.
+    const dir = repoWithChangesets({ 'real.md': REAL });
+    writeFileSync(join(dir, '.changeset', 'sneaky.md'), REAL, 'utf-8');
+    await expect(countNonEmptyChangesetsAt(dir, 'HEAD')).resolves.toBe(1);
+  });
+});

--- a/scripts/count-pending-changesets.ts
+++ b/scripts/count-pending-changesets.ts
@@ -1,0 +1,114 @@
+/**
+ * Counts NON-EMPTY pending changesets at a git ref (#4646).
+ *
+ * ## Why this exists
+ *
+ * `release.yml`'s `#2382` publish-race fallback used to count `.changeset/*.md`
+ * files. `changesets/action` counts *releases*:
+ *
+ * ```ts
+ * const hasNonEmptyChangesets = changesets.some((c) => c.releases.length > 0);
+ * case hasChangesets && !hasNonEmptyChangesets:
+ *   core.info("All changesets are empty; not creating PR");
+ *   return;
+ * ```
+ *
+ * An empty changeset is one file and zero releases, so the two disagreed about
+ * the same directory. When a version PR merged while an empty changeset sat on
+ * `main`, the action published nothing *and opened no PR*, while the fallback
+ * stood down logging "the next release-PR merge should close the loop" — a
+ * premise that was false, because no such PR existed. The release stalled
+ * silently with both components green.
+ *
+ * This repo makes that reachable rather than exotic: `CLAUDE.md` prescribes
+ * `pnpm changeset --empty` for genuinely no-release-impact PRs.
+ *
+ * ## Parity, not reimplementation
+ *
+ * It calls `@changesets/read` — the same library `changesets/action` uses via
+ * its own `readChangesetState` — so the two cannot drift on what counts as
+ * empty. Re-deriving the predicate in bash is what caused the divergence; doing
+ * it again in TypeScript would only move the seam (compare #4640, where two
+ * copies of one list sat on opposite sides of the same gate).
+ *
+ * ## Reading the commit, not the tree
+ *
+ * `#4625` hardened the fallback to derive its verdict from the commit object,
+ * because `changesets/action` leaves an uncommitted version bump in the working
+ * tree and that once made the fallback force-publish on every feature merge
+ * (#4487, #2696). `@changesets/read` only reads a directory, so this
+ * materialises the ref's `.changeset/` into a temp dir first and reads that.
+ * The immutable-input property is preserved.
+ *
+ * @module scripts/count-pending-changesets
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+
+import { readChangesets } from '@changesets/read';
+
+/** Runs git in `repoDir` and returns stdout. */
+function git(repoDir: string, args: readonly string[]): string {
+  return execFileSync('git', ['-C', repoDir, ...args], { encoding: 'utf-8' });
+}
+
+/**
+ * Number of changesets at `ref` that declare at least one release.
+ *
+ * Empty changesets, `README.md` and `config.json` are all excluded — the first
+ * because it declares no release, the others because they are not changesets.
+ */
+export async function countNonEmptyChangesetsAt(repoDir: string, ref: string): Promise<number> {
+  const staging = mkdtempSync(join(tmpdir(), 'changeset-count-'));
+  try {
+    const changesetDir = join(staging, '.changeset');
+    mkdirSync(changesetDir, { recursive: true });
+
+    // `git ls-tree` on a missing path exits 0 with empty output, so a repo with
+    // no .changeset/ at that ref reports zero rather than failing.
+    const listed = git(repoDir, ['ls-tree', '--name-only', ref, '.changeset/'])
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '');
+
+    for (const path of listed) {
+      const name = basename(path);
+      if (!name.endsWith('.md') && name !== 'config.json') continue;
+      writeFileSync(join(changesetDir, name), git(repoDir, ['show', `${ref}:${path}`]), 'utf-8');
+    }
+
+    // readChangesets needs a config.json present; synthesize a minimal one if
+    // the ref did not carry one, so a missing config cannot be read as "no
+    // pending changesets" and licence a force-publish.
+    const hasConfig = listed.some((p) => basename(p) === 'config.json');
+    if (!hasConfig) {
+      writeFileSync(
+        join(changesetDir, 'config.json'),
+        JSON.stringify({ changelog: false }),
+        'utf-8'
+      );
+    }
+
+    const changesets = await readChangesets(staging);
+    return changesets.filter((changeset) => changeset.releases.length > 0).length;
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1]?.endsWith('count-pending-changesets.ts') === true) {
+  const ref = process.argv[2] ?? 'HEAD';
+  countNonEmptyChangesetsAt(process.cwd(), ref)
+    .then((count) => {
+      process.stdout.write(`${String(count)}\n`);
+    })
+    .catch((error: unknown) => {
+      // Fail loud rather than printing 0 — a swallowed error here would read as
+      // "nothing pending" and licence a force-publish.
+      process.stderr.write(`count-pending-changesets failed: ${String(error)}\n`);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
Closes #4646. Answers #4626.

## #4626 first: the race is still open under v2.1.0 — keep the fallback

Read from `changesets/action` at the exact pinned SHA (`198f833…`, v2.1.0), `src/index.ts`:

```ts
let hasChangesets = changesets.length !== 0;
switch (true) {
  case !hasChangesets && !hasPublishScript:            return;
  case !hasChangesets && hasPublishScript:  { …publish…  return; }   // ← only publish path
  case hasChangesets && !hasNonEmptyChangesets:        return;
  case hasChangesets:                       { runVersion(…); return; }
}
```

Publishing lives in exactly one branch, chosen purely on `changesets.length`. A version-PR merge landing on a `main` that already carries changesets takes `case hasChangesets`, opens the next version PR, and returns **without publishing the version it just bumped**. That is #2382, unchanged. The v2 GitHub-API push path (#692) sits inside `runVersion`, downstream of the switch, and cannot affect whether publish runs.

So the fallback is **load-bearing**. No scratch-repo reproduction was needed — the source is unambiguous, and #4626 rightly forbids testing it here.

## What that reading turned up

Case 3 — `hasChangesets && !hasNonEmptyChangesets` → `All changesets are empty; not creating PR` → return. **No publish and no PR.**

The fallback's gate counted files:

```bash
pending_changesets=$(git ls-tree … | grep -E '\.md$' | grep -cv 'README\.md')
if [ "$pending_changesets" -gt 0 ]; then
  echo "::warning::… The next release-PR merge should close the loop. Not force-publishing."
```

An empty changeset is one file and zero releases. So:

1. A version PR merges (bumping to X) while an empty changeset sits on `main`.
2. Action: `hasChangesets` true, `hasNonEmptyChangesets` false → no publish, **no PR**.
3. Fallback: X > npm, but `pending_changesets = 1` → stands down, citing a release-PR merge that will never happen.

X never publishes, nothing is open to fix it, both components exit 0 having logged a reason. The stall clears only when someone incidentally lands a non-empty changeset — the recovery is accidental.

This is reachable here *because of* our own documented practice: `CLAUDE.md` prescribes `pnpm changeset --empty` for no-release-impact PRs.

## The fix is parity, not a better reimplementation

`scripts/count-pending-changesets.ts` calls `@changesets/read` — the same library the action uses through its `readChangesetState`. Re-deriving the predicate in bash caused the divergence; re-deriving it in TypeScript would only move the seam. Same shape as #4640, where two copies of one list sat on opposite sides of the same gate.

`@changesets/read@1.0.0` was already resolved in the tree transitively via `@changesets/cli`; this promotes it to an explicit devDependency, so no new install weight.

**It reads the commit, not the tree.** `@changesets/read` only takes a directory, so the script materialises the ref's `.changeset/` from the commit object into a temp dir first. That preserves #4625's hardening — the reason the fallback force-published on every feature merge (#4487, #2696) was reading an uncommitted bump the action had left in the working tree.

Two smaller decisions worth flagging: a missing `config.json` is **synthesised** rather than treated as "no changesets", and a read failure **exits 1** rather than printing 0 — in both cases the silent-zero would read as "nothing pending" and licence a force-publish.

## Tests

Six, against real git repos with real commits, including the two that pin the bug:

- an empty changeset counts **0** (the bug)
- a mixed directory counts only the non-empty one
- the count comes from the named commit, not from a file added to the working tree afterwards (#4625's property)

Verified `pnpm changeset --empty` emits exactly `---\n---\n` by running the generator, rather than assuming the format.

## Also

`docs/ops/release-changeset-race.md` said the action "runs in one of two modes." v2 has four, and the third is the one that stalls. Corrected, with case 3 called out explicitly.

## Verification

- 6 new tests pass; eslint, prettier, markdownlint, export ratchet clean
- YAML parses; the script runs green against this repo's `HEAD` and correctly reports `1` (#4644's unconsumed changeset)
- `pnpm build` precedes the step, so `npx tsx` resolves
- the two `tsc` errors in the repo (`check-harness-alignment.ts`, `website/src/content.config.ts`) are pre-existing on `main`
