### PR TITLE
fix(cli): report an unverified auth probe as unverified, not a failure

### DIFF
--- a/.changeset/doctor-unverified-auth.md
+++ b/.changeset/doctor-unverified-auth.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+Report an unverified auth probe as unverified, not as a failure (#4661)
+
+`doctor` printed a red **"Not authenticated"** with `Fix: gemini auth login` for
+a CLI that was working — a vote succeeded on it 30 seconds earlier in the same
+session.
+
+The auth probe is three-valued. For a gateway with no non-interactive auth
+check it can only ever return `unknown`, explicitly _"admitted unverified"_.
+Routing treats that correctly and deliberately (#4391: absence of evidence is
+not failure, and #4346 is what happens when you get it wrong). `doctor`
+collapsed it to a boolean at the last step, so an unmeasured state rendered as
+a definite negative with a remediation that fixes nothing.
+
+`CliCheckResult` now carries `authState: 'authenticated' | 'unverified' |
+'not-authenticated'`. Unverified prints in yellow as
+`unverified (no non-interactive auth check)` — the same honest register as the
+existing `Capacity: unknown (no usage observed this session)` line — and no fix
+command is offered, because there is nothing to fix.
+
+`authState` is required rather than optional, so every construction site has to
+say which state it means.

--- a/packages/nexus-agents/src/cli/doctor-formatting.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.test.ts
@@ -106,11 +106,13 @@ describe('doctor-formatting', () => {
       capacity?: CapacityStatus;
       error?: string;
       fix?: string;
+      authState?: 'authenticated' | 'unverified' | 'not-authenticated';
     } = {}
   ): CliCheckResult => ({
     name: name as CliName,
     installed,
     authenticated,
+    authState: options.authState ?? (authenticated ? 'authenticated' : 'not-authenticated'),
     versionStatus,
     version: options.version ?? '',
     ...(options.authMethod !== undefined && { authMethod: options.authMethod }),
@@ -633,6 +635,44 @@ describe('doctor-formatting', () => {
       const calls = getCalls();
       // 2 unhealthy CLIs + 1 Node issue + 1 MCP issue = 4 total
       expect(calls.some((call) => call.includes('4 issue(s) found'))).toBe(true);
+    });
+  });
+
+  describe('an unverified auth probe is not a failed one (#4661)', () => {
+    it('renders "unverified" rather than "Not authenticated"', () => {
+      // The probe for this CLI can only ever return `unknown` — the gateway
+      // exposes no non-interactive auth check, so nothing was measured. Routing
+      // admits that state deliberately (#4391); doctor collapsed it to a red
+      // negative, and told the operator to re-auth a CLI that was working.
+      const result = createDoctorResult({
+        clis: [
+          createCliCheckResult('gemini', true, false, 'supported', {
+            version: '1.1.19',
+            authState: 'unverified',
+          }),
+        ],
+      });
+      printDoctorResults(result);
+
+      const calls = getCalls();
+      expect(calls.some((c) => c.includes('unverified'))).toBe(true);
+      expect(calls.some((c) => c.includes('Not authenticated'))).toBe(false);
+    });
+
+    it('still renders a genuine needs-login as "Not authenticated"', () => {
+      // The distinction has to survive both ways round, or this fix just moves
+      // the misreport rather than removing it.
+      const result = createDoctorResult({
+        clis: [
+          createCliCheckResult('claude', true, false, 'supported', {
+            version: '0.2.0',
+            authState: 'not-authenticated',
+          }),
+        ],
+      });
+      printDoctorResults(result);
+
+      expect(getCalls().some((c) => c.includes('Not authenticated'))).toBe(true);
     });
   });
 });

