### PR TITLE
fix(adapters): the failover signal now names the adapter that failed

### DIFF
--- a/.changeset/failover-carries-prior-state.md
+++ b/.changeset/failover-carries-prior-state.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+fix(adapters): the failover signal now names the adapter that failed
+
+`applySelection` overwrote `this.health` with the incoming adapter's
+`state: 'healthy'`, and `emitFailover` then read it — destroying the outgoing
+state one statement earlier. Every `adapter.failover` payload therefore reported
+healthy, `unhealthyCliFrom` returned `undefined` for all of them, and
+`signal.swarm_unhealthy` was never produced by this path. Its sibling producer
+still worked, but the module's own docs call that one less reliable, so the
+reliable arm was the dead one.
+
+The payload now describes the adapter that was left, which is what the consumer
+means by "which CLI is unhealthy". `failoverCount` is a run-level counter rather
+than a property of that adapter, so it carries the post-increment value.
+
+An unknown outgoing state emits nothing rather than falling back to the current
+health: the fallback would silently restore the old behaviour, and a failover
+whose prior state cannot be described is not evidence the prior adapter was
+healthy.

--- a/packages/nexus-agents/src/adapters/resilient-adapter.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.ts
@@ -246,6 +246,11 @@ export class ResilientAdapter implements IResilientAdapter {
 
   private applySelection(selection: AdapterSelection): void {
     const isFailover = this.hasEverDetected;
+    // #4670: capture the OUTGOING health before it is overwritten below. The
+    // failover signal is about the adapter we are leaving — `unhealthyCliFrom`
+    // reads `payload.source` as "which CLI is unhealthy" — and that state was
+    // being destroyed one statement before `emitFailover` read it.
+    const outgoingHealth = this.health;
     this.currentAdapter = selection.adapter;
     this.currentSelection = selection;
     this.hasEverDetected = true;
@@ -269,7 +274,11 @@ export class ResilientAdapter implements IResilientAdapter {
     });
 
     if (isFailover) {
-      this.emitFailover();
+      // The state/source describe the adapter we LEFT; `failoverCount` is a
+      // run-level counter, so it carries the post-increment value.
+      this.emitFailover(
+        outgoingHealth === undefined ? undefined : { ...outgoingHealth, failoverCount }
+      );
     }
   }
 
@@ -342,8 +351,22 @@ export class ResilientAdapter implements IResilientAdapter {
     }
   }
 
