### PR TITLE
fix(workflows): record real token usage in the budget ledger, not wall-clock time

### DIFF
--- a/.changeset/real-token-usage.md
+++ b/.changeset/real-token-usage.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+fix(workflows): record real token usage in the budget ledger instead of wall-clock time
+
+`recordPhaseUsage` recorded `Math.round(result.durationMs * 0.5)` — a duration
+reading in a field named tokens, with a comment conceding "in real usage, this
+would come from actual token counting". A budget enforced against that would
+cap on elapsed time: a slow-but-cheap step could exhaust it while a fast
+expensive one passed.
+
+The real count was already on the step's task metadata (populated from adapter
+usage); `step-executor` dropped it when building `StepResult`. It is threaded
+through now.
+
+An unmeasured step is NOT recorded as zero. For a cap, under-counting spend is
+the dangerous direction — the budget would believe it had headroom it does not.
+Unmeasured steps are counted and returned in a new `PhaseUsageReport`, so a
+caller enabling enforcement can see whether the ledger it enforces against is
+complete; `unmeasuredSteps > 0` means the recorded spend is a lower bound.
+
+Budget enforcement itself remains off, deliberately — it is separately
+unreachable (#4673), and turning it on before the estimate was real would have
+enforced a cap against a clock.

--- a/packages/nexus-agents/src/core/types/workflow.ts
+++ b/packages/nexus-agents/src/core/types/workflow.ts
@@ -103,6 +103,15 @@ export interface StepResult {
   status: 'success' | 'failed' | 'skipped';
   /** Error message if failed */
   error?: string;
+  /**
+   * Real tokens consumed by this step (#4673).
+   *
+   * `undefined` means the step reported no usage — a step that ran no model,
+   * or an adapter that returned none. It does NOT mean zero. That distinction
+   * matters for budgets specifically: silently treating unmeasured as zero
+   * under-counts spend, which is the dangerous direction for a cap.
+   */
+  tokensUsed?: number;
 }
 
 /**

--- a/packages/nexus-agents/src/workflows/step-executor.ts
+++ b/packages/nexus-agents/src/workflows/step-executor.ts
@@ -66,13 +66,7 @@ export class ExpertFactoryAdapter implements IExpertFactory {
     }
 
     type BuiltInType =
-      | 'code'
-      | 'architecture'
-      | 'security'
-      | 'documentation'
-      | 'testing'
-      | 'devops'
-      | 'research';
+      'code' | 'architecture' | 'security' | 'documentation' | 'testing' | 'devops' | 'research';
     return this.factory.createBuiltIn(expertType as BuiltInType);
   }
 }
@@ -307,11 +301,17 @@ export class StepExecutor {
         );
       }
 
+      // #4673: carry the REAL token count through. It was already on
+      // `taskResult.value.metadata` (populated from adapter usage) and was
+      // dropped here, which is why the budget ledger had to estimate from
+      // wall-clock duration.
+      const tokensUsed = taskResult.value.metadata.tokensUsed;
       return ok({
         stepId: step.id,
         output: taskResult.value.output,
         durationMs: getTimeProvider().now() - startTime,
         status: 'success',
+        ...(typeof tokensUsed === 'number' ? { tokensUsed } : {}),
       });
     } catch (error) {
       return this.handleExecutionError(error, step, timeoutMs);

--- a/packages/nexus-agents/src/workflows/workflow-engine-execution.test.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine-execution.test.ts
@@ -555,15 +555,52 @@ describe('recordPhaseUsage', () => {
       budgetEvents: [],
       budgetCircuitBreaker: createMockCircuitBreaker({ recordUsage: mockRecordUsage }),
     };
+    // #4673: this asserted `200ms * 0.5 = 100 tokens` — a wall-clock reading
+    // recorded into a token budget. It pinned the defect as intended
+    // behaviour. Real usage is now carried on the step result.
     const results: StepResult[] = [
-      { stepId: 's1', status: 'success', output: 'ok', durationMs: 200 },
+      { stepId: 's1', status: 'success', output: 'ok', durationMs: 200, tokensUsed: 1500 },
+      { stepId: 's2', status: 'success', output: 'ok', durationMs: 400, tokensUsed: 90 },
+    ];
+    const report = recordPhaseUsage(results, context);
+    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+    expect(mockRecordUsage).toHaveBeenCalledWith(1500);
+    expect(mockRecordUsage).toHaveBeenCalledWith(90);
+    // Note the ordering the old heuristic would have produced: s1 ran for less
+    // than half as long as s2 yet cost ~17x more. A budget enforced on
+    // duration would have capped the cheap step and let the expensive one run.
+    expect(report).toEqual({ recordedSteps: 2, unmeasuredSteps: 0, tokensRecorded: 1590 });
+  });
+
+  it('does NOT treat an unmeasured step as zero spend (#4673)', () => {
+    const mockRecordUsage = vi.fn();
+    const context: ExecutionContext = {
+      workflowId: 'test',
+      executionId: 'exec-1',
+      inputs: {},
+      stepResults: new Map(),
+      variables: new Map(),
+      abortController: new AbortController(),
+      contextManager: undefined,
+      budgetEvents: [],
+      budgetCircuitBreaker: createMockCircuitBreaker({ recordUsage: mockRecordUsage }),
+    };
+    const results: StepResult[] = [
+      { stepId: 's1', status: 'success', output: 'ok', durationMs: 200, tokensUsed: 500 },
+      // No tokensUsed — the step reported nothing.
       { stepId: 's2', status: 'success', output: 'ok', durationMs: 400 },
     ];
-    recordPhaseUsage(results, context);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
-    // 200ms * 0.5 = 100 tokens, 400ms * 0.5 = 200 tokens
-    expect(mockRecordUsage).toHaveBeenCalledWith(100);
-    expect(mockRecordUsage).toHaveBeenCalledWith(200);
+
+    const report = recordPhaseUsage(results, context);
+
+    // Recording 0 for s2 would under-count spend, which for a CAP is the
+    // dangerous direction — the budget would believe it had more headroom
+    // than it does.
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+    expect(mockRecordUsage).toHaveBeenCalledWith(500);
+    expect(report.unmeasuredSteps).toBe(1);
+    expect(report.recordedSteps).toBe(1);
+    expect(report.tokensRecorded).toBe(500);
   });
 
   it('handles empty results array', () => {

--- a/packages/nexus-agents/src/workflows/workflow-engine-execution.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine-execution.ts
@@ -220,14 +220,54 @@ export function enforceStepBudgets(
 /**
  * Record token usage after phase completion.
  */
-export function recordPhaseUsage(results: StepResult[], context: ExecutionContext): void {
-  if (context.budgetCircuitBreaker === undefined) return;
+/**
+ * What a phase's usage accounting actually covered (#4673).
+ *
+ * Returned rather than logged so the coverage is assertable: a caller enabling
+ * budget enforcement can see whether the ledger it is enforcing against is
+ * complete. `unmeasuredSteps > 0` means the recorded spend is a LOWER BOUND.
+ */
+export interface PhaseUsageReport {
+  /** Steps that reported real token usage and were recorded. */
+  recordedSteps: number;
+  /** Steps that reported no usage — not counted, and not treated as zero. */
+  unmeasuredSteps: number;
+  /** Total tokens recorded to the breaker for this phase. */
+  tokensRecorded: number;
+}
 
-  // Estimate token usage from step duration (rough heuristic)
-  // In real usage, this would come from actual token counting
-  const estimatedTokensPerMs = 0.5;
-  for (const result of results) {
-    const estimatedTokens = Math.round(result.durationMs * estimatedTokensPerMs);
-    context.budgetCircuitBreaker.recordUsage(estimatedTokens);
+export function recordPhaseUsage(
+  results: StepResult[],
+  context: ExecutionContext
+): PhaseUsageReport {
+  if (context.budgetCircuitBreaker === undefined) {
+    return { recordedSteps: 0, unmeasuredSteps: 0, tokensRecorded: 0 };
   }
+
+  // #4673: record REAL token usage. This used to be
+  // `Math.round(result.durationMs * 0.5)` — a wall-clock reading in a field
+  // named tokens, with a comment conceding "in real usage, this would come
+  // from actual token counting". A budget enforced against that would cap on
+  // elapsed time, so a slow-but-cheap step could exhaust it while a fast
+  // expensive one passed.
+  //
+  // The real count was already on the step's task metadata; `step-executor`
+  // simply dropped it.
+  let unmeasuredSteps = 0;
+  let recordedSteps = 0;
+  let tokensRecorded = 0;
+  for (const result of results) {
+    if (typeof result.tokensUsed !== 'number') {
+      // Unmeasured is NOT zero. Recording zero would under-count spend, which
+      // for a cap is the dangerous direction — so it is counted and reported
+      // rather than letting absence quietly look free.
+      unmeasuredSteps += 1;
+      continue;
+    }
+    context.budgetCircuitBreaker.recordUsage(result.tokensUsed);
+    recordedSteps += 1;
+    tokensRecorded += result.tokensUsed;
+  }
+
+  return { recordedSteps, unmeasuredSteps, tokensRecorded };
 }

--- a/packages/nexus-agents/src/workflows/workflow-engine-execution.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine-execution.ts
@@ -227,7 +227,7 @@ export function enforceStepBudgets(
  * budget enforcement can see whether the ledger it is enforcing against is
  * complete. `unmeasuredSteps > 0` means the recorded spend is a LOWER BOUND.
  */
-export interface PhaseUsageReport {
+interface PhaseUsageReport {
   /** Steps that reported real token usage and were recorded. */
   recordedSteps: number;
   /** Steps that reported no usage — not counted, and not treated as zero. */

--- a/packages/nexus-agents/src/workflows/workflow-engine.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine.ts
@@ -273,6 +273,27 @@ export class WorkflowEngine implements IWorkflowEngine {
     return ok(undefined);
   }
 
+  /**
+   * Surface incomplete budget accounting (#4673).
+   *
+   * `recordPhaseUsage` returns which steps it could actually account for. A
+   * ledger containing unmeasured steps is a LOWER BOUND on spend, and that is
+   * precisely what anyone enabling enforcement needs to know before trusting
+   * the cap — so it is reported rather than dropped.
+   */
+  private reportUsageCoverage(
+    usage: ReturnType<typeof recordPhaseUsage>,
+    workflowName: string
+  ): void {
+    if (usage.unmeasuredSteps === 0) return;
+    this.logger.warn('Budget ledger is incomplete — recorded spend is a lower bound', {
+      workflow: workflowName,
+      unmeasuredSteps: usage.unmeasuredSteps,
+      recordedSteps: usage.recordedSteps,
+      tokensRecorded: usage.tokensRecorded,
+    });
+  }
+
   private async executePhases(
     plan: ExecutionPlan,
     context: ExecutionContext,
@@ -319,8 +340,9 @@ export class WorkflowEngine implements IWorkflowEngine {
       const phaseResult = await this.deps.executePhase(phase.steps, context, options);
       if (!phaseResult.ok) return phaseResult;
 
-      // Record usage in circuit breaker after phase completion
-      recordPhaseUsage(phaseResult.value, context);
+      // Record usage in circuit breaker after phase completion (#4673): the
+      // coverage report is consumed, not discarded — see reportUsageCoverage.
+      this.reportUsageCoverage(recordPhaseUsage(phaseResult.value, context), workflow.name);
 
       for (const result of phaseResult.value) {
         context.stepResults.set(result.stepId, result);


### PR DESCRIPTION
Addresses the second half of #4673. Enforcement stays off — see "Scope" below.

## The defect

```ts
// Estimate token usage from step duration (rough heuristic)
// In real usage, this would come from actual token counting
const estimatedTokensPerMs = 0.5;
const estimatedTokens = Math.round(result.durationMs * estimatedTokensPerMs);
context.budgetCircuitBreaker.recordUsage(estimatedTokens);
```

A wall-clock reading, recorded into a field named tokens. The comment concedes it.

A budget enforced against this caps **elapsed time**, not spend — so a slow-but-cheap step exhausts it while a fast expensive one sails through.

## The real number already existed

`simple-agent.ts:60` sets `tokensUsed: result.value.usage?.totalTokens ?? 0` on the task metadata. `step-executor.ts` then built `StepResult` from `taskResult.value` taking only `.output`, and dropped it. Threaded through now — `StepResult` gains an optional `tokensUsed`.

## Unmeasured is not zero

A step that reports no usage is not a free step. Recording `0` under-counts spend, and for a **cap** that is the dangerous direction: the budget believes it has headroom it does not.

So unmeasured steps are counted rather than zeroed, and `recordPhaseUsage` returns a `PhaseUsageReport`:

```ts
{ recordedSteps, unmeasuredSteps, tokensRecorded }
```

`unmeasuredSteps > 0` means the recorded spend is a **lower bound** — which is precisely what someone enabling enforcement needs to know before trusting the ledger.

Returned rather than logged for two reasons: `ExecutionContext` has no logger, and `BudgetEnforcementEvent` is shaped around per-step budget application so it would have needed a fabricated `budget` to fit. Returning it also makes the coverage assertable instead of buried in log output.

## The existing test pinned the defect

```ts
// 200ms * 0.5 = 100 tokens, 400ms * 0.5 = 200 tokens
expect(mockRecordUsage).toHaveBeenCalledWith(100);
```

That is the fifth test in this repo I have found asserting a vacuous or wrong behaviour as intended. Rewritten with real figures where the **slower** step is ~17x cheaper — the exact inversion the heuristic produced, made visible in the fixture.

Added the unmeasured case and mutation-verified it: recording `0` for an unmeasured step fails the test.

## Scope — enforcement stays off

#4673 has two findings. The other is that budget enforcement is unreachable: `enableBudgetEnforcement` defaults `false` and the sole production construction (`cli-server-tools.ts:341-358`) never sets it.

I am not enabling it here. Turning on a cap while the estimate was a clock would have been worse than no cap, and this ordering was the explicit recommendation from the verification pass. Enforcement is now *possible* to enable meaningfully; whether to is a separate decision, and it also warrants noting that each workflow step creates a fresh expert, so the existing per-agent budget guard resets per step and provides no whole-workflow cap.

## Verification

Full suite **28337 passed, 0 failed** (1191 files). Workflows + core: 2563 passing. Typecheck and lint clean.