### PR TITLE
fix(mcp): stop recording a constant trust tier as if it were a measurement

### DIFF
--- a/.changeset/measured-trust-tier.md
+++ b/.changeset/measured-trust-tier.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): stop recording a constant trust tier as if it were a measurement
+
+`createRequestContext` falls back to `caller = {}`, and `deriveTrustTier({})`
+returns `'3'`. Nothing in the tree supplies `callerInfo` — its only references
+are the declaration and one forward — so every recorded tier was that fallback.
+The stage-entry telemetry added in #4699 therefore recorded `'3'` on every run,
+which reads as a measurement and is not one.
+
+`measuredTrustTier` returns the tier only when it was actually derived from
+caller information, so consumers record `unmeasured` instead of a constant. When
+a real `callerInfo` producer lands it starts returning values with no further
+change.
+
+This does not make the tier vary — that needs the producer. It stops the record
+claiming otherwise. Also documents at the helper that this is caller
+AUTHENTICATION, not content provenance: a trusted client can submit hostile
+content, and `classifyTrust` (the closest provenance signal) requires a GitHub
+actor and does not apply to a bare goal string.

--- a/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
@@ -14,6 +14,7 @@ import {
   extractCallerInfo,
   contextForLogging,
   isRequestContext,
+  measuredTrustTier,
 } from './request-context.js';
 
 // ============================================================================
@@ -310,5 +311,44 @@ describe('isRequestContext', () => {
       trustTier: '5',
     };
     expect(isRequestContext(invalid)).toBe(false);
+  });
+});
+
+describe('measuredTrustTier (#4733)', () => {
+  // `createRequestContext` falls back to `caller = {}`, and `deriveTrustTier({})`
+  // returns '3'. Since nothing supplies callerInfo today, EVERY tier is that
+  // fallback — so recording `context.trustTier` records a constant that reads
+  // as a measurement. That is what #4699 shipped.
+
+  it('returns undefined when no caller info was supplied — the shipped reality', () => {
+    const ctx = createRequestContext({ toolName: 'run_pipeline' });
+    // The raw field looks like a measurement...
+    expect(ctx.trustTier).toBe('3');
+    // ...and is not one.
+    expect(measuredTrustTier(ctx)).toBeUndefined();
+  });
+
+  it('returns the tier once caller info exists', () => {
+    const ctx = createRequestContext({
+      toolName: 'run_pipeline',
+      caller: { transport: 'stdio' },
+    });
+    expect(measuredTrustTier(ctx)).toBe('1');
+  });
+
+  it('distinguishes a genuine tier 3 from the fallback tier 3', () => {
+    // The case the raw field cannot express: an authenticated caller with an
+    // unknown client is really tier 3, and must not be conflated with "we did
+    // not measure".
+    const real = createRequestContext({
+      toolName: 'run_pipeline',
+      caller: { authenticated: false, clientId: 'something-unknown' },
+    });
+    expect(real.trustTier).toBe('3');
+    expect(measuredTrustTier(real)).toBe('3');
+
+    const fallback = createRequestContext({ toolName: 'run_pipeline' });
+    expect(fallback.trustTier).toBe('3');
+    expect(measuredTrustTier(fallback)).toBeUndefined();
   });
 });

--- a/packages/nexus-agents/src/mcp/middleware/request-context.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.ts
@@ -250,3 +250,33 @@ export function isRequestContext(value: unknown): value is RequestContext {
     ['1', '2', '3', '4'].includes(obj['trustTier'])
   );
 }
