### PR TITLE
fix(ci): report coverage as unmeasured rather than 0% when it was not measured

### DIFF
--- a/.github/workflows/sica-test-generation.yml
+++ b/.github/workflows/sica-test-generation.yml
@@ -68,21 +68,41 @@ jobs:
           # it to a non-staged path with a non-JSON extension.
           pnpm test:coverage > coverage-report.log 2>&1 || true
 
-          # Extract coverage metrics
-          if [ -f packages/nexus-agents/coverage/coverage-summary.json ]; then
-            LINE_COV=$(jq '.total.lines.pct // 0' packages/nexus-agents/coverage/coverage-summary.json)
-            BRANCH_COV=$(jq '.total.branches.pct // 0' packages/nexus-agents/coverage/coverage-summary.json)
-            FUNC_COV=$(jq '.total.functions.pct // 0' packages/nexus-agents/coverage/coverage-summary.json)
+          # Extract coverage metrics (#4727).
+          #
+          # These are REPORTING only — the generator targets $TARGET_COVERAGE and
+          # never reads them. But they are printed in the PR body and the job
+          # summary, so a wrong number here is read by a human as fact.
+          #
+          # `// 0` and the else-branch previously turned "no measurement" into
+          # "0% coverage" at two levels. Absence must not read as the worst
+          # possible measurement; it reads as `unmeasured`.
+          #
+          # Until #4668 added the `json-summary` reporter this file was never
+          # produced, so the else-branch was the only path and every run
+          # reported 0%.
+          SUMMARY=packages/nexus-agents/coverage/coverage-summary.json
+          # Emits "87.5%" or "unmeasured" — the unit travels with the value so
+          # consumers cannot append "%" to a non-number.
+          read_pct() {
+            local pct
+            pct=$(jq -er "$1" "$SUMMARY" 2>/dev/null) && echo "${pct}%" || echo "unmeasured"
+          }
+          if [ -f "$SUMMARY" ]; then
+            LINE_COV=$(read_pct '.total.lines.pct')
+            BRANCH_COV=$(read_pct '.total.branches.pct')
+            FUNC_COV=$(read_pct '.total.functions.pct')
           else
-            LINE_COV=0
-            BRANCH_COV=0
-            FUNC_COV=0
+            echo "::warning::$SUMMARY not found — coverage reported as unmeasured, not 0%"
+            LINE_COV=unmeasured
+            BRANCH_COV=unmeasured
+            FUNC_COV=unmeasured
           fi
 
           echo "line_coverage=$LINE_COV" >> $GITHUB_OUTPUT
           echo "branch_coverage=$BRANCH_COV" >> $GITHUB_OUTPUT
           echo "function_coverage=$FUNC_COV" >> $GITHUB_OUTPUT
-          echo "Current coverage: Lines=$LINE_COV%, Branches=$BRANCH_COV%, Functions=$FUNC_COV%"
+          echo "Current coverage: Lines=$LINE_COV, Branches=$BRANCH_COV, Functions=$FUNC_COV"
 
       - name: Run SICA Test Generator
         id: generate
@@ -180,9 +200,9 @@ jobs:
             **Target Coverage:** ${{ env.TARGET_COVERAGE }}%
 
             ### Coverage Metrics (Before)
-            - Line: ${{ steps.coverage.outputs.line_coverage }}%
-            - Branch: ${{ steps.coverage.outputs.branch_coverage }}%
-            - Function: ${{ steps.coverage.outputs.function_coverage }}%
+            - Line: ${{ steps.coverage.outputs.line_coverage }}
+            - Branch: ${{ steps.coverage.outputs.branch_coverage }}
+            - Function: ${{ steps.coverage.outputs.function_coverage }}
 
             ### Generated
             - Tests: ${{ steps.generate.outputs.test_count }}
@@ -211,9 +231,9 @@ jobs:
           echo "**Target Coverage:** ${{ env.TARGET_COVERAGE }}%" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "#### Coverage Before" >> $GITHUB_STEP_SUMMARY
-          echo "- Line: ${{ steps.coverage.outputs.line_coverage }}%" >> $GITHUB_STEP_SUMMARY
-          echo "- Branch: ${{ steps.coverage.outputs.branch_coverage }}%" >> $GITHUB_STEP_SUMMARY
-          echo "- Function: ${{ steps.coverage.outputs.function_coverage }}%" >> $GITHUB_STEP_SUMMARY
+          echo "- Line: ${{ steps.coverage.outputs.line_coverage }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Branch: ${{ steps.coverage.outputs.branch_coverage }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Function: ${{ steps.coverage.outputs.function_coverage }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "#### Results" >> $GITHUB_STEP_SUMMARY
           echo "- Tests Generated: ${{ steps.generate.outputs.test_count || 0 }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Closes #4727. Filed while fixing #4668, because that PR makes this path live for the first time.

## The defect

```bash
if [ -f .../coverage-summary.json ]; then
  LINE_COV=$(jq '.total.lines.pct // 0' .../coverage-summary.json)
  ...
else
  LINE_COV=0
```

A missing measurement read as **0% coverage** at two levels — the `// 0` fallback *and* the else-branch.

And until #4668 added the `json-summary` reporter, `coverage-summary.json` was never produced, so the else-branch was the **only** path. Every run of this workflow has reported 0%.

## Severity — corrected from my own filing

I filed this saying the generator "would act on" the fiction. **It does not.** The SICA generator uses `TARGET_COVERAGE` (a workflow input, default 85) and never reads the measured values.

They are consumed in exactly two places — the PR body (`:203-205`) and the job summary (`:234-236`). So the harm is a **human-facing misreport**: a PR stating "Line: 0%" when coverage simply was not measured.

Lower severity than I claimed. Still worth fixing, for the reason this repo keeps running into — a record that misreports is worse than a missing one, because a reader trusts it.

## The fix

Absence reads as `unmeasured`, and the unit travels with the value:

```bash
read_pct() {
  local pct
  pct=$(jq -er "$1" "$SUMMARY" 2>/dev/null) && echo "${pct}%" || echo "unmeasured"
}
```

The unit moved to the producer because the consumers append a literal `%` — a naive fallback would have rendered `unmeasured%`. That is the kind of detail that makes an "obvious" fix look sloppy in the output nobody re-reads.

A `::warning::` fires when the file is absent, so an unmeasured run is visible in the log rather than only in the summary.

## Verified

All four cases, exercised as shell rather than reasoned about:

| Input | Result |
|---|---|
| valid report | `87.5%` |
| field missing | `unmeasured` |
| file absent | `unmeasured` |
| malformed JSON | `unmeasured` |

None yield `0%`.

## Note

`.github/workflows/` is CODEOWNERS review-requested but not on CLAUDE.md's never-auto-merge list, so this is self-mergeable under the standing approval — flagging the call rather than making it silently.