### PR TITLE
feat(pipeline): record the input trust tier on every stage entry

### DIFF
--- a/.changeset/thread-trust-tier.md
+++ b/.changeset/thread-trust-tier.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': minor
+---
+
+feat(pipeline): record the input trust tier on every stage entry
+
+The shared executor path could not say what provenance drove a run.
+`AgentExecutorConfig` had no `trustTier` field and `run_pipeline` had none at
+all — zero references in `pipeline-tool.ts` — so `pipeline` and `research` runs
+carried no tier anywhere.
+
+Record-only: no stage refuses on it. A consensus vote (7-0, option D, 6/7
+selections) established why enforcement cannot land yet — the tier was
+unreachable at every candidate guard site, so a fail-closed guard would have
+blocked every `pipeline` and `research` run rather than only untrusted ones.
+
+The tier is stamped at STAGE ENTRY rather than at the expert call, because
+`runExpert` is not the only model path: `executeVoting` dispatches consensus
+voters through its own adapters and never touches it. A guard or recorder at
+`runExpert` would cover four of five model paths while reporting success. Stage
+entry is the point both pass through.
+
+An absent tier records as `UNMEASURED_TRUST_TIER` (`'unmeasured'`), never as a
+trusted default — an unmeasured run must not be indistinguishable from a
+trusted one in the record. A test pins that the sentinel is not a valid tier
+value, so it cannot be tidied into `'1'`.
+
+`run_pipeline` gains the 2-arg context-aware handler form that
+`run_dev_pipeline` adopted in #3712.

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -214,7 +214,11 @@ async function resolveTaskInput(input: DevPipelineInput): Promise<string> {
 
 /** Create pipeline stages wired to real agents via agent-executor. */
 async function createStages(
-  input: DevPipelineInput
+  input: DevPipelineInput,
+  // #4694: record-only. The consensus→execute seam already ENFORCES on this
+  // tier; the executor stages have never even recorded it, so a run's stage
+  // telemetry could not say what provenance drove it.
+  trustTier?: string
 ): Promise<ReturnType<typeof createAgentStages>> {
   // Auto-detect tracker backend if set to 'auto' or default
   const backendChoice = input.trackerBackend;
@@ -225,6 +229,7 @@ async function createStages(
       ? createTaskTracker({ backend, repo: input.repo, labels: input.labels })
       : undefined;
   return createAgentStages({
+    ...(trustTier !== undefined ? { trustTier } : {}),
     scanTarget: input.workingDir,
     simulateVotes: input.simulateVotes,
     votingStrategy: input.votingStrategy,
@@ -250,7 +255,7 @@ export async function runDevPipelineForGoal(
   trustTier?: string
 ): Promise<DevPipelineResult> {
   const input = DevPipelineInputSchema.parse({ task: goal });
-  const stages = await createStages(input);
+  const stages = await createStages(input, trustTier);
   // #3712: thread the caller's real content-provenance trust tier into the
   // consensus→execute policy snapshot. Undefined ⇒ seam fail-closes to tier 4
   // (never infer trust from absence). The `run` entry point passes the caller's
@@ -367,7 +372,7 @@ async function runDevPipelineHandler(
     // Sync prelude — fast: input resolution + stage wiring + option build.
     // Only the pipeline BODY backgrounds in async mode (#3726).
     const taskText = await resolveTaskInput(input);
-    const stages = await createStages(input);
+    const stages = await createStages(input, trustTier);
     const pipelineOptions = buildPipelineOptions(input, trustTier, auditLogger);
     const hasOptions = Object.keys(pipelineOptions).length > 0;
     const resolvedOptions = hasOptions ? pipelineOptions : undefined;

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -30,7 +30,7 @@ import {
 import { listTemplateIds } from '../../pipeline/templates.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
-import { createSecureHandler } from '../middleware/secure-handler.js';
+import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
   toolStructuredError,
   toolSuccessStructured,
@@ -306,7 +306,11 @@ async function executePipelineBody(
 }
 
 /** Validates input, runs the adaptive orchestrator, and shapes the result. */
-async function runPipelineHandler(args: unknown, logger: ILogger): Promise<ToolResult> {
+async function runPipelineHandler(
+  args: unknown,
+  logger: ILogger,
+  trustTier?: string
+): Promise<ToolResult> {
   const parsed = PipelineInputSchema.safeParse(args);
   if (!parsed.success) {
     return toolStructuredError({
@@ -333,6 +337,9 @@ async function runPipelineHandler(args: unknown, logger: ILogger): Promise<ToolR
       simulateVotes: input.simulateVotes,
       votingStrategy: input.votingStrategy,
       quickMode: input.quickMode,
+      // #4694: record-only. Absent stays absent — createAgentStages stamps
+      // UNMEASURED_TRUST_TIER rather than inventing a trusted default.
+      ...(trustTier !== undefined ? { trustTier } : {}),
       budget: resolveRunBudget(task, input.template, logger),
     });
     const stages = selectStageRegistry(input.template, task, agentStages);
@@ -375,11 +382,19 @@ async function runPipelineHandler(args: unknown, logger: ILogger): Promise<ToolR
  */
 export function registerPipelineTool(server: McpServer, deps: BaseMcpToolDeps): void {
   const logger = deps.logger ?? createLogger({ tool: 'run_pipeline' });
-  const secureHandler = createSecureHandler((args: unknown) => runPipelineHandler(args, logger), {
-    toolName: 'run_pipeline',
-    rateLimiter: deps.rateLimiter,
-    logger,
-  });
+  // #4694: 2-arg context-aware form, mirroring dev-pipeline-tool (#3712).
+  // `run_pipeline` had NO trust tier at all — zero references in this file —
+  // so the shared executor path it drives could not record, let alone enforce,
+  // the provenance of its input. createSecureHandler always supplies a
+  // HandlerContext with a derived trustTier.
+  const secureHandler = createSecureHandler(
+    // Optional chaining is deliberate, not defensive noise: a handler invoked
+    // without a context has genuinely NOT measured a tier, and that flows to
+    // UNMEASURED_TRUST_TIER rather than to a default. Absence stays absence.
+    (args: unknown, ctx?: HandlerContext) =>
+      runPipelineHandler(args, logger, ctx?.requestContext.trustTier),
+    { toolName: 'run_pipeline', rateLimiter: deps.rateLimiter, logger }
+  );
   const timeoutMs = getToolTimeout('run_pipeline', deps.security);
   const wrapped = wrapToolWithTimeout('run_pipeline', secureHandler, { timeoutMs, logger });
 

--- a/packages/nexus-agents/src/pipeline/agent-executor-trust-tier.test.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor-trust-tier.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Trust-tier recording on the shared executor path (#4694).
+ *
+ * RECORD-ONLY by design. The consensus vote (7-0, option D, 6/7 selections)
+ * established that enforcement cannot land yet: the tier was unreachable at
+ * every candidate guard site, so a fail-closed guard would have blocked every
+ * `pipeline` and `research` run rather than only untrusted ones.
+ *
+ * The property these tests protect is that the record is HONEST — an
+ * unmeasured tier must be recorded as unmeasured, never as a trusted default.
+ * Four voters made that an explicit condition of approving the record-first
+ * approach.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./expert-bridge.js', () => ({
+  executeExpert: vi.fn(() =>
+    Promise.resolve({ success: true, text: 'ok', expertType: 'code', durationMs: 1, tokensUsed: 1 })
+  ),
+}));
+
+const { emitMock } = vi.hoisted(() => ({ emitMock: vi.fn() }));
+vi.mock('./pipeline-observability.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./pipeline-observability.js')>();
+  return { ...actual, emitPipelineStageEvent: emitMock };
+});
+
+import { createAgentStages, UNMEASURED_TRUST_TIER } from './agent-executor.js';
+
+beforeEach(() => {
+  emitMock.mockClear();
+});
+
+/** Trust tiers recorded on every `started` event emitted so far. */
+function recordedTiers(): unknown[] {
+  return emitMock.mock.calls
+    .filter((c) => c[2] === 'started')
+    .map((c) => (c[3] as Record<string, unknown> | undefined)?.['trustTier']);
+}
+
+describe('trust tier is recorded at stage entry (#4694)', () => {
+  it('records the tier the caller supplied', async () => {
+    const stages = createAgentStages({ trustTier: '3' });
+    await stages.implement({ id: 't1', title: 'x', description: 'y' } as never);
+    expect(recordedTiers()).toContain('3');
+  });
+
+  it('records an ABSENT tier as unmeasured, never as a trusted default', async () => {
+    // The named empty case. Omitting the field, or defaulting it to '1', would
+    // make an unmeasured run indistinguishable from a trusted one in the
+    // record — and the record is the artifact a later human spot-check trusts.
+    const stages = createAgentStages({});
+    await stages.implement({ id: 't2', title: 'x', description: 'y' } as never);
+
+    const tiers = recordedTiers();
+    expect(tiers).toContain(UNMEASURED_TRUST_TIER);
+    expect(tiers).not.toContain('1');
+    expect(tiers).not.toContain(undefined);
+  });
+
+  it('the unmeasured sentinel is not a valid trust tier', () => {
+    // Guards against someone "tidying" this into '1'..'4'. If the sentinel ever
+    // becomes a real tier value, absence starts reading as a measurement.
+    expect(['1', '2', '3', '4']).not.toContain(UNMEASURED_TRUST_TIER);
+  });
+
+  it('stamps EVERY stage entry, including the consensus path', async () => {
+    // runExpert and executeVoting are parallel model paths — a guard on
+    // runExpert alone would have missed the whole consensus voter fan-out.
+    // Stage entry is the point both pass through, which is why the tier is
+    // recorded here rather than at the expert call.
+    const stages = createAgentStages({ trustTier: '2' });
+    await stages.qaReview({ id: 't3', title: 'x', description: 'y' } as never, 'impl');
+
+    const started = emitMock.mock.calls.filter((c) => c[2] === 'started');
+    expect(started.length).toBeGreaterThan(0);
+    for (const call of started) {
+      const details = call[3] as Record<string, unknown> | undefined;
+      expect(details?.['trustTier'], `stage '${String(call[1])}' recorded no tier`).toBe('2');
+    }
+  });
+});

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -105,6 +105,17 @@ function classifyVoteStageResult(votingResult: {
 }
 
 // DRY: delegate to shared pipeline-observability.ts (#1734 Phase 1.1)
+/**
+ * What a stage records when no trust tier reached it (#4694).
+ *
+ * The empty case is NAMED rather than defaulted. Recording an absent tier as
+ * `'1'`, or omitting the field, would make an unmeasured run indistinguishable
+ * from a trusted one — and four voters made this an explicit condition of
+ * approving the record-first approach: "a check that cannot fail is not a
+ * check, and neither is a recorder that fills in trusted-by-default."
+ */
+export const UNMEASURED_TRUST_TIER = 'unmeasured';
+
 function emitStageEvent(
   stage: string,
   status: 'started' | 'completed' | 'failed',
@@ -192,6 +203,20 @@ export interface AgentExecutorConfig {
    * rather than aborting mid-pipeline. Absent → no enforcement (default).
    */
   readonly budget?: AgentBudgetConfig | undefined;
+  /**
+   * Trust tier of the input driving this run (#4694), threaded from the MCP
+   * request context.
+   *
+   * RECORD-ONLY today: no stage refuses on it. The consensus vote (7-0, option
+   * D) established why enforcement cannot land yet — the tier was unreachable
+   * here at all, so a fail-closed guard would have blocked every `pipeline` and
+   * `research` run rather than only untrusted ones. Threading and measuring
+   * comes first; the enforcement point is chosen on the measured distribution.
+   *
+   * `undefined` means NOT MEASURED, and is recorded as such — never defaulted
+   * to a trusted value. See {@link UNMEASURED_TRUST_TIER}.
+   */
+  readonly trustTier?: string | undefined;
 }
 
 /**
@@ -493,13 +518,24 @@ function getTrendContext(): string {
 export function createAgentStages(config: AgentExecutorConfig = {}): DevPipelineStages {
   // Per-run budget guard (#3395). No-op unless config.budget is set.
   const guard = createBudgetGuard(config.budget);
+
+  // #4694: stamp every stage entry with the tier of the input driving the run.
+  // Stage entry is the one point BOTH model paths pass through — `runExpert`
+  // (plan/decompose/implement/qaReview) and `executeVoting`, which dispatches
+  // consensus voters through its own adapters and never touches `runExpert`.
+  // Recording here therefore has no coverage gap, which a `runExpert` guard
+  // would have had while reporting success.
+  const trustTier = config.trustTier ?? UNMEASURED_TRUST_TIER;
+  const startStage = (stage: string): void => {
+    emitStageEvent(stage, 'started', { trustTier });
+  };
   return {
     research: async (task) => {
       // #3372 Option A (7/7 vote): call the research tools DIRECTLY for structured
       // data instead of routing through an LLM expert that discards it. The text
       // returned here is DERIVED from that same structure (single source of truth);
       // increment 2 threads the structured metadata through plan/vote.
-      emitStageEvent('research', 'started');
+      startStage('research');
       await postProgress(config, 'Research', 'Querying research tools (structured)...');
       const start = getTimeProvider().now();
       const topic = task.slice(0, 200);
@@ -550,7 +586,7 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
     },
 
     plan: async (task, research, feedback) => {
-      emitStageEvent('plan', 'started');
+      startStage('plan');
       const outcomeCtx = getOutcomeContext();
       const trendCtx = getTrendContext();
       const weatherCtx = await getWeatherContext();
@@ -578,7 +614,7 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
     },
 
     vote: async (plan, research) => {
-      emitStageEvent('vote', 'started');
+      startStage('vote');
       const start = getTimeProvider().now();
       const strategy = config.votingStrategy ?? 'higher_order';
       await postProgress(config, 'Vote', `Running consensus with ${strategy} strategy...`);
@@ -654,7 +690,7 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
     },
 
     decompose: async (plan) => {
-      emitStageEvent('decompose', 'started');
+      startStage('decompose');
       await postProgress(config, 'PM', 'PM expert decomposing...');
       const r = await runExpert(
         guard,
@@ -676,7 +712,7 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
     },
 
     implement: async (task) => {
-      emitStageEvent(`impl-${task.id}`, 'started');
+      startStage(`impl-${task.id}`);
       await postProgress(config, `Code [${task.id}]`, task.title);
       const fb = task.feedback !== undefined ? `\n\nQA feedback: ${task.feedback}` : '';
       const r = await runExpert(
@@ -709,7 +745,7 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
     },
 
     qaReview: async (task, implementation) => {
-      emitStageEvent(`qa-${task.id}`, 'started');
+      startStage(`qa-${task.id}`);
       await postProgress(config, `QA [${task.id}]`, 'QA expert reviewing...');
       const r = await runExpert(
         guard,
@@ -744,7 +780,7 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
     },
 
     qualityGate: async () => {
-      emitStageEvent('quality-gate', 'started');
+      startStage('quality-gate');
       const start = getTimeProvider().now();
       const target = config.scanTarget ?? process.cwd();
       await postProgress(config, 'QualityGate', `Typecheck/lint/tests on ${target}...`);
@@ -782,7 +818,7 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
     },
 
     securityScan: async () => {
-      emitStageEvent('security', 'started');
+      startStage('security');
       const start = getTimeProvider().now();
       const target = config.scanTarget ?? process.cwd();
       await postProgress(config, 'Security', `Scanning ${target}...`);


### PR DESCRIPTION
Implements #4694 step 1. Record-only — nothing refuses on this tier yet, by design.

## Why record before enforcing

`consensus_vote` (higher_order, absolute_quorum): **approved 7–0**, option D with 6/7 selections.

The deciding fact, verified directly:

```
trustTier references in pipeline-tool.ts .......... 0
trustTier fields on AgentExecutorConfig .......... 0
```

The tier existed only on `DevPipelineOptions`. So a fail-closed guard installed today would have blocked **every** `pipeline` and `research` run — not only untrusted ones. Threading is a prerequisite of every enforcement option, not an alternative to one. The Contrarian, voting approve, put it as: enforcing on unthreaded state is "a classic recipe for widespread outages."

## Why stage entry, not `runExpert`

`runExpert` is not the only model path. `executeVoting` (`agent-executor.ts:587`) dispatches consensus voters through its own gateway adapters and **never touches `runExpert`** — it also bypasses the budget guard and `model.called`.

A recorder at `runExpert` would cover plan / decompose / implement / qaReview and miss the entire consensus fan-out, while reporting success. That is the partial-coverage-reading-as-complete failure this issue was written to avoid, so it would have been an unusually poor place to reproduce it.

Stage entry is the point both paths pass through, and it stays correct if a future stage adds a third. It is also the site the vote named as the presumptive eventual enforcement point, so enforcement later is a change *in place* rather than a relocation.

All eight stage-entry events carry the tier, including the two with dynamic names (`impl-${task.id}`, `qa-${task.id}`) — those were easy to miss, since a literal grep for `'started'` skips right past them.

## The empty case is named

```ts
export const UNMEASURED_TRUST_TIER = 'unmeasured';
```

An absent tier records as *absent*, never as a trusted default. Four voters independently made this a condition of approving the record-first approach — Scope Steward: *"a check that cannot fail is not a check, and neither is a recorder that fills in trusted-by-default."*

Two tests protect it:

- **Mutation-verified**: changing the fallback to `'1'` fails the empty-case test.
- A second test pins that the sentinel is **not** a valid tier value, so it cannot be quietly tidied into `'1'..'4'` — which would make absence start reading as a measurement.

## Threading

- `run_dev_pipeline` — tier was already available; `createStages` now passes it (both call sites).
- `run_pipeline` — gains the 2-arg context-aware handler form `run_dev_pipeline` adopted in #3712, since it had no context at all.

The optional chaining on `ctx?.requestContext.trustTier` is deliberate rather than defensive noise: a handler invoked without a context has genuinely not measured a tier, and that flows to the sentinel. Absence stays absence.

## What is deliberately NOT here

No refusal. `enforceConsensusExecutePolicy` (`dev-pipeline.ts:324`) remains the one enforcing seam throughout. The enforcement decision is step 3, made on the measured tier distribution — tracked on #4694 per the Scope Steward's condition that it be an issue, not a note.

DevEx dissented in favour of guarding now at stage entry (option C). Several approvers agreed C is the right eventual site; the disagreement was sequencing. Recorded on the issue so the follow-up does not relitigate it.

## Verification

Full suite **28325 passed, 0 failed** (1191 files). Typecheck and lint clean.
