### PR TITLE
fix(workflows): let the ledger see that a step was never measured

### DIFF
--- a/.changeset/unmeasured-tokens.md
+++ b/.changeset/unmeasured-tokens.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': minor
+---
+
+fix(workflows): an unmeasured step no longer reports as having spent zero tokens
+
+`ResultMetadata.tokensUsed` is required, and producers coerced absence away with
+`usage?.totalTokens ?? 0`. So the workflow ledger's unmeasured branch
+(`typeof result.tokensUsed !== 'number'`) could never run, `unmeasuredSteps` was
+permanently `0`, and `reportUsageCoverage` could never warn. The coverage
+reporting added in #4710 was decoration over a signal already destroyed upstream.
+
+Adds `ResultMetadata.tokensMeasured?: boolean` — additive and optional, so no
+existing reader breaks. Producers set it to `false` when the adapter reported no
+usage, and `step-executor` then omits `StepResult.tokensUsed` (already optional)
+so the ledger counts the step as unmeasured rather than free. For a spend cap,
+under-counting is the dangerous direction.
+
+An absent flag means "legacy producer, unknown" and is left alone — a value is
+dropped only on an explicit `false`.
+
+Chosen over widening `tokensUsed` to `number | undefined` by a 6-1 panel (5/6
+selecting this option). That widening would have been a **breaking** change:
+`ResultMetadata` is not exported by name, but `TaskResult` is
+(`exports/core.ts:52`) and carries `metadata: ResultMetadata`, so it is publicly
+reachable and every downstream `const n: number = r.metadata.tokensUsed` would
+stop compiling. Detection gap tracked in #4749.
+
+Also fixes a second `?? 0` on the retry path in the same producer
+(`simple-agent.ts:93`) that the first-attempt test could not reach.

--- a/packages/nexus-agents/src/agents/simple-agent.test.ts
+++ b/packages/nexus-agents/src/agents/simple-agent.test.ts
@@ -138,6 +138,75 @@ describe('SimpleAgent', () => {
       }
     });
 
