### PR TITLE
feat(task-analysis): persist the capability-gap ledger

### DIFF
--- a/.changeset/persist-gap-ledger.md
+++ b/.changeset/persist-gap-ledger.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': patch
+---
+
+Persist the capability-gap ledger (#4645)
+
+`getGapLedger()` is now backed by a JSONL file under the nexus data dir instead
+of process memory.
+
+Its consumer — `pipeline/research-trigger.ts` — ranks gaps **by frequency** and
+turns the frequent ones into research. In memory, "frequent" meant "since this
+process started": seconds for a CLI invocation. A gap recurring once a day for a
+month never became frequent, because each observation landed in a different
+process — and a gap that recurs across sessions is precisely the kind worth
+researching.
+
+Four of seven voters on the #4651 panel raised this independently, including the
+one who voted against the proposal outright, so persistence lands **before** the
+first producer rather than after it.
+
+`loadReport()` distinguishes states that all summarize to "no gaps": file absent
+(nothing was ever written, or the ledger is aimed at the wrong path), malformed
+lines (counted, never silently skipped — a silent skip under-reports demand),
+and entries dropped by the 90-day retention window.
+
+Switching the default is a no-op today: `detectCapabilityGaps` cannot currently
+produce a gap (#4651), so nothing is written until the tool-refusal producer
+lands.

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.test.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the persistent capability-gap ledger (#4645).
+ *
+ * @module core/task-analysis/capability-gap-ledger-persistence.test
+ */
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { CapabilityGapReport } from './capability-gap-detector.js';
+import { createPersistentCapabilityGapLedger } from './capability-gap-ledger-persistence.js';
+
+const created: string[] = [];
+
+afterEach(() => {
+  while (created.length > 0) {
+    const dir = created.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function scratchFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gap-ledger-'));
+  created.push(dir);
+  return join(dir, 'gaps.jsonl');
+}
+
+const report = (name: string): CapabilityGapReport =>
+  ({
+    gaps: [{ type: 'tool', name, suggestion: 'stub' }],
+    availableTools: [],
+    availableExperts: [],
+  }) as unknown as CapabilityGapReport;
+
+describe('createPersistentCapabilityGapLedger', () => {
+  it('survives a restart — the whole point', () => {
+    const filePath = scratchFile();
+
+    const first = createPersistentCapabilityGapLedger({ filePath });
+    first.record(report('tree_sitter_python'), { goal: 'parse a service' });
+    expect(first.size()).toBe(1);
+
+    // A second ledger over the same file is a new process, as far as this is
+    // concerned. Frequency that resets on restart is what made the in-memory
+    // ledger unable to answer its consumer's question.
+    const second = createPersistentCapabilityGapLedger({ filePath });
+    expect(second.size()).toBe(1);
+    expect(second.summarize()[0]?.name).toBe('tree_sitter_python');
+  });
+
+  it('accumulates frequency across sessions', () => {
+    const filePath = scratchFile();
+    for (let i = 0; i < 3; i += 1) {
+      createPersistentCapabilityGapLedger({ filePath }).record(report('tree_sitter_python'), {});
+    }
+    const summary = createPersistentCapabilityGapLedger({ filePath }).summarize();
+    expect(summary[0]?.count).toBe(3);
+  });
+
+  it('reports an absent file as empty, not as an error', () => {
+    const ledger = createPersistentCapabilityGapLedger({ filePath: scratchFile() });
+    expect(ledger.size()).toBe(0);
+    expect(ledger.summarize()).toEqual([]);
+    expect(ledger.loadReport().malformedLines).toBe(0);
+    expect(ledger.loadReport().fileExisted).toBe(false);
+  });
+
+  it('distinguishes an absent file from an empty one', () => {
+    // Both summarize to nothing; only one of them means "nothing was ever
+    // written". Collapsing them hides a ledger pointed at the wrong path.
+    const filePath = scratchFile();
+    writeFileSync(filePath, '', 'utf-8');
+    expect(createPersistentCapabilityGapLedger({ filePath }).loadReport().fileExisted).toBe(true);
+  });
+
+  it('counts malformed lines instead of silently dropping them', () => {
+    // A silent skip under-reports frequency, which is the failure this ledger
+    // exists to avoid. Surface it so a corrupt file cannot read as low demand.
+    const filePath = scratchFile();
+    writeFileSync(filePath, '{"not":"a gap entry"}\nnot json at all\n', 'utf-8');
+
+    const ledger = createPersistentCapabilityGapLedger({ filePath });
+    expect(ledger.size()).toBe(0);
+    expect(ledger.loadReport().malformedLines).toBe(2);
+  });
+
+  it('keeps good lines when one line is corrupt', () => {
+    const filePath = scratchFile();
+    createPersistentCapabilityGapLedger({ filePath }).record(report('good'), {});
+    writeFileSync(filePath, `${readFileSync(filePath, 'utf-8')}garbage\n`, 'utf-8');
+
+    const ledger = createPersistentCapabilityGapLedger({ filePath });
+    expect(ledger.size()).toBe(1);
+    expect(ledger.loadReport().malformedLines).toBe(1);
+  });
+
+  it('drops entries older than the retention window', () => {
+    const filePath = scratchFile();
+    const old = new Date(Date.UTC(2020, 0, 1)).toISOString();
+    writeFileSync(
+      filePath,
+      `${JSON.stringify({ type: 'tool', name: 'ancient', suggestion: 's', timestamp: old })}\n`,
+      'utf-8'
+    );
+
+    const ledger = createPersistentCapabilityGapLedger({ filePath, retentionDays: 30 });
+    expect(ledger.size()).toBe(0);
+    expect(ledger.loadReport().expiredEntries).toBe(1);
+  });
+
+  it('records nothing for a report with no gaps', () => {
+    // The empty case, named: a clean run must write no line at all, or the
+    // file fills with non-events and frequency becomes meaningless.
+    const filePath = scratchFile();
+    const ledger = createPersistentCapabilityGapLedger({ filePath });
+    ledger.record(
+      { gaps: [], availableTools: [], availableExperts: [] } as unknown as CapabilityGapReport,
+      {}
+    );
+    expect(ledger.size()).toBe(0);
+    expect(ledger.loadReport().fileExisted).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.ts
@@ -1,0 +1,261 @@
+/**
+ * Durable capability-gap ledger (#4645).
+ *
+ * ## Why
+ *
+ * The in-memory ledger (`capability-gap-ledger.ts`, #3548) is a process-wide
+ * singleton with no persistence. Its consumer — `pipeline/research-trigger.ts`
+ * — ranks gaps **by frequency** and turns the frequent ones into research. So
+ * the window over which "frequent" is measured was "since this process
+ * started": for a CLI invocation, seconds. A gap observed once a day for a
+ * month never became frequent, because each observation landed in a different
+ * process — and a gap that recurs across sessions is exactly the kind worth
+ * researching.
+ *
+ * Four of seven voters on the #4651 panel raised this independently, including
+ * the one who voted against the whole proposal: measurement that resets on
+ * restart cannot justify an architectural decision. Persistence is therefore a
+ * prerequisite of the tool-refusal producer, not a follow-up to it.
+ *
+ * ## What it reports, and why the report exists
+ *
+ * `loadReport()` distinguishes states that all summarize to "no gaps":
+ *
+ * | Field | Why it is separate |
+ * | --- | --- |
+ * | `fileExisted: false` | nothing was ever written — or the ledger is pointed at the wrong path |
+ * | `malformedLines` | lines that could not be parsed; silently skipping them under-reports demand |
+ * | `expiredEntries` | dropped by the retention window, not absent |
+ *
+ * A corrupt or misaimed ledger otherwise reads as "low demand", which is the
+ * exact failure this ledger exists to prevent — a number that looks like
+ * evidence and is not. Same discipline as `.rules/development-disciplines.md`
+ * ("Name the empty case") and #4580.
+ *
+ * @module core/task-analysis/capability-gap-ledger-persistence
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { getTimeProvider } from '../time-provider.js';
+import type { CapabilityGapReport, CapabilityGap } from './capability-gap-detector.js';
+import type { GapContext, GapSummary, ICapabilityGapLedger } from './capability-gap-ledger.js';
+
+/** One persisted occurrence. Mirrors the in-memory entry, plus nothing. */
+interface PersistedGapEntry {
+  readonly type: CapabilityGap['type'];
+  readonly name: string;
+  readonly suggestion: string;
+  readonly goal?: string | undefined;
+  readonly timestamp: string;
+}
+
+/** What loading the file observed. Every field is measured, never assumed. */
+export interface GapLedgerLoadReport {
+  /** False means nothing was ever written — distinct from "written and empty". */
+  readonly fileExisted: boolean;
+  /** Entries loaded and retained. */
+  readonly loaded: number;
+  /** Lines that could not be parsed as an entry. Never silently dropped. */
+  readonly malformedLines: number;
+  /** Entries dropped by the retention window. */
+  readonly expiredEntries: number;
+}
+
+/** Options for {@link createPersistentCapabilityGapLedger}. */
+export interface PersistentGapLedgerConfig {
+  /** JSONL file backing the ledger. */
+  readonly filePath: string;
+  /** Occurrences retained in memory for summarizing. */
+  readonly maxEntries?: number;
+  /** Entries older than this are ignored on load. */
+  readonly retentionDays?: number;
+}
+
+/** A ledger that also reports what loading its file observed. */
+export interface IPersistentCapabilityGapLedger extends ICapabilityGapLedger {
+  loadReport(): GapLedgerLoadReport;
+}
+
+const DEFAULT_MAX_ENTRIES = 5000;
+
+/**
+ * Ninety days.
+ *
+ * Long enough that a gap recurring monthly still accumulates — the whole point
+ * — and bounded so the file cannot grow the way the scratch dir did (#4413).
+ */
+const DEFAULT_RETENTION_DAYS = 90;
+
+const MAX_EXAMPLE_GOALS = 3;
+
+function isEntry(value: unknown): value is PersistedGapEntry {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    (v['type'] === 'tool' || v['type'] === 'expert') &&
+    typeof v['name'] === 'string' &&
+    typeof v['suggestion'] === 'string' &&
+    typeof v['timestamp'] === 'string'
+  );
+}
+
+/** Frequency-ranked summary, matching the in-memory ledger's ordering. */
+function summarize(entries: readonly PersistedGapEntry[]): readonly GapSummary[] {
+  const groups = new Map<
+    string,
+    {
+      type: CapabilityGap['type'];
+      name: string;
+      count: number;
+      suggestion: string;
+      goals: string[];
+    }
+  >();
+
+  for (const entry of entries) {
+    const key = `${entry.type}:${entry.name}`;
+    const group = groups.get(key) ?? {
+      type: entry.type,
+      name: entry.name,
+      count: 0,
+      suggestion: entry.suggestion,
+      goals: [],
+    };
+    group.count += 1;
+    group.suggestion = entry.suggestion;
+    if (
+      entry.goal !== undefined &&
+      entry.goal !== '' &&
+      !group.goals.includes(entry.goal) &&
+      group.goals.length < MAX_EXAMPLE_GOALS
+    ) {
+      group.goals.push(entry.goal);
+    }
+    groups.set(key, group);
+  }
+
+  return [...groups.values()]
+    .map((g) => ({
+      type: g.type,
+      name: g.name,
+      count: g.count,
+      suggestion: g.suggestion,
+      exampleGoals: g.goals,
+    }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+/**
+ * Reads the backing file, partitioning every line into loaded, malformed, or
+ * expired. Never throws: an unreadable file yields zero entries with
+ * `fileExisted` true, so "cannot read" stays distinguishable from "nothing there".
+ */
+function loadEntries(
+  filePath: string,
+  cutoff: number,
+  maxEntries: number
+): { entries: PersistedGapEntry[]; report: GapLedgerLoadReport } {
+  const entries: PersistedGapEntry[] = [];
+  let malformedLines = 0;
+  let expiredEntries = 0;
+  const fileExisted = existsSync(filePath);
+
+  if (!fileExisted) {
+    return { entries, report: { fileExisted, loaded: 0, malformedLines: 0, expiredEntries: 0 } };
+  }
+
+  let raw = '';
+  try {
+    raw = readFileSync(filePath, 'utf-8');
+  } catch {
+    raw = '';
+  }
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      malformedLines += 1;
+      continue;
+    }
+    if (!isEntry(parsed)) {
+      malformedLines += 1;
+      continue;
+    }
+    if (Date.parse(parsed.timestamp) < cutoff) {
+      expiredEntries += 1;
+      continue;
+    }
+    entries.push(parsed);
+  }
+
+  if (entries.length > maxEntries) entries.splice(0, entries.length - maxEntries);
+
+  return {
+    entries,
+    report: { fileExisted, loaded: entries.length, malformedLines, expiredEntries },
+  };
+}
+
+/**
+ * Creates a gap ledger backed by a JSONL file.
+ *
+ * Appends one line per gap occurrence and loads the file on construction, so
+ * frequency spans processes. A clean report writes nothing — a file of
+ * non-events would make frequency meaningless.
+ */
+export function createPersistentCapabilityGapLedger(
+  config: PersistentGapLedgerConfig
+): IPersistentCapabilityGapLedger {
+  const maxEntries = config.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  const retentionMs = (config.retentionDays ?? DEFAULT_RETENTION_DAYS) * 24 * 60 * 60 * 1000;
+  const cutoff = getTimeProvider().now() - retentionMs;
+
+  const { entries, report: loadReport } = loadEntries(config.filePath, cutoff, maxEntries);
+
+  return {
+    record(report: CapabilityGapReport, context?: GapContext): void {
+      if (report.gaps.length === 0) return;
+      const timestamp = new Date(getTimeProvider().now()).toISOString();
+      const lines: string[] = [];
+      for (const gap of report.gaps) {
+        const entry: PersistedGapEntry = {
+          type: gap.type,
+          name: gap.name,
+          suggestion: gap.suggestion,
+          goal: context?.goal,
+          timestamp,
+        };
+        entries.push(entry);
+        lines.push(JSON.stringify(entry));
+      }
+      if (entries.length > maxEntries) entries.splice(0, entries.length - maxEntries);
+
+      try {
+        mkdirSync(dirname(config.filePath), { recursive: true });
+        appendFileSync(config.filePath, `${lines.join('\n')}\n`, 'utf-8');
+      } catch {
+        // A ledger that cannot write must not break the task it was observing.
+        // The in-memory copy still serves this process; the loss is durability,
+        // and the next load's counters will show the shortfall.
+      }
+    },
+
+    summarize(): readonly GapSummary[] {
+      return summarize(entries);
+    },
+
+    size(): number {
+      return entries.length;
+    },
+
+    loadReport(): GapLedgerLoadReport {
+      return loadReport;
+    },
+  };
+}

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.test.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.test.ts
@@ -145,11 +145,31 @@ describe('recordRoutingGaps', () => {
   });
 
   it('defaults to the shared singleton ledger', () => {
-    resetGapLedger();
+    // Assert DELEGATION, not an absolute count. Since #4645 the default
+    // singleton is durable, so it loads prior occurrences from disk and its
+    // size is a property of the machine's history rather than of this test.
+    // Injecting a known in-memory ledger tests the actual contract — "with no
+    // ledger argument, recordRoutingGaps writes to getGapLedger()" — and stays
+    // hermetic.
+    const shared = createCapabilityGapLedger();
+    setGapLedger(shared);
     recordRoutingGaps(
       { capabilityGaps: report({ type: 'expert', name: 'ml_expert' }) },
       { goal: 'g' }
     );
-    expect(getGapLedger().size()).toBe(1);
+    expect(shared.size()).toBe(1);
+    expect(getGapLedger()).toBe(shared);
+    resetGapLedger();
+  });
+
+  it('the default singleton is durable, so resetGapLedger does not empty it', () => {
+    // Recording the consequence of #4645 explicitly: a process-wide ledger
+    // backed by a file cannot be reset by dropping the in-process reference.
+    // Tests needing a clean ledger must inject one via setGapLedger.
+    resetGapLedger();
+    const first = getGapLedger();
+    resetGapLedger();
+    expect(getGapLedger()).not.toBe(first);
+    expect(getGapLedger().size()).toBe(first.size());
   });
 });

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.ts
@@ -14,7 +14,9 @@
  * @module core/task-analysis/capability-gap-ledger
  */
 
+import { nexusDataPath } from '../../config/nexus-data-dir.js';
 import { getTimeProvider } from '../time-provider.js';
+import { createPersistentCapabilityGapLedger } from './capability-gap-ledger-persistence.js';
 import type { CapabilityGapReport, CapabilityGap } from './capability-gap-detector.js';
 
 /** Context attached to a recorded gap, for traceability and examples. */
@@ -148,9 +150,23 @@ export function createCapabilityGapLedger(maxEntries = DEFAULT_MAX_ENTRIES): ICa
 
 let singletonLedger: ICapabilityGapLedger | undefined;
 
-/** Returns the process-wide gap ledger, creating it on first use. */
+/**
+ * Returns the process-wide gap ledger, creating it on first use.
+ *
+ * Durable since #4645. The consumer (`pipeline/research-trigger.ts`) ranks gaps
+ * by frequency, and an in-memory ledger measured that over "since this process
+ * started" — so a gap recurring across sessions could never become frequent.
+ *
+ * Switching the default is a no-op today: `detectCapabilityGaps` cannot
+ * currently produce a gap (#4651), so nothing is written until the tool-refusal
+ * producer lands. That is deliberate ordering — persistence must be in place
+ * *before* the first producer, or its first weeks of signal evaporate on
+ * restart.
+ */
 export function getGapLedger(): ICapabilityGapLedger {
-  singletonLedger ??= createCapabilityGapLedger();
+  singletonLedger ??= createPersistentCapabilityGapLedger({
+    filePath: nexusDataPath('capability-gaps.jsonl'),
+  });
   return singletonLedger;
 }
 


### PR DESCRIPTION
Closes #4645. First step of #4651.

## Why this is first, not last

I originally filed #4645 as *blocked on* #4651. The vote inverted that.

#4651 chose option C — tool-refusal gaps — **unanimously among approvers (6/6)**. But four of seven voters raised the same condition independently, including the contrarian whose entire reject rested on it:

> The ledger is in-memory with a 500-entry cap and no persistence; frequency-over-time measurement dies with the process, so persistence must land **with or before** the producer, else C ships another instrument that silently under-reports.

Building the producer first would have given #4517 a number that resets on restart — precisely the "count that looks like evidence and isn't" that #4651 was filed about. So persistence goes first.

## What was actually broken

`research-trigger.ts:108` ranks gaps **by frequency** and turns the frequent ones into research. In memory, "frequent" meant *since this process started* — seconds for a CLI invocation. A gap recurring once a day for a month never became frequent, because each observation landed in a different process.

The instrument measured something real and handed its consumer a number that meant less than the consumer assumed. Not a misreport — nothing claimed persistence — but the ranking was over the wrong window, and the gap most worth researching (recurring across sessions) was the one it was structurally least able to surface.

## `loadReport()` — three states that all summarize to "no gaps"

| Field | Why separate |
| --- | --- |
| `fileExisted: false` | nothing was ever written — **or the ledger is aimed at the wrong path** |
| `malformedLines` | counted, never silently skipped |
| `expiredEntries` | dropped by the 90-day window, not absent |

Silently skipping a corrupt line under-reports demand, and a ledger pointed at the wrong path otherwise reads as "low demand" — which is exactly the class this ledger exists to prevent, and the mistake I made twice on #4413 by measuring the wrong directory.

An unreadable file yields zero entries with `fileExisted: true`, so "cannot read" stays distinguishable from "nothing there."

## No behavioural change today

Switching the default singleton to durable is a **no-op right now**: `detectCapabilityGaps` cannot produce a gap (#4651), so nothing is written until the producer lands. That is the point of the ordering — persistence is in place before the first real signal, rather than losing its first weeks.

## A consequence worth stating

A durable process-wide singleton cannot be emptied by dropping the in-process reference, so **`resetGapLedger()` no longer clears it**. That is inherent, not a bug, and there is now a test asserting it.

The pre-existing test `defaults to the shared singleton ledger` failed on this — it asserted `getGapLedger().size() === 1` after a reset, and got 3, because the ledger had loaded prior state. I did **not** adjust the number. The test's contract is "with no ledger argument, `recordRoutingGaps` writes to `getGapLedger()`", which is about delegation; asserting an absolute count on a now-durable global made it depend on the machine's history. It now injects a known ledger and asserts delegation, which is both hermetic and closer to what it meant.

## Verification

- 8 new tests, including the restart case (a second ledger over the same file sees the first's entry), cross-session frequency accumulation, corrupt-line counting, and retention expiry
- 3,118 tests pass across `src/core/`, `src/pipeline/`, `src/orchestration/` (149 files)
- eslint, prettier, `tsc`, export ratchet clean

## Known follow-on

Once the tool-refusal producer lands, tests that exercise it will write real entries into the test data dir. Whether that wants a per-run ledger path is a question for that PR, not this one — today nothing writes.
