### PR TITLE
docs(pipeline): stop the core plugins and the v2 gate overclaiming

### DIFF
--- a/.changeset/honest-execute-boundary.md
+++ b/.changeset/honest-execute-boundary.md
@@ -1,0 +1,31 @@
+---
+'nexus-agents': patch
+---
+
+docs(pipeline): stop the core plugins and the v2 gate claiming capability they do not have
+
+The three core pipeline plugins each advertised real behaviour they have never
+had. `nexus:model-router` described itself as "Routes tasks to optimal model via
+Budget→TOPSIS→LinUCB pipeline"; it is built by `createCorePlugin`, whose handler
+returns `{ stub: true }` and routes nothing. Real routing is the V1 path. The
+task-analyzer and cli-executor descriptions were wrong the same way.
+
+That mattered beyond documentation. The v2-delegate entry policy gate guards
+`route-model`, backed by that stub, inside a pipeline the delegate tool runs
+fire-and-forget as `instrumentV2Pipeline`. The gate emits `policy.evaluated` on
+every run and always allows, which reads in the #3653 autonomy soak as "policy
+enforced at the stage boundary, no violations" — reassuring telemetry about a
+boundary that does nothing.
+
+The gate machinery itself is fine: `plan-compiler.test.ts` already proves a gate
+in front of an `execute`-typed stage throws `PolicyBlockedError` in block mode.
+What is missing is a production plan that gives it something to deny, and that
+is now an asserted fact rather than something to rediscover — tests pin that the
+guarded stage is `route`-typed, that no production stage is `execute`-typed, and
+that the backing plugin is still a skeleton.
+
+No behaviour change. `v2-orchestrate`'s `checkPipelinePolicy(task, 'execute')`
+keeps its literal deliberately: passing the accurate stage type would make the
+rule allow, removing a fail-closed refusal on untrusted input in exchange for
+nothing but an accurate label. Its comment now states what a denial there does
+and does not prove.

--- a/packages/nexus-agents/src/pipeline/core-plugins.ts
+++ b/packages/nexus-agents/src/pipeline/core-plugins.ts
@@ -57,24 +57,47 @@ function createCorePlugin(
 // Core Plugin Definitions
 // ============================================================================
 
-/** Task analyzer plugin — wraps SharedTaskAnalyzer for pipeline stages. */
+/**
+ * Task analyzer plugin — SKELETON (#4657). Registered so `analyze` stages
+ * resolve, but `createCorePlugin` gives it a no-op handler: it does not wrap
+ * SharedTaskAnalyzer, and it analyses nothing.
+ */
 export const TASK_ANALYZER_PLUGIN = createCorePlugin(
   'nexus:task-analyzer',
-  'Analyzes task complexity, type, and required capabilities',
+  'SKELETON: no-op placeholder for analyze stages (does not analyze)',
   ['analyze']
 );
 
-/** Model router plugin — wraps CompositeRouter for pipeline routing stages. */
+/**
+ * Model router plugin — SKELETON (#4657). It does NOT wrap CompositeRouter and
+ * does NOT route: `createCorePlugin` gives it a no-op handler returning
+ * `{ stub: true }`. Real routing is the V1 path (`tryCompositeRoute` in
+ * `mcp/tools/delegate-to-model.ts`).
+ *
+ * The previous description ("Routes tasks to optimal model via
+ * Budget→TOPSIS→LinUCB pipeline") named a real subsystem this plugin has never
+ * touched, which is what made the v2-delegate policy gate look like it guarded
+ * a routing decision.
+ */
 export const MODEL_ROUTER_PLUGIN = createCorePlugin(
   'nexus:model-router',
-  'Routes tasks to optimal model via Budget→TOPSIS→LinUCB pipeline',
+  'SKELETON: no-op placeholder for route stages (does not route)',
   ['route']
 );
 
-/** CLI executor plugin — executes tasks via CLI adapters (claude/gemini/codex). */
+/**
+ * CLI executor plugin — SKELETON (#4657). It does NOT invoke a CLI adapter and
+ * has no retry: `createCorePlugin` gives it a no-op handler.
+ *
+ * This is the plugin that would serve an `execute`-typed stage, and it is worth
+ * being loud about: it is the ONLY registration for that stage type, so the
+ * first plan to declare `type: 'execute'` would satisfy the trust-tier policy
+ * rule while executing nothing. Wire a real handler before declaring an
+ * execute stage, or the gate becomes fireable against a stub.
+ */
 export const CLI_EXECUTOR_PLUGIN = createCorePlugin(
   'nexus:cli-executor',
-  'Executes tasks via external CLI adapters with resilient retry',
+  'SKELETON: no-op placeholder for execute stages (does not execute)',
   ['execute']
 );
 

--- a/packages/nexus-agents/src/pipeline/v2-delegate.test.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.test.ts
@@ -403,3 +403,46 @@ describe('blast radius — compilePlan default unchanged (#3703)', () => {
     expect(gate?.status).toBe('success'); // no-op pass, did not throw/evaluate
   });
 });
