### PR TITLE
feat(governance): give the tool-fitness ledger its first production writer

### DIFF
--- a/.changeset/tool-fitness-producer.md
+++ b/.changeset/tool-fitness-producer.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': minor
+---
+
+feat(governance): give the tool-fitness ledger its first production writer
+
+`report()` returned `[]` because nothing ever called `record()`, so
+`detectConsolidationCandidates` and `detectDeprecationCandidates` could not
+emit — while the consumer chain below them was fully wired all the way to
+remediation tasks and GitHub issue filing.
+
+Every wrapped MCP tool call now appends one fitness event at the middleware
+chain's per-call completion point.
+
+Site choice matters here. The obvious-looking site — `tool-wrapper.ts`'s
+`classifyResult` — is reached only from `runMismatchedCall`, the
+timeout-mismatch path. Writing there would have recorded a sample biased toward
+mismatched calls and systematically mislabelled tools as unfit; a biased
+producer is worse than none, because its output looks like data.
+
+Known gap, documented in code so absence is not misread: `execute_expert`
+registers via `registerToolTask` and does not pass through this chain, so it
+produces no fitness events. "No data" means unmeasured, not unused.
+
+Best-effort — a ledger write never fails a tool call — and bounded by the
+ledger's existing retained-event cap.

--- a/packages/nexus-agents/src/mcp/middleware/middleware-chain.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/middleware-chain.test.ts
@@ -15,6 +15,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { z } from 'zod';
 import type { ILogger } from '../../core/index.js';
 import {
@@ -1383,5 +1386,83 @@ describe('integration tests', () => {
 
     expect(requestIds.length).toBe(3);
     expect(new Set(requestIds).size).toBe(3); // All unique
+  });
+});
+
+describe('tool-fitness events are produced for every wrapped call (#4656)', () => {
+  // The ledger had no production writer, so `report()` returned [] and the
+  // consolidation/deprecation detectors could not emit — while their consumer
+  // chain (improvement-review -> remediation tasks -> issue filing) was fully
+  // wired. This is the seam that fills it.
+
+  // The ledger is homedir-scoped by design (cross-repo fitness data), so these
+  // tests must NOT use the real one — the module doc says so explicitly, and a
+  // first pass of this suite created ~/.nexus-agents/tool-fitness/ on the
+  // developer's machine. Point the data dir at a throwaway instead.
+  let tmpDataDir: string;
+
+  beforeEach(async () => {
+    tmpDataDir = mkdtempSync(join(tmpdir(), 'tool-fitness-test-'));
+    vi.stubEnv('NEXUS_DATA_DIR', tmpDataDir);
+    const { _resetToolFitnessLedgerForTests } =
+      await import('../../governance/tool-fitness-ledger.js');
+    _resetToolFitnessLedgerForTests();
+  });
+
+  afterEach(async () => {
+    const { _resetToolFitnessLedgerForTests } =
+      await import('../../governance/tool-fitness-ledger.js');
+    _resetToolFitnessLedgerForTests();
+    vi.unstubAllEnvs();
+    rmSync(tmpDataDir, { recursive: true, force: true });
+  });
+
+  it('records a success for a tool call that returns cleanly', async () => {
+    const { getToolFitnessLedger } = await import('../../governance/tool-fitness-ledger.js');
+    const wrapped = withMiddleware('demo_tool', () =>
+      Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] })
+    );
+
+    await wrapped({});
+
+    const demo = getToolFitnessLedger()
+      .report()
+      .find((r) => r.tool === 'demo_tool');
+    expect(demo?.invocationCount).toBe(1);
+    expect(demo?.failureCount).toBe(0);
+  });
+
+  it('records a failure for an isError result', async () => {
+    const { getToolFitnessLedger } = await import('../../governance/tool-fitness-ledger.js');
+    const wrapped = withMiddleware('failing_tool', () =>
+      Promise.resolve({ content: [{ type: 'text' as const, text: 'nope' }], isError: true })
+    );
+
+    await wrapped({});
+
+    const demo = getToolFitnessLedger()
+      .report()
+      .find((r) => r.tool === 'failing_tool');
+    expect(demo?.failureCount).toBe(1);
+  });
+
+  it('records a failure when the handler THROWS', async () => {
+    // A thrown handler does NOT reject here — an error middleware converts it
+    // to `{ isError: true }` — so this is recorded through the normal return
+    // path, not the catch. Asserted because "throws" and "returns isError"
+    // must land in the ledger identically: otherwise a tool that throws would
+    // look cleaner than one that fails politely.
+    const { getToolFitnessLedger } = await import('../../governance/tool-fitness-ledger.js');
+    const wrapped = withMiddleware('throwing_tool', () => {
+      throw new Error('boom');
+    });
+
+    const result = await wrapped({});
+    expect(result.isError).toBe(true);
+
+    const demo = getToolFitnessLedger()
+      .report()
+      .find((r) => r.tool === 'throwing_tool');
+    expect(demo?.failureCount).toBe(1);
   });
 });

--- a/packages/nexus-agents/src/mcp/middleware/middleware-chain.ts
+++ b/packages/nexus-agents/src/mcp/middleware/middleware-chain.ts
@@ -9,6 +9,7 @@
  */
 
 import type { z } from 'zod';
