### PR TITLE
fix(audit): report an unanchored chain head instead of verifying it clean

### DIFF
--- a/.changeset/audit-chain-unanchored-head.md
+++ b/.changeset/audit-chain-unanchored-head.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+fix(audit): report an unanchored chain head instead of verifying it clean
+
+`verifyEvent` guarded the `previousHash` comparison with `index > 0`, so
+`verifyChain` never asserted that a chain STARTS at a genesis. Deleting the
+first n lines needed no rehash — the remainder returned `{ ok: true }` while its
+new head still carried a live 64-hex pointer to the deleted predecessor. The
+evidence was present and discarded.
+
+This is a gap against what the threat model claims, not accepted risk: the
+document says the chain reliably detects naive deletions by an adversary who
+does not recompute it, and front-deletion is exactly that class. Tail truncation
+and the empty chain remain documented and accepted, and are unchanged.
+
+`verifyChain` now reports `unanchoredHead: { previousHash, detail }`.
+Deliberately not `ok: false` — routine log rotation produces an identical shape
+and the verifier cannot distinguish the two, so reporting tamper would flag
+every rotated deployment and teach operators to dismiss it. The honest verdict
+is: links verified, origin unverified.
+
+Threat-model T6 moves from "Detected? No / HIGH" to partial / MEDIUM, naming
+what is still undetected — a fabricated genesis with recomputed hashes remains
+indistinguishable, and needs an external anchor.

--- a/docs/security/audit-hash-chain-threat-model.md
+++ b/docs/security/audit-hash-chain-threat-model.md
@@ -248,14 +248,34 @@ omission is invisible — same root cause as T3.
 to bind to. An adversary can substitute a fabricated "genesis" event, or splice
 a fabricated history before the real first event.
 
-**Detected?** **No.** `verifyEvent` deliberately skips the `previousHash` check
-for `index === 0` (`audit-logger.ts:91`, the `index > 0` guard). The head of the
-chain is unanchored, so its provenance is unverifiable. This is the structural
-twin of T1 (tail) at the head.
+**Detected?** **Partially, since #4703.** `verifyEvent` still skips the
+`previousHash` comparison at `index === 0` — there is genuinely nothing in the
+chain to compare against. But `verifyChain` now reports `unanchoredHead` when
+the first event carries a `previousHash` at all, which is the observable trace
+of a front-deletion that did not recompute anything.
 
-**Residual risk: HIGH.** No genesis anchor, no binding of the first hash to any
-external value (a config commit, a deployment ID, a previous log file's final
-hash). Each log directory's chain floats free.
+This closes a specific gap rather than T6 as a whole. Before #4703 a
+front-truncated chain returned a clean `ok: true` **while its head still
+carried a live 64-hex pointer to the deleted predecessor** — the evidence was
+present and discarded. That contradicted this document's own claim (§ Threat
+Coverage) to detect naive deletions by an adversary who does not recompute the
+chain, since deleting the first _n_ lines is exactly that class.
+
+What is reported is deliberately **not** `ok: false`. Routine log rotation
+(`pruneOldFiles`, `audit-storage.ts`) produces an identical shape, and a
+verifier that reports tamper on every rotated deployment is one operators learn
+to dismiss — which is how a real tamper gets waved through. The verifier cannot
+distinguish the two cases, so it says so: links verified, origin unverified.
+
+**Still undetected:** a fabricated genesis (`previousHash` absent, hashes
+recomputed from a forged first event) is indistinguishable from a real one.
+That is the part needing an external anchor.
+
+**Residual risk: MEDIUM** (was HIGH). No genesis anchor and no binding of the
+first hash to an external value (a config commit, a deployment ID, a previous
+log file's final hash) — each log directory's chain still floats free. What
+changed is that a chain which _claims_ a predecessor it cannot show now says so
+instead of reporting clean.
 
 ### T7: Content tampering in unhashed fields
 
@@ -328,7 +348,7 @@ of the log. The single-key/no-key in-repo design cannot self-defend here.
 | T3  | Rewrite-and-rehash                   | **No** (fundamental)                      | HIGH          |
 | T4  | Reordering                           | Yes if not rehashed; No if rehashed       | MEDIUM        |
 | T5  | Missing / selective omission         | Yes if not re-stitched; No if re-stitched | MEDIUM–HIGH   |
-| T6  | First-record integrity (no anchor)   | No                                        | HIGH          |
+| T6  | First-record integrity (no anchor)   | Partial (unanchoredHead, #4703)           | MEDIUM        |
 | T7  | Content tampering in unhashed fields | **No**                                    | HIGH          |
 | T8  | Chain-disable / downgrade            | No (reports OK)                           | HIGH          |
 | T9  | Verifier tampering                   | No (by definition)                        | HIGH          |

--- a/packages/nexus-agents/src/audit/audit-chain-verify.test.ts
+++ b/packages/nexus-agents/src/audit/audit-chain-verify.test.ts
@@ -147,3 +147,58 @@ describe('verifyChain', () => {
     }
   });
 });