+
+describe('the entry gate guards a stage that does not execute (#4657)', () => {
+  // The compiled-gate machinery works: plan-compiler.test.ts proves a gate in
+  // front of an `execute`-typed stage throws PolicyBlockedError in block mode.
+  // What is missing is a PRODUCTION plan that gives it something to deny.
+  //
+  // These assertions pin the honest current state so it is a stated fact
+  // rather than something the next reader rediscovers by tracing four files —
+  // and so the day someone declares this stage `execute`, they are forced to
+  // confront that `nexus:model-router` is a no-op skeleton and the gate would
+  // then be firing against a stub.
+
+  it('the guarded stage is route-typed, so the trust-tier rule cannot deny here', async () => {
+    const { buildDelegatePlan } = await import('./v2-delegate.js');
+    const plan = buildDelegatePlan(makeTask());
+
+    const gate = plan.policyGates?.[0];
+    expect(gate).toBeDefined();
+    const guarded = plan.stages.find((s) => s.id === gate?.beforeStage);
+    expect(guarded).toBeDefined();
+
+    // `trustTierRule` denies only on stageType === 'execute'.
+    expect(guarded?.type).toBe('route');
+    expect(guarded?.type).not.toBe('execute');
+  });
+
+  it('no stage in the production delegate plan is execute-typed', async () => {
+    const { buildDelegatePlan } = await import('./v2-delegate.js');
+    const plan = buildDelegatePlan(makeTask());
+    expect(plan.stages.filter((s) => s.type === 'execute')).toEqual([]);
+  });
+
+  it('the plan is backed by a skeleton plugin, which is why route is honest', async () => {
+    const { MODEL_ROUTER_PLUGIN } = await import('./core-plugins.js');
+    const { buildDelegatePlan } = await import('./v2-delegate.js');
+    const plan = buildDelegatePlan(makeTask());
+
+    expect(plan.stages[0]?.pluginId).toBe(MODEL_ROUTER_PLUGIN.manifest.id);
+    // If this description ever stops saying SKELETON, the plugin gained a real
+    // handler and this whole block should be revisited.
+    expect(MODEL_ROUTER_PLUGIN.manifest.description).toContain('SKELETON');
+  });
+});

