### PR TITLE
fix(security): two review findings that could not fail

### DIFF
--- a/.changeset/vacuous-review-fixes.md
+++ b/.changeset/vacuous-review-fixes.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': patch
+---
+
+fix(security): two checks from an adversarial review that could not fail
+
+**The corroboration-rules test could not fail.** It asserted
+`getCorroborationRules(action)` is `toBeDefined()`, but
+`ACTION_CORROBORATION_RULES` is a total `Record<AgentActionType, ...>` — TypeScript
+already guarantees a value for every key, so an action registered with `[]` passed
+silently. It now asserts the rules are non-empty, with the two deliberate
+exemptions (`RequestHumanApproval`, `RefuseAction`) named: requiring corroboration
+in order to refuse or escalate would make refusal blockable.
+
+**`measuredTrustTier` accepted a caller that cannot be derived from.** It gated on
+`Object.keys(caller).length > 0`, but `extractCallerInfo` can return `{ sessionId }`
+or `{ userAgent }` alone, and neither is an input to `deriveTrustTier`. The first
+producer supplying only those would have made the `'3'` fallback read as a
+measurement — reintroducing the constant this function exists to prevent. It now
+gates on `transport` / `authenticated` / `clientId`.
+
+Both were found by an adversarial review of my own self-merged work, and both are
+mutation-verified: emptying `ClassifyIssue`'s rules fails the first, and restoring
+the non-empty predicate fails the second.
+
+Not fixed here: the drift tests iterate a hand-maintained action list rather than
+the schema, and `HandoffMessage` is missing from both it and the citation-floor
+table. That touches a governor-owned path — #4750.

