### PR TITLE
feat(task-analysis): record tool-refusal capability gaps

### DIFF
--- a/.changeset/tool-refusal-gap.md
+++ b/.changeset/tool-refusal-gap.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': patch
+---
+
+Record tool-refusal capability gaps (#4651)
+
+The capability-gap loop was inert: `detectCapabilityGaps` compares required
+against available capabilities, and the required set is drawn from static
+lookup tables whose every entry is already available — a subset of a superset,
+so the difference is always empty. The ledger recorded nothing and
+`research-trigger` ranked frequency over an always-empty list.
+
+This gives it a real producer, chosen by a 7-voter panel (option C, unanimous
+among approvers). `CapabilityGap['type']` gains `tool_refusal`: a tool that
+exists, ran, and declined work it can name — as opposed to a registry gap,
+which is a capability that does not exist at all.
+
+First emitter is `extract_symbols` hitting its extension gate. It records at
+the MCP tool boundary rather than in the extractor, so the count reflects what
+agents actually asked for; the `search_codebase` sweep pre-filters by extension
+and cannot inflate it. `no-declarations` is deliberately not recorded — a file
+that parsed and declares nothing is a measured zero, not a missing capability.
+
+`research-trigger`'s generated tasks are now phrased per gap kind. The single
+wording was routing-specific ("observed Nx in routing decisions … route the
+goal through the MetaOrchestrator"), which would have made the loop's first
+real signal produce a task that misdescribes its own evidence.

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.ts
@@ -37,6 +37,20 @@ export interface AvailableCapabilities {
 }
 
 /**
+ * Every kind of capability gap, as runtime data.
+ *
+ * The array is the single source and {@link CapabilityGapType} derives from it,
+ * so a validator that needs to check a type at runtime cannot drift from the
+ * union. It did: the persistence layer hardcoded `'tool' | 'expert'`, so every
+ * persisted `tool_refusal` was discarded as malformed on load — the producer
+ * wrote three entries and the next process read zero (#4651).
+ */
+export const CAPABILITY_GAP_TYPES = ['tool', 'expert', 'tool_refusal'] as const;
+
+/** What kind of capability gap this is. Derived from {@link CAPABILITY_GAP_TYPES}. */
+export type CapabilityGapType = (typeof CAPABILITY_GAP_TYPES)[number];
+
+/**
  * A single capability gap with suggestion.
  */
 export interface CapabilityGap {
@@ -55,7 +69,7 @@ export interface CapabilityGap {
    * of refusal. Added by the #4651 panel decision (option C, unanimous among
    * approvers) because the registry diff could not represent it.
    */
-  readonly type: 'tool' | 'expert' | 'tool_refusal';
+  readonly type: CapabilityGapType;
   readonly name: string;
   readonly suggestion: string;
 }

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-detector.ts
@@ -40,7 +40,22 @@ export interface AvailableCapabilities {
  * A single capability gap with suggestion.
  */
 export interface CapabilityGap {
-  readonly type: 'tool' | 'expert';
+  /**
+   * What kind of gap this is.
+   *
+   * `tool` and `expert` are *registry* gaps — a task required something the
+   * registry does not contain. They are produced by {@link detectCapabilityGaps},
+   * which is currently unable to emit one: `requiredCapabilities` is drawn from
+   * static lookup tables whose every entry is already available, so the required
+   * set is a subset of the available set by construction (#4651).
+   *
+   * `tool_refusal` is a *capability* gap of a different kind — a tool that
+   * exists, ran, and declined the work for a reason it can name. It is not
+   * derived from the registry diff; producers record it directly at the point
+   * of refusal. Added by the #4651 panel decision (option C, unanimous among
+   * approvers) because the registry diff could not represent it.
+   */
+  readonly type: 'tool' | 'expert' | 'tool_refusal';
   readonly name: string;
   readonly suggestion: string;
 }

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.test.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { CAPABILITY_GAP_TYPES } from './capability-gap-detector.js';
 import type { CapabilityGapReport } from './capability-gap-detector.js';
 import { createPersistentCapabilityGapLedger } from './capability-gap-ledger-persistence.js';
 
@@ -121,5 +122,29 @@ describe('createPersistentCapabilityGapLedger', () => {
     );
     expect(ledger.size()).toBe(0);
     expect(ledger.loadReport().fileExisted).toBe(false);
+  });
+});
+
+describe('every declared gap type survives a round trip (#4651)', () => {
+  // The regression that motivated this: the validator hardcoded 'tool' |
+  // 'expert', so persisted tool_refusal entries loaded as malformed and the
+  // producer's output vanished between processes. Unit tests missed it because
+  // the persistence tests used 'tool' and the producer tests used an in-memory
+  // ledger — neither crossed the seam. Iterating CAPABILITY_GAP_TYPES makes a
+  // newly added type fail here instead of silently disappearing on disk.
+  it.each([...CAPABILITY_GAP_TYPES])('round-trips a %s gap', (type) => {
+    const filePath = scratchFile();
+    createPersistentCapabilityGapLedger({ filePath }).record(
+      {
+        available: { tools: [], experts: [] },
+        gaps: [{ type, name: `x:${type}`, suggestion: 's' }],
+        allSatisfied: false,
+      },
+      {}
+    );
+
+    const reloaded = createPersistentCapabilityGapLedger({ filePath });
+    expect(reloaded.loadReport().malformedLines).toBe(0);
+    expect(reloaded.summarize()[0]?.type).toBe(type);
   });
 });

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.ts
@@ -39,6 +39,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import { getTimeProvider } from '../time-provider.js';
+import { CAPABILITY_GAP_TYPES } from './capability-gap-detector.js';
 import type { CapabilityGapReport, CapabilityGap } from './capability-gap-detector.js';
 import type { GapContext, GapSummary, ICapabilityGapLedger } from './capability-gap-ledger.js';
 
