### PR TITLE
fix(ci): stop the system-review summary rendering "Unknown%" for unmeasured coverage

### DIFF
--- a/.github/workflows/system-review.yml
+++ b/.github/workflows/system-review.yml
@@ -237,18 +237,25 @@ jobs:
           if ! pnpm lint 2>/dev/null; then
             LINT_RESULT="Fail"
           fi
+          # #4727 sibling: this correctly defaults to Unknown rather than 0%,
+          # but rendered it as "Unknown%" — and a bare `jq` (no -e) returns the
+          # string "null" for a missing field, which rendered as "null%". The
+          # unit now travels with the value so the summary cannot append "%" to
+          # a non-number.
           COVERAGE="Unknown"
           if pnpm test:coverage 2>/dev/null; then
             COVERAGE_FILE="packages/nexus-agents/coverage/coverage-summary.json"
             if [ -f "$COVERAGE_FILE" ]; then
-              COVERAGE=$(jq '.total.lines.pct' "$COVERAGE_FILE")
+              PCT=$(jq -er '.total.lines.pct' "$COVERAGE_FILE" 2>/dev/null) \
+                && COVERAGE="${PCT}%" \
+                || COVERAGE="Unknown (report present, .total.lines.pct missing)"
             fi
           fi
           echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| TypeScript | $TYPECHECK_RESULT |" >> $GITHUB_STEP_SUMMARY
           echo "| ESLint | $LINT_RESULT |" >> $GITHUB_STEP_SUMMARY
-          echo "| Coverage | ${COVERAGE}% |" >> $GITHUB_STEP_SUMMARY
+          echo "| Coverage | ${COVERAGE} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
   create-issue:


### PR DESCRIPTION
Sibling of #4727 / #4728. Found by closing a loose end I had explicitly flagged as unchecked on that issue — *"whether it has an equivalent fallback I have not checked."*

## What it got right

Unlike the SICA workflow, this one defaults `COVERAGE="Unknown"` and only overwrites when the report exists. **Absence never reads as 0%** — the semantics were already correct.

## What it got wrong

The summary line appends a literal `%`:

```bash
echo "| Coverage | ${COVERAGE}% |" >> $GITHUB_STEP_SUMMARY
```

So an unmeasured run rendered **`Unknown%`**.

And a quieter case: `jq '.total.lines.pct'` without `-e` returns the string `"null"` for a missing field, so a present-but-incomplete report rendered **`null%`** — which reads as a number far more than `Unknown%` does.

## The fix

The unit travels with the value, matching #4728. And a present-but-incomplete report now says so, rather than collapsing into the same `Unknown` as an absent one — those are different conditions and the second one means something is broken.

| Input | Renders |
|---|---|
| valid report | `72.4%` |
| field missing | `Unknown (report present, .total.lines.pct missing)` |
| file absent | `Unknown` |
| malformed JSON | `Unknown (report present, .total.lines.pct missing)` |

Verified by running the shell, not by reading it.

## Why bother with a cosmetic bug

Because this summary is where a human reads the number. `Unknown%` is merely odd; `null%` is a value-shaped string in a percentage column, and that is the same class of misreport the rest of this work has been about — just rendered rather than computed.