### PR TITLE
fix(security): refuse label proposals that grant privilege or skip review

### DIFF
--- a/.changeset/privileged-label-denylist.md
+++ b/.changeset/privileged-label-denylist.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+fix(security): never let an agent propose a label that grants privilege or skips review
+
+Labels in this repository are not all descriptive taxonomy — some are CI
+control inputs. `owner-ratified` is the label `check-governor-ratification.ts`
+accepts as proof of ratification, so applying it bypasses the
+governance-of-the-governor gate on `src/audit/`, `.rules/` and `CODEOWNERS`.
+`skip-pr-review` suppresses the review workflow.
+
+`ProposeLabels` was constrained only by "must exist in the repository label
+set", which these do. No production code applies a proposed label today
+(`addLabels` has no non-test caller), so the path is latent — but it stops
+being latent the moment triage output is wired to `addLabels`, and a guard
+added after that wiring is a guard added after the incident.
+
+Proposals naming a privilege-granting label are now refused with
+`PRIVILEGED_LABEL`. The check keys on the action's effect, not the author's
+trust: an OWNER-authored body proposing its own ratification is exactly the
+self-modification the governor exists to prevent. It is also independent of
+`checkLabelValidity`, which returns early when the repository label set is
+unknown — a denylist layered on that would inherit the vacuous pass.

--- a/packages/nexus-agents/src/security/policy-gate.test.ts
+++ b/packages/nexus-agents/src/security/policy-gate.test.ts
@@ -358,3 +358,75 @@ describe('evaluatePolicy audit emission (#3191)', () => {
     ).toContain('REQUIRE_CITATION');
   });
 });
+
+describe('privilege-granting labels are never proposable (#4688)', () => {
+  // A consensus panel chose tier-aware corroboration, which lets a bounded
+  // proposal cite the input it was derived from. The dissenting seat objected
+  // that labels are not zero-blast-radius because they gate CI — and in THIS
+  // repo that is verifiably true:
+  //
+  //   .github/workflows/governor-review.yml triggers on label events, and
+  //   `owner-ratified` is the label that BYPASSES the governor ratification
+  //   gate. .github/workflows/pr-review.yml honours `skip-pr-review`.
+  //
+  // Nothing applies a proposed label today (`addLabels` has no non-test
+  // caller), so this is latent rather than live. It stops being latent the
+  // moment someone wires triage output to `addLabels` — exactly the kind of
+  // change that looks harmless in review. The denylist has to exist BEFORE
+  // that wiring, not after.
+  //
+  // These use TIER 1 deliberately. At tier 3 ProposeLabels is already refused
+  // by the influence block, so a tier-3 fixture would pass without exercising
+  // the denylist at all — green for the wrong reason.
+
+  it('blocks the governance-bypass label even from a Tier 1 source', () => {
+    const decision = evaluatePolicy(
+      makePropose([repoSource], ['bug', 'owner-ratified']),
+      makeContext('1')
+    );
+    expect(decision.allowed).toBe(false);
+    expect(JSON.stringify(decision)).toContain('PRIVILEGED_LABEL');
+  });
+
+  it('blocks a label that would skip review', () => {
+    const decision = evaluatePolicy(
+      makePropose([repoSource], ['skip-pr-review']),
+      makeContext('1')
+    );
+    expect(decision.allowed).toBe(false);
+    expect(JSON.stringify(decision)).toContain('PRIVILEGED_LABEL');
+  });
+
+  it('blocks on the ACTION effect, not the author — OWNER included', () => {
+    // An OWNER-authored issue body must not be able to propose its own
+    // ratification. That is the self-modification hazard the governor exists
+    // to prevent, and it does not soften with author trust.
+    const decision = evaluatePolicy(
+      makePropose([maintainerSource], ['owner-ratified']),
+      makeContext('1')
+    );
+    expect(decision.allowed).toBe(false);
+    expect(JSON.stringify(decision)).toContain('PRIVILEGED_LABEL');
+  });
+
+  it('still allows ordinary labels', () => {
+    const decision = evaluatePolicy(
+      makePropose([repoSource], ['bug', 'documentation']),
+      makeContext('1')
+    );
+    expect(JSON.stringify(decision)).not.toContain('PRIVILEGED_LABEL');
+  });
+
+  it('does not depend on existingLabels being supplied', () => {
+    // checkLabelValidity returns early when the repo label set is unknown, so
+    // a denylist layered on top of it would inherit that vacuous pass.
+    // `makeContext` supplies no `existingLabels`, which is exactly the
+    // unknown-label-set state that makes checkLabelValidity return early.
+    const decision = evaluatePolicy(
+      makePropose([repoSource], ['owner-ratified']),
+      makeContext('1')
+    );
+    expect(decision.allowed).toBe(false);
+    expect(JSON.stringify(decision)).toContain('PRIVILEGED_LABEL');
+  });
+});

--- a/packages/nexus-agents/src/security/policy-gate.ts
+++ b/packages/nexus-agents/src/security/policy-gate.ts
@@ -145,6 +145,61 @@ export function checkRuleOfTwo(context: ActionContext): Violation | undefined {
   return undefined;
 }
 
