### PR TITLE
fix(governance): give the ratification backstop its missing producer

### DIFF
--- a/.changeset/backstop-label-actor.md
+++ b/.changeset/backstop-label-actor.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): the post-merge ratification backstop can see who applied the label
+
+#4698 taught the ratification gate to require an owner-applied label and pass
+`RATIFICATION_LABEL_ACTOR`. The pre-merge job produces it. The post-merge
+backstop job **consumes it and never produced it** — its own evidence step wrote
+only `approvals` and `labels`.
+
+An unset step output is an empty string, not an error, so the backstop read
+"applier unknown", correctly refused to treat that as ratified, and failed. Every
+governor-path PR ratified by label reddened `main` after merge, unfixable by
+re-running. #4698 and #4704 did exactly that.
+
+Adds the missing producer, and `| tail -n1` on both timeline queries: `gh api
+--paginate --jq` applies the filter per page, so `| last` can emit one line per
+page and corrupt the step output.
+
+Also adds `scripts/workflow-output-wiring.test.ts`, which asserts every
+`steps.<id>.outputs.<name>` a job consumes has a producer in the same job. It
+fails against the pre-fix workflow and passes after — the defect class is
+mechanically detectable and should not need a human to catch it twice.
+
+Governance path (the governor workflow) — requires owner ratification.

--- a/.github/workflows/governor-review.yml
+++ b/.github/workflows/governor-review.yml
@@ -143,7 +143,7 @@ jobs:
           LABEL_ACTOR=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/timeline" \
             --paginate \
             --jq '[.[] | select(.event == "labeled" and .label.name == "owner-ratified")] | last | .actor.login // empty' \
-            2>/dev/null || echo '')
+            2>/dev/null | tail -n1 || echo '')
           {
             echo 'files<<FILES_EOF'
             echo "${FILES}"
@@ -201,11 +201,19 @@ jobs:
             # by construction — there is no PR to carry the evidence.
             APPROVALS=""
             LABELS=""
+            LABEL_ACTOR=""
           else
             APPROVALS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
               --paginate --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u | tr '\n' ' ')
             LABELS=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
               --jq '.labels[].name' | tr '\n' ',')