--- a/packages/nexus-agents/src/pipeline/v2-delegate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.ts
@@ -261,6 +261,28 @@ const ROUTE_STAGE_ID = 'route-model';
  * Enforcement is resolved by the runtime enforcement bundle (warn by default;
  * block opt-in via `NEXUS_POLICY_GATE_MODE`), NOT a per-gate field (#4019).
  */
+/**
+ * The v2-delegate entry gate.
+ *
+ * HONEST SCOPE (#4657): this gate cannot deny, and the reason is worth stating
+ * where the gate is defined rather than leaving it to be rediscovered.
+ *
+ * `trustTierRule` — the only policy rule — denies on
+ * `tier >= 3 && stageType === 'execute'`. This gate guards `route-model`, which
+ * is declared `type: 'route'`, so the rule always allows. Declaring the stage
+ * `execute` would make the gate fire, but it would be a lie: `nexus:model-router`
+ * resolves to a no-op skeleton plugin (`core-plugins.ts`) and the whole pipeline
+ * runs fire-and-forget as `instrumentV2Pipeline`.
+ *
+ * The consequence to watch is the telemetry, not the missing refusal. This gate
+ * emits `policy.evaluated` on every run and always allows, which reads as
+ * "policy enforced at the stage boundary, no violations" in the #3653 autonomy
+ * soak. It is really "policy evaluated against a stage that does nothing". Do
+ * not count these events as evidence of enforcement.
+ *
+ * Real trust-tier enforcement lives at `dev-pipeline.ts` (`enforceConsensusExecutePolicy`,
+ * `stageType: 'execute'`, fails closed), which guards an actual invocation.
+ */
 const ENTRY_GATE: PolicyGateSpec = {
   id: 'gate-delegate-entry',
   afterStage: START,

--- a/packages/nexus-agents/src/pipeline/v2-orchestrate.ts
+++ b/packages/nexus-agents/src/pipeline/v2-orchestrate.ts
@@ -69,6 +69,21 @@ export function orchestrateInputToTaskContract(
 
 /** Executes the V2 orchestrate pipeline and returns metrics. */
 export async function executeOrchestratePipeline(task: TaskContract): Promise<PipelineMetrics> {
+  // #4657: this 'execute' does NOT correspond to an execute-typed stage. The
+  // plan compiled below has one stage, `route-model`, declared `type: 'route'`
+  // and backed by a no-op skeleton plugin — nothing in it executes.
+  //
+  // It is kept anyway, deliberately. Passing the real stage type ('route')
+  // would make `trustTierRule` allow, which REMOVES a fail-closed refusal on
+  // untrusted input in exchange for nothing: the only thing the current
+  // refusal suppresses is fire-and-forget instrumentation. Weakening a
+  // fail-closed path to make a label accurate is the wrong trade, and a test
+  // pins this refusal as intended behaviour.
+  //
+  // What must not be inferred from it: a denial here is NOT evidence that an
+  // execution was blocked, and an allow here is NOT evidence that an execution
+  // was authorised. Real trust-tier enforcement over an actual invocation is
+  // `dev-pipeline.ts` (`enforceConsensusExecutePolicy`).
   const policyResult = checkPipelinePolicy(task, 'execute');
   if (!policyResult.allowed) {
     const violations = policyResult.violations.map((v) => `${v.ruleId}: ${v.reason}`);


### PR DESCRIPTION
Addresses #4657 — and corrects that issue, which I wrote.

## What I got wrong in #4657

I claimed the compiled graph policy gate "cannot deny". The machinery denies fine: `plan-compiler.test.ts:276` already proves a gate in front of an `execute`-typed stage throws `PolicyBlockedError` in block mode, with the downstream stage never running.

The true statement is narrower and worse: **no production plan gives it anything to deny**, and the stage it does guard is a no-op.

## What is actually there

`nexus:model-router` is built by `createCorePlugin`, whose handler is:

```ts
function noopStageResult(): StageResult {
  return { success: true, outputArtifacts: [], metadata: { stub: true } };
}
```

Its description said:

> Routes tasks to optimal model via Budget→TOPSIS→LinUCB pipeline

It has never touched any of that. Real routing is the V1 path (`tryCompositeRoute`). `nexus:task-analyzer` and `nexus:cli-executor` overclaimed identically.

And the pipeline containing it is not on the critical path — the delegate tool runs it as `instrumentV2Pipeline`, `void`-ed, with a handler that logs failures as "instrumentation failed".

## Why this is a fidelity bug, not a docs nit

The v2-delegate entry gate guards that stub stage. It emits `policy.evaluated` on every run and **always allows**. In the #3653 autonomy soak that reads as *"policy enforced at the stage boundary, no violations"*.

It is really *"policy evaluated against a stage that does nothing"*. A check that cannot fail, producing reassuring evidence — which per the mission is worse than no evidence, because it is exactly the artifact a human spot-check trusts.

## Changes

- The three plugin descriptions now say `SKELETON: ... (does not route/analyze/execute)`. `CLI_EXECUTOR_PLUGIN` gets an extra warning: it is the **only** registration for `execute`-typed stages, so the first plan to declare one would satisfy the trust-tier rule while executing nothing.
- `ENTRY_GATE` documents why it cannot deny and that its telemetry is not evidence of enforcement, pointing at `dev-pipeline.ts`'s `enforceConsensusExecutePolicy` as the real one.
- Three tests pin the honest state: the guarded stage is `route`-typed, no production stage is `execute`-typed, and the backing plugin's description still says `SKELETON`. The last one fails the day someone wires a real handler, which is when this block should be revisited.

## A change I made and reverted

I retyped `v2-orchestrate.ts:72` from `checkPipelinePolicy(task, 'execute')` to `'route'`, on the grounds that the literal was false — the plan it guards has no execute stage.

A pre-existing test failed, and it was right. Passing the accurate stage type makes `trustTierRule` **allow**, which removes a fail-closed refusal on untrusted input and buys nothing: the only thing that refusal currently suppresses is fire-and-forget instrumentation. Weakening a fail-closed path to make a label accurate is the wrong trade.

The literal stays. Its comment now records what a denial there does and does not prove.

## Not done here

Adding real enforcement at the model-invocation seam in `agent-executor.ts` — that is a new enforcement point on a live path and deserves its own change, its own soak, and probably its own vote. Filed separately; #4657 stays open for it.

## Verification

Full suite: **28321 passed, 0 failed** (1190 files). Typecheck and lint clean. No behaviour change.
