### PR TITLE
fix(workflows): stop retrying validation failures

### DIFF
--- a/.changeset/nonretryable-through-cause.md
+++ b/.changeset/nonretryable-through-cause.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+fix(workflows): stop retrying validation failures
+
+`isNonRetryableError` could not return true. `step-executor` wraps every
+failure in a `WorkflowError`, and `WorkflowError` hardcodes
+`code: ErrorCode.WORKFLOW_ERROR` while `Omit`-ing `code` from its options — so
+a caller cannot set `VALIDATION_ERROR` even deliberately, and `name` is always
+`'WorkflowError'`. Both branches of the guard were unreachable from the one
+call site that uses it, and a validation failure was retried to exhaustion:
+same input, same failure, every time.
+
+The original error survives as `cause` on the wrap, so the guard now walks the
+cause chain rather than changing the error class. The walk is cycle-guarded —
+`cause` is untyped at that boundary, and a loop would hang the retry rather
+than fail it.
+
+Absence of a cause still means retry. No evidence of a permanent failure is not
+evidence of one.

--- a/packages/nexus-agents/src/workflows/step-executor-helpers.test.ts
+++ b/packages/nexus-agents/src/workflows/step-executor-helpers.test.ts
@@ -260,3 +260,61 @@ describe('isNonRetryableError', () => {
     expect(isNonRetryableError(error)).toBe(false);
   });
 });
