### PR TITLE
fix(learning): an unmeasured run no longer earns a maximal routing reward

### DIFF
--- a/.changeset/absence-is-not-efficiency.md
+++ b/.changeset/absence-is-not-efficiency.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix(learning): an unmeasured run no longer earns a maximal routing reward
+
+`Math.min(1, targetTokenUsage / outcome.tokenUsage)` with `tokenUsage: 0` is
+`Math.min(1, Infinity)` — which is `1`, the full efficiency bonus. The only
+production caller passes `tokenUsage: 0` deliberately, because
+`delegate-to-model` recommends rather than executes and genuinely has no token
+count. So every routed decision collected a maximal efficiency bonus, and
+`efficiencyWeight` was a tuning knob attached to a constant.
+
+`durationMs` has identical arithmetic and the same trap, so both now go through
+one helper that names the empty case: a non-positive or non-finite measurement
+earns zero, not everything. Zero is the conservative direction — an unmeasured
+run earns nothing rather than out-scoring a measured one.
+
+This is the vacuous-pass shape in arithmetic rather than in a boolean: a
+missing measurement entering an expression as the best possible value.

--- a/packages/nexus-agents/src/learning/outcome-feedback.test.ts
+++ b/packages/nexus-agents/src/learning/outcome-feedback.test.ts
@@ -266,6 +266,58 @@ describe('OutcomeFeedbackCollector', () => {
       );
     });
 
