### PR TITLE
fix(consensus): say whether the higher-order analysis actually decided the vote

### DIFF
--- a/.changeset/label-deciding-aggregation.md
+++ b/.changeset/label-deciding-aggregation.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+fix(consensus): say whether the higher-order analysis actually decided the vote
+
+`strategy: 'higher_order'` does not produce a higher-order verdict. The decision
+comes from `ConsensusEngine.close()` → `HigherOrderVotingStrategy.calculateOutcome`,
+which calls `aggregateSimpleInternal` — a plain `approve / (approve + reject)`
+ratio with no correlation input. The correlation-aware run happens separately
+and is consumed only as response metadata plus one escalation check.
+
+That made the metadata actively misleading rather than merely incomplete:
+`method` can read `'ow'` with a non-empty `downweightedAgents`, from which a
+reader reasonably concludes the correlation analysis produced the verdict. It
+did not — the "several voters that are really one opinion" case is detected and
+then discarded.
+
+`HigherOrderMetadata.appliedToDecision` now states this, and it travels into the
+persisted vote record, which is the artifact a later reviewer trusts. It is
+hardcoded `false` rather than computed, because no code path currently routes
+that result to the verdict and a computed `false` would imply one exists.
+
+Making the tally genuinely correlation-aware changes governance outcomes and is
+tracked separately. This makes the current state legible in the meantime.

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -5,6 +5,15 @@
  * @module mcp/tools/consensus-vote-types
  */
 
+/* eslint-disable max-lines --
+ * #4701: this file sat exactly at the 400-line cap, so adding
+ * `HigherOrderMetadata.appliedToDecision` (a field plus its assignment) puts it
+ * one over. Taking the exemption rather than splitting an 18-export types
+ * module inside a two-line governance-fidelity fix. Second file this session to
+ * hit the cap this way — see #4702 for the same situation in `audit-logger.ts`.
+ * Do not keep adding here; split it.
+ */
+
 import { z } from 'zod';
 import type { AgentVoteResult, VotingResult } from '../../cli/vote-types.js';
 import { VOTER_ROLES } from '../../cli/vote-types.js';
