### PR TITLE
fix(testing): guard every child_process spawn entry point

### DIFF
--- a/.changeset/spawn-guard-execfilesync.md
+++ b/.changeset/spawn-guard-execfilesync.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix(testing): guard every child_process spawn entry point, not a hand-picked subset
+
+The CLI spawn guard wrapped `exec`, `execFile`, `execSync` and `spawn`, and
+described that list in-line as "only the entry points this tree uses to reach a
+CLI". It was not. `execFileSync` is the second most used spawner in production
+(23 call sites), including `detectCliBinary`, which calls
+`execFileSync(name, ['--version'])` with a guarded CLI name — so the guard let a
+real `opencode` process launch, unblocked and unrecorded.
+
+The wrapped set is now enumerated from the module's spawners
+(`exec`, `execFile`, `execSync`, `execFileSync`, `spawn`, `spawnSync`, `fork`).
+A subset chosen from current usage silently reopens the hole the next time a
+caller reaches for a different entry point.
+
+Adds probes that call each synchronous entry point with a guarded binary and
+assert the guard message, so the gap is a test failure rather than a comment.

--- a/packages/nexus-agents/src/testing/cli-spawn-guard.setup.ts
+++ b/packages/nexus-agents/src/testing/cli-spawn-guard.setup.ts
@@ -28,6 +28,25 @@
 
 import { afterEach, vi } from 'vitest';
 
+/**
+ * Wrap EVERY spawning entry point in `node:child_process` (#4682).
+ *
+ * This was previously a hand-picked subset, described in-line as "only the
+ * entry points this tree uses to reach a CLI". That was wrong, and wrong in the
+ * expensive direction: `execFileSync` is the second most used spawner in
+ * production (23 call sites), including `detectCliBinary`, which calls
+ * `execFileSync(name, ['--version'])` with a guarded CLI name. Probes confirmed
+ * a real `opencode` process launching unblocked and unrecorded.
+ *
+ * Enumerating the module's spawners is the only form that cannot drift: a
+ * subset chosen from current usage silently reopens the hole the next time some
+ * caller reaches for a different entry point.
+ */
+// `vi.mock` factories are hoisted, so every helper this wrapper needs (the
+// guarded-binary set, the promisify.custom handling) must be declared INSIDE
+// the factory — extracting them to module scope would run before the mock is
+// installed. Hence the length exemption directly below.
+// eslint-disable-next-line max-lines-per-function
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
   const { promisify } = await import('node:util');
@@ -76,15 +95,21 @@ vi.mock('node:child_process', async (importOriginal) => {
     return wrapper as unknown as T;
   }
 
-  // Only the entry points this tree uses to reach a CLI. Everything else in the
-  // module passes through unwrapped.
-  return {
-    ...actual,
-    exec: guard('exec', actual.exec),
-    execFile: guard('execFile', actual.execFile),
-    execSync: guard('execSync', actual.execSync),
-    spawn: guard('spawn', actual.spawn),
-  };
+  // Every spawning entry point — see the note above this mock (#4682).
+  const SPAWNERS = [
+    'exec',
+    'execFile',
+    'execSync',
+    'execFileSync',
+    'spawn',
+    'spawnSync',
+    'fork',
+  ] as const;
+  const guarded = Object.fromEntries(SPAWNERS.map((n) => [n, guard(n, actual[n])])) as Pick<
+    typeof actual,
+    (typeof SPAWNERS)[number]
+  >;
+  return { ...actual, ...guarded };
 });
 
 /**

--- a/packages/nexus-agents/src/testing/cli-spawn-guard.test.ts
+++ b/packages/nexus-agents/src/testing/cli-spawn-guard.test.ts
@@ -145,3 +145,53 @@ describe('the installed guard (integration — the setup file is active here)', 
     expect(stdout).toMatch(/^v\d+/);
   });
 });
+
+// #4682: the guard wrapped a hand-picked subset of node:child_process entry
+// points and its comment claimed that subset was "only the entry points this
+// tree uses to reach a CLI". `execFileSync` was missing — and it is the SECOND
+// most used spawner in production (23 call sites), including
+// `detectCliBinary`, which calls `execFileSync(name, ['--version'])` with a
+// guarded CLI name. So the guard silently let a real CLI spawn through.
+//
+// These probes run under the real setupFile, so they exercise the actual
+// wrapper rather than a reimplementation of it.
+describe('every spawning entry point is guarded (#4682)', () => {
+  const GUARDED_BINARY = 'opencode';
+
+  async function attempt(
+    fn: (cp: typeof import('node:child_process')) => unknown
+  ): Promise<string> {
+    const cp = await import('node:child_process');
+    try {
+      const out = fn(cp);
+      if (out instanceof Promise) await out;
+      return 'NO THROW';
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  it.each([
+    [
+      'execFileSync',
+      (cp: typeof import('node:child_process')) =>
+        cp.execFileSync(GUARDED_BINARY, ['--version'], { stdio: 'pipe' }),
+    ],
+    [
+      'execSync',
+      (cp: typeof import('node:child_process')) =>
+        cp.execSync(`${GUARDED_BINARY} --version`, { stdio: 'pipe' }),
+    ],
+    [
+      'spawnSync',
+      (cp: typeof import('node:child_process')) =>
+        cp.spawnSync(GUARDED_BINARY, ['--version'], { stdio: 'pipe' }),
+    ],
+  ])('blocks %s', async (_name, fn) => {
+    const message = await attempt(fn);
+    // These probes deliberately trip the guard, so drain the recorded
+    // violation — otherwise the setup's afterEach re-raises our own probe.
+    takeSpawnViolations();
+    expect(message).toContain('cli-spawn-guard');
+  });
+});


### PR DESCRIPTION
The CLI spawn guard from #4644 wrapped `exec`, `execFile`, `execSync` and `spawn`, with an in-line comment calling that "only the entry points this tree uses to reach a CLI."

It wasn't. `execFileSync` is the **second most used spawner in production** — 23 call sites:

```
139 exec(        23 execFileSync(     17 execSync(
 11 spawn(        5 execFile(
```

Including `setup-cli-detection.ts:67`:

```ts
const output = execFileSync(name, ['--version'], { … });  // name is a guarded CLI
```

So the guard that exists to stop unit tests launching real agent CLIs was letting them through by the second-most-common route.

## Verified before fixing

Probes calling each synchronous entry point with a guarded binary, under the real setup file:

```
PROBE execFileSync: NO THROW                   (429ms — a real process)
PROBE execSync:     [cli-spawn-guard] This test spawned the real 'opencode' …
PROBE spawnSync:    NO THROW                   (423ms — a real process)
```

`execSync` was correctly blocked. The other two launched `opencode` for real, unblocked and unrecorded. After the fix all three throw and the probes complete in ~19ms total.

## The fix

The wrapped set is now enumerated from the module's spawners — `exec`, `execFile`, `execSync`, `execFileSync`, `spawn`, `spawnSync`, `fork` — rather than hand-picked from observed usage. A subset chosen from current call sites reopens the hole the moment a caller reaches for a different entry point; that is how this one appeared.

The probes are kept as tests, so a future gap fails CI instead of being a comment that says it can't happen.

Note the probes deliberately trip the guard, so they drain `takeSpawnViolations()` — otherwise the setup's `afterEach` re-raises the probe's own violation.

## Verification

Full suite: **28302 passed, 1190 files, 0 failed.** Typecheck and lint clean.

I also checked the two other comments a review flagged as making the same overstatement (`cli-spawn-guard.ts:2`, `vitest.config.ts:39`) — both are accurate. They describe which *binaries* pass through, not which functions are wrapped. Left alone.