+
+describe('isNonRetryableError sees through the WorkflowError wrap (#4672)', () => {
+  // The guard could not fire in production. `step-executor.ts` wraps EVERY
+  // failure in a `WorkflowError` (`executeAttempt`'s error paths), and
+  // `WorkflowError` hardcodes `code: ErrorCode.WORKFLOW_ERROR` while `Omit`-ing
+  // `code` from its options — so a caller cannot set VALIDATION_ERROR even
+  // deliberately, and `name` is always `'WorkflowError'`. Both branches of the
+  // guard were therefore unreachable from the one call site that uses it, and
+  // validation failures were retried to exhaustion.
+  //
+  // The original error survives as `cause` (step-executor.ts:341), so the fix
+  // is to look there rather than to change the error class.
+
+  it('is non-retryable when a ValidationError is wrapped', () => {
+    const original = new Error('bad input');
+    original.name = 'ValidationError';
+    const wrapped = new WorkflowError("Unexpected error in step 's1': bad input", {
+      cause: original,
+    });
+    expect(isNonRetryableError(wrapped)).toBe(true);
+  });
+
+  it('is non-retryable when a VALIDATION_ERROR-coded NexusError is wrapped', () => {
+    const original = new NexusError('bad input', { code: ErrorCode.VALIDATION_ERROR });
+    const wrapped = new WorkflowError('wrapped', { cause: original });
+    expect(isNonRetryableError(wrapped)).toBe(true);
+  });
+
+  it('is non-retryable for INVALID_INPUT and WORKFLOW_PARSE_ERROR too', () => {
+    for (const code of [ErrorCode.INVALID_INPUT, ErrorCode.WORKFLOW_PARSE_ERROR]) {
+      const wrapped = new WorkflowError('wrapped', {
+        cause: new NexusError('nope', { code }),
+      });
+      expect(isNonRetryableError(wrapped), `code ${code}`).toBe(true);
+    }
+  });
+
+  it('stays RETRYABLE for a wrapped transient failure', () => {
+    // The whole point of retrying. A network blip must not be mistaken for a
+    // validation failure just because it arrived wrapped.
+    const wrapped = new WorkflowError('wrapped', { cause: new Error('ECONNRESET') });
+    expect(isNonRetryableError(wrapped)).toBe(false);
+  });
+
+  it('handles an absent cause — the named empty case', () => {
+    // No cause is not evidence of non-retryability. Absence must read as
+    // "retry", the pre-existing behaviour, not as a default in either direction.
+    expect(isNonRetryableError(new WorkflowError('step failed'))).toBe(false);
+  });
+
+  it('terminates on a self-referential cause chain', () => {
+    // Defensive: `cause` is untyped at the boundary and a cycle would hang the
+    // retry loop rather than fail it.
+    const a = new WorkflowError('a');
+    (a as { cause?: unknown }).cause = a;
+    expect(isNonRetryableError(a)).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/workflows/step-executor-helpers.ts
+++ b/packages/nexus-agents/src/workflows/step-executor-helpers.ts
@@ -8,7 +8,7 @@
  */
 
 import type { WorkflowStep } from '../core/index.js';
-import { WorkflowError, TimeoutError, ErrorCode } from '../core/index.js';
+import { WorkflowError, TimeoutError, ErrorCode, NexusError } from '../core/index.js';
 import type { WorkflowExecutionContext } from './execution-context.js';
 
 /** Maximum retry delay (capped with exponential backoff). */
@@ -150,18 +150,46 @@ export function extractErrorMessage(error: Error | undefined): string {
   return error.message;
 }
 
+/** Error codes that mean "this will fail identically next time — stop". */
+const NON_RETRYABLE_CODES: ReadonlySet<string> = new Set<string>([
+  ErrorCode.VALIDATION_ERROR,
+  ErrorCode.WORKFLOW_PARSE_ERROR,
+  ErrorCode.INVALID_INPUT,
+]);
+
+/** Whether THIS error (ignoring its cause) is one we must not retry. */
+function isNonRetryableSelf(error: Error): boolean {
+  if (error.name === 'ValidationError') return true;
+  return error instanceof NexusError && NON_RETRYABLE_CODES.has(error.code);
+}
+
 /**
  * Determines if an error should not be retried.
+ *
+ * Walks the `cause` chain (#4672). It has to: `step-executor` wraps EVERY
+ * failure in a `WorkflowError`, and `WorkflowError` hardcodes
+ * `code: ErrorCode.WORKFLOW_ERROR` while `Omit`-ing `code` from its options —
+ * so a wrapped validation failure arrives with `name === 'WorkflowError'` and
+ * the workflow code, and neither of the original checks could ever be true.
+ * The guard was structurally incapable of stopping a retry, and validation
+ * failures were retried to exhaustion.
+ *
+ * The original error survives as `cause` (`step-executor.ts` sets it on the
+ * wrap), so the identity is recoverable — it was just never looked at.
+ *
+ * Absence of a cause means RETRY, the prior behaviour: no evidence of a
+ * permanent failure is not evidence of one.
  */
 export function isNonRetryableError(error: Error): boolean {
-  if (error.name === 'ValidationError') return true;
-  if (error instanceof WorkflowError) {
-    const code = error.code;
-    return (
-      code === ErrorCode.VALIDATION_ERROR ||
-      code === ErrorCode.WORKFLOW_PARSE_ERROR ||
-      code === ErrorCode.INVALID_INPUT
-    );
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  // `cause` is untyped at the boundary, and a cycle would hang the retry loop
+  // rather than fail it — so track what we have visited.
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    if (isNonRetryableSelf(current)) return true;
+    current = (current as { cause?: unknown }).cause;
   }
   return false;
 }

--- a/packages/nexus-agents/src/workflows/step-executor.test.ts
+++ b/packages/nexus-agents/src/workflows/step-executor.test.ts
@@ -578,6 +578,71 @@ describe('StepExecutor', () => {
   });
 
   describe('retry logic', () => {
+    // #4672 seam test. `isNonRetryableError` was structurally unable to fire —
+    // every failure reaches it wrapped in a `WorkflowError`, whose code is
+    // hardcoded and whose name is never 'ValidationError'. Unit-testing the
+    // helper alone would not have caught that: the helper looked correct, and
+    // the defect lived in the join between the wrap and the guard. So this
+    // asserts the observable consequence — attempt COUNT — through the real
+    // executor.
+    it('does NOT retry a validation failure (#4672)', async () => {
+      let attemptCount = 0;
+      const validationFactory: IExpertFactory = {
+        createForRole: () => {
+          attemptCount++;
+          const validation = new Error('input "target" is required');
+          validation.name = 'ValidationError';
+          return ok(createMockExpert({ executeResult: err(validation as AgentError) }));
+        },
+      };
+
+      const executor = createStepExecutor({ expertFactory: validationFactory });
+      const step: WorkflowStep = {
+        id: 'step1',
+        agent: 'code_expert',
+        action: 'analyze',
+        inputs: {},
+        retries: 3,
+      };
+
+      const result = await executor.execute(step, context, { retryDelayMs: 1 });
+
+      // Retrying a validation failure cannot succeed — the input is identical
+      // every time — so it must stop after the first attempt.
+      expect(attemptCount).toBe(1);
+
+      // And it surfaces as an ERROR result, not the ok({status:'failed'})
+      // envelope that exhausted retries produce. The two are different
+      // outcomes and the caller can tell them apart: "this will never work"
+      // versus "this kept not working".
+      expect(result.ok).toBe(false);
+    });
+
+    it('still retries a transient failure the full allowance (#4672 control)', async () => {
+      // The other direction: the fix must not turn every wrapped error into a
+      // permanent one. Without this, "does not retry" could pass by breaking
+      // retries entirely.
+      let attemptCount = 0;
+      const transientFactory: IExpertFactory = {
+        createForRole: () => {
+          attemptCount++;
+          return ok(createMockExpert({ executeResult: err(new AgentError('ECONNRESET')) }));
+        },
+      };
+
+      const executor = createStepExecutor({ expertFactory: transientFactory });
+      const step: WorkflowStep = {
+        id: 'step1',
+        agent: 'code_expert',
+        action: 'analyze',
+        inputs: {},
+        retries: 3,
+      };
+
+      await executor.execute(step, context, { retryDelayMs: 1 });
+      expect(attemptCount).toBeGreaterThan(1);
+    });
+
     it('should retry on failure', async () => {
       let attemptCount = 0;
       const failingFactory: IExpertFactory = {


### PR DESCRIPTION
Closes #4672.

## The defect

`isNonRetryableError` could not return true, so a validation failure was retried to exhaustion — identical input, identical failure, every attempt.

```ts
export function isNonRetryableError(error: Error): boolean {
  if (error.name === 'ValidationError') return true;
  if (error instanceof WorkflowError) {
    const code = error.code;
    return code === ErrorCode.VALIDATION_ERROR || /* … */;
  }
  return false;
}
```

Both branches are unreachable from the only call site:

- **`step-executor` wraps every failure in a `WorkflowError`** (`executeAttempt`'s error paths), so `name` is always `'WorkflowError'` — the first check can't fire.
- **`WorkflowError` cannot carry those codes.** It hardcodes `code: ErrorCode.WORKFLOW_ERROR` and `Omit`s `code` from its options type, so a caller cannot set `VALIDATION_ERROR` *even deliberately* — the second check can't fire either.

This is the shape that reading the function never reveals: the comparison is sound, and what makes it dead is the shape of the values that can reach it.

## The fix

The original error survives as `cause` on the wrap (`step-executor.ts:341` sets it). The guard walks the cause chain rather than changing the error class — which would have meant touching a widely-used error type to fix one call site.

Cycle-guarded: `cause` is untyped at that boundary, and a self-referential chain would **hang** the retry loop rather than fail it.

An absent cause still means retry. No evidence of a permanent failure is not evidence of one.

## Tested at the seam

The helper looked correct in isolation — the defect lived in the *join* between the wrap and the guard, which is exactly what a unit test of the helper would miss. So the test asserts attempt **count** through the real executor.

Writing it caught a wrong assumption of mine. I asserted `result.ok === true` and it failed:

```
PROBE result.ok= false attempts= 1
```

The fix worked — one attempt, no retry — but a non-retryable failure returns `err` immediately, whereas *exhausted* retries return `ok({ status: 'failed' })`. Those are different outcomes and a caller can distinguish "this will never work" from "this kept not working." Both are asserted now rather than the assertion being quietly relaxed.

## The control test

`still retries a transient failure the full allowance` exists so that "does not retry a validation failure" cannot pass by having broken retries entirely. A one-directional test here would be satisfied by the worst possible regression.

## Verification

Mutation-verified: disabling the cause walk fails **4 tests**, including the seam test.

Full suite **28333 passed, 0 failed** (1191 files). Workflows suite 1289 passing. Typecheck and lint clean.
