### PR TITLE
fix(observability): report the dashboard health score as unmeasured, not a constant 0.8

### DIFF
--- a/.changeset/unmeasured-health-score.md
+++ b/.changeset/unmeasured-health-score.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+fix(observability): report the dashboard health score as unmeasured instead of a constant 0.8
+
+`computeHealthScore` averaged four indicators, but with no recorded outcomes
+three of them are defaults rather than measurements: `calculateRegret([])`
+returns `optimalRate: 1`, so `isLearning` answered "yes" on the strength of no
+data, and `noUnderperformers` was vacuously true because there were no
+performers. `recordOutcome` has no production caller, so the score was exactly
+`0.8` on every real run.
+
+A confident number computed from nothing reads as a live signal and is harder
+to distrust than an obvious gap. It now returns `null` when there is not enough
+data to score, and the dashboard prints "unmeasured (not enough recorded
+outcomes to score)".
+
+Five tests in this area encoded the old behaviour, including one asserting
+`healthScore >= 0 && <= 1` — true of every possible value, including the
+constant. All rewritten to assert the contract in both directions rather than
+deleted.

--- a/packages/nexus-agents/src/observability/validation-dashboard-calc.test.ts
+++ b/packages/nexus-agents/src/observability/validation-dashboard-calc.test.ts
@@ -577,29 +577,39 @@ describe('computeHealthScore', () => {
     expect(computeHealthScore(true, true, true, true)).toBe(1.0);
   });
 
