### PR TITLE
feat(ci): detect a main head with zero push-triggered runs

### DIFF
--- a/.github/workflows/release-stall-check.yml
+++ b/.github/workflows/release-stall-check.yml
@@ -86,3 +86,21 @@ jobs:
         run: |
           echo "::error::Release pipeline is stalled — see the tracking issue."
           exit 1
+
+      # A second, independent question on the same schedule (#4648): did main's
+      # head get its push-triggered runs at all? On 2026-08-23 a merge produced
+      # ZERO — no CI, no Release — while its neighbours got 7-9 each. The
+      # release half of that is already covered by the assess step above, but
+      # nothing noticed that main had never been CI'd: the commit is not marked
+      # failing, it is unmarked, so main looks green.
+      #
+      # `always()` because the stall step above exits 1 and would otherwise skip
+      # this. No tracking issue: unlike a stall, a dropped event is transient and
+      # clears on the next push, so a red scheduled run is the proportionate
+      # alarm and duplicating the issue-filing block would not earn its keep.
+      - name: Check main's head has push-triggered runs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: npx tsx scripts/check-missing-push-runs.ts

--- a/scripts/check-missing-push-runs.test.ts
+++ b/scripts/check-missing-push-runs.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the dropped-push-event detector (#4648).
+ *
+ * @module scripts/check-missing-push-runs.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { assessPushRuns, MIN_COMMIT_AGE_MS } from './check-missing-push-runs.js';
+
+const NOW = Date.UTC(2026, 7, 23, 18, 0, 0);
+const MINUTE = 60_000;
+
+describe('assessPushRuns', () => {
+  it('reports ok when push runs exist', () => {
+    const verdict = assessPushRuns({
+      sha: 'abc1234',
+      committedAtMs: NOW - 60 * MINUTE,
+      pushRunCount: 9,
+      now: NOW,
+    });
+    expect(verdict.kind).toBe('ok');
+  });
+
+  it('reports missing when an old commit has zero push runs', () => {
+    // The observed failure: e7caa41835 had 0 while every neighbouring commit
+    // had 7-9. No CI, no Release, and the commit is not marked failing.
+    const verdict = assessPushRuns({
+      sha: 'e7caa418',
+      committedAtMs: NOW - 60 * MINUTE,
+      pushRunCount: 0,
+      now: NOW,
+    });
+    expect(verdict.kind).toBe('missing');
+  });
+
+  it('withholds judgement on a commit too recent to have registered runs', () => {
+    // Not "ok" — unmeasured. A push seconds old legitimately has no runs yet,
+    // and reporting that as healthy is the same defect the detector exists to
+    // catch, one level up.
+    const verdict = assessPushRuns({
+      sha: 'fresh123',
+      committedAtMs: NOW - MINUTE,
+      pushRunCount: 0,
+      now: NOW,
+    });
+    expect(verdict.kind).toBe('too-recent');
+  });
+
+  it('still reports ok for a recent commit that already has runs', () => {
+    const verdict = assessPushRuns({
+      sha: 'fresh456',
+      committedAtMs: NOW - MINUTE,
+      pushRunCount: 3,
+      now: NOW,
+    });
+    expect(verdict.kind).toBe('ok');
+  });
+
+  it('treats the age boundary as too-recent, not missing', () => {
+    // Retain on the tie: a false alarm on a commit that was about to register
+    // its runs would train people to ignore the detector.
+    const verdict = assessPushRuns({
+      sha: 'boundary',
+      committedAtMs: NOW - MIN_COMMIT_AGE_MS,
+      pushRunCount: 0,
+      now: NOW,
+    });
+    expect(verdict.kind).toBe('too-recent');
+  });
+
+  it('carries the sha and count so the alarm can name them', () => {
+    const verdict = assessPushRuns({
+      sha: 'e7caa418',
+      committedAtMs: NOW - 6 * 60 * MINUTE,
+      pushRunCount: 0,
+      now: NOW,
+    });
+    expect(verdict.kind).toBe('missing');
+    if (verdict.kind === 'missing') {
+      expect(verdict.sha).toBe('e7caa418');
+      expect(verdict.ageMinutes).toBe(360);
+    }
+  });
+});

--- a/scripts/check-missing-push-runs.ts
+++ b/scripts/check-missing-push-runs.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env npx tsx
+/**
+ * Dropped-push-event detector (#4648).
+ *
+ * ## The failure
+ *
+ * On 2026-08-23 a merge to `main` (`e7caa41835`) produced **no push-triggered
+ * workflow runs at all** — no CI, no Release, no CodeQL — while the commits on
+ * either side got 7–9 each. The only runs carrying that SHA came from `issues`
+ * events. Nothing in the repo's configuration explains it: `release.yml` has no
+ * `paths:` filter, so it fires on every push to `main`. It looks like a dropped
+ * event on GitHub's side, and it recovered on the next merge.
+ *
+ * ## Why it needs a detector at all
+ *
+ * The release half self-heals and is already covered: `check-release-stuck.ts`
+ * (#4500) keys on changesets present with no version PR, which catches "no run
+ * at all" even though its author only enumerated "run went green without a PR"
+ * and "run went red".
+ *
+ * The CI half is not covered. The commit is not marked failing — it is
+ * **unmarked**. Branch protection gates pull requests, so a squash-merge whose
+ * post-merge CI never runs leaves `main` in a state nobody verified and nothing
+ * reports. The next person sees no red X and reasonably concludes it is green.
+ * Absence of a result reading as a passing result is the same defect this repo
+ * treats as a p1 on the governor path (#4580), one level up from verdicts.
+ *
+ * ## Why "zero push runs" is the predicate
+ *
+ * Measured across the 12 most recent `main` commits before this was written:
+ * every one had 7–9 push-event runs except the dropped commit, which had 0.
+ * The signature is unambiguous, and it needs no model of which workflows *should*
+ * have fired — parsing every `paths:` filter against the commit's diff would be
+ * an elaborate way to reach the same answer with more ways to be wrong.
+ *
+ * @module scripts/check-missing-push-runs
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * How old a commit must be before zero runs counts as evidence.
+ *
+ * A push seconds old legitimately has no registered runs yet. Fifteen minutes
+ * is far beyond GitHub's normal dispatch latency and far below this check's
+ * six-hour cadence, so it costs no detection time.
+ */
+export const MIN_COMMIT_AGE_MS = 15 * 60 * 1000;
+
+/** What the detector concluded. */
+export type PushRunVerdict =
+  | { kind: 'ok'; sha: string; pushRunCount: number }
+  | { kind: 'too-recent'; sha: string; ageMinutes: number }
+  | { kind: 'missing'; sha: string; ageMinutes: number };
+
+/** Everything the verdict is computed from. */
+export interface PushRunInputs {
+  readonly sha: string;
+  readonly committedAtMs: number;
+  readonly pushRunCount: number;
+  readonly now: number;
+}
+
+/**
+ * Decides whether `main`'s head is missing its push-triggered runs.
+ *
+ * `too-recent` is deliberately distinct from `ok`. A fresh commit with no runs
+ * has not been measured, and reporting that as healthy would be the same
+ * absence-as-success error the detector exists to catch.
+ */
+export function assessPushRuns(inputs: PushRunInputs): PushRunVerdict {
+  const ageMs = inputs.now - inputs.committedAtMs;
+  const ageMinutes = Math.round(ageMs / 60_000);
+
+  if (inputs.pushRunCount > 0) {
+    return { kind: 'ok', sha: inputs.sha, pushRunCount: inputs.pushRunCount };
+  }
+  // Retain on the tie — a false alarm on a commit that was about to register
+  // its runs would train everyone to ignore this.
+  if (ageMs <= MIN_COMMIT_AGE_MS) {
+    return { kind: 'too-recent', sha: inputs.sha, ageMinutes };
+  }
+  return { kind: 'missing', sha: inputs.sha, ageMinutes };
+}
+
+/** Renders a verdict for the run log, keeping the three outcomes distinct. */
+export function formatPushRunVerdict(verdict: PushRunVerdict): string {
+  switch (verdict.kind) {
+    case 'ok':
+      return `main@${verdict.sha} has ${String(verdict.pushRunCount)} push-triggered run(s).`;
+    case 'too-recent':
+      return `main@${verdict.sha} is ${String(verdict.ageMinutes)}m old with no runs yet — too recent to judge.`;
+    case 'missing':
+      return (
+        `::error::main@${verdict.sha} is ${String(verdict.ageMinutes)}m old and has ZERO ` +
+        `push-triggered workflow runs. No CI evaluated this commit and no Release ran. ` +
+        `The commit is not marked failing — it is unmarked, so main looks green. ` +
+        `Recovery: re-dispatch the workflows for this SHA (\`gh workflow run release.yml --ref main\` ` +
+        `for the release path), or land another commit, which re-triggers everything.`
+      );
+  }
+}
+
+function sh(command: string, args: readonly string[]): string {
+  return execFileSync(command, [...args], { encoding: 'utf-8' }).trim();
+}
+
+if (process.argv[1]?.endsWith('check-missing-push-runs.ts') === true) {
+  const sha = sh('git', ['rev-parse', 'HEAD']);
+  const committedAtMs = Number(sh('git', ['log', '-1', '--format=%ct', sha])) * 1000;
+  const pushRunCount = Number(
+    sh('gh', [
+      'api',
+      `repos/${process.env['GITHUB_REPOSITORY'] ?? 'nexus-substrate/nexus-agents'}/actions/runs?head_sha=${sha}&per_page=100`,
+      '-q',
+      '[.workflow_runs[] | select(.event=="push")] | length',
+    ])
+  );
+
+  const verdict = assessPushRuns({ sha, committedAtMs, pushRunCount, now: Date.now() });
+  console.error(formatPushRunVerdict(verdict));
+  process.exit(verdict.kind === 'missing' ? 1 : 0);
+}


### PR DESCRIPTION
Closes #4648.

## The gap

On 2026-08-23 a merge to `main` (`e7caa41835`) produced **no push-triggered workflow runs at all** — no CI, no Release, no CodeQL. Only `issues`-event runs carried that SHA. `release.yml` has no `paths:` filter, so nothing in our configuration explains it; the event was dropped on GitHub's side and recovered on the next merge.

**The release half was already covered.** `check-release-stuck.ts` (#4500) keys on durable repo state — changesets present with no version PR — so it catches "no run at all" even though its author only enumerated "run went green without a PR" and "run went red." Verified: it fired correctly on the live state. That is a design outperforming its own rationale, and it is why this PR adds no second release detector.

**The CI half was not covered.** The commit is not marked failing — it is **unmarked**. Branch protection gates pull requests, so a squash-merge whose post-merge CI never runs leaves `main` in a state nobody verified and nothing reports. The next person sees no red X and reasonably concludes it is green.

Absence of a result reading as a passing result is the defect this repo treats as p1 on the governor path (#4580), one level up from verdicts.

## Why "zero push runs" is the whole predicate

Measured across the 12 most recent `main` commits before writing anything:

```
a7a28ad7  push-runs=9      43a5f50d  push-runs=8      73343406  push-runs=9
b5af10e8  push-runs=9      306f9b24  push-runs=8      a48aa881  push-runs=8
e7caa418  push-runs=0  ←   1a303db7  push-runs=9      6d4e13ff  push-runs=9
db1a5572  push-runs=9      78e1ce9c  push-runs=8      3efca8c3  push-runs=7
```

Unambiguous. The detector needs no model of *which* workflows should have fired — parsing every `paths:` filter against the commit's diff would reach the same answer with considerably more ways to be wrong.

## Three verdicts, and the third earns its place

| Verdict | Meaning |
| --- | --- |
| `ok` | runs exist |
| `too-recent` | commit younger than 15m with no runs — **not measured** |
| `missing` | old enough, zero runs — the alarm |

`too-recent` is deliberately distinct from `ok`. A push seconds old legitimately has no registered runs, and reporting that as healthy would be the same absence-as-success error the detector exists to catch. Ties go to `too-recent`, because a false alarm on a commit that was about to register its runs is how a detector gets ignored.

## Control

Not just unit tests — run against the real commits:

```
MISSING     main@e7caa418 is 26m old and has ZERO push-triggered workflow runs…
OK          main@a7a28ad7 has 9 push-triggered run(s).
OK          main@b5af10e8 has 9 push-triggered run(s).
OK          main@db1a5572 has 9 push-triggered run(s).
```

Plus 6 unit tests on the pure predicate, including the age boundary.

## Placement

Added to the existing 6-hourly `release-stall-check.yml` rather than a new workflow — it already asks a scheduled question about `main`'s durable state. `if: always()` because the stall step above exits 1 and would otherwise skip it.

**No tracking issue is filed on detection**, unlike the stall path. A dropped event is transient and clears on the next push, so a red scheduled run is the proportionate alarm; duplicating the issue-filing block would not earn its keep. That is a deliberate asymmetry, not an oversight.

## Verification

eslint, prettier, `tsc`, export ratchet clean; YAML parses; the script exits 0 against current `main`. No changeset — this touches no shippable source.