-  private emitFailover(): void {
-    const info = this.health;
+  /**
+   * Emit the failover signal describing the adapter we failed AWAY FROM (#4670).
+   *
+   * This used to read `this.health`, which `applySelection` had just replaced
+   * with the incoming adapter's `state: 'healthy'`. So every `adapter.failover`
+   * payload said healthy, `unhealthyCliFrom` (`observability/failover-signals.ts`)
+   * returned undefined for all of them, and `signal.swarm_unhealthy` was never
+   * produced by this — the more reliable of its two producers.
+   *
+   * An undefined outgoing health emits NOTHING rather than falling back to the
+   * current one. Falling back would silently restore the old behaviour, and a
+   * failover whose prior state we cannot describe is not evidence that the
+   * prior adapter was healthy.
+   */
+  private emitFailover(outgoingHealth: AdapterHealthInfo | undefined): void {
+    const info = outgoingHealth;
     if (info === undefined) return;
 
     for (const cb of this.failoverCallbacks) {

--- a/packages/nexus-agents/src/observability/failover-signals.test.ts
+++ b/packages/nexus-agents/src/observability/failover-signals.test.ts
@@ -129,3 +129,82 @@ describe('startFailoverSignals / shutdownFailoverSignals (#3321)', () => {
     expect(seen).toHaveLength(1); // no emissions after shutdown
   });
 });
+
+describe('the production failover payload carries the outgoing state (#4670)', () => {
+  // The unit tests above hand-build `state: 'degraded'` payloads and assert
+  // `unhealthyCliFrom` narrows them correctly. It does. What none of them
+  // covered is the payload ResilientAdapter ACTUALLY emits — which was the new
+  // adapter's `state: 'healthy'`, because `applySelection` overwrote
+  // `this.health` one statement before `emitFailover` read it.
+  //
+  // So the narrowing was right, the producer was wrong, and every test passed.
+  // This asserts across that seam instead of on either side of it.
+
+  it('emits the health of the adapter it failed AWAY from, not the new one', async () => {
+    const { ResilientAdapter } = await import('../adapters/resilient-adapter.js');
+    const adapter = new ResilientAdapter();
+
+    const payloads: unknown[] = [];
+    adapter.onFailover((info) => payloads.push(info));
+
+    const internals = adapter as unknown as {
+      hasEverDetected: boolean;
+      health: { source: string; state: string; selectedAt: Date; failoverCount: number };
+      applySelection: (s: unknown) => void;
+    };
+
+    // Simulate an established, then degraded, gemini adapter.
+    internals.hasEverDetected = true;
+    internals.health = {
+      source: 'gemini',
+      state: 'degraded',
+      selectedAt: new Date(),
+      failoverCount: 0,
+    };
+
+    // Fail over to a healthy claude adapter.
+    internals.applySelection({
+      adapter: { providerId: 'p', modelId: 'm' },
+      source: 'cli',
+      name: 'claude',
+      reason: 'failover',
+    });
+
+    expect(payloads.length).toBe(1);
+    const narrowed = unhealthyCliFrom(payloads[0]);
+    // The unhealthy CLI is the one we LEFT.
+    expect(narrowed?.cli).toBe('gemini');
+    expect(narrowed?.reason).toContain('degraded');
+
+    adapter.dispose();
+  });
+
+  it('emits nothing when the outgoing state is unknown, rather than claiming healthy', async () => {
+    // The named empty case. Falling back to the current health would silently
+    // restore the original bug, and a failover whose prior state we cannot
+    // describe is not evidence the prior adapter was fine.
+    const { ResilientAdapter } = await import('../adapters/resilient-adapter.js');
+    const adapter = new ResilientAdapter();
+
+    const payloads: unknown[] = [];
+    adapter.onFailover((info) => payloads.push(info));
+
+    const internals = adapter as unknown as {
+      hasEverDetected: boolean;
+      health: unknown;
+      applySelection: (s: unknown) => void;
+    };
+    internals.hasEverDetected = true;
+    internals.health = undefined;
+
+    internals.applySelection({
+      adapter: { providerId: 'p', modelId: 'm' },
+      source: 'cli',
+      name: 'claude',
+      reason: 'failover',
+    });
+
+    expect(payloads).toEqual([]);
+    adapter.dispose();
+  });
+});


### PR DESCRIPTION
Addresses the failover-health guard in #4670. The other two guards in that issue are verified but blocked — see the bottom.

## The defect

```ts
private applySelection(selection: AdapterSelection): void {
  …
  this.health = { source, state: 'healthy', … };   // outgoing state destroyed
  …
  if (isFailover) this.emitFailover();              // reads this.health
}
```

`emitFailover` read `this.health`, which had just been replaced with the **incoming** adapter's `state: 'healthy'`.

So every `adapter.failover` payload reported healthy, `unhealthyCliFrom` (`observability/failover-signals.ts:52`) returned `undefined` for all of them, and `signal.swarm_unhealthy` was never produced by this path.

`signal.swarm_unhealthy` does have a second producer (`swarm-health-signals.ts:87`) — but `failover-signals.ts`'s own module doc calls that one *less* reliable, the `confidentCliSlot` guesswork path. **The reliable arm was the dead one**, which is the inverse of how defence-in-depth is supposed to fail.

## The fix, and why the payload changes meaning

`unhealthyCliFrom` reads `payload.source` as *"which CLI is unhealthy"*. That has to be the adapter we failed **away from** — the new one is, by definition, the healthy one. So the payload now describes the outgoing adapter.

Two judgement calls worth review:

**An unknown outgoing state emits nothing.** Falling back to the current health would silently restore the original behaviour, and a failover whose prior state we cannot describe is not evidence the prior adapter was fine. Named empty case, with its own test.

**`failoverCount` carries the post-increment value.** A pre-existing test asserting `failoverCount: 1` failed against my first version, and it was right — that counter is run-level, not a property of the outgoing adapter. The payload is outgoing `state`/`source` with the current count.

## Why the existing tests could not catch this

Every test sat on one side of the seam:

- the unit tests hand-build `state: 'degraded'` payloads and assert `unhealthyCliFrom` narrows them — the narrowing is correct
- the integration tests inject payloads through a local `emitFailover(sourceBus, info)` helper that never touches `ResilientAdapter`

So the consumer was verified against a payload the producer never emitted. The new test drives the real `applySelection` and asserts the emitted payload narrows to the CLI that failed.

**One correction to how this was reported to me:** `failover-signals.test.ts:45` asserts a healthy payload yields no signal, and that was flagged as pinning the defect. It is not — that assertion is correct and stays. It simply could not see the bug, which is a different (and more common) problem than a test encoding one.

## Verification

Mutation-verified both directions. Full suite **28339 passed, 0 failed**; adapters + observability 1384 passing. Typecheck and lint clean.

## The other two guards in #4670 — verified, not fixed

- **Tainted-rule gate** — real, but no producer exists: `TaskOutcome` has no untrusted-provenance field, so the remedy is a cross-cutting change rather than a wiring fix. A third consumer (`distilled-rule-stage.ts:78`) reads `getRules('active')` and ignores the bit entirely, so it would need fixing too.
- **Dashboard health score** — real; `healthScore` is exactly `0.8` on every run. Reporting surface only, and the full remedy is blocked on `allModelRewards`, which has zero producers in `src`.