+    // #4734: `tokensUsed` stays 0 here because the field is required on a
+    // public type. `tokensMeasured: false` is what tells the ledger that 0 is a
+    // placeholder, not a count — without it the unmeasured-step branch is
+    // unreachable from any real run.
+    it('marks tokens unmeasured when the adapter reports no usage', async () => {
+      const adapter = createMockAdapter({
+        content: [{ type: 'text', text: 'output' }],
+        stopReason: 'end_turn',
+        model: 'large-model',
+      });
+      const agent = createTestAgent({ adapter });
+
+      const result = await agent.execute(createTestTask());
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.metadata.tokensMeasured).toBe(false);
+        expect(result.value.metadata.tokensUsed).toBe(0);
+      }
+    });
+
+    it('marks tokens measured when the adapter does report usage', async () => {
+      const adapter = createMockAdapter({
+        content: [{ type: 'text', text: 'output' }],
+        usage: { inputTokens: 50, outputTokens: 75, totalTokens: 125 },
+        stopReason: 'end_turn',
+        model: 'large-model',
+      });
+      const agent = createTestAgent({ adapter });
+
+      const result = await agent.execute(createTestTask());
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.metadata.tokensMeasured).toBe(true);
+      }
+    });
+
+    // The retry path is a SECOND producer in the same file. The first-attempt
+    // test cannot reach it, because its response has text and never retries.
+    it('marks tokens unmeasured when a successful RETRY reports no usage', async () => {
+      const emptyResponse: CompletionResponse = {
+        content: [{ type: 'text', text: '' }],
+        usage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 },
+        stopReason: 'end_turn',
+        model: 'test-model',
+      };
+      const adapter = createMockAdapter(emptyResponse);
+      adapter.complete = vi
+        .fn()
+        .mockResolvedValueOnce(ok(emptyResponse))
+        .mockResolvedValueOnce(
+          ok({
+            content: [{ type: 'text', text: 'recovered' }],
+            stopReason: 'end_turn',
+            model: 'test-model',
+          })
+        );
+      const agent = createTestAgent({ adapter });
+
+      const result = await agent.execute(createTestTask());
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.output).toBe('recovered');
+        expect(result.value.metadata.tokensMeasured).toBe(false);
+      }
+    });
+
     it('should include model name from adapter response', async () => {
       const adapter = createMockAdapter({
         content: [{ type: 'text', text: 'output' }],
@@ -460,8 +529,7 @@ describe('SimpleAgent', () => {
       await agent.execute(createTestTask());
 
       const callArg = (adapter.complete as Mock).mock.calls[0]?.[0] as
-        | CompletionRequest
-        | undefined;
+        CompletionRequest | undefined;
       expect(callArg).toBeDefined();
       expect(callArg).not.toHaveProperty('systemPrompt');
     });

--- a/packages/nexus-agents/src/agents/simple-agent.ts
+++ b/packages/nexus-agents/src/agents/simple-agent.ts
@@ -58,6 +58,7 @@ export class SimpleAgent extends BaseAgent {
       metadata: {
         durationMs,
         tokensUsed: result.value.usage?.totalTokens ?? 0,
+        tokensMeasured: result.value.usage?.totalTokens !== undefined,
         toolsUsed: [],
         model: result.value.model,
       },
@@ -91,6 +92,7 @@ export class SimpleAgent extends BaseAgent {
       metadata: {
         durationMs,
         tokensUsed: retry.value.usage?.totalTokens ?? 0,
+        tokensMeasured: retry.value.usage?.totalTokens !== undefined,
         toolsUsed: [],
         model: retry.value.model,
       },

--- a/packages/nexus-agents/src/cli/cli-adapter-agent.test.ts
+++ b/packages/nexus-agents/src/cli/cli-adapter-agent.test.ts
@@ -228,6 +228,8 @@ describe('CliAdapterAgent - execute', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.metadata.tokensUsed).toBe(0);
+      // #4734: the 0 above is a placeholder. This is the field that says so.
+      expect(result.value.metadata.tokensMeasured).toBe(false);
     }
   });
 

--- a/packages/nexus-agents/src/cli/cli-adapter-agent.ts
+++ b/packages/nexus-agents/src/cli/cli-adapter-agent.ts
@@ -69,6 +69,7 @@ export class CliAdapterAgent implements IAgent {
       metadata: {
         durationMs: getTimeProvider().now() - startTime,
         tokensUsed: result.value.usage?.totalTokens ?? 0,
+        tokensMeasured: result.value.usage?.totalTokens !== undefined,
         toolsUsed: [],
         model: this.cliName,
       },

--- a/packages/nexus-agents/src/core/types/agent.ts
+++ b/packages/nexus-agents/src/core/types/agent.ts
@@ -119,8 +119,27 @@ export interface Task {
 export interface ResultMetadata {
   /** Execution duration in ms */
   durationMs: number;
-  /** Tokens used */
+  /** Tokens used. Meaningful only when {@link ResultMetadata.tokensMeasured} is not `false`. */
   tokensUsed: number;
+  /**
+   * Whether `tokensUsed` is a measurement (#4734).
+   *
+   * `false` means the adapter reported no usage, so `tokensUsed` is a
+   * placeholder zero and NOT a count — a step that consumed unreported tokens
+   * must not be read as having spent nothing, which for a spend cap
+   * under-counts in the dangerous direction.
+   *
+   * Absent means the producer predates this distinction: unknown, not
+   * measured. `step-executor` only drops a value on an explicit `false`, so a
+   * legacy producer keeps its current behaviour.
+   *
+   * This flag exists because `tokensUsed` is required on a structurally public
+   * type (`TaskResult.metadata`, exported via `exports/core.ts:52`), so making
+   * it optional would break every downstream reader. The workflow ledger reads
+   * `StepResult.tokensUsed`, which is already optional and CAN represent
+   * absence — see #4744.
+   */
+  tokensMeasured?: boolean;
   /** Tools invoked */
   toolsUsed: string[];
   /** Model used */

--- a/packages/nexus-agents/src/workflows/step-executor.test.ts
+++ b/packages/nexus-agents/src/workflows/step-executor.test.ts
@@ -846,6 +846,80 @@ describe('StepExecutor', () => {
       }
     });
 
+    // #4734: the SEAM, not the parts. `recordPhaseUsage` already had a passing
+    // unit test for its unmeasured branch, but that test hand-built a
+    // StepResult with no tokensUsed — an input production could not produce
+    // while every producer coerced absence to 0. This asserts the executor
+    // really drops the placeholder, so the branch is reachable from a real run.
+    it('omits tokensUsed when the agent marked the count unmeasured', async () => {
+      const unmeasuredFactory: IExpertFactory = {
+        createForRole: () =>
+          ok(
+            createMockExpert({
+              executeResult: ok({
+                taskId: 'test',
+                output: 'done',
+                metadata: {
+                  durationMs: 100,
+                  tokensUsed: 0,
+                  tokensMeasured: false,
+                  toolsUsed: [],
+                  model: 'test',
+                },
+              }),
+            })
+          ),
+      };
+
+      const unmeasuredExecutor = createStepExecutor({ expertFactory: unmeasuredFactory });
+      const step: WorkflowStep = {
+        id: 'step1',
+        agent: 'code_expert',
+        action: 'analyze',
+        inputs: {},
+      };
+
+      const result = await unmeasuredExecutor.execute(step, context);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect('tokensUsed' in result.value).toBe(false);
+      }
+    });
+
+    // A legacy producer that sets no flag must keep its current behaviour:
+    // unknown is not the same as known-unmeasured, and silently dropping real
+    // counts would under-report spend in the other direction.
+    it('keeps tokensUsed when the producer sets no measured flag', async () => {
+      const legacyFactory: IExpertFactory = {
+        createForRole: () =>
+          ok(
+            createMockExpert({
+              executeResult: ok({
+                taskId: 'test',
+                output: 'done',
+                metadata: { durationMs: 100, tokensUsed: 42, toolsUsed: [], model: 'test' },
+              }),
+            })
+          ),
+      };
+
+      const legacyExecutor = createStepExecutor({ expertFactory: legacyFactory });
+      const step: WorkflowStep = {
+        id: 'step1',
+        agent: 'code_expert',
+        action: 'analyze',
+        inputs: {},
+      };
+
+      const result = await legacyExecutor.execute(step, context);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.tokensUsed).toBe(42);
+      }
+    });
+
     it('should capture step output on success', async () => {
       const outputFactory: IExpertFactory = {
         createForRole: () => {

--- a/packages/nexus-agents/src/workflows/step-executor.ts
+++ b/packages/nexus-agents/src/workflows/step-executor.ts
@@ -305,13 +305,19 @@ export class StepExecutor {
       // `taskResult.value.metadata` (populated from adapter usage) and was
       // dropped here, which is why the budget ledger had to estimate from
       // wall-clock duration.
-      const tokensUsed = taskResult.value.metadata.tokensUsed;
+      // #4734: `tokensUsed` is required on ResultMetadata, so an unmeasured
+      // step still carries a placeholder 0. `tokensMeasured: false` is the
+      // producer saying that 0 is not a count — drop it here so the ledger
+      // counts the step as unmeasured rather than free. Absent (legacy
+      // producer) is left alone: unknown is not the same as known-unmeasured.
+      const { tokensUsed, tokensMeasured } = taskResult.value.metadata;
+      const isMeasured = tokensMeasured !== false && typeof tokensUsed === 'number';
       return ok({
         stepId: step.id,
         output: taskResult.value.output,
         durationMs: getTimeProvider().now() - startTime,
         status: 'success',
-        ...(typeof tokensUsed === 'number' ? { tokensUsed } : {}),
+        ...(isMeasured ? { tokensUsed } : {}),
       });
     } catch (error) {
       return this.handleExecutionError(error, step, timeoutMs);


### PR DESCRIPTION
Fixes the reachability half of #4734 — my own defect from #4710.

**Rewritten after review.** The first version of this PR widened `ResultMetadata.tokensUsed` to `number | undefined` and claimed it was internal-only. That claim was false and the approach is abandoned; details below, because the mistake is more instructive than the fix.

## The defect

#4710's changeset claimed *"An unmeasured step is NOT recorded as zero."* It was not true as shipped. Producers destroyed absence a layer above the guard:

```ts
tokensUsed: result.value.usage?.totalTokens ?? 0,
```

So `typeof result.tokensUsed !== 'number'` was never true, `unmeasuredSteps` was permanently `0`, and `reportUsageCoverage` could never warn. The guard was correct; its input had already been flattened.

## What I got wrong the first time

I claimed "not a public API change" on the strength of grepping for `ResultMetadata` in `src/exports/*.ts` and `src/index.ts` — zero hits.

The type is reachable **structurally**:

```
src/exports/core.ts:52     TaskResult,          (re-exported from src/index.ts)
core/types/agent.ts:139      metadata: ResultMetadata;
```

Widening it breaks every downstream `const n: number = r.metadata.tokensUsed`. A name grep answers "is this symbol re-exported?", not "is this type reachable?" — and those differ whenever an exported type references another, which is the common case. Third time today (#4736, #4740, this), so the detection gap is now filed as **#4749**: derive the surface from the AST instead.

## What this ships instead

A 6-1 panel (5 of 6 approvers selecting it) chose the non-breaking route:

- `ResultMetadata.tokensMeasured?: boolean` — additive and optional, so no reader breaks.
- Producers set it `false` when the adapter reported no usage.
- `step-executor` then omits `StepResult.tokensUsed`, which was **already optional and already public** — the layer the ledger actually reads can represent absence natively. That fact is what made a non-breaking fix possible, and I had missed it.
- An absent flag means "legacy producer, unknown" and is left alone. A value is dropped only on an explicit `false`; silently discarding real counts would under-report spend in the other direction.

Typecheck is clean with zero changes at any call site, which is the practical confirmation that it is non-breaking.

## Second producer in the same file

`simple-agent.ts:93`, the retry path, had its own `?? 0`. I fixed line 60 and missed its sibling. The first-attempt test cannot reach it — that response has text and never retries — so it has its own test that enters the retry.

## Tests: the seam, not the parts

`recordPhaseUsage` **already had a passing unit test** for the unmeasured branch. It passed by hand-building a `StepResult` with no `tokensUsed` — an input production could not produce. A green test sitting directly on a dead branch, which is exactly how this survived.

The new tests cross the real boundary, and each fails when its half is reverted:

- revert the producer flag → the producer test fails
- revert the `step-executor` guard → the seam test fails

Plus a guard in the other direction: a legacy producer with no flag must keep its count.

## Verification

Full suite green; `step-executor` + `simple-agent` + `cli-adapter-agent` 83 passing. Typecheck 0 errors, lint clean.

Marked **minor**, not patch: additive public field.

## Related

**#4743** needs rewording after this — non-workflow consumers still read `tokensUsed` alone, but they now *can* read `tokensMeasured`, so it becomes "teach the consumers" rather than "absence is unrepresentable". I will update it.
