### PR TITLE
fix(self-eval): produce coverage-summary.json, and read per-file coverage from it

### DIFF
--- a/.changeset/coverage-producer.md
+++ b/.changeset/coverage-producer.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': minor
+---
+
+fix(self-eval): produce coverage-summary.json, and read per-file coverage from it
+
+`component-scanner` hardcoded `testCoverage: null` with the comment "Would need
+coverage report integration". Integration was impossible for a reason nobody had
+traced: **`coverage-summary.json` is never written.** The vitest coverage
+reporter list was `['text', 'json', 'html']`, and `json` produces
+`coverage-final.json` — a different file.
+
+Three consumers read the missing one — the SICA test-generation workflow, the
+system-review workflow, and `cli/system-review.ts`. All three silently saw no
+coverage, their `existsSync` guards permanently false. The SICA workflow's
+`jq '.total.lines.pct // 0'` then turns that absence into 0%, the dangerous
+direction for a coverage figure.
+
+Adding `json-summary` to the reporter list produces the file (verified: 1406
+per-file entries alongside `total`), which unblocks all three and makes per-file
+coverage available to the scanner.
+
+The scanner now reads its own file's entry, not the project total — a
+project-wide number stamped onto every component would be a fabricated per-file
+metric. An absent report, or a file missing from it, stays `null`: unmeasured is
+not 0%, and coercing it would turn the `deprecate` recommendation from one that
+could never fire into one that fires for the wrong reason.

--- a/packages/nexus-agents/src/self-eval/component-scanner.test.ts
+++ b/packages/nexus-agents/src/self-eval/component-scanner.test.ts
@@ -3,7 +3,9 @@
  * (Source: Issue #137)
  */
 
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { ComponentScanner, createComponentScanner, scanComponents } from './component-scanner.js';
 import { join } from 'node:path';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
@@ -233,5 +235,76 @@ export default function() {}
   // Cleanup after all tests
   afterAll(async () => {
     await cleanupTestDir();
+  });
+});
+
+describe('per-file test coverage (#4668)', () => {
+  // `deprecate` was unreachable: `analyzeFile` hardcoded `testCoverage: null`,
+  // which gated the -0.2 low-coverage penalty and left the score floor at 0.45
+  // against a `deprecate` boundary of < 0.3.
+  //
+  // The existing regression test for this hand-builds a ComponentInfo with
+  // `testCoverage: 20` — a value the real scanner never produced — so it proved
+  // the evaluator's arithmetic while the feature was dead. These run against
+  // scanner output instead.
+
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'scanner-cov-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads per-file coverage from coverage-summary.json', async () => {
+    const src = join(dir, 'thing.ts');
+    writeFileSync(src, 'export const a = 1;\n');
+
+    const covDir = join(dir, 'coverage');
+    mkdirSync(covDir, { recursive: true });
+    writeFileSync(
+      join(covDir, 'coverage-summary.json'),
+      JSON.stringify({ total: { lines: { pct: 50 } }, [src]: { lines: { pct: 17 } } })
+    );
+
+    const scanner = new ComponentScanner({ coverageDir: covDir });
+    const inventory = await scanner.scan(dir);
+    const thing = inventory.components.find((c) => c.name === 'thing');
+
+    // 17, the file's own coverage — NOT 50, the project total. A project-wide
+    // number stamped onto every file would be a fabricated per-file metric.
+    expect(thing?.testCoverage).toBe(17);
+  });
+
+  it('leaves coverage NULL when no report exists — unmeasured is not 0%', async () => {
+    // The condition that makes this fix safe. Coercing absence to 0 would make
+    // every file without a coverage run look maximally bad and turn `deprecate`
+    // from "can never fire" into "fires for the wrong reason".
+    writeFileSync(join(dir, 'thing.ts'), 'export const a = 1;\n');
+
+    const scanner = new ComponentScanner({ coverageDir: join(dir, 'nope') });
+    const inventory = await scanner.scan(dir);
+
+    expect(inventory.components[0]?.testCoverage).toBeNull();
+  });
+
+  it('leaves coverage NULL for a file absent from the report', async () => {
+    writeFileSync(join(dir, 'thing.ts'), 'export const a = 1;\n');
+    const covDir = join(dir, 'coverage');
+    mkdirSync(covDir, { recursive: true });
+    writeFileSync(
+      join(covDir, 'coverage-summary.json'),
+      JSON.stringify({
+        total: { lines: { pct: 50 } },
+        '/some/other/file.ts': { lines: { pct: 90 } },
+      })
+    );
+
+    const scanner = new ComponentScanner({ coverageDir: covDir });
+    const inventory = await scanner.scan(dir);
+
+    expect(inventory.components[0]?.testCoverage).toBeNull();
   });
 });