+import { getToolFitnessLedger } from '../../governance/tool-fitness-ledger.js';
 import type { ILogger } from '../../core/index.js';
 import { createLogger, getTimeProvider } from '../../core/index.js';
 import { validateToolInput } from './validation.js';
@@ -399,9 +400,53 @@ export function createMiddlewareChain(
       const requestContext = createRequestContext({ toolName: config.toolName });
       const requestLogger = logger.child(contextForLogging(requestContext));
       const ctx: MiddlewareContext = { requestContext, logger: requestLogger };
-      return composed(args, ctx, (finalArgs, finalCtx) => handler(finalArgs, finalCtx));
+      try {
+        const result = await composed(args, ctx, (finalArgs, finalCtx) =>
+          handler(finalArgs, finalCtx)
+        );
+        recordToolFitness(config.toolName, result.isError !== true);
+        return result;
+      } catch (error: unknown) {
+        // BACKSTOP, not the normal path: an error middleware converts a thrown
+        // handler into `{ isError: true }`, so throws are already recorded
+        // above. This catches a throw that escapes that middleware — if it is
+        // ever removed or itself fails, the ledger must not silently lose the
+        // failure and make the tool look cleaner than it is.
+        recordToolFitness(config.toolName, false);
+        throw error;
+      }
     };
   };
+}
+
+/**
+ * Append one tool-call outcome to the tool-fitness ledger (#4656).
+ *
+ * This is the ledger's first production writer. Without it `report()` returned
+ * `[]`, so `detectConsolidationCandidates` and `detectDeprecationCandidates`
+ * could not emit — while the consumer chain below them was fully wired
+ * (`improvement-review.ts` → remediation tasks → issue filing).
+ *
+ * SITE CHOICE. The obvious-looking site, `tool-wrapper.ts`'s `classifyResult`,
+ * is reached only from `runMismatchedCall` — the timeout-mismatch path. Writing
+ * there would have recorded a sample biased toward mismatched calls and
+ * systematically mislabelled tools as unfit. This is the per-call completion
+ * point every wrapped tool passes through.
+ *
+ * KNOWN GAP, stated so absence is not misread: `execute_expert` registers via
+ * `registerToolTask` and does not go through this chain, so it produces no
+ * fitness events. "No data for execute_expert" means unmeasured, NOT unused.
+ *
+ * Best-effort: a ledger write must never fail a tool call. Growth is bounded by
+ * the ledger's own retained-event cap.
+ */
+function recordToolFitness(toolName: string, success: boolean): void {
+  try {
+    getToolFitnessLedger().record({ tool: toolName, success });
+  } catch {
+    // Intentionally silent — this is telemetry on the hot path, and a logger
+    // call here would itself be a failure mode on a broken data dir.
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #4656.

## The gap

`report()` returned `[]` because nothing ever called `record()`. So `detectConsolidationCandidates` and `detectDeprecationCandidates` could not emit — while the consumer chain below them was **fully wired**: `improvement-review.ts:1003` loads the signals, `:1042` turns them into remediation tasks, `:1035` files GitHub issues, and `auto-remediation-cycle.ts:174` consumes downstream.

A missing producer, not dead code. Worth saying plainly: I had this queued as a likely **deletion**, on the strength of "no writer, no consumer". Verification showed the consumer chain is live, so the deletion argument collapsed on its own premise.

## Site choice is the substance of this PR

The recommended site was `tool-wrapper.ts`'s `classifyResult`, described as running for every wrapped call. It has **exactly one caller**: `runMismatchedCall` — the timeout-mismatch path.

Writing there would have recorded a sample biased toward mismatched calls, and a fitness ledger fed on mismatches would systematically mislabel tools as unfit. **A biased producer is worse than none, because its output looks like data.**

The actual per-call completion point is in `createMiddlewareChain`, which all 45 wrapped tools pass through.

## Known gap, stated in code

`execute_expert` registers via `registerToolTask` and does not go through this chain, so it produces no fitness events. Documented at the write site so **"no data for `execute_expert`" reads as unmeasured, not unused** — the distinction this ledger's own detectors turn on.

## Safety

Best-effort: a ledger write never fails a tool call. Growth is bounded by the ledger's existing `DEFAULT_MAX_EVENTS` cap, so the "unbounded append loop" concern is already handled upstream.

## Two test corrections

**The suite was writing to the developer's real homedir ledger.** `~/.nexus-agents/tool-fitness/` appeared during development. The module doc warns about precisely this. These tests now use a throwaway `NEXUS_DATA_DIR`, and the pollution was removed.

This turns out to be **pre-existing and broader** — `capability-gaps.jsonl`, `memory` and `learning` are written by the same run, predating this change. Filed as #4722 rather than fixed inline, since it needs a suite-wide setup file and a check on how many tests are coupled to developer-local state.

**My "records a failure when the handler throws" test asserted a rejection that never happens.** An error middleware converts throws into `{ isError: true }`, so throws are recorded through the *normal* return path. The `catch` is a backstop for a throw escaping that middleware — the comment now says that instead of claiming it is the mechanism.

## Verification

Full suite **28345 passed, 0 failed**. middleware + governance: 718 passing. Typecheck and lint clean.