-  it('returns minimum when all indicators are false', () => {
-    const score = computeHealthScore(false, false, false, false);
-    // (0.5 + 0.5 + 0.7 + 0.8) / 4 = 0.625
-    expect(score).toBeCloseTo(0.625, 10);
+  // #4714: these three asserted that no data still yields a score. It did —
+  // exactly 0.625 here, and exactly 0.8 on every real run, because with no
+  // outcomes the other three indicators are defaults rather than measurements.
+  // A confident number computed from nothing reads as a live signal, which is
+  // harder to distrust than an obvious gap.
+  it('returns null when there is not enough data to score', () => {
+    expect(computeHealthScore(false, false, false, false)).toBeNull();
+    // Null even when every OTHER indicator is true — those "trues" are
+    // defaults (empty regret gives optimalRate 1; no performers means no
+    // underperformers), not evidence of health.
+    expect(computeHealthScore(false, true, true, true)).toBeNull();
   });
 
-  it('weights indicators differently', () => {
-    // hasMinimumData false => 0.5 (biggest penalty)
-    const noData = computeHealthScore(false, true, true, true);
-    // noUnderperformers false => 0.8 (smallest penalty)
+  it('weights indicators differently once there IS data', () => {
+    const healthy = computeHealthScore(true, true, true, true);
+    const notLearning = computeHealthScore(true, false, true, true);
     const hasUnder = computeHealthScore(true, true, true, false);
-    expect(noData).toBeLessThan(hasUnder);
+    // isLearning false => 0.5 (bigger penalty); noUnderperformers false => 0.8
+    expect(notLearning).toBeLessThan(hasUnder as number);
+    expect(hasUnder).toBeLessThan(healthy as number);
   });
 
-  it('returns between 0.5 and 1.0', () => {
-    const allFalse = computeHealthScore(false, false, false, false);
+  it('a measured score stays within 0.5 and 1.0', () => {
+    const worstMeasured = computeHealthScore(true, false, false, false);
     const allTrue = computeHealthScore(true, true, true, true);
-    expect(allFalse).toBeGreaterThanOrEqual(0.5);
-    expect(allTrue).toBeLessThanOrEqual(1.0);
+    expect(worstMeasured).toBeGreaterThanOrEqual(0.5);
+    expect(allTrue).toBe(1.0);
   });
 
-  it('hasMinimumData false gives (0.5+1+1+1)/4 = 0.875', () => {
-    expect(computeHealthScore(false, true, true, true)).toBeCloseTo(0.875, 10);
+  it('hasMinimumData false is unmeasured, not 0.875 (#4714)', () => {
+    // Previously (0.5+1+1+1)/4 = 0.875. The three "1"s are defaults, not
+    // measurements, so the average was arithmetic over nothing.
+    expect(computeHealthScore(false, true, true, true)).toBeNull();
   });
 
   it('isLearning false gives (1+0.5+1+1)/4 = 0.875', () => {

--- a/packages/nexus-agents/src/observability/validation-dashboard-calc.ts
+++ b/packages/nexus-agents/src/observability/validation-dashboard-calc.ts
@@ -200,15 +200,31 @@ export function calculateAvgReward(outcomes: readonly DashboardOutcome[]): numbe
   return outcomes.reduce((sum, o) => sum + o.reward, 0) / outcomes.length;
 }
 
-/** Compute overall health score from indicators. */
+/**
+ * Compute overall health score from indicators — or `null` when there is not
+ * enough data to score at all (#4714).
+ *
+ * Without `hasMinimumData` the other three indicators are not measurements,
+ * they are defaults: an empty outcome set makes `calculateRegret` return
+ * `optimalRate: 1`, so `isLearning` answers "yes" on the strength of no data,
+ * and `noUnderperformers` is vacuously true because there are no performers.
+ * The arithmetic then produced exactly 0.8 on every real run — a confident
+ * number computed from nothing, which reads as a live signal and is harder to
+ * distrust than an obvious gap.
+ *
+ * Returning `null` is the same rule this codebase applies elsewhere: a gate
+ * that reports `unmeasured` beats one that reports a default as a measurement.
+ */
 export function computeHealthScore(
   hasMinimumData: boolean,
   isLearning: boolean,
   healthyExploration: boolean,
   noUnderperformers: boolean
-): number {
+): number | null {
+  if (!hasMinimumData) return null;
+
   const scores = [
-    hasMinimumData ? 1 : 0.5,
+    1, // hasMinimumData, established above
     isLearning ? 1 : 0.5,
     healthyExploration ? 1 : 0.7,
     noUnderperformers ? 1 : 0.8,

--- a/packages/nexus-agents/src/observability/validation-dashboard-render.ts
+++ b/packages/nexus-agents/src/observability/validation-dashboard-render.ts
@@ -147,7 +147,13 @@ export function renderHealthIndicators(health: DashboardHealthIndicators): strin
   lines.push(`${check(health.healthyExploration)} Healthy Exploration`);
   lines.push(`${check(health.noUnderperformers)} No Underperformers`);
   lines.push('');
-  lines.push(`Overall Health: ${(health.healthScore * 100).toFixed(0)}%`);
+  // #4714: absence renders as absence. A percentage here computed from
+  // default indicators looked like a measurement and was always 80%.
+  lines.push(
+    health.healthScore === null
+      ? 'Overall Health: unmeasured (not enough recorded outcomes to score)'
+      : `Overall Health: ${(health.healthScore * 100).toFixed(0)}%`
+  );
 
   if (health.warnings.length > 0) {
     lines.push('');

--- a/packages/nexus-agents/src/observability/validation-dashboard-types.ts
+++ b/packages/nexus-agents/src/observability/validation-dashboard-types.ts
@@ -112,7 +112,14 @@ export interface DashboardHealthIndicators {
   /** Whether any model is significantly underperforming */
   readonly noUnderperformers: boolean;
   /** Overall health score (0-1) */
-  readonly healthScore: number;
+  /**
+   * Overall health, or `null` when there is not enough data to score (#4714).
+   *
+   * `null` is not zero and not a bad score — it means the indicators would be
+   * defaults rather than measurements. Render it as "unmeasured"; do not
+   * coerce it to a number.
+   */
+  readonly healthScore: number | null;
   /** Warning messages */
   readonly warnings: readonly string[];
 }

--- a/packages/nexus-agents/src/observability/validation-dashboard.test.ts
+++ b/packages/nexus-agents/src/observability/validation-dashboard.test.ts
@@ -205,11 +205,15 @@ describe('validation-dashboard', () => {
       expect(summary.healthIndicators.healthyExploration).toBe(true);
     });
 
-    it('should calculate health score', () => {
+    it('reports the health score as unmeasured with no recorded outcomes (#4714)', () => {
+      // This previously asserted `>= 0 && <= 1` — true of every possible
+      // value, including the constant 0.8 the dashboard actually produced on
+      // every real run. A check that cannot fail.
+      //
+      // `recordOutcome` has no production caller, so an unmeasured score is
+      // the real shipped state, and saying so is the point.
       const summary = dashboard.getSummary();
-
-      expect(summary.healthIndicators.healthScore).toBeGreaterThanOrEqual(0);
-      expect(summary.healthIndicators.healthScore).toBeLessThanOrEqual(1);
+      expect(summary.healthIndicators.healthScore).toBeNull();
     });
   });
 


### PR DESCRIPTION
Closes #4714 (split out of #4670).

## The defect

`healthScore` was **exactly 0.8 on every real run**. Not approximately — exactly, because none of its inputs vary.

`ValidationDashboard.recordOutcome` has no production caller, so `outcomes` is always `[]`, and the four indicators resolve to fixed values:

| Indicator | With no outcomes | Contribution |
|---|---|---|
| `hasMinimumData` | false (threshold 100) | 0.5 |
| `isLearning` | **true** — `calculateRegret([])` returns `optimalRate: 1` | 1.0 |
| `healthyExploration` | false (`explorationRate` 0) | 0.7 |
| `noUnderperformers` | vacuously true — there are no performers | 1.0 |

Note the second row: *"is the system learning?"* answers **yes** on the strength of no data. That is the reporting analogue of a check that cannot fail — and it is the one that makes the average look reassuring rather than alarming.

## The fix

`computeHealthScore` returns `null` when `hasMinimumData` is false, and the renderer prints:

```
Overall Health: unmeasured (not enough recorded outcomes to score)
```

Same rule this codebase applies elsewhere: a gate that reports `unmeasured` beats one that reports a default as a measurement. A confident number computed from nothing reads as a live signal and is *harder* to distrust than an obvious gap — which is why I did not take the partial fix (#4714 explains why feeding two of four inputs would have been worse than leaving it visibly constant).

## Five tests encoded the old behaviour

Worth listing, because the shape recurs:

- `returns minimum when all indicators are false` — asserted 0.625 from no data
- `hasMinimumData false gives (0.5+1+1+1)/4 = 0.875` — the title *is* the defect
- `returns between 0.5 and 1.0`
- `weights indicators differently` — compared two unmeasured values
- `should calculate health score` — asserted `healthScore >= 0 && <= 1`, true of **every possible value** including the constant

Each is individually reasonable. Together they measured the arithmetic rather than whether the arithmetic had inputs, so the suite stayed green while the feature was dead.

All rewritten rather than deleted, so the contract is now asserted in both directions: `null` when unmeasured, real weighting once data exists.

## Safe to change shape

The only consumer is `validation-dashboard-render.ts:150`. No gate reads `healthScore`, so widening it to `number | null` cannot break enforcement anywhere.

## Verification

Full suite **28342 passed, 0 failed**. `src/observability`: 457 passing. Typecheck and lint clean.

## Not fixed

Making the score *real* needs a producer for `recordOutcome`, and `allModelRewards` (`validation-dashboard-types.ts:172`) has zero producers in `src`. That is a larger piece of work; #4714 records the options. This change makes the current state honest in the meantime.