--- a/packages/nexus-agents/src/self-eval/component-scanner.ts
+++ b/packages/nexus-agents/src/self-eval/component-scanner.ts
@@ -8,6 +8,7 @@
  * (Source: Issue #137, Multi-Agent Evaluation research)
  */
 
+import { readFileSync } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { join, basename, extname, relative } from 'node:path';
 import type { ILogger } from '../core/index.js';
@@ -71,6 +72,11 @@ export interface ScannerConfig {
   readonly maxFileSize?: number;
   /** Logger instance */
   readonly logger?: ILogger;
+  /**
+   * Directory holding `coverage-summary.json` (#4668). Defaults to `coverage`.
+   * Absent report ⇒ every component's `testCoverage` is `null` (unmeasured).
+   */
+  readonly coverageDir?: string;
 }
 
 // ============================================================================
@@ -109,17 +115,48 @@ const EXPORT_PATTERN =
 /**
  * Scans codebase components and extracts metrics.
  */
+/** Shape of istanbul/v8 `coverage-summary.json` (#4668) — `total` plus one key per absolute file path. */
+interface CoverageSummary {
+  readonly [absolutePath: string]: { readonly lines?: { readonly pct?: number } } | undefined;
+}
+
+/** Default location of the coverage report, relative to the package root. */
+const DEFAULT_COVERAGE_DIR = 'coverage';
+
+/** Apply scanner defaults in one place, so the constructor stays a plain assignment. */
+function resolveScannerConfig(config: ScannerConfig = {}): {
+  extensions: readonly string[];
+  skipTests: boolean;
+  maxFileSize: number;
+  logger: ILogger;
+  coverageDir: string;
+} {
+  return {
+    extensions: config.extensions ?? DEFAULT_EXTENSIONS,
+    skipTests: config.skipTests ?? false,
+    maxFileSize: config.maxFileSize ?? DEFAULT_MAX_FILE_SIZE,
+    logger: config.logger ?? createLogger({ component: 'component-scanner' }),
+    coverageDir: config.coverageDir ?? DEFAULT_COVERAGE_DIR,
+  };
+}
+
 export class ComponentScanner {
   private readonly extensions: readonly string[];
   private readonly skipTests: boolean;
   private readonly maxFileSize: number;
   private readonly log: ILogger;
+  /** Where `coverage-summary.json` lives (#4668). */
+  private readonly coverageDir: string;
+  /** Memoized report: `undefined` = not loaded, `null` = absent/unreadable. */
+  private coverageSummary: CoverageSummary | null | undefined;
 
   constructor(config?: ScannerConfig) {
-    this.extensions = config?.extensions ?? DEFAULT_EXTENSIONS;
-    this.skipTests = config?.skipTests ?? false;
-    this.maxFileSize = config?.maxFileSize ?? DEFAULT_MAX_FILE_SIZE;
-    this.log = config?.logger ?? createLogger({ component: 'component-scanner' });
+    const resolved = resolveScannerConfig(config);
+    this.extensions = resolved.extensions;
+    this.skipTests = resolved.skipTests;
+    this.maxFileSize = resolved.maxFileSize;
+    this.log = resolved.logger;
+    this.coverageDir = resolved.coverageDir;
   }
 
   /**
@@ -186,6 +223,41 @@ export class ComponentScanner {
   }
 
   /**
+   * Per-file line coverage, or `null` when it was not measured (#4668).
+   *
+   * `null` is NOT zero. An unmeasured file must not look maximally bad — the
+   * `deprecate` recommendation is gated on a low score, so coercing absence to
+   * 0% would make every file without a coverage run a deprecation candidate.
+   * That trades a recommendation that could never fire for one that fires
+   * for the wrong reason.
+   *
+   * The report is only present after a coverage run, and is loaded once per
+   * scan rather than per file.
+   */
+  private coverageFor(absolutePath: string): number | null {
+    const report = this.loadCoverageSummary();
+    if (report === null) return null;
+    const entry = report[absolutePath];
+    return typeof entry?.lines?.pct === 'number' ? entry.lines.pct : null;
+  }
+
+  /** Load + memoize `coverage-summary.json`; `null` when absent or unreadable. */
+  private loadCoverageSummary(): CoverageSummary | null {
+    if (this.coverageSummary !== undefined) return this.coverageSummary;
+
+    const file = join(this.coverageDir, 'coverage-summary.json');
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(file, 'utf-8'));
+      this.coverageSummary = parsed as CoverageSummary;
+    } catch {
+      // Absent (no coverage run) or malformed — both mean unmeasured, and
+      // neither should fail a scan.
+      this.coverageSummary = null;
+    }
+    return this.coverageSummary;
+  }
+
+  /**
    * Analyze a single file and extract metrics.
    */
   private async analyzeFile(root: string, filePath: string): Promise<ComponentInfo | null> {
@@ -207,7 +279,7 @@ export class ComponentScanner {
         name,
         lines: this.countLines(content),
         complexity: this.estimateComplexity(content),
-        testCoverage: null, // Would need coverage report integration
+        testCoverage: this.coverageFor(filePath),
         dependencies: this.extractDependencies(content),
         isTest,
         sizeBytes: stats.size,

--- a/packages/nexus-agents/vitest.config.ts
+++ b/packages/nexus-agents/vitest.config.ts
@@ -83,7 +83,14 @@ export default defineConfig({
       provider: 'v8',
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/testing/**', 'src/**/*.d.ts'],
-      reporter: ['text', 'json', 'html'],
+      // #4668: `json-summary` writes `coverage-summary.json`. Without it that
+      // file is never produced, yet THREE consumers read it — the SICA
+      // test-generation workflow, the system-review workflow, and
+      // `cli/system-review.ts`. All three silently saw no coverage: the
+      // existsSync guards were permanently false, and the workflow's
+      // `jq '.total.lines.pct // 0'` fallback turned absence into 0%.
+      // (`json` writes coverage-final.json, which is a different shape.)
+      reporter: ['text', 'json', 'json-summary', 'html'],
       // Thresholds
       thresholds: {
         statements: 60,


### PR DESCRIPTION
Closes #4668. Larger than that issue describes, because the blocker turned out to be one level down.

## The comment was right, and nobody had asked why

```ts
testCoverage: null, // Would need coverage report integration
```

Integration was impossible because **`coverage-summary.json` is never written**. The vitest reporter list was `['text', 'json', 'html']` — and `json` produces `coverage-final.json`, a different file with a different shape.

## Three consumers were reading a file nothing produces

- `.github/workflows/sica-test-generation.yml:72`
- `.github/workflows/system-review.yml:242`
- `src/cli/system-review.ts:182`

All three guard with `existsSync`, so all three silently saw no coverage — for however long the reporter list has looked like that.

The SICA one is the worst of the three:

```bash
LINE_COV=$(jq '.total.lines.pct // 0' .../coverage-summary.json)
```

`// 0` turns "file absent" into **0% coverage**. For a workflow that generates tests to close coverage gaps, absence reading as *maximally uncovered* is the dangerous direction — and it is guarded by an `if [ -f ]` that never passes, so it has been inert rather than wrong. Adding the producer makes that guard start passing, which is why the `// 0` fallback is worth a look separately.

## Verified empirically, not from the docs

I did not trust the reporter naming. Ran coverage with `json-summary` against one test file:

```
per-file entries: 1406
sample key:   .../src/cli-auth-handler.ts
sample lines: {"total": 5, "covered": 0, "skipped": 0, "pct": 0}
```

`total` plus one entry per absolute file path. So per-file coverage genuinely is available — which the fix depends on.

## Per-file, not project total

`ComponentInfo.testCoverage` is per-component. The existing reader in `system-review.ts` takes `total.lines.pct` — a project-wide figure. Stamping that onto every component would be a **fabricated per-file metric**: every file would report identically and none of it would be true.

A test pins the distinction: given a report with `total: 50` and the file at `17`, the scanner must produce **17**.

## Unmeasured is not 0%

An absent report, or a file missing from an existing report, stays `null`.

This is the condition that makes the fix safe. `deprecate` fires below 0.3, and low coverage carries a −0.2 penalty — so coercing absence to 0% would turn a recommendation that **could never fire** into one that fires **for the wrong reason**. That is not an improvement; it is the same defect with the sign flipped.

Mutation-verified: changing the lookup to `?? 0` fails the test.

## On the existing regression test

#4668 proposes adding a durable test. One already exists and passes — `code-quality-evaluator.test.ts:217` hand-builds `testCoverage: 20`, a value the real scanner never produced. It proved the evaluator's arithmetic while the feature was dead. The new tests run against **scanner output**, which is the only way to catch this class.

## Verification

Full suite **28348 passed, 0 failed**. `src/self-eval`: 185 passing. Typecheck and lint clean.