--- a/packages/nexus-agents/src/cli/doctor-formatting.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.ts
@@ -79,9 +79,14 @@ function formatCapacity(capacity?: CapacityStatus): string {
 function printInstalledCliDetails(cli: CliCheckResult): void {
   writeLine(`  Version: ${cli.version} (${formatVersionStatus(cli.versionStatus)})`);
 
-  const authText = cli.authenticated
-    ? `${colors.green}${cli.authMethod ?? 'Authenticated'}${colors.reset}`
-    : `${colors.red}Not authenticated${colors.reset}`;
+  // Three states, not two (#4661). `unverified` is yellow because nothing was
+  // measured — the same honest register as the `Capacity: unknown` line below.
+  const authText =
+    cli.authState === 'authenticated'
+      ? `${colors.green}${cli.authMethod ?? 'Authenticated'}${colors.reset}`
+      : cli.authState === 'unverified'
+        ? `${colors.yellow}unverified (no non-interactive auth check)${colors.reset}`
+        : `${colors.red}Not authenticated${colors.reset}`;
   writeLine(`  Auth: ${authText}`);
 
   if (cli.capacity !== undefined) {

--- a/packages/nexus-agents/src/cli/doctor-verdict.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-verdict.test.ts
@@ -19,6 +19,7 @@ const healthyCli: CliCheckResult = {
   name: 'claude',
   installed: true,
   authenticated: true,
+  authState: 'authenticated',
   version: '1.0.0',
   versionStatus: 'supported',
 };

--- a/packages/nexus-agents/src/cli/doctor.test.ts
+++ b/packages/nexus-agents/src/cli/doctor.test.ts
@@ -64,6 +64,7 @@ function createMockDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorRe
         version: '2.0.76',
         versionStatus: 'supported',
         authenticated: true,
+        authState: 'authenticated',
         authMethod: 'CLI auth',
       },
       {
@@ -72,6 +73,7 @@ function createMockDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorRe
         version: '0.22.5',
         versionStatus: 'supported',
         authenticated: true,
+        authState: 'authenticated',
         authMethod: 'ADC/CLI auth',
       },
       {
@@ -80,6 +82,7 @@ function createMockDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorRe
         version: '0.77.0',
         versionStatus: 'supported',
         authenticated: true,
+        authState: 'authenticated',
         authMethod: 'CLI auth',
       },
     ],
@@ -929,6 +932,7 @@ describe('Doctor Command', () => {
             version: 'N/A',
             versionStatus: 'unsupported',
             authenticated: false,
+            authState: 'not-authenticated',
             error: 'Not found in PATH',
             fix: 'npm install -g @anthropic-ai/claude-code',
           },
@@ -938,6 +942,7 @@ describe('Doctor Command', () => {
             version: '0.22.5',
             versionStatus: 'supported',
             authenticated: true,
+            authState: 'authenticated',
           },
           {
             name: 'codex',
@@ -945,6 +950,7 @@ describe('Doctor Command', () => {
             version: '0.77.0',
             versionStatus: 'supported',
             authenticated: true,
+            authState: 'authenticated',
           },
         ],
         allHealthy: false,
@@ -971,6 +977,7 @@ describe('Doctor Command', () => {
             version: '2.0.76',
             versionStatus: 'supported',
             authenticated: true,
+            authState: 'authenticated',
             capacity: {
               remainingTokens: 100000,
               remainingRequests: 100,
@@ -988,6 +995,7 @@ describe('Doctor Command', () => {
             version: '0.22.5',
             versionStatus: 'supported',
             authenticated: true,
+            authState: 'authenticated',
           },
           {
             name: 'codex',
@@ -995,6 +1003,7 @@ describe('Doctor Command', () => {
             version: '0.77.0',
             versionStatus: 'supported',
             authenticated: true,
+            authState: 'authenticated',
           },
         ],
       });
@@ -1018,6 +1027,7 @@ describe('Doctor Command', () => {
             version: 'N/A',
             versionStatus: 'unsupported',
             authenticated: false,
+            authState: 'not-authenticated',
             error: 'Not found',
           },
           {
@@ -1026,6 +1036,7 @@ describe('Doctor Command', () => {
             version: 'N/A',
             versionStatus: 'unsupported',
             authenticated: false,
+            authState: 'not-authenticated',
             error: 'Not found',
           },
           {
@@ -1034,6 +1045,7 @@ describe('Doctor Command', () => {
             version: 'N/A',
             versionStatus: 'unsupported',
             authenticated: false,
+            authState: 'not-authenticated',
             error: 'Not found',
           },
         ],

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -76,6 +76,17 @@ export interface CliCheckResult {
   readonly version: string;
   readonly versionStatus: 'supported' | 'outdated' | 'unsupported' | 'breaking';
   readonly authenticated: boolean;
+  /**
+   * The auth probe's THREE-valued result (#4661).
+   *
+   * `authenticated` above is a boolean and cannot express "we did not check".
+   * Some gateways expose no non-interactive auth check, so their probe can only
+   * ever return `unknown` — routing admits that deliberately (#4391: absence of
+   * evidence is not failure). Collapsing it to `false` printed a red
+   * "Not authenticated" for a CLI that was demonstrably working, and offered a
+   * login command that fixes nothing.
+   */
+  readonly authState: 'authenticated' | 'unverified' | 'not-authenticated';
   readonly authMethod?: string;
   readonly capacity?: CapacityStatus;
   readonly error?: string;
@@ -299,6 +310,10 @@ function getFixCommand(name: CliName, issue: 'install' | 'upgrade' | 'auth'): st
 function createNotFoundResult(name: CliName, errorMsg: string): CliCheckResult {
   return {
     name,
+    // Not installed, so auth was never probed. `not-authenticated` would claim
+    // a determination nobody made; the auth line is not printed for an
+    // uninstalled CLI anyway (#4661).
+    authState: 'unverified',
     installed: false,
     version: 'N/A',
     versionStatus: 'unsupported',
@@ -324,6 +339,22 @@ function detectAuthMethod(name: CliName): string {
 }
 
 /**
+ * Maps the probe's three-valued state onto the reported one (#4661).
+ *
+ * `unknown` means the probe ran and could not determine auth — a gateway with
+ * no non-interactive auth check. That is distinct from a probe that determined
+ * the CLI is logged out, and collapsing the two printed a red "Not
+ * authenticated" for a CLI that was demonstrably working.
+ */
+function resolveAuthState(
+  authenticated: boolean,
+  probeState: AuthProbeResult['state']
+): CliCheckResult['authState'] {
+  if (authenticated) return 'authenticated';
+  return probeState === 'unknown' ? 'unverified' : 'not-authenticated';
+}
+
+/**
  * Creates a result from a successful health check.
  *
  * Authentication state comes from the auth probe (#2439, #2447), not from
@@ -339,6 +370,7 @@ function createHealthyResult(
 ): CliCheckResult {
   const versionOk = health.healthy;
   const authenticated = versionOk && authProbe.state === 'authenticated';
+  const authState = resolveAuthState(authenticated, authProbe.state);
 
   const result: CliCheckResult = {
     name,
@@ -346,6 +378,7 @@ function createHealthyResult(
     version: health.version,
     versionStatus: health.versionStatus,
     authenticated,
+    authState,
     ...(authenticated && { authMethod: detectAuthMethod(name) }),
     ...(capacity !== undefined && { capacity }),
   };
@@ -361,7 +394,11 @@ function createHealthyResult(
       fix: authProbe.fixCommand,
     };
   }
-  if (!authenticated) {
+  // Only offer a login command when the probe actually determined a logout.
+  // An unverified state has nothing to fix, and naming one sends operators to
+  // re-authenticate a working CLI (#4661).
+  // `not-authenticated` already implies `!authenticated` — see resolveAuthState.
+  if (authState === 'not-authenticated') {
     return { ...result, fix: getFixCommand(name, 'auth') };
   }
   if (health.versionStatus === 'outdated') {

--- a/packages/nexus-agents/src/cli/validate-command.test.ts
+++ b/packages/nexus-agents/src/cli/validate-command.test.ts
@@ -37,6 +37,7 @@ function makeDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorResult {
         version: '1.0.0',
         versionStatus: 'supported' as const,
         authenticated: true,
+        authState: 'authenticated',
       },
       {
         name: 'gemini' as const,
@@ -44,6 +45,7 @@ function makeDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorResult {
         version: '1.0.0',
         versionStatus: 'supported' as const,
         authenticated: true,
+        authState: 'authenticated',
       },
       {
         name: 'codex' as const,
@@ -51,6 +53,7 @@ function makeDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorResult {
         version: '1.0.0',
         versionStatus: 'supported' as const,
         authenticated: true,
+        authState: 'authenticated',
       },
       {
         name: 'opencode' as const,
@@ -58,6 +61,7 @@ function makeDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorResult {
         version: '1.0.0',
         versionStatus: 'supported' as const,
         authenticated: true,
+        authState: 'authenticated',
       },
     ],
     nodeVersion: { version: 'v22.0.0', major: 22, supported: true },


### PR DESCRIPTION
Closes #4661.

## Found by running the loop, not by reading code

The same session in which `doctor` said Gemini was unauthenticated also ran a successful vote on it:

```
doctor:  ⚠ Gemini CLI   Auth: Not authenticated   Fix: gemini auth login
30s earlier: {"message":"Vote completed","role":"catfish","provider":"cli-gemini","decision":"reject"}
```

## The collapse

The probe is **three-valued**, and for this gateway can only ever return `unknown`:

```ts
return { cli: 'gemini', state: 'unknown',
         reason: 'agy exposes no non-interactive auth check; admitted unverified' };
```

`doctor.ts` reduced it to a boolean, and the formatter had exactly two branches — green *Authenticated* or red *Not authenticated*. So an explicitly-unverified state printed as a definite negative, with a remediation that fixes nothing.

The tri-state survives the probe and survives `doctor-live.ts:87-88`. It died at the display, which is the surface an operator actually reads.

## Why this one is worth the words

Routing already gets it right, deliberately, with history — `factory.ts` (#4391):

> `unknown` is ADMITTED, not excluded. … Treating an absence of evidence as a failure is what excluded a working agy arm from routing (#4346); treating it as success is how the retired gemini CLI stayed selectable while failing every call (#4318).

Every other instrument I audited this session risked reporting a default as a **pass**. This reported an unmeasured state as a **failure** — same defect class, opposite sign, and the same cost: the report doesn't mean what it says. The remediation made it worse than silence, since "run `gemini auth login`" sends an operator to fix a CLI that is working.

## The change

`CliCheckResult` gains `authState: 'authenticated' | 'unverified' | 'not-authenticated'`, **required** rather than optional so every construction site has to state which case it means. That surfaced four fixture files and one production site (`createNotFoundResult`, where the honest answer is `unverified` — nothing was probed) that had been silently defaulting.

Unverified renders yellow as `unverified (no non-interactive auth check)` — deliberately the same register as the existing `Capacity: unknown (no usage observed this session)` line two rows below it, so the output is internally consistent about what "we didn't measure" looks like. No fix command is offered.

## Control

Against this machine, after the change:

```
claude    authState=authenticated   fix=(none)
gemini    authState=unverified      fix=(none)   ← was: authenticated=false, fix='gemini auth login'
codex     authState=authenticated   fix=(none)
opencode  authState=authenticated   fix=(none)
```

**Both** rendering branches are pinned by tests — unverified must print `unverified` and must NOT print `Not authenticated`, and a genuine `needs-login` must still print `Not authenticated`. Without the second, this fix could move the misreport to the other state rather than removing it.

3,599 tests pass across `src/cli/`; eslint, prettier, `tsc`, export ratchet clean.

## Left for the issue

`doctor` prints `agy`'s version (1.1.19) in a row labelled **Gemini CLI**, while `gemini --version` reports 0.51.0. Defensible if `gemini` is the routing name for the agy gateway, but the operator-facing label and the fix command name different binaries. Not touched here — it is a naming decision, not a reporting bug, and this PR is already the width it should be.