+            # Must mirror the pre-merge job: the gate step below consumes
+            # `label_actor`, and without a producer here every label-ratified
+            # governor PR lands as `indeterminate` and reddens main.
+            LABEL_ACTOR=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/timeline" \
+              --paginate \
+              --jq '[.[] | select(.event == "labeled" and .label.name == "owner-ratified")] | last | .actor.login // empty' \
+              2>/dev/null | tail -n1 || echo '')
           fi
           {
             echo 'files<<FILES_EOF'
@@ -213,6 +221,7 @@ jobs:
             echo 'FILES_EOF'
             echo "approvals=${APPROVALS}"
             echo "labels=${LABELS}"
+            echo "label_actor=${LABEL_ACTOR}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Run ratification gate against what actually landed

--- a/scripts/workflow-output-wiring.test.ts
+++ b/scripts/workflow-output-wiring.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Every `steps.<id>.outputs.<name>` a job consumes must have a producer in the
+ * same job (#4698 follow-up).
+ *
+ * The ratification backstop consumed `steps.evidence.outputs.label_actor` while
+ * its own `evidence` step never wrote it. The reference resolved to an empty
+ * string, the gate read that as "applier unknown", and every label-ratified
+ * governor PR reddened `main` after merge. Nothing failed at author time: YAML
+ * is happy, and an unset output is empty rather than an error.
+ *
+ * That is the NO-PRODUCER shape, and it is mechanically detectable, so it
+ * should not need a human to notice it twice.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOW_DIR = join(process.cwd(), '.github', 'workflows');
+
+/** A `run:` step can only publish an output by writing `name=` to $GITHUB_OUTPUT. */
+function producedOutputs(jobBody: string, stepId: string): Set<string> {
+  const produced = new Set<string>();
+  // Find the step with this id, then read to the start of the next step.
+  const idAt = jobBody.indexOf(`id: ${stepId}`);
+  if (idAt === -1) return produced;
+  const rest = jobBody.slice(idAt);
+  const nextStep = rest.indexOf('\n      - ');
+  const stepBody = nextStep === -1 ? rest : rest.slice(0, nextStep);
+  // `name=` after a quote, backtick or space. Deliberately loose: outputs are
+  // written by `echo "name=..."`, by heredocs, and by `appendFileSync` with a
+  // template literal (registry-refresh.yml does the last). Matching only `echo`
+  // reported that file as broken when it is fine.
+  for (const m of stepBody.matchAll(/[\s"'`]([A-Za-z_][A-Za-z0-9_-]*)=/g)) {
+    produced.add(m[1] as string);
+  }
+  // Heredoc form: `echo 'name<<EOF'`
+  for (const m of stepBody.matchAll(/["']([A-Za-z_][A-Za-z0-9_-]*)<</g)) {
+    produced.add(m[1] as string);
+  }
+  return produced;
+}
+
+/** Steps that delegate to an action publish outputs we cannot read from YAML. */
+function usesAction(jobBody: string, stepId: string): boolean {
+  const idAt = jobBody.indexOf(`id: ${stepId}`);
+  if (idAt === -1) return true; // unknown step — do not guess
+  const rest = jobBody.slice(idAt);
+  const nextStep = rest.indexOf('\n      - ');
+  const stepBody = nextStep === -1 ? rest : rest.slice(0, nextStep);
+  return /^\s+uses:/m.test(stepBody);
+}
+
+describe('workflow step-output wiring (#4698)', () => {
+  const files = readdirSync(WORKFLOW_DIR).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+
+  it('finds workflows to check', () => {
+    // Guard the guard: an empty directory would make every assertion below vacuous.
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const file of files) {
+    it(`${file}: every consumed step output has a producer in the same job`, () => {
+      const text = readFileSync(join(WORKFLOW_DIR, file), 'utf8');
+      // Split on job keys (two-space indent under `jobs:`) so producer lookup
+      // stays within the job that consumes the value.
+      const jobs = text.split(/\n {2}(?=[A-Za-z0-9_-]+:\n)/);
+      const missing: string[] = [];
+
+      for (const job of jobs) {
+        for (const m of job.matchAll(/steps\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)/g)) {
+          const [, stepId, output] = m as unknown as [string, string, string];
+          if (usesAction(job, stepId)) continue;
+          if (!producedOutputs(job, stepId).has(output)) {
+            missing.push(`${stepId}.outputs.${output}`);
+          }
+        }
+      }
+
+      expect(missing).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
**Main is red right now.** This fixes it. Found by an adversarial review of my own self-merged work, not by me.

## What broke

#4698 taught the ratification gate to require an *owner-applied* label, passing `RATIFICATION_LABEL_ACTOR` into the check. The pre-merge job produces it (`:143`). The post-merge backstop job **consumes it at `:232` and never produced it** — its evidence step wrote only `approvals` and `labels`.

An unset step output is an empty string, not an error. So the backstop read "applier cannot be established", correctly refused to call that ratified, and exited 1:

```
failure  b5948fdca  #4704
failure  d9b4cafe6  #4698
success  10bdacc8b  #4697   <- merged 4s before #4698 landed the workflow change
```

Every governor-path PR ratified by label reddens `main` after merge, and re-running cannot fix it.

The irony is worth stating plainly: this is a **consumer with no producer**, shipped inside the PR about attribution, on the same day I fixed roughly ten of that exact shape and wrote a memory note telling myself to trace producers. Fluency in a failure mode is not immunity to it.

## Second defect, same lines

`gh api --paginate --jq` applies the filter **per page**, so `| last` emits one line *per page* that contains a `labeled` event. Two such pages produce a bare second line in `$GITHUB_OUTPUT` → "Invalid format" step failure. The sibling `APPROVALS` query is guarded with `| tr '\n' ' '`; this one wasn't. Both timeline queries now end `| tail -n1`.

## The gate, not just the fix

`scripts/workflow-output-wiring.test.ts` asserts that every `steps.<id>.outputs.<name>` a job consumes has a producer in the same job.

**Mutation-verified against the real bug**, which is the only reason to trust it: it fails when run against the pre-fix `governor-review.yml` from `origin/main`, and passes against the fix. Not a synthetic mutant — the actual defect.

It also found a false positive on the first pass (`registry-refresh.yml` writes outputs via `appendFileSync` with a template literal rather than `echo`). Detection was broadened rather than the file excluded, since an exclusion list is how a gate quietly stops covering things. Steps that delegate to an action are skipped — their outputs aren't readable from YAML.

## Why the backstop is worth keeping strict

It refused to ratify on missing evidence, which is correct behaviour and exactly what the mission asks for — it failed *closed*. The bug was that it could never receive the evidence. Fixing the producer keeps the fail-closed semantics rather than loosening the gate to make the red go away.

## Ratification

Touches `.github/workflows/governor-review.yml` — a governance path, so this needs owner ratification and I am not self-merging it, despite it being a CI-red fix.

Note the bootstrap: once merged, the backstop runs from the merged tree, so the fixed workflow evaluates itself and self-heals.