+
+describe('front-truncation is detected (#4703)', () => {
+  // The threat model is tamper-EVIDENT, not tamper-proof, and it accepts that
+  // an adversary who recomputes the whole chain wins. What it claims to catch
+  // is "naive deletions by an adversary who does not recompute the chain".
+  //
+  // Deleting the FIRST n lines is exactly that class, and it needed no rehash:
+  // `verifyEvent` guarded the previousHash comparison with `index > 0`, so it
+  // never asserted the chain starts at a genesis. The remainder verified clean
+  // while its new head still carried a live 64-hex pointer to a deleted event —
+  // the evidence was in hand and discarded.
+
+  it('reports unanchored_head when the head still points at a predecessor', () => {
+    const full = chain(6);
+    const truncated = full.slice(3);
+
+    // Precondition: nothing was rehashed. The head carries its old pointer.
+    expect(truncated[0]?.previousHash).toBeDefined();
+
+    const verdict = verifyChain(truncated);
+
+    // Deliberately NOT ok:false. Routine log rotation produces this identical
+    // shape, and a verifier that reports tamper on every rotated deployment is
+    // one operators learn to dismiss — which is how a real tamper gets waved
+    // through. The links DO all verify; what is unverified is the origin.
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok) {
+      expect(verdict.unanchoredHead).toBeDefined();
+      // The pointer to the deleted predecessor belongs in the record, not the bin.
+      expect(verdict.unanchoredHead?.previousHash).toBe(truncated[0]?.previousHash);
+      expect(verdict.unanchoredHead?.detail).toContain('ORIGIN is unverified');
+    }
+  });
+
+  it('a genesis chain carries NO unanchoredHead — absence is meaningful', () => {
+    const verdict = verifyChain(chain(6));
+    expect(verdict.ok).toBe(true);
+    if (verdict.ok) expect(verdict.unanchoredHead).toBeUndefined();
+  });
+
+  it('a genuine genesis chain still verifies', () => {
+    const verdict = verifyChain(chain(6));
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('a single genesis event verifies', () => {
+    expect(verifyChain(chain(1)).ok).toBe(true);
+  });
+
+  it('an empty chain is unchanged — documented and accepted', () => {
+    // Not in scope here: the threat model explicitly accepts this (§1.4).
+    // Asserted so a future change to the empty case is a deliberate one.
+    expect(verifyChain([]).ok).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/audit/audit-logger.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.ts
@@ -9,6 +9,15 @@
  * @module audit/audit-logger
  */
 
+/* eslint-disable max-lines --
+ * This file sat EXACTLY at the 400-line cap before #4703, so the 16 lines the
+ * unanchored-head check adds push it over. Taking the exemption rather than
+ * bundling a refactor into a security fix: the right split is to move
+ * `verifyChain`/`verifyEvent` beside their existing test
+ * (`audit-chain-verify.test.ts`), tracked as #4702. Do not add to
+ * this file without doing that extraction first.
+ */
+
 import * as crypto from 'node:crypto';
 import type { ILogger } from '../core/logger.js';
 import { createLogger } from '../core/logger.js';
@@ -88,7 +97,17 @@ function computeEventHash(event: AuditEvent): string {
  * or one of three named tampering signals fires at a specific event index.
  */
 export type ChainVerification =
-  | { ok: true; eventCount: number }
+  | {
+      ok: true;
+      eventCount: number;
+      /**
+       * Set when the chain's first event carries a `previousHash` (#4703):
+       * links verified, ORIGIN unverified. Rotation and front-truncation look
+       * identical here and the verifier cannot tell them apart, so it reports
+       * rather than judges — see T6 in the audit hash-chain threat model.
+       */
+      unanchoredHead?: { previousHash: string; detail: string };
+    }
   | {
       ok: false;
       reason: 'hash_mismatch' | 'previous_hash_mismatch' | 'missing_hash';
@@ -162,6 +181,26 @@ export function verifyChain(events: readonly AuditEvent[]): ChainVerification {
     if (failure !== null) return failure;
     priorHash = event.hash;
   }
+
+  // #4703: links verified — but did the chain START where it claims to?
+  // `verifyEvent` skips the previousHash comparison at index 0, so a
+  // front-truncated chain used to return a clean `ok: true` while its head
+  // still carried a live pointer to the deleted event.
+  const headPreviousHash = events[0].previousHash;
+  if (headPreviousHash !== undefined) {
+    return {
+      ok: true,
+      eventCount: events.length,
+      unanchoredHead: {
+        previousHash: headPreviousHash,
+        detail:
+          `chain head references predecessor ${headPreviousHash} which is not in this chain — ` +
+          `expected after log rotation/pruning, and also what front-truncation looks like. ` +
+          `Links all verify; the chain's ORIGIN is unverified.`,
+      },
+    };
+  }
+
   return { ok: true, eventCount: events.length };
 }
 


### PR DESCRIPTION
Closes #4703.

> **Governance path (`src/audit/`) — needs your ratification. Never auto-merged.**

## The defect

`verifyEvent` guards the `previousHash` comparison with `index > 0`, so `verifyChain` never asserted that a chain **starts at a genesis**. Deleting the first _n_ lines needed no rehash.

Reproduced against the real v1 projection before fixing:

```
intact (6 events)    : {"ok":true,"eventCount":6}
front-truncated (-3) : {"ok":true,"eventCount":3}
   head.previousHash = 12bdd3686fd13e3e...   <- live pointer to a DELETED event
```

The chain reported clean **while holding the evidence of its own truncation**.

## Why this is a gap and not accepted risk

The threat model is explicitly tamper-*evident*, not tamper-proof, and I scoped the review against that. It accepts an adversary who recomputes the whole chain, and it accepts tail truncation and the empty chain — those are unchanged here, and now have tests asserting they are unchanged, so altering them later is a deliberate act.

What it **claims** is to reliably detect "naive deletions by an adversary who does not recompute the chain." Deleting the first _n_ lines is exactly that class.

## Why `unanchoredHead` and not `ok: false`

Routine log rotation (`pruneOldFiles`) produces an identical shape. The verifier genuinely cannot distinguish rotation from truncation, so it reports rather than judges:

> links verified, ORIGIN unverified

I implemented it as `ok: false` first and reworked it. Flagging every rotated deployment as tampered is how a verifier teaches operators to dismiss it — the same alert-fatigue failure that makes the restart-time `previous_hash_mismatch` (separately logged) actively harmful. A verifier nobody believes is worse than one that admits what it cannot determine.

## Threat model

T6 moves from **"Detected? No / residual HIGH"** to **partial / MEDIUM**, and names the case still undetected rather than implying the gap is closed: a fabricated genesis with recomputed hashes remains indistinguishable from a real one, and that needs an external anchor.

## The `max-lines` exemption

`audit-logger.ts` sat at **exactly** the 400-line cap, so any addition trips lint.

I started extracting `verifyChain` into its own module and backed it out — it is a larger change to a never-auto-merge file than the security fix it would ride along with, and I got the mechanics wrong: `computeEventHash` is used by both the writer and the verifier, so a naive move duplicates it. Duplicating *that* function is the one thing that must not happen here, because the writer and verifier drifting apart on the hashed projection means the chain verifies against a projection it was not written with.

So: file-level exemption with the reason inline, extraction tracked as **#4702** with those hazards written down, and the comment tells the next person to do the extraction before adding a line.

## Verification

Full suite **28330 passed, 0 failed** (1191 files). That run predates the comment-only issue-reference corrections; the audit suites (which contain the changed test file) were re-run after at **305 passing**, and lint/typecheck/markdownlint are clean on the final state.

## Also found, not fixed here

Three further audit-chain findings are recorded in the gitignored security log rather than filed publicly. The one worth your attention operationally: **every process restart currently reports `previous_hash_mismatch`**, because the logger sets `lastHash = null` and never recovers the ledger tip, while storage resumes the same file. The sibling stores (`vote-record-store.ts:439`, `pr-review-record-store.ts:325`) read the tip first and get this right.
