### PR TITLE
fix(consensus): name the empty case in the higher-order strategy

### DIFF
--- a/.changeset/higher-order-empty-case.md
+++ b/.changeset/higher-order-empty-case.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+fix(consensus): the higher-order strategy reports an empty or all-abstain panel as no votes cast, not 50%
+
+`OWVoting.toVotingOutcome` published `aggregateSimple`'s `posteriorApproval = 0.5`
+fallback as `approvalPercentage: 50` whenever nothing countable was cast — a
+measured-looking midpoint standing in for an unmeasured panel.
+
+This was the only one of the four strategies missing the guard;
+`SimpleMajorityStrategy` and `SupermajorityStrategy` already answer the same
+input with `0` and `'No votes cast (excluding abstentions)'`. The fix matches
+them, so the four strategies now give one answer to the empty case.
+
+Reachable in production rather than theoretical: an errored voter
+(`voter-execution.ts:92`) and an unparseable response
+(`protocol-helpers.ts:101`) both produce `abstain`.
+
+Scope: this is the non-breaking half of #4701's defect 2. A split panel is
+still recorded as `rejected` — distinguishing it needs a new
+`VoteDecisionStatus` member, which is a breaking change to an exported type and
+is tracked in #4740 behind a unanimous vote.

--- a/packages/nexus-agents/src/consensus/higher-order-voting.test.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-voting.test.ts
@@ -20,6 +20,7 @@ import {
   type AgentPairKey,
 } from './higher-order-types.js';
 import { CorrelationTracker, createCorrelationTracker } from './correlation-tracker.js';
+import { SimpleMajorityStrategy } from './strategies.js';
 import {
   OWVoting,
   createOWVoting,
@@ -679,6 +680,60 @@ describe('OWVoting', () => {
       expect(outcome.approvalPercentage).toBeDefined();
       expect(outcome.voteCounts).toBeDefined();
       expect(outcome.reason).toBeDefined();
+    });
+  });
+
+  // #4701: the higher-order strategy was the only one of the four missing the
+  // zero-voting-votes guard its siblings have (`strategies.ts:136`, `:174`).
+  // `aggregateSimple` fell to `total > 0 ? approve/total : 0.5`, so a panel that
+  // cast no countable votes reported a measured-looking 50%.
+  describe('empty and all-abstain panels (#4701)', () => {
+    it('reports 0% and says no votes were cast, not a fabricated 50% midpoint', () => {
+      const outcome = voting.calculateOutcome(new Map());
+
+      expect(outcome.approvalPercentage).toBe(0);
+      expect(outcome.approved).toBe(false);
+      expect(outcome.reason).toContain('No votes cast');
+    });
+
+    it('treats an all-abstain panel as no votes cast — abstentions are not a split', () => {
+      // Reachable in production: an errored voter (voter-execution.ts:92) and an
+      // unparseable response (protocol-helpers.ts:101) both yield `abstain`.
+      const votes = createVoteMap([
+        ['alice', 'abstain'],
+        ['bob', 'abstain'],
+        ['charlie', 'abstain'],
+      ]);
+
+      const outcome = voting.calculateOutcome(new Map(votes));
+
+      expect(outcome.approvalPercentage).toBe(0);
+      expect(outcome.approved).toBe(false);
+      expect(outcome.reason).toContain('No votes cast');
+      expect(outcome.voteCounts).toEqual({ approve: 0, reject: 0, abstain: 3, total: 3 });
+    });
+
+    it('matches SimpleMajorityStrategy on the same empty input', () => {
+      // The point of the fix is consistency: four strategies, one empty-case answer.
+      const simple = new SimpleMajorityStrategy();
+
+      const higherOrder = voting.calculateOutcome(new Map());
+      const simpleOutcome = simple.calculateOutcome(new Map());
+
+      expect(higherOrder.approvalPercentage).toBe(simpleOutcome.approvalPercentage);
+      expect(higherOrder.approved).toBe(simpleOutcome.approved);
+    });
+
+    it('still reports a real 1-1 split as 50% — the guard must not swallow a genuine tie', () => {
+      const votes = createVoteMap([
+        ['alice', 'approve'],
+        ['bob', 'reject'],
+      ]);
+
+      const outcome = voting.calculateOutcome(new Map(votes));
+
+      expect(outcome.approvalPercentage).toBe(50);
+      expect(outcome.reason).not.toContain('No votes cast');
     });
   });
 