@@ -94,7 +95,13 @@ function isEntry(value: unknown): value is PersistedGapEntry {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
   return (
-    (v['type'] === 'tool' || v['type'] === 'expert') &&
+    // Derived from CAPABILITY_GAP_TYPES, never re-listed here — hardcoding the
+    // union is what made every persisted tool_refusal load as malformed.
+    // The array is widened rather than the value asserted: `includes` on a
+    // readonly tuple will not accept `unknown`, and asserting the value would
+    // claim a narrowing this guard has not yet done.
+    typeof v['type'] === 'string' &&
+    (CAPABILITY_GAP_TYPES as readonly string[]).includes(v['type']) &&
     typeof v['name'] === 'string' &&
     typeof v['suggestion'] === 'string' &&
     typeof v['timestamp'] === 'string'

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.ts
@@ -40,12 +40,12 @@ import { dirname } from 'node:path';
 
 import { getTimeProvider } from '../time-provider.js';
 import { CAPABILITY_GAP_TYPES } from './capability-gap-detector.js';
-import type { CapabilityGapReport, CapabilityGap } from './capability-gap-detector.js';
+import type { CapabilityGapReport, CapabilityGapType } from './capability-gap-detector.js';
 import type { GapContext, GapSummary, ICapabilityGapLedger } from './capability-gap-ledger.js';
 
 /** One persisted occurrence. Mirrors the in-memory entry, plus nothing. */
 interface PersistedGapEntry {
-  readonly type: CapabilityGap['type'];
+  readonly type: CapabilityGapType;
   readonly name: string;
   readonly suggestion: string;
   readonly goal?: string | undefined;
@@ -113,7 +113,7 @@ function summarize(entries: readonly PersistedGapEntry[]): readonly GapSummary[]
   const groups = new Map<
     string,
     {
-      type: CapabilityGap['type'];
+      type: CapabilityGapType;
       name: string;
       count: number;
       suggestion: string;

--- a/packages/nexus-agents/src/core/task-analysis/gap-loop.e2e-seam.test.ts
+++ b/packages/nexus-agents/src/core/task-analysis/gap-loop.e2e-seam.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The gap loop across every seam: producer → durable file → new process → consumer.
+ *
+ * ## Why this file exists
+ *
+ * #4651's producer shipped with a bug no unit test could see. The persistence
+ * guard hardcoded `'tool' | 'expert'`, so every persisted `tool_refusal` loaded
+ * as a malformed line: the producer wrote three entries and the next process
+ * read zero. Both suites were green — the persistence tests used type `'tool'`,
+ * and the producer tests used an in-memory ledger. Nothing crossed the seam
+ * between them, so nothing failed.
+ *
+ * Unit tests prove the parts. This proves the joins, which is where that class
+ * of bug lives.
+ *
+ * @module core/task-analysis/gap-loop.e2e-seam.test
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { checkForCapabilityGapTriggers } from '../../pipeline/research-trigger.js';
+import { createPersistentCapabilityGapLedger } from './capability-gap-ledger-persistence.js';
+import { recordToolRefusal } from './tool-refusal-gap.js';
+
+const created: string[] = [];
+
+afterEach(() => {
+  while (created.length > 0) {
+    const dir = created.pop();
+    if (dir !== undefined) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function ledgerFile(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'gap-loop-'));
+  created.push(dir);
+  return join(dir, 'capability-gaps.jsonl');
+}
+
+describe('the capability-gap loop, end to end', () => {
+  it('carries a refusal from producer to research task across a process boundary', () => {
+    const filePath = ledgerFile();
+
+    // SESSION 1 — three agent asks that the tool declined.
+    const session1 = createPersistentCapabilityGapLedger({ filePath });
+    for (const p of ['/svc/a.py', '/svc/b.py', '/svc/c.py']) {
+      recordToolRefusal(
+        { tool: 'extract_symbols', capability: '.py', suggestion: 'needs a Python parser' },
+        { goal: `extract_symbols ${p}` },
+        session1
+      );
+    }
+    expect(readFileSync(filePath, 'utf-8').trim().split('\n')).toHaveLength(3);
+
+    // SESSION 2 — a different ledger over the same file, i.e. a later process.
+    const session2 = createPersistentCapabilityGapLedger({ filePath });
+    expect(session2.loadReport().malformedLines).toBe(0);
+    const [gap] = session2.summarize();
+    expect(gap?.type).toBe('tool_refusal');
+    expect(gap?.name).toBe('extract_symbols:.py');
+    expect(gap?.count).toBe(3);
+
+    // CONSUMER — the frequency must reach research-trigger as a task.
+    const [task] = checkForCapabilityGapTriggers({ ledger: session2 });
+    expect(task?.title).toBe('Extend capability: extract_symbols:.py');
+    expect(task?.description).toContain('declined work it cannot do');
+    expect(task?.description).toContain('across sessions');
+    expect(task?.description).not.toContain('in routing decisions');
+  });
+
+  it('a refusal below the threshold reaches the ledger but not the consumer', () => {
+    // The two halves must disagree here, and for the right reason: the signal
+    // is recorded (so it can accumulate) but not yet acted on. A loop that
+    // triggered on one occurrence would turn every unsupported file into a
+    // research task.
+    const filePath = ledgerFile();
+    const ledger = createPersistentCapabilityGapLedger({ filePath });
+    recordToolRefusal(
+      { tool: 'extract_symbols', capability: '.rs', suggestion: 's' },
+      { goal: 'read main.rs' },
+      ledger
+    );
+
+    expect(ledger.summarize()[0]?.count).toBe(1);
+    expect(checkForCapabilityGapTriggers({ ledger })).toHaveLength(0);
+  });
+
+  it('an empty ledger produces no tasks and says so as a measured zero', () => {
+    const ledger = createPersistentCapabilityGapLedger({ filePath: ledgerFile() });
+    expect(ledger.loadReport().fileExisted).toBe(false);
+    expect(ledger.summarize()).toEqual([]);
+    expect(checkForCapabilityGapTriggers({ ledger })).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/core/task-analysis/tool-refusal-gap.test.ts
+++ b/packages/nexus-agents/src/core/task-analysis/tool-refusal-gap.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for tool-refusal capability gaps (#4651).
+ *
+ * @module core/task-analysis/tool-refusal-gap.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createCapabilityGapLedger } from './capability-gap-ledger.js';
+import { recordToolRefusal, toolRefusalGapName } from './tool-refusal-gap.js';
+
+describe('toolRefusalGapName', () => {
+  it('is a stable, deduplicable key of tool plus capability', () => {
+    expect(toolRefusalGapName('extract_symbols', '.py')).toBe('extract_symbols:.py');
+  });
+
+  it('normalises case so .PY and .py are one gap, not two', () => {
+    // The dedup key IS the frequency count. Two spellings of one capability
+    // would each sit below the trigger threshold while their sum was above it.
+    expect(toolRefusalGapName('extract_symbols', '.PY')).toBe('extract_symbols:.py');
+  });
+});
+
+describe('recordToolRefusal', () => {
+  it('records a gap the ledger can rank', () => {
+    const ledger = createCapabilityGapLedger();
+    recordToolRefusal(
+      { tool: 'extract_symbols', capability: '.py', suggestion: 'add a Python parser' },
+      { goal: 'read the handler' },
+      ledger
+    );
+
+    const [summary] = ledger.summarize();
+    expect(summary?.type).toBe('tool_refusal');
+    expect(summary?.name).toBe('extract_symbols:.py');
+    expect(summary?.count).toBe(1);
+  });
+
+  it('accumulates repeats of the same refusal', () => {
+    const ledger = createCapabilityGapLedger();
+    for (let i = 0; i < 4; i += 1) {
+      recordToolRefusal(
+        { tool: 'extract_symbols', capability: '.py', suggestion: 's' },
+        {},
+        ledger
+      );
+    }
+    expect(ledger.summarize()[0]?.count).toBe(4);
+  });
+
+  it('keeps distinct capabilities distinct', () => {
+    const ledger = createCapabilityGapLedger();
+    recordToolRefusal({ tool: 'extract_symbols', capability: '.py', suggestion: 's' }, {}, ledger);
+    recordToolRefusal({ tool: 'extract_symbols', capability: '.go', suggestion: 's' }, {}, ledger);
+    expect(ledger.summarize()).toHaveLength(2);
+  });
+
+  it('records nothing when the capability is empty', () => {
+    // A refusal with no nameable capability is unmeasured, not a gap. Recording
+    // it under an empty key would inflate a bucket that means nothing.
+    const ledger = createCapabilityGapLedger();
+    recordToolRefusal({ tool: 'extract_symbols', capability: '', suggestion: 's' }, {}, ledger);
+    expect(ledger.size()).toBe(0);
+  });
+
+  it('carries the goal through as an example', () => {
+    const ledger = createCapabilityGapLedger();
+    recordToolRefusal(
+      { tool: 'extract_symbols', capability: '.rs', suggestion: 's' },
+      { goal: 'audit the parser' },
+      ledger
+    );
+    expect(ledger.summarize()[0]?.exampleGoals).toContain('audit the parser');
+  });
+});

--- a/packages/nexus-agents/src/core/task-analysis/tool-refusal-gap.ts
+++ b/packages/nexus-agents/src/core/task-analysis/tool-refusal-gap.ts
@@ -1,0 +1,89 @@
+/**
+ * Tool-refusal capability gaps (#4651).
+ *
+ * ## What this is for
+ *
+ * A registry gap ("the task needed a tool we do not have") is what
+ * `detectCapabilityGaps` was built for, and it cannot currently produce one —
+ * `requiredCapabilities` is drawn from static tables whose every entry is
+ * already available, so the diff is always empty.
+ *
+ * A **tool refusal** is a different thing: a tool that exists, ran, and
+ * declined the work for a reason it can name. `extract_symbols` hard-gating on
+ * file extension is the first producer — an agent asked it to read a `.py`
+ * file and it could not. That is real, deterministic, observable demand for a
+ * capability we do not have, and the registry diff has no vocabulary for it.
+ *
+ * The #4651 panel chose this shape unanimously among approvers over three
+ * alternatives, in particular over inferring gaps from LLM-named capabilities:
+ * `parse python` / `python AST` / `py support` would each count once, and a
+ * frequency-ranked consumer cannot do anything useful with an unnormalised
+ * label space. A refusal keyed on a file extension has no such problem.
+ *
+ * ## Why the key matters more than it looks
+ *
+ * The name IS the frequency bucket. Two spellings of one capability each sit
+ * below the trigger threshold while their sum is above it, so the gap that
+ * should surface is exactly the one that does not. Hence normalisation, and
+ * hence a refusal with no nameable capability records nothing at all rather
+ * than accumulating under an empty key.
+ *
+ * @module core/task-analysis/tool-refusal-gap
+ */
+
+import type { CapabilityGapReport } from './capability-gap-detector.js';
+import {
+  getGapLedger,
+  type GapContext,
+  type ICapabilityGapLedger,
+} from './capability-gap-ledger.js';
+
+/** A tool declining work it cannot do. */
+export interface ToolRefusal {
+  /** The tool that refused, by its MCP name. */
+  readonly tool: string;
+  /** What it could not handle — the dedup key. An extension, a format, a language. */
+  readonly capability: string;
+  /** What would close the gap, for whoever reads the summary. */
+  readonly suggestion: string;
+}
+
+/**
+ * The ledger key for a refusal: `<tool>:<capability>`, lowercased.
+ *
+ * Lowercasing is load-bearing rather than cosmetic — see the module note on
+ * why a split bucket hides the gap it is meant to surface.
+ */
+export function toolRefusalGapName(tool: string, capability: string): string {
+  return `${tool}:${capability}`.toLowerCase();
+}
+
+/**
+ * Records a tool refusal to the gap ledger.
+ *
+ * A refusal with no nameable capability is **not** recorded: it is an
+ * unmeasured refusal, and filing it under an empty key would inflate a bucket
+ * that means nothing. Callers with nothing to name should not call this.
+ */
+export function recordToolRefusal(
+  refusal: ToolRefusal,
+  context: GapContext,
+  ledger: ICapabilityGapLedger = getGapLedger()
+): void {
+  const capability = refusal.capability.trim();
+  if (capability === '') return;
+
+  const report: CapabilityGapReport = {
+    gaps: [
+      {
+        type: 'tool_refusal',
+        name: toolRefusalGapName(refusal.tool, capability),
+        suggestion: refusal.suggestion,
+      },
+    ],
+    available: { tools: [], experts: [] },
+    allSatisfied: false,
+  };
+
+  ledger.record(report, context);
+}

--- a/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.test.ts
@@ -10,7 +10,7 @@
  * isolation. The wrappers are covered elsewhere.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolve } from 'node:path';
 
 // Mock the symbol extractor so we don't need real source files for every test.
@@ -26,6 +26,11 @@ import {
   DEFAULT_EXTRACT_MAX_SYMBOLS,
 } from './extract-symbols-tool.js';
 import { createLogger } from '../../core/index.js';
+import {
+  createCapabilityGapLedger,
+  resetGapLedger,
+  setGapLedger,
+} from '../../core/task-analysis/capability-gap-ledger.js';
 import * as symbolExtractor from '../../indexer/symbol-extractor.js';
 import type { CodeSymbol } from '../../indexer/symbol-extractor.js';
 
@@ -313,5 +318,70 @@ describe('extract-symbols-tool (#2159)', () => {
       const result = await extractSymbolsHandler({ filePath: resolve('./x.ts') }, makeCtx());
       expect(result.isError).toBe(true);
     });
+  });
+});
+
+describe('tool-refusal gap recording (#4651)', () => {
+  let ledger: ReturnType<typeof createCapabilityGapLedger>;
+
+  beforeEach(() => {
+    ledger = createCapabilityGapLedger();
+    setGapLedger(ledger);
+  });
+
+  afterEach(() => {
+    resetGapLedger();
+  });
+
+  it('records a gap when the tool declines an unsupported extension', async () => {
+    mockedExtractIndexResult.mockResolvedValueOnce({ kind: 'empty', reason: 'unsupported' });
+
+    await extractSymbolsHandler({ filePath: resolve('./service.py') }, makeCtx());
+
+    const [summary] = ledger.summarize();
+    expect(summary?.type).toBe('tool_refusal');
+    expect(summary?.name).toBe('extract_symbols:.py');
+    expect(summary?.count).toBe(1);
+  });
+
+  it('records NOTHING when the file parsed and simply declares nothing', async () => {
+    // The measured zero. A re-export barrel is not a missing capability, and
+    // counting it would make the demand number meaningless — this is the
+    // distinction #4534 drew in the message and it has to hold here too.
+    mockedExtractIndexResult.mockResolvedValueOnce({ kind: 'empty', reason: 'no-declarations' });
+
+    await extractSymbolsHandler({ filePath: resolve('./barrel.ts') }, makeCtx());
+
+    expect(ledger.size()).toBe(0);
+  });
+
+  it('records nothing on a successful extraction', async () => {
+    mockedExtractIndexResult.mockResolvedValueOnce({ kind: 'index', index: 'fn foo:10' });
+
+    await extractSymbolsHandler({ filePath: resolve('./ok.ts') }, makeCtx());
+
+    expect(ledger.size()).toBe(0);
+  });
+
+  it('buckets repeated refusals of the same language together', async () => {
+    for (const f of ['./a.py', './b.py', './c.py']) {
+      mockedExtractIndexResult.mockResolvedValueOnce({ kind: 'empty', reason: 'unsupported' });
+      await extractSymbolsHandler({ filePath: resolve(f) }, makeCtx());
+    }
+    expect(ledger.summarize()).toHaveLength(1);
+    expect(ledger.summarize()[0]?.count).toBe(3);
+  });
+
+  it('keeps different languages in different buckets', async () => {
+    for (const f of ['./a.py', './b.go']) {
+      mockedExtractIndexResult.mockResolvedValueOnce({ kind: 'empty', reason: 'unsupported' });
+      await extractSymbolsHandler({ filePath: resolve(f) }, makeCtx());
+    }
+    expect(
+      ledger
+        .summarize()
+        .map((g) => g.name)
+        .sort()
+    ).toEqual(['extract_symbols:.go', 'extract_symbols:.py']);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/extract-symbols-tool.ts
@@ -21,6 +21,7 @@ import {
 } from '../../indexer/symbol-extractor.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
+import { recordToolRefusal } from '../../core/task-analysis/tool-refusal-gap.js';
 import {
   toolStructuredError,
   toolSuccess,
@@ -259,6 +260,18 @@ async function extractSymbolsHandler(args: unknown, ctx: HandlerContext): Promis
     // 20 exports were all re-exports declaring nothing locally.
     const result = await extractSymbolIndexResult(resolvedPath);
     if (result.kind === 'empty') {
+      // #4651: an `unsupported` result is a tool that ran and declined work it
+      // cannot do — real, agent-chosen demand for a capability we lack. Record
+      // it so the frequency is measurable (#4517 gates a tree-sitter dependency
+      // on exactly this number). Recorded HERE and not in the extractor: this
+      // is the boundary an agent actually asks across, so internal callers and
+      // the search_codebase sweep — which pre-filters by extension and never
+      // reaches the gate — cannot inflate the count.
+      //
+      // `no-declarations` is deliberately NOT recorded. The file parsed fine
+      // and genuinely declares nothing; that is a measured zero, not a missing
+      // capability, and conflating them would make the count meaningless.
+      recordRefusalIfUnsupported(result.reason, resolvedPath);
       return toolSuccess(emptyIndexMessage(result.reason, resolvedPath));
     }
     return toolSuccess(result.index);
@@ -270,6 +283,35 @@ async function extractSymbolsHandler(args: unknown, ctx: HandlerContext): Promis
       message: `Symbol extraction failed: ${e.message}`,
     });
   }
+}
+
+/**
+ * Record a tool-refusal capability gap when the file could not be parsed (#4651).
+ *
+ * `unsupported` is a tool that ran and declined work it cannot do — real,
+ * agent-chosen demand for a capability we lack, and what #4517 gates a
+ * tree-sitter dependency on. `no-declarations` is deliberately NOT recorded:
+ * the file parsed fine and genuinely declares nothing, which is a measured
+ * zero rather than a missing capability. Conflating them makes the count
+ * meaningless — the same distinction #4534 drew in the user-facing message.
+ *
+ * Recorded at this boundary rather than in the extractor because this is where
+ * an agent actually asks. Internal callers and the `search_codebase` sweep —
+ * which pre-filters by extension and never reaches the gate — cannot inflate it.
+ */
+function recordRefusalIfUnsupported(reason: EmptyIndexReason, resolvedPath: string): void {
+  if (reason !== 'unsupported') return;
+  const ext = extname(resolvedPath).toLowerCase();
+  recordToolRefusal(
+    {
+      tool: 'extract_symbols',
+      capability: ext,
+      suggestion:
+        `extract_symbols parses ${SUPPORTED_EXTENSIONS.join(', ')} only. ` +
+        `Supporting ${ext === '' ? 'extensionless files' : ext} needs a parser for it.`,
+    },
+    { goal: `extract_symbols ${resolvedPath}` }
+  );
 }
 
 /**

--- a/packages/nexus-agents/src/pipeline/research-trigger.test.ts
+++ b/packages/nexus-agents/src/pipeline/research-trigger.test.ts
@@ -13,7 +13,10 @@ vi.mock('./expert-bridge.js', () => ({
 }));
 
 import { checkForResearchTriggers, checkForCapabilityGapTriggers } from './research-trigger.js';
-import { createCapabilityGapLedger } from '../core/task-analysis/capability-gap-ledger.js';
+import {
+  createCapabilityGapLedger,
+  type ICapabilityGapLedger,
+} from '../core/task-analysis/capability-gap-ledger.js';
 import type { CapabilityGapReport } from '../core/task-analysis/capability-gap-detector.js';
 
 /** Build a gap report with a single tool gap for ledger seeding. */
@@ -182,5 +185,45 @@ describe('checkForCapabilityGapTriggers (#3576)', () => {
 
   it('returns empty for an empty ledger', () => {
     expect(checkForCapabilityGapTriggers({ ledger: createCapabilityGapLedger() })).toEqual([]);
+  });
+});
+
+describe('gap task wording is accurate per gap kind (#4651)', () => {
+  const ledgerWith = (type: 'tool' | 'tool_refusal', name: string): ICapabilityGapLedger => {
+    const ledger = createCapabilityGapLedger();
+    for (let i = 0; i < 3; i += 1) {
+      ledger.record(
+        {
+          available: { tools: [], experts: [] },
+          gaps: [{ type, name, suggestion: 'do the thing' }],
+          allSatisfied: false,
+        },
+        { goal: 'a goal' }
+      );
+    }
+    return ledger;
+  };
+
+  it('describes a tool refusal as a tool that declined, not a routing observation', () => {
+    const [task] = checkForCapabilityGapTriggers({
+      ledger: ledgerWith('tool_refusal', 'extract_symbols:.py'),
+    });
+    expect(task?.title).toBe('Extend capability: extract_symbols:.py');
+    expect(task?.description).toContain('declined work it cannot do');
+    // The routing phrasing would be false here — the refusal never went
+    // through a routing decision and the MetaOrchestrator is not the remedy.
+    expect(task?.description).not.toContain('in routing decisions');
+    expect(task?.description).not.toContain('MetaOrchestrator');
+  });
+
+  it('still describes a registry gap as a routing observation', () => {
+    const [task] = checkForCapabilityGapTriggers({ ledger: ledgerWith('tool', 'ml_thing') });
+    expect(task?.title).toBe('Build capability: tool "ml_thing"');
+    expect(task?.description).toContain('in routing decisions');
+  });
+
+  it('says counts span sessions, since the ledger became durable', () => {
+    const [task] = checkForCapabilityGapTriggers({ ledger: ledgerWith('tool_refusal', 'x:.py') });
+    expect(task?.description).toContain('across sessions');
   });
 });

--- a/packages/nexus-agents/src/pipeline/research-trigger.ts
+++ b/packages/nexus-agents/src/pipeline/research-trigger.ts
@@ -94,6 +94,52 @@ export interface CapabilityGapTriggerConfig {
 const DEFAULT_MIN_OCCURRENCES = 3;
 
 /**
+ * Title for a gap-derived task, phrased for the kind of gap it is.
+ *
+ * A registry gap asks for a capability to be *added*; a tool refusal asks for
+ * an existing tool to be *extended*. Same ledger, different remedy.
+ */
+function gapTaskTitle(gap: GapSummary): string {
+  if (gap.type === 'tool_refusal') {
+    return `Extend capability: ${gap.name}`;
+  }
+  return `Build capability: ${gap.type} "${gap.name}"`;
+}
+
+/**
+ * Description for a gap-derived task.
+ *
+ * Split by kind because the generic wording was routing-specific — "observed
+ * Nx in routing decisions … route the goal through the MetaOrchestrator". A
+ * tool refusal was not observed in a routing decision and that is not its
+ * remedy, so the single phrasing would have made the loop's first real signal
+ * produce a task that misdescribes its own evidence (#4651).
+ *
+ * Occurrence counts span sessions since the ledger became durable (#4645), so
+ * the wording says so rather than letting a reader assume one run.
+ */
+function gapTaskDescription(gap: GapSummary): string {
+  const examples = gap.exampleGoals.join('; ') || '(none recorded)';
+  const seen = `observed ${String(gap.count)}x across sessions`;
+
+  if (gap.type === 'tool_refusal') {
+    return (
+      `Auto-suggested from the capability-gap ledger (#4651): a tool ran and declined work it ` +
+      `cannot do — ${seen}. Suggestion: ${gap.suggestion}. ` +
+      `Example requests: ${examples}. ` +
+      `Assess whether extending the tool is worth it; the count is the demand evidence.`
+    );
+  }
+
+  return (
+    `Auto-suggested from the capability-gap ledger (#3555): ${seen} in routing decisions. ` +
+    `Suggestion: ${gap.suggestion}. ` +
+    `Example goals: ${examples}. ` +
+    `Assess whether to add this ${gap.type} (e.g. route the goal through the MetaOrchestrator, #3540).`
+  );
+}
+
+/**
  * Convert recurring capability gaps (from the shared ledger, #3555) into
  * candidate pipeline tasks for a human/orchestrator to review. SUGGEST-ONLY:
  * builds task objects in memory; files/executes nothing. The human-gated front
@@ -114,12 +160,8 @@ export function checkForCapabilityGapTriggers(
 
   const tasks: PipelineTask[] = qualified.slice(0, maxTriggers).map((gap) => ({
     id: gapTaskId(gap),
-    title: `Build capability: ${gap.type} "${gap.name}"`,
-    description:
-      `Auto-suggested from the capability-gap ledger (#3555): observed ${String(gap.count)}x ` +
-      `in routing decisions. Suggestion: ${gap.suggestion}. ` +
-      `Example goals: ${gap.exampleGoals.join('; ') || '(none recorded)'}. ` +
-      `Assess whether to add this ${gap.type} (e.g. route the goal through the MetaOrchestrator, #3540).`,
+    title: gapTaskTitle(gap),
+    description: gapTaskDescription(gap),
     assignedTo: 'researcher' as const,
     status: 'pending' as const,
   }));


### PR DESCRIPTION
Step 2 of #4651. Makes the capability-gap loop capable of carrying a signal for the first time.

## What was wrong

`detectCapabilityGaps` diffs required capabilities against available ones. `requiredCapabilities` has one producer, reading two static lookup tables whose every entry is already in `AVAILABLE_TOOLS`/`AVAILABLE_EXPERTS` — **a subset of a superset, so the difference is always empty.** Measured 0 gaps across every task type, with a control showing 2 for invented names.

The ledger recorded nothing. `research-trigger` ranked frequency over an empty list. The loop was fully wired, looked live, and produced nothing.

## The producer

A 7-voter panel chose option C — **unanimous among approvers (6/6)**. `CapabilityGap['type']` gains `tool_refusal`: a tool that exists, ran, and declined work it can name. That is a different thing from a registry gap (a capability that does not exist), and the registry diff has no vocabulary for it.

Rejected alternatives, briefly: inferring gaps from LLM-named capabilities gives an unnormalised label space — `parse python` / `python AST` / `py support` each counting once — which a frequency ranker cannot use. Mining `OutcomeStore` makes attribution itself an unmeasured judgement feeding that same ranker.

**First emitter:** `extract_symbols` hitting its extension gate.

## Three decisions worth reviewing

**Recorded at the MCP tool boundary, not in the extractor.** `symbol-extractor.ts` is a deliberately dependency-free leaf — its own comment says so. More importantly, the boundary is where an *agent* asks. Internal callers and the `search_codebase` sweep (which pre-filters by extension and never reaches the gate) therefore cannot inflate the count. The signal is agent-chosen by construction.

**`no-declarations` is not recorded.** A file that parsed fine and declares nothing is a **measured zero**, not a missing capability. Recording it would make the demand number meaningless — the same distinction #4534 drew in the user-facing message, holding here too. There is a test asserting silence on that path.

**The dedup key is lowercased.** The key *is* the frequency bucket, so two spellings of one capability would each sit below the trigger threshold while their sum was above it — the gap that should surface would be exactly the one that does not.

## The consumer had to change too

`research-trigger`'s generated wording was routing-specific: *"observed 3x in routing decisions … route the goal through the MetaOrchestrator."* A tool refusal was not observed in a routing decision and that is not its remedy. Left alone, the loop's first real signal would have produced a task misdescribing its own evidence — the failure this repo treats as p1 on the governor path, arriving inside the change meant to fix the loop. Wording is now split by kind, with tests pinning both branches.

Counts also now say "across sessions", since #4652 made the ledger durable.

## A threshold I deliberately did not change

`MIN_OCCURRENCES = 3` was chosen when occurrences counted within one process. It now spans sessions and a 90-day window, which is a much lower bar. I left it at 3: it gates only a **suggest-only** research task, reachable as a GitHub issue solely through the explicit `research autofile` subcommand (verified — not on any default path, with rate-limit, dedup, `machine-suggested` label, scrub, and fail-closed safeguards). The decision it actually feeds, #4517's tree-sitter go/no-go, reads raw counts. Raising it would delay the suggestion without improving the decision.

Flagging it rather than silently inheriting a number that now means something different.

## Control

Not just unit tests on the helper — the handler itself:

| Case | Result |
| --- | --- |
| `unsupported` (`.py`) | records `tool_refusal` / `extract_symbols:.py`, count 1 |
| `no-declarations` | records **nothing** |
| successful extraction | records **nothing** |
| three `.py` refusals | one gap, count 3 |
| `.py` and `.go` | two distinct gaps |

5,380 tests pass across `src/mcp/`, `src/pipeline/`, `src/core/task-analysis/`, `src/indexer/` (280 files). eslint, prettier, `tsc`, export ratchet clean.

## Not in scope

No tree-sitter. That is the dependency this measurement exists to gate (#4517), and adding it now would answer the question before the data arrives.
