### PR TITLE
chore: remove a config knob nothing sets and correct a stale ledger comment

### DIFF
--- a/.changeset/dead-config-and-stale-comment.md
+++ b/.changeset/dead-config-and-stale-comment.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+chore: remove a config knob nothing sets and correct a stale ledger comment
+
+`PersistentGapLedgerConfig.maxEntries` had no writer anywhere — production or
+test — so the in-memory cap was permanently its default. It is a constant now
+rather than a knob nothing turns. Its sibling `retentionDays` stays: a test uses
+it to control retention without manipulating clocks.
+
+`issue-triage.ts` re-exported `formatTriageComment` "for convenience" from
+`issue-triage-helpers.js`, but nothing imported it via that path — the barrel
+already re-exports it from the helpers module directly.
+
+The `getGapLedger` doc still said "nothing is written until the tool-refusal
+producer lands". It landed: `extract-symbols-tool.ts` calls `recordToolRefusal`,
+which defaults to this ledger and writes `tool_refusal` entries (#4654).

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger-persistence.ts
@@ -68,8 +68,6 @@ export interface GapLedgerLoadReport {
 export interface PersistentGapLedgerConfig {
   /** JSONL file backing the ledger. */
   readonly filePath: string;
-  /** Occurrences retained in memory for summarizing. */
-  readonly maxEntries?: number;
   /** Entries older than this are ignored on load. */
   readonly retentionDays?: number;
 }
@@ -219,7 +217,9 @@ function loadEntries(
 export function createPersistentCapabilityGapLedger(
   config: PersistentGapLedgerConfig
 ): IPersistentCapabilityGapLedger {
-  const maxEntries = config.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  // #4684: not configurable — no caller ever set it. The cap stays a constant
+  // rather than a knob nothing turns.
+  const maxEntries = DEFAULT_MAX_ENTRIES;
   const retentionMs = (config.retentionDays ?? DEFAULT_RETENTION_DAYS) * 24 * 60 * 60 * 1000;
   const cutoff = getTimeProvider().now() - retentionMs;
 

--- a/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.ts
+++ b/packages/nexus-agents/src/core/task-analysis/capability-gap-ledger.ts
@@ -157,11 +157,12 @@ let singletonLedger: ICapabilityGapLedger | undefined;
  * by frequency, and an in-memory ledger measured that over "since this process
  * started" — so a gap recurring across sessions could never become frequent.
  *
- * Switching the default is a no-op today: `detectCapabilityGaps` cannot
- * currently produce a gap (#4651), so nothing is written until the tool-refusal
- * producer lands. That is deliberate ordering — persistence must be in place
- * *before* the first producer, or its first weeks of signal evaporate on
- * restart.
+ * Persistence deliberately landed BEFORE the first producer — otherwise the
+ * first weeks of signal would evaporate on restart. That producer has since
+ * arrived: `extract-symbols-tool.ts` calls `recordToolRefusal`, which defaults
+ * to this ledger and writes `type: 'tool_refusal'` entries (#4654). This
+ * comment previously still said "nothing is written until the tool-refusal
+ * producer lands".
  */
 export function getGapLedger(): ICapabilityGapLedger {
   singletonLedger ??= createPersistentCapabilityGapLedger({

--- a/packages/nexus-agents/src/dogfooding/issue-triage.ts
+++ b/packages/nexus-agents/src/dogfooding/issue-triage.ts
@@ -53,9 +53,6 @@ import type {
 } from './issue-triage-types.js';
 import { DEFAULT_ISSUE_TRIAGE_CONFIG } from './issue-triage-types.js';
 
-// Re-export for convenience
-export { formatTriageComment } from './issue-triage-helpers.js';
-
 const logger = createLogger({ component: 'IssueTriage' });
 
 /**


### PR DESCRIPTION
Closes #4684 — at about a third of the originally reported scope, because checking each candidate individually reversed most of them.

## Removed

- **`PersistentGapLedgerConfig.maxEntries`** — no writer anywhere, production or test. The in-memory cap was permanently `DEFAULT_MAX_ENTRIES`, so it is a constant now rather than a knob nothing turns.
- **`export { formatTriageComment }` from `issue-triage.ts`** — added "for convenience"; nothing imported it via that path. `dogfooding/index.ts` already re-exports it from the helpers module directly.

## Corrected

- **`getGapLedger` doc** still said *"nothing is written until the tool-refusal producer lands"*. It landed — `extract-symbols-tool.ts:305` calls `recordToolRefusal`, which defaults to this ledger and writes `type: 'tool_refusal'` (#4654).

## Kept, with the reason — I had these wrong

I listed four items as "genuinely dead" in the issue triage. Three are not, and the greps that established it are worth recording so the next sweep does not re-flag them:

| Symbol | Why it stays |
|---|---|
| `createCapabilityGapLedger` | **33 test usages** across `meta-orchestrator.test.ts`, `research-trigger.test.ts` and others. It is the DI seam that lets tests build an isolated ledger instead of sharing the `getGapLedger()` singleton. Removing it would force tests onto shared state. |
| `getAvailableToolCount` / `getAvailableExpertCount` | Used as cross-check assertions — `expect(getAvailableToolCount()).toBe(TOOL_MANIFEST.length)`. That is the same declaration-vs-reality check pattern `executorAvailable` uses, and it is the thing that catches manifest drift. |
| `retentionDays` | Written by `capability-gap-ledger-persistence.test.ts:109` to control retention without manipulating clocks. Its sibling `maxEntries` genuinely had no writer, which is the asymmetry that made the pair look uniformly dead. |
| `ReapReport.retained` | Redundant with `scanned - reaped`, but load-bearing in the tests as an independent assertion of the tie-retention rule. Marginal either way; not worth churn. |
| `githubToken` | Reported as dead, and it *was* the sole input to `hasSecretAccess` before #4681. It is now the explicit-override arm of `config.githubToken !== undefined \|\| hasToken('github')`, and part of the Zod config schema. Redundant, not dead. |

## The general point

**"No production consumer" and "dead" are not the same thing.** The export ratchet (#3024) correctly flags the first and cannot distinguish the second — test-only dependency-injection seams and cross-check helpers look identical to it. That is fine for a ratchet, whose job is to make you look; it is not a delete list.

Worth noting because I nearly deleted a 33-usage test seam on the strength of "importers are tests + barrel".

## Verification

`src/dogfooding` + `src/core/task-analysis` + `src/pipeline`: 1076 passing across 62 files. Typecheck and lint clean.