+/**
+ * Labels that GRANT PRIVILEGE or REDUCE SCRUTINY, and so may never be proposed
+ * by an agent acting on external input (#4688).
+ *
+ * These are not ordinary taxonomy labels. In this repository they are control
+ * inputs to CI:
+ *
+ * - `owner-ratified` — the label `check-governor-ratification.ts` accepts as
+ *   proof of owner ratification. Applying it BYPASSES the governance-of-the-
+ *   governor gate on `src/audit/`, `.rules/`, `CODEOWNERS` and friends.
+ * - `skip-pr-review` — suppresses the PR review workflow.
+ * - `pr-review-ci` — triggers the review workflow; less dangerous than the
+ *   two above, but still a workflow control rather than a description.
+ *
+ * Why this exists BEFORE it is needed: no production code applies a proposed
+ * label today (`addLabels` has no non-test caller), so the path is latent. But
+ * the consensus panel's dissenting seat was right that labels are not
+ * zero-blast-radius, and the day someone wires triage output to `addLabels` is
+ * the day an issue body can propose its own ratification. A guard added after
+ * that wiring is a guard added after the incident.
+ *
+ * This is deliberately checked on the ACTION's effect rather than the author's
+ * trust: an OWNER-authored body proposing `owner-ratified` is precisely the
+ * self-modification the governor exists to prevent, so author trust must not
+ * soften it.
+ */
+const PRIVILEGE_GRANTING_LABELS: ReadonlySet<string> = new Set([
+  'owner-ratified',
+  'skip-pr-review',
+  'pr-review-ci',
+]);
+
+/**
+ * Refuse any proposal naming a privilege-granting label.
+ *
+ * Independent of {@link checkLabelValidity} on purpose: that check returns
+ * early when the repository label set is unknown, and a denylist layered on
+ * top of it would inherit that vacuous pass. This one needs no world state.
+ */
+function checkPrivilegedLabels(action: AgentAction): Violation | undefined {
+  if (action.type !== 'ProposeLabels') return undefined;
+
+  const privileged = action.labels.filter((l) => PRIVILEGE_GRANTING_LABELS.has(l));
+  if (privileged.length === 0) return undefined;
+
+  return {
+    rule: 'PRIVILEGED_LABEL',
+    message:
+      `Proposed labels grant privilege or reduce review scrutiny: ` +
+      `${privileged.join(', ')}. These are CI control inputs, not descriptions, ` +
+      `and are never proposable from agent-processed input (#4688).`,
+    severity: 'block',
+  };
+}
+
 /** Check that proposed labels exist in the repository's label set. */
 function checkLabelValidity(action: AgentAction, context: ActionContext): Violation | undefined {
   if (action.type !== 'ProposeLabels') return undefined;
@@ -213,6 +268,7 @@ export function evaluatePolicy(
     checkInfluenceBlock(action, context),
     checkRuleOfTwo(context),
     checkLabelValidity(action, context),
+    checkPrivilegedLabels(action),
     checkSourceTrustTiers(action),
   ];
 


### PR DESCRIPTION
Part of #4688.

## The hole

`ProposeLabels` was constrained by exactly one label rule: *must exist in the repository label set*. But not every label in this repo is descriptive taxonomy — some are **CI control inputs**:

| Label | Effect |
|---|---|
| `owner-ratified` | the label `check-governor-ratification.ts` accepts as proof of ratification — applying it **bypasses the governance gate** on `src/audit/`, `.rules/`, `CODEOWNERS` |
| `skip-pr-review` | suppresses the PR review workflow |
| `pr-review-ci` | triggers the review workflow |

All three exist in the label set, so all three passed the only check.

## Latent, not live — and that is the point

`addLabels` has **zero non-test callers**, so nothing applies a proposed label today. I checked before claiming otherwise.

It stops being latent the moment someone wires triage output to `addLabels` — a change that reads as an obvious improvement in review. A guard added after that wiring is a guard added after the incident, so this lands first.

## Design

Two deliberate choices:

**Keyed on the action's effect, not the author's trust.** An OWNER-authored issue body proposing `owner-ratified` is precisely the self-modification the governor exists to prevent. Author trust must not soften it — there is a test pinning that at Tier 1 with a maintainer-command source.

**Independent of `checkLabelValidity`.** That function returns early when `context.existingLabels` is undefined. A denylist layered on top would inherit that vacuous pass, so this one needs no world state. Also pinned by a test.

## How this was found

By verifying a dissenting consensus vote instead of outvoting it.

The panel chose tier-aware corroboration 6–1 (unanimous among approvers). The Contrarian rejected, arguing labels are not zero-blast-radius because they gate CI. Grepping `.github/workflows/` confirmed it *for this repo specifically* — `governor-review.yml` triggers on label events. The dissent was right about the premise even though the panel was right about the direction, so the fix is C **plus** this carve-out rather than either alone.

## Note on the test fixtures

My first draft used Tier 3 contexts and three of five tests "passed" immediately — because at Tier 3 `ProposeLabels` is already refused by the influence block, so they never exercised the denylist. They are Tier 1 now, and were verified RED (4 failing, 1 correctly-passing control) before the implementation.

## Verification

`src/security` + `src/dogfooding`: 1697 passing across 64 files. Typecheck and lint clean.

## Still open under #4688

The governance text itself contradicts itself four ways on what corroborates a typed action. The vote picked reading C; reconciling `.rules/untrusted-input.md` and `CLAUDE.md` to match is a governance-path change and will land as a separate ratification PR — including the AI/ML seat's condition that an action absent from the per-action table gets the **strict** floor, so the table fails closed when it drifts.