+
+/**
+ * The request's trust tier ONLY when it was actually derived from caller
+ * information (#4733).
+ *
+ * `createRequestContext` falls back to `caller = {}`, and `deriveTrustTier({})`
+ * returns `'3'` — so an absent caller is indistinguishable from a genuinely
+ * untrusted one at the reading end. Nothing in this tree supplies `callerInfo`
+ * today (its only references are the declaration and one forward in
+ * `secure-handler.ts`), so every tier is that fallback.
+ *
+ * Returning `undefined` for the fallback lets a consumer record `unmeasured`
+ * rather than a constant that reads as a measurement. When a real
+ * `callerInfo` producer lands this starts returning values without further
+ * change.
+ *
+ * NOTE this is caller AUTHENTICATION (transport / authenticated / clientId),
+ * not content provenance. A trusted client can submit hostile content. Consumers
+ * wanting provenance need a different signal — `classifyTrust` is the closest,
+ * but it requires a GitHub actor and does not apply to a bare goal string.
+ */
+export function measuredTrustTier(context: RequestContext): string | undefined {
+  // `caller` is always set by `createRequestContext` (to `{}` at minimum), but
+  // a partially-constructed context can omit it — and an absent caller is the
+  // same condition as an empty one: nothing was measured.
+  const caller: unknown = context.caller;
+  const hasCallerInfo =
+    typeof caller === 'object' && caller !== null && Object.keys(caller).length > 0;
+  return hasCallerInfo ? context.trustTier : undefined;
+}

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -343,16 +343,33 @@ describe('registerDevPipelineTool', () => {
 describe('registerDevPipelineTool — trustTier threading (#3712)', () => {
   beforeEach(() => runDevPipelineMock.mockClear());
 
+  // #4733: these fixtures now carry `caller`, because a tier without one is
+  // not a measurement — `createRequestContext` derives from `caller = {}` and
+  // no production site supplies `options.trustTier` explicitly, so a
+  // caller-less tier is the constant fallback rather than a threaded value.
   it('threads the real RequestContext.trustTier into runDevPipeline options', async () => {
     const handler = captureHandler();
-    await handler({ task: 'Build feature X' }, { requestContext: { trustTier: '1' } });
+    await handler(
+      { task: 'Build feature X' },
+      { requestContext: { trustTier: '1', caller: { transport: 'stdio' } } }
+    );
     expect(runDevPipelineMock).toHaveBeenCalledTimes(1);
     expect(runDevPipelineMock.mock.calls[0]?.[2]?.trustTier).toBe('1');
   });
 
   it("forwards an untrusted tier '3' unchanged (not silently downgraded to trusted)", async () => {
     const handler = captureHandler();
-    await handler({ task: 'Build feature X' }, { requestContext: { trustTier: '3' } });
+    await handler(
+      { task: 'Build feature X' },
+      { requestContext: { trustTier: '3', caller: { authenticated: false } } }
+    );
     expect(runDevPipelineMock.mock.calls[0]?.[2]?.trustTier).toBe('3');
+  });
+
+  it('does NOT thread a caller-less tier — that is the constant, not a measurement', async () => {
+    // The shipped reality until a callerInfo producer exists (#4733).
+    const handler = captureHandler();
+    await handler({ task: 'Build feature X' }, { requestContext: { trustTier: '3' } });
+    expect(runDevPipelineMock.mock.calls[0]?.[2]?.trustTier).toBeUndefined();
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -46,9 +46,13 @@ import { ERROR_ENVELOPE_META_KEY } from '../error-envelope.js';
 import { readJobResult } from '../jobs/job-result-store.js';
 import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
 import { resetNexusDataDirCache } from '../../config/nexus-data-dir.js';
+import type { CallerInfo } from '../middleware/request-context.js';
 
 interface HandlerCtx {
-  requestContext: { trustTier: string };
+  // `caller` is part of the real RequestContext and is what makes the tier a
+  // measurement rather than the `deriveTrustTier({})` fallback (#4733), so the
+  // fixture type has to carry it.
+  requestContext: { trustTier: string; caller?: CallerInfo };
 }
 type CtxHandler = (args: unknown, ctx: HandlerCtx) => Promise<CapturedToolResult>;
 
@@ -57,8 +61,14 @@ interface CapturedToolResult {
   content: Array<{ type: string; text: string }>;
 }
 
-/** A stdio-tier (trusted) context, the production default for a local CLI caller. */
-const STDIO_CTX: HandlerCtx = { requestContext: { trustTier: '1' } };
+/**
+ * A stdio-tier (trusted) context, the production default for a local CLI caller.
+ * The `caller` is what a real stdio request carries; without it the tier is the
+ * constant fallback and is deliberately not threaded (#4733).
+ */
+const STDIO_CTX: HandlerCtx = {
+  requestContext: { trustTier: '1', caller: { transport: 'stdio' } },
+};
 
 /**
  * Registers the tool against a mock server and returns the captured callback.

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -22,6 +22,7 @@ import { createTaskTracker, detectBackend } from '../../pipeline/task-tracker.js
 import { getToolAnnotations } from '../tool-annotations.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
+import { measuredTrustTier } from '../middleware/request-context.js';
 import {
   toolStructuredError,
   toolSuccessStructured,
@@ -475,7 +476,7 @@ export function registerDevPipelineTool(server: McpServer, deps: DevPipelineTool
   // so the gate persists policy decisions to the shared hash chain.
   const secureHandler = createSecureHandler(
     (args: unknown, ctx: HandlerContext) =>
-      runDevPipelineHandler(args, logger, ctx.requestContext.trustTier, deps.auditLogger),
+      runDevPipelineHandler(args, logger, measuredTrustTier(ctx.requestContext), deps.auditLogger),
     { toolName: 'run_dev_pipeline', rateLimiter: deps.rateLimiter, logger }
   );
   const timeoutMs = getToolTimeout('run_dev_pipeline', deps.security);

--- a/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pipeline-tool.ts
@@ -31,6 +31,7 @@ import { listTemplateIds } from '../../pipeline/templates.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
+import { measuredTrustTier } from '../middleware/request-context.js';
 import {
   toolStructuredError,
   toolSuccessStructured,
@@ -392,7 +393,7 @@ export function registerPipelineTool(server: McpServer, deps: BaseMcpToolDeps): 
     // without a context has genuinely NOT measured a tier, and that flows to
     // UNMEASURED_TRUST_TIER rather than to a default. Absence stays absence.
     (args: unknown, ctx?: HandlerContext) =>
-      runPipelineHandler(args, logger, ctx?.requestContext.trustTier),
+      runPipelineHandler(args, logger, ctx && measuredTrustTier(ctx.requestContext)),
     { toolName: 'run_pipeline', rateLimiter: deps.rateLimiter, logger }
   );
   const timeoutMs = getToolTimeout('run_pipeline', deps.security);


### PR DESCRIPTION
Partial fix for #4733, a self-review finding against #4699 which I merged earlier today.

## The defect

```ts
const caller = options.caller ?? {};
trustTier: options.trustTier ?? deriveTrustTier(caller),
```

`deriveTrustTier({})` falls past `transport` and `authenticated` and returns `'3'`. **Nothing supplies `callerInfo`** — its only references are the declaration (`secure-handler.ts:70`) and one forward (`:419`).

So the stage-entry telemetry I added in #4699 recorded `'3'` on every run. A constant that reads as a measurement — which is precisely the defect class that work was meant to address.

## What I checked before choosing a fix

The tempting repair is to record content provenance instead, since that is what the field's name implies. **There is no producer for it on this path.** `classifyTrust` requires `username` and `authorAssociation` — it classifies a GitHub actor, and its only callers are `issue-triage`, `pr-reviewer` and the firewall. A bare goal string has no author.

So both candidate signals are unavailable, and the honest move is to stop claiming one.

## The change

`measuredTrustTier(context)` returns the tier only when it was derived from real caller info, so the pipeline records `unmeasured` rather than a fabricated `'3'`. When a `callerInfo` producer lands, it starts returning values with no further change.

The helper documents that this measures **caller authentication**, not content provenance — a trusted client can submit hostile content, and conflating the two is how the mislabel happened.

## Two test corrections

**The helper threw** on contexts lacking a `caller` field. An absent caller is the same condition as an empty one, so it is total now.

**Two #3712 fixtures failed**, passing an explicit `trustTier` with no caller. I did not assume they were pinning the old behaviour — I checked whether production ever supplies `options.trustTier` explicitly, and **it does not**: both `secure-handler.ts:421` and `middleware-chain.ts:399` rely on derivation. Those fixtures simulate a shape that cannot occur, so they now carry `caller` and still prove threading, plus a third asserting a caller-less tier is *not* threaded.

## What this does not do

It does not make the tier vary. That needs a `callerInfo` producer at the transport boundary, which #4733 still tracks — along with the open question of whether this path wants caller auth, content provenance, or both recorded separately.

**#4694 step 2 stays blocked**: measuring a constant produces no evidence, and now at least the record says `unmeasured` instead of implying otherwise.

## Verification

Mutation-verified — removing the caller check fails two of the three new tests. Full suite **28350 passed, 0 failed**. `src/mcp` + `src/pipeline`: 4829 passing. Typecheck and lint clean.