@@ -322,16 +331,46 @@ export const VoteDecisionStatusSchema = z.enum([
 
 export type VoteDecisionStatus = z.infer<typeof VoteDecisionStatusSchema>;
 
-/** Higher-Order Voting metadata (Issue #514). */
+/**
+ * Higher-Order Voting metadata (Issue #514).
+ *
+ * ADVISORY, not the verdict (#4701). Read `appliedToDecision` before drawing
+ * any conclusion from the rest of this object.
+ */
 export interface HigherOrderMetadata {
   posteriorApproval: number;
   posteriorRejection: number;
   effectiveVoteCount: number;
+  /**
+   * Aggregation used for THIS correlation-aware run — not necessarily the one
+   * that produced `decision`. See {@link HigherOrderMetadata.appliedToDecision}.
+   */
   method: 'ow' | 'isp' | 'simple';
   usedCorrelationData: boolean;
   improvementOverBaseline: number;
   downweightedAgents: readonly string[];
   reasoning: string;
+  /**
+   * Whether this correlation-aware result actually produced the response's
+   * `decision` (#4701).
+   *
+   * Currently ALWAYS FALSE. The verdict comes from `ConsensusEngine.close()`,
+   * which calls `HigherOrderVotingStrategy.calculateOutcome` — and that calls
+   * `aggregateSimpleInternal`, a plain `approve / (approve + reject)` ratio
+   * with no correlation input. This object is computed separately and consumed
+   * only as metadata plus one escalation check.
+   *
+   * The field exists because the omission was actively misleading: `method`
+   * can read `'ow'` while `downweightedAgents` is non-empty, from which any
+   * reasonable reader concludes the correlation analysis decided the vote. It
+   * did not — the "seven voters that are really one opinion" case is detected
+   * here and then discarded.
+   *
+   * Making the decision genuinely correlation-aware changes governance
+   * outcomes and is tracked separately; this field makes the current state
+   * legible in the meantime, including in persisted vote records.
+   */
+  appliedToDecision: boolean;
 }
 
 export interface ConsensusVoteResponse {
@@ -785,5 +824,10 @@ function toHigherOrderMetadata(r: HigherOrderVotingResult): HigherOrderMetadata 
     improvementOverBaseline: r.improvementOverBaseline,
     downweightedAgents: r.downweightedAgents,
     reasoning: r.reasoning,
+    // #4701: the engine's `calculateOutcome` decides, and it aggregates simple.
+    // Hardcoded false rather than computed, because there is currently no code
+    // path where this result reaches the verdict — a computed `false` would
+    // imply one exists.
+    appliedToDecision: false,
   };
 }

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -1165,6 +1165,20 @@ describe('opinion_wise is treated as a higher_order alias (#3271)', () => {
     expect(buildResponse(input, makeResult('higher_order')).higherOrderMetadata).toBeDefined();
   });
 
+  it('marks the metadata as NOT having decided the vote (#4701)', () => {
+    // `strategy: 'higher_order'` does not produce a higher-order verdict. The
+    // decision comes from ConsensusEngine.close() ->
+    // HigherOrderVotingStrategy.calculateOutcome -> aggregateSimpleInternal, a
+    // plain approve/(approve+reject) ratio. The correlation-aware run happens
+    // separately and is consumed only as metadata plus one escalation check.
+    //
+    // Without this flag the metadata is actively misleading: `method` can read
+    // a correlation method with a non-empty `downweightedAgents` while the
+    // verdict ignored all of it — and the vote record is governance evidence.
+    const r = buildResponse(input, makeResult('higher_order'));
+    expect(r.higherOrderMetadata?.appliedToDecision).toBe(false);
+  });
+
   it('simple_majority does NOT surface higherOrderMetadata', () => {
     expect(buildResponse(input, makeResult('simple_majority')).higherOrderMetadata).toBeUndefined();
   });
@@ -1577,6 +1591,10 @@ describe('CONSENSUS_VOTE_OUTPUT_SCHEMA covers the full response (#4032)', () => 
       posteriorRejection: 0.2,
       effectiveVoteCount: 2.4,
       method: 'ow',
+      // #4701: 'ow' with correlation data, and it still did not decide — the
+      // exact shape that reads as "the correlation analysis produced this
+      // verdict" when it did not.
+      appliedToDecision: false,
       usedCorrelationData: true,
       improvementOverBaseline: 0.05,
       downweightedAgents: ['devex'],


### PR DESCRIPTION
Partial fix for #4701 — the honest half, which needs no decision. The other half does; see "Not fixed here".

## The defect

`strategy: 'higher_order'` does not produce a higher-order verdict.

```ts
// higher-order-voting.ts:82-85 — the IVotingStrategy method the engine calls
calculateOutcome(votes, _weights?): VotingOutcome {
  const result = this.aggregateSimpleInternal(votes);   // plain ratio
  return this.toVotingOutcome(votes, result);
}
```

`aggregateSimple` is `approve / (approve + reject)`. No correlation input, no down-weighting — note the discarded `_weights` parameter.

The correlation-aware method **does** run (`runHigherOrderVoting`, `consensus-vote.ts:322`), but its result is consumed only as response metadata (`:740`) and by one escalation check (`:728`). The binding decision comes from `ConsensusEngine.close()`.

## Why this is a fidelity bug, not an internal detail

The metadata is **actively misleading**, not merely incomplete. `method` can read `'ow'` with a non-empty `downweightedAgents`, from which any reasonable reader concludes the correlation analysis produced the verdict.

It did not. **The "several voters that are really one opinion" case is detected here and then discarded** — which is the exact case the mechanism exists to catch.

Vote records are governance evidence, and this one overclaims.

## The change

`HigherOrderMetadata.appliedToDecision`, which travels into the persisted vote record.

Hardcoded `false` rather than computed: no code path currently routes that result to the verdict, and a computed `false` would imply one exists.

The test fixture that had `method: 'ow'` with `usedCorrelationData: true` is annotated — it is precisely the shape that reads as "the correlation analysis decided this."

## Not fixed here

Making the tally genuinely correlation-aware, and mapping `no_consensus` to something other than `rejected` (a 3-3 tie is currently indistinguishable from a real rejection).

Both change governance outcomes, so they want a vote — with the awkward property that the vote would be tallied by the mechanism under review. Worth stating plainly rather than routing around. #4701 stays open.

## Disclosure

I used `higher_order` for several governance decisions in this session and cited it in PR bodies. Being precise about what that does and does not invalidate:

- **Option selection stands.** `tallyOptions`/`applyOptionGate` is a separate, audited-sound mechanism and is what chose the winning option.
- **The approve/reject verdict was a simple ratio.** Margins were 6-1, 6-1, 7-0, 6-1 with option shares of 4/6, 6/6, 6/7 — none near the `|Δ| < 0.1` band, so down-weighting is unlikely to have flipped any. "Unlikely" is not "verified", and I am not claiming it is.

## Verification

Full suite **28340 passed, 0 failed**. mcp + consensus: 4695 passing. Typecheck, lint, and the export ratchet clean.

Two process notes, both self-inflicted and worth seeing in review: my first test imported a module-private helper — exactly what the export ratchet catches — so it was rewritten against the real response path. And this file sat *exactly* at the 400-line cap, so a two-line field required a `max-lines` exemption; it is the second file this session in that position, and the comment points at #4702 as precedent.