+    // #4669: absence must not read as perfection. `Math.min(1, target / 0)` is
+    // `Math.min(1, Infinity)` = 1, so an outcome carrying NO measurement scored
+    // the FULL bonus — as though it had used zero tokens against target. The
+    // only production caller (`delegate-to-model-router.ts`) passes
+    // `tokenUsage: 0` deliberately, because delegate-to-model recommends rather
+    // than executes and genuinely has no token count. So every routed decision
+    // received a maximal efficiency bonus, which made `efficiencyWeight` a
+    // tuning knob attached to a constant.
+    it('gives NO efficiency bonus when token usage is unmeasured (#4669)', () => {
+      const decision = createTestDecision();
+      collector.recordRoutingDecision(decision);
+
+      const unmeasured = collector.computeReward(createTestOutcome(decision.id, { tokenUsage: 0 }));
+      const wasteful = collector.computeReward(
+        createTestOutcome(decision.id, { tokenUsage: 100_000 })
+      );
+
+      expect(unmeasured.components.efficiencyBonus).toBe(0);
+      // And specifically NOT the maximal bonus it used to receive.
+      const efficient = collector.computeReward(createTestOutcome(decision.id, { tokenUsage: 1 }));
+      expect(unmeasured.components.efficiencyBonus).toBeLessThan(
+        efficient.components.efficiencyBonus
+      );
+      // Unmeasured must not beat a genuinely wasteful measured run either way
+      // round: it earns nothing, rather than earning everything.
+      expect(unmeasured.components.efficiencyBonus).toBeLessThanOrEqual(
+        wasteful.components.efficiencyBonus
+      );
+    });
+
+    it('gives NO speed bonus when duration is unmeasured (#4669)', () => {
+      // Same arithmetic, same trap: target / 0 -> Infinity -> clamped to a
+      // full bonus.
+      const decision = createTestDecision();
+      collector.recordRoutingDecision(decision);
+
+      const unmeasured = collector.computeReward(createTestOutcome(decision.id, { durationMs: 0 }));
+      expect(unmeasured.components.speedBonus).toBe(0);
+    });
+
+    it('a measured-good run still earns its bonuses', () => {
+      // Control: the fix must not zero the terms for real measurements.
+      const decision = createTestDecision();
+      collector.recordRoutingDecision(decision);
+
+      const good = collector.computeReward(
+        createTestOutcome(decision.id, { tokenUsage: 100, durationMs: 100 })
+      );
+      expect(good.components.efficiencyBonus).toBeGreaterThan(0);
+      expect(good.components.speedBonus).toBeGreaterThan(0);
+    });
+
     it('should clamp reward to 0-1 range', () => {
       const decision = createTestDecision();
       collector.recordRoutingDecision(decision);

--- a/packages/nexus-agents/src/learning/outcome-feedback.ts
+++ b/packages/nexus-agents/src/learning/outcome-feedback.ts
@@ -41,6 +41,20 @@ const logger = createLogger({ component: 'OutcomeFeedback' });
 /**
  * Outcome feedback collector implementation.
  */
+/**
+ * A "lower than target is better" bonus, with absence named (#4669).
+ *
+ * Returns 0 when `actual` is not a positive finite measurement. Dividing by
+ * zero yields `Infinity`, which `Math.min(1, …)` silently converts into a
+ * perfect score — so without this guard, "we did not measure" and "we used no
+ * resources at all" are indistinguishable, and the missing measurement is the
+ * one that scores best.
+ */
+function ratioBonus(target: number, actual: number, weight: number): number {
+  if (!Number.isFinite(actual) || actual <= 0) return 0;
+  return Math.min(1, target / actual) * weight;
+}
+
 export class OutcomeFeedbackCollector implements IOutcomeFeedback {
   private readonly config: FeedbackCollectorConfig;
   private readonly pendingDecisions: Map<TraceId, RoutingDecision> = new Map();
@@ -165,13 +179,30 @@ export class OutcomeFeedbackCollector implements IOutcomeFeedback {
     // Quality bonus from quality score
     const qualityBonus = outcome.qualityScore * this.config.qualityWeight;
 
-    // Speed bonus (faster than target = bonus)
-    const speedRatio = Math.min(1, this.config.targetDurationMs / outcome.durationMs);
-    const speedBonus = speedRatio * this.config.speedWeight;
-
-    // Efficiency bonus (fewer tokens than target = bonus)
-    const efficiencyRatio = Math.min(1, this.config.targetTokenUsage / outcome.tokenUsage);
-    const efficiencyBonus = efficiencyRatio * this.config.efficiencyWeight;
+    // Speed and efficiency bonuses — "used less than target" earns a bonus.
+    //
+    // #4669: a non-positive measurement means UNMEASURED, and earns nothing.
+    // `Math.min(1, target / 0)` is `Math.min(1, Infinity)` = 1, so an outcome
+    // carrying no measurement previously scored the FULL bonus, as though it
+    // had used zero tokens (or zero time) against target. The only production
+    // caller passes `tokenUsage: 0` deliberately — delegate-to-model
+    // recommends rather than executes and genuinely has no token count — so
+    // EVERY routed decision was collecting a maximal efficiency bonus, and
+    // `efficiencyWeight` was a tuning knob attached to a constant.
+    //
+    // Absence must not be able to RAISE a reward. Scoring it zero is the
+    // conservative direction: an unmeasured run earns nothing rather than
+    // everything, and a genuinely efficient measured run still out-scores it.
+    const speedBonus = ratioBonus(
+      this.config.targetDurationMs,
+      outcome.durationMs,
+      this.config.speedWeight
+    );
+    const efficiencyBonus = ratioBonus(
+      this.config.targetTokenUsage,
+      outcome.tokenUsage,
+      this.config.efficiencyWeight
+    );
 
     // Retry penalty
     const retryPenalty = signals.retryCount * this.config.retryPenalty;


### PR DESCRIPTION
Closes #4669 (partially — see "Not fixed" below).

## The defect

```ts
const efficiencyRatio = Math.min(1, this.config.targetTokenUsage / outcome.tokenUsage);
```

With `tokenUsage: 0` that is `Math.min(1, Infinity)` → **`1`**. The full efficiency bonus, awarded for having measured nothing.

And the only production caller passes exactly that, on purpose:

```ts
// delegate-to-model-router.ts:127
tokenUsage: 0, // delegate-to-model is a recommendation, not execution
```

The comment is correct — a recommendation genuinely has no token count. The reward function is what's wrong: it reads absence as perfection.

**Consequence:** every routed decision has been collecting a maximal efficiency bonus. Relative ranking between arms is unaffected (they all get the same constant), but the usable reward range is compressed and `efficiencyWeight` is a tuning knob attached to a constant. Anyone who tuned it was adjusting nothing.

## Beyond what the issue reported

`durationMs` has identical arithmetic — `Math.min(1, targetDurationMs / 0)` is also `1`. The issue named only `tokenUsage`; both are fixed, through one helper so the next ratio term added here cannot reintroduce it:

```ts
function ratioBonus(target: number, actual: number, weight: number): number {
  if (!Number.isFinite(actual) || actual <= 0) return 0;
  return Math.min(1, target / actual) * weight;
}
```

Zero is the conservative direction: an unmeasured run earns **nothing** rather than out-scoring a measured one. Absence must not be able to *raise* a reward.

## Not fixed — and I think the issue is wrong here

#4669 also reports the always-zero `retryPenalty` as a defect. It isn't one.

`retryCount: 0` is **correct** for the only caller: a recommendation path performs no retries, so zero retries is the true value, not a missing one. The term is *unexercised*, not wrong. Wiring a fake retry count to make the term "live" would be the actual defect — a measurement invented to satisfy a check.

That leaves a real but different problem — `recordStepOutcome`, the writer that would supply a genuine retry count, has no non-test callers. That is a missing-producer issue and wants its own remedy, not a patch to the reward arithmetic.

## Verification

Mutation direction covered both ways. A control test — `a measured-good run still earns its bonuses` — pins that the fix cannot pass by zeroing the terms outright, which is exactly how a one-directional test here would be satisfied by the worst possible regression.

Full suite **28336 passed, 0 failed** (1191 files). Learning + cli-adapters: 3093 passing. Typecheck and lint clean.