--- a/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
@@ -315,6 +315,28 @@ describe('isRequestContext', () => {
 });
 
 describe('measuredTrustTier (#4733)', () => {
+  // #4738 review: `extractCallerInfo` can return `{ sessionId }` or
+  // `{ userAgent }` alone. Neither is an input to `deriveTrustTier`, so a
+  // "caller object is non-empty" test would have labelled the '3' fallback a
+  // measurement the moment a producer supplied only those.
+  it('does not treat a caller with only sessionId as measured', () => {
+    const context = createRequestContext({ toolName: 'test', caller: { sessionId: 'abc123' } });
+
+    expect(measuredTrustTier(context)).toBeUndefined();
+  });
+
+  it('does not treat a caller with only userAgent as measured', () => {
+    const context = createRequestContext({ toolName: 'test', caller: { userAgent: 'curl/8' } });
+
+    expect(measuredTrustTier(context)).toBeUndefined();
+  });
+
+  it('treats a caller with a derivation input as measured', () => {
+    const context = createRequestContext({ toolName: 'test', caller: { transport: 'stdio' } });
+
+    expect(measuredTrustTier(context)).toBe('1');
+  });
+
   // `createRequestContext` falls back to `caller = {}`, and `deriveTrustTier({})`
   // returns '3'. Since nothing supplies callerInfo today, EVERY tier is that
   // fallback — so recording `context.trustTier` records a constant that reads

--- a/packages/nexus-agents/src/mcp/middleware/request-context.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.ts
@@ -276,7 +276,17 @@ export function measuredTrustTier(context: RequestContext): string | undefined {
   // a partially-constructed context can omit it — and an absent caller is the
   // same condition as an empty one: nothing was measured.
   const caller: unknown = context.caller;
-  const hasCallerInfo =
-    typeof caller === 'object' && caller !== null && Object.keys(caller).length > 0;
-  return hasCallerInfo ? context.trustTier : undefined;
+  if (typeof caller !== 'object' || caller === null) return undefined;
+
+  // Gate on the fields `deriveTrustTier` actually reads, not on "the object has
+  // any key at all" (#4738 review). `extractCallerInfo` can return
+  // `{ sessionId }` or `{ userAgent }` alone; neither feeds the derivation, so
+  // a non-empty check would have called the '3' fallback a measurement as soon
+  // as a producer supplied only those — reintroducing the constant this
+  // function exists to prevent, in the function that prevents it.
+  const info = caller as Partial<CallerInfo>;
+  const derivable =
+    info.transport !== undefined || info.authenticated !== undefined || info.clientId !== undefined;
+
+  return derivable ? context.trustTier : undefined;
 }

--- a/packages/nexus-agents/src/security/corroboration-validator.test.ts
+++ b/packages/nexus-agents/src/security/corroboration-validator.test.ts
@@ -381,9 +381,27 @@ describe('the governance text matches the code (#4688)', () => {
     }
   });
 
+  /**
+   * The two safety valves carry no corroboration requirement on purpose:
+   * requiring evidence in order to refuse or escalate would make refusal
+   * blockable, which is the opposite of failing closed. Named here so a THIRD
+   * empty entry has to be added deliberately.
+   */
+  const NO_CORROBORATION_REQUIRED = new Set(['RequestHumanApproval', 'RefuseAction']);
+
   it('every typed action has corroboration rules in code', () => {
+    // #4698-review: this asserted `toBeDefined()`, which could not fail —
+    // ACTION_CORROBORATION_RULES is a total `Record<AgentActionType, ...>`, so
+    // TypeScript already guarantees a value for every key and an action
+    // registered with `[]` passed silently. Assert the rules are non-empty
+    // instead, exempting the two that are deliberately empty.
     for (const action of TYPED_ACTIONS) {
-      expect(getCorroborationRules(action), `'${action}' has no rules entry`).toBeDefined();
+      const rules = getCorroborationRules(action);
+      if (NO_CORROBORATION_REQUIRED.has(action)) {
+        expect(rules, `'${action}' is a safety valve and must stay unconditional`).toHaveLength(0);
+        continue;
+      }
+      expect(rules.length, `'${action}' has an empty rules entry`).toBeGreaterThan(0);
     }
   });
 


### PR DESCRIPTION
Two of three findings from an adversarial review of my own self-merged work. The third touches a governor-owned path and is split out to #4750.

## 1. The corroboration-rules test could not fail

```ts
expect(getCorroborationRules(action), `'${action}' has no rules entry`).toBeDefined();
```

`ACTION_CORROBORATION_RULES` is `Readonly<Record<AgentActionType, readonly CorroborationRule[]>>` — a **total** Record. TypeScript already guarantees a value for every key, so this could never be undefined, and an action registered with `[]` passed silently while requiring no corroboration at all.

**The reviewer's suggested fix was wrong**, and checking is what caught it. It proposed asserting a rule count per action. Two actions have legitimately empty rules:

```
RequestHumanApproval: []
RefuseAction: []
```

That is deliberate and documented — *"safety valves; requiring corroboration to refuse would make refusal blockable"*. A blanket `length > 0` would have failed on the two entries that are correct.

So the test now requires non-empty rules for every action **except** those two, which are named in a `NO_CORROBORATION_REQUIRED` set and asserted to stay empty. A third empty entry has to be added deliberately.

Mutation-verified: emptying `ClassifyIssue`'s rules produces `'ClassifyIssue' has an empty rules entry: expected 0 to be greater than 0`.

## 2. `measuredTrustTier` accepted a caller it cannot derive from

The predicate was `Object.keys(caller).length > 0`. But `extractCallerInfo` can return `{ sessionId }` or `{ userAgent }` alone, and **neither is an input to `deriveTrustTier`**, which reads `transport` / `authenticated` / `clientId`.

It cannot fire today, because nothing supplies `callerInfo` at all. It fires the moment someone wires the producer — which is the entire point of #4733 — and at that moment the `'3'` fallback starts being reported as a measurement. The constant would have come back **inside the function written to prevent it**, and #4738's tests would all still have passed.

Now gated on the three fields the derivation actually reads. Three tests cover it, and restoring the old predicate fails two of them.

## Verification

Full suite **28372 passed, 0 failed**. Typecheck 0 errors, lint clean.

## Deliberately not in scope

The drift tests iterate a hand-maintained `TYPED_ACTIONS` const rather than deriving from `AgentActionSchema`, so adding a schema member leaves both drift directions green. Checking whether that had already bitten: **`HandoffMessage` has corroboration rules in code and no row in the citation-floor table.** A live undocumented action, invisible to the test built to catch exactly that.

It fails closed — the rule text gives an absent action the STRICT floor — so it is not a live hole. The fix needs a row in `.rules/untrusted-input.md`, a governor-owned path, so it is #4750 rather than bundled here.