--- a/packages/nexus-agents/src/consensus/higher-order-voting.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-voting.ts
@@ -267,6 +267,21 @@ export class OWVoting implements IHigherOrderVoting, IVotingStrategy {
 
     const voteCounts: VoteCounts = { approve, reject, abstain, total: votes.size };
 
+    // #4701: name the empty case, and name it the same way the other three
+    // strategies do (`strategies.ts:136`, `:174`, `:210`). `aggregateSimple`
+    // falls back to `posteriorApproval = 0.5` when nothing countable was cast,
+    // which this method would otherwise publish as a measured-looking 50% —
+    // absence rendered as a split. An all-abstain panel is reachable in
+    // production: an errored voter and an unparseable response both abstain.
+    if (approve + reject === 0) {
+      return {
+        approved: false,
+        approvalPercentage: 0,
+        voteCounts,
+        reason: 'No votes cast (excluding abstentions)',
+      };
+    }
+
     const rawPercentage = result.posteriorApproval * 100;
     const approvalPercentage = Number.isFinite(rawPercentage) ? rawPercentage : 0;
 


### PR DESCRIPTION
The non-breaking half of #4701 defect 2.

## The defect

`aggregateSimple` sets `posteriorApproval = total > 0 ? approve / total : 0.5`, and `toVotingOutcome` published that fallback straight through:

```ts
const rawPercentage = result.posteriorApproval * 100;   // 50 when nothing was cast
```

So a panel that cast no countable votes reported `approvalPercentage: 50` — absence rendered as a measured even split, on the record that governance decisions are read from.

**Reachable, not theoretical.** `abstain` is produced in production by an errored voter (`voter-execution.ts:92`) and by an unparseable response (`protocol-helpers.ts:101`). The weighted-random producer is the simulation path, fail-closed outside tests (#4170).

## Why this fix and not the one I first proposed

I was going to design a new "no votes cast" representation. Grepping for tests that pinned the old behaviour turned up something better: **three of the four strategies already answer this input correctly.**

```
strategies.ts:136   if (votingVotes === 0) → approvalPercentage: 0,
strategies.ts:174     reason: 'No votes cast (excluding abstentions)'
```

The higher-order strategy was the only one missing the guard. So this stopped being a design decision and became a consistency fix: four strategies, one answer to the empty case, reusing the sibling reason string verbatim rather than inventing a parallel one.

## Verification

Red first — the three new tests fail without the guard and pass with it. A fourth test is the guard-rail in the other direction: a genuine 1-1 split must still report 50% and must **not** claim "No votes cast". One test asserts the higher-order and simple-majority outcomes agree on the same empty input, so the consistency this fix claims is what's actually checked.

Also checked and deliberately left alone: three existing assertions of `approvalPercentage === 50` in `engine.test.ts` are real 1-1 and 2-2 splits, not the vacuous case.

Full suite **28364 passed, 0 failed**; consensus + both consumer suites (`iterative-consensus`, `vote-command`) 729 passing. Typecheck and lint clean.

## Scope — what this does NOT fix

A split panel is **still recorded as `rejected`**, indistinguishable from a rejection on the merits. Fixing that needs a `no_consensus` member on `VoteDecisionStatus`, which is exported via `src/index.ts:50` and therefore a compile-time break for downstream exhaustive switches. The #4701 panel voted 6-1 to ship it as semver-minor; that premise is false, and breaking changes need unanimous, so it is split out to #4740 behind its own gate.

Correlation weighting still does not reach the verdict either — `higherOrderMetadata.appliedToDecision: false` already discloses that, and it is out of scope here.

## Note

Touches `src/consensus/`, which CODEOWNERS marks review-requested (not merge-blocked). Flagging rather than assuming: this changes only the zero-vote path, and every non-empty tally is byte-identical to before.