### PR TITLE
fix(agents): let progress pet the watchdog, not the timer

### DIFF
--- a/.changeset/heartbeat-from-progress.md
+++ b/.changeset/heartbeat-from-progress.md
@@ -1,0 +1,39 @@
+---
+'nexus-agents': minor
+---
+
+fix(agents): the stall detector can now detect a stall — the watchdog no longer pets itself
+
+`heartbeat()` was only ever called from the same `setInterval` that read the
+session's health, so `timeSinceHeartbeat` could never exceed the 15s tick. The
+60s `slow` and 120s `stalled` thresholds were unreachable, `stalledSessions` was
+structurally `0`, and a session whose work had genuinely hung reported `alive`
+for as long as the process lived. In `orchestrate.ts` the pet was on the line
+immediately above the check.
+
+Progress now drives the heartbeat. The three monitored regions each wrap a
+single opaque `await`, so there was nowhere in-line to emit from — but
+`withStep` already emits on `stepBus` for every nested step inside that await,
+and `EventEmitter` handlers run synchronously within `emit()`, so the emitting
+code's async context is live in the handler. A session-scoped
+`AsyncLocalStorage` plus one subscriber therefore attributes step activity to
+exactly the session that produced it, at a single wiring point. The timers now
+only read.
+
+Adds a `SessionHealth` state of `unmeasured` for sessions nothing has claimed to
+report progress for — silence only means something once something has spoken.
+Sessions that ARE instrumented and still emit nothing keep reporting `stalled`,
+which is the immediate-hang case and the most important one to preserve.
+
+`weather-report` gains an additive `unmeasuredSessions` count rather than a
+widened `health` union: `AgentSessionEntry` is reachable from the exported
+`generateWeatherReport`, so adding a member would break downstream readers
+(#4740 class).
+
+The regression guard is source-level on purpose. Restoring the timer pet leaves
+the entire behavioural suite green — a timer-driven heartbeat is
+indistinguishable from a healthy session — so `heartbeat-self-petting.test.ts`
+asserts that only the progress subscriber calls `heartbeat()`.
+
+Resolves the reachability half of #4665. Panel chose this over deleting the
+liveness layer, 6-1.

--- a/packages/nexus-agents/src/agents/base-agent-execute-flow.ts
+++ b/packages/nexus-agents/src/agents/base-agent-execute-flow.ts
@@ -23,7 +23,7 @@ import {
 } from './base-agent-task-helpers.js';
 import { recordFailedTaskError, persistMemoryAfterTask } from './base-agent-execution-helpers.js';
 import { HEARTBEAT_TIMEOUTS } from '../config/timeouts.js';
-import { getHeartbeatMonitor } from './heartbeat-monitor.js';
+import { getHeartbeatMonitor, runInHeartbeatSession } from './heartbeat-monitor.js';
 import { createLogger } from '../core/index.js';
 
 const MAX_HISTORY_ITEMS = 100;
@@ -144,7 +144,9 @@ export async function runTaskWithTimeout(
         heartbeatLogger.info(msg, { agentId, sessionId, elapsedMs: transition.elapsedMs });
       }
     }
-    monitor.heartbeat(sessionId);
+    // #4665: the timer OBSERVES only. It used to pet the session here, one
+    // line after reading its health, so `timeSince` could never exceed the
+    // 15s tick and the 60s/120s thresholds were unreachable.
     if (monitor.isExpired(sessionId)) {
       heartbeatLogger.warn('Agent session expired — aborting', { agentId, sessionId });
       controller.abort();
@@ -152,13 +154,16 @@ export async function runTaskWithTimeout(
   }, HEARTBEAT_TIMEOUTS.heartbeatIntervalMs);
 
   try {
-    return await executeWithTimeout({
-      task,
-      maxDurationMs: maxDuration,
-      executeTask,
-      transformError: (error, taskId) => transformTaskError(error, agentId, taskId),
-      signal: controller.signal,
-    });
+    // Step activity inside this scope is what keeps the session alive.
+    return await runInHeartbeatSession(sessionId, () =>
+      executeWithTimeout({
+        task,
+        maxDurationMs: maxDuration,
+        executeTask,
+        transformError: (error, taskId) => transformTaskError(error, agentId, taskId),
+        signal: controller.signal,
+      })
+    );
   } finally {
     clearInterval(healthCheckTimer);
     monitor.endSession(sessionId);

--- a/packages/nexus-agents/src/agents/heartbeat-monitor.test.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-monitor.test.ts
@@ -10,8 +10,11 @@ import {
   HeartbeatMonitor,
   getHeartbeatMonitor,
   resetHeartbeatMonitor,
+  runInHeartbeatSession,
+  currentHeartbeatSession,
   type HealthTransition,
 } from './heartbeat-monitor.js';
+import { stepBus } from '../core/step-bus.js';
 
 describe('heartbeat-monitor', () => {
   beforeEach(() => {
@@ -27,6 +30,7 @@ describe('heartbeat-monitor', () => {
     it('should start and end sessions', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
       expect(sid).toContain('expert-1');
       expect(monitor.activeCount).toBe(1);
 
@@ -45,6 +49,7 @@ describe('heartbeat-monitor', () => {
     it('should record heartbeats', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
       monitor.heartbeat(sid);
       monitor.heartbeat(sid);
       monitor.heartbeat(sid);
@@ -57,6 +62,7 @@ describe('heartbeat-monitor', () => {
     it('should classify session as alive when recent heartbeat', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
       monitor.heartbeat(sid);
 
       const health = monitor.getHealth();
@@ -67,6 +73,7 @@ describe('heartbeat-monitor', () => {
     it('should classify session as slow after threshold', () => {
       const monitor = new HeartbeatMonitor({ slowThresholdMs: 10_000 });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(15_000);
 
@@ -78,6 +85,7 @@ describe('heartbeat-monitor', () => {
     it('should classify session as stalled after threshold', () => {
       const monitor = new HeartbeatMonitor({ stalledThresholdMs: 20_000 });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(25_000);
 
@@ -89,6 +97,7 @@ describe('heartbeat-monitor', () => {
     it('should reset stall timer on heartbeat', () => {
       const monitor = new HeartbeatMonitor({ stalledThresholdMs: 20_000 });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(15_000);
       monitor.heartbeat(sid);
@@ -100,6 +109,7 @@ describe('heartbeat-monitor', () => {
     it('should detect expired sessions', () => {
       const monitor = new HeartbeatMonitor({ absoluteMaxMs: 50_000 });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(60_000);
 
@@ -109,6 +119,7 @@ describe('heartbeat-monitor', () => {
     it('should not expire if within max', () => {
       const monitor = new HeartbeatMonitor({ absoluteMaxMs: 100_000 });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(50_000);
 
@@ -135,6 +146,7 @@ describe('heartbeat-monitor', () => {
     it('should include elapsed and timeSince in snapshot', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(5_000);
 
@@ -149,7 +161,9 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 10_000,
       });
       const sid1 = monitor.startSession('expert-1');
-      monitor.startSession('expert-2');
+      monitor.markInstrumented(sid1);
+      const sid2 = monitor.startSession('expert-2');
+      monitor.markInstrumented(sid2);
 
       vi.advanceTimersByTime(15_000);
       monitor.heartbeat(sid1); // expert-1 alive, expert-2 stalled
@@ -167,6 +181,7 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 60_000,
       });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       // Simulate periodic heartbeats every 15s for 90s
       for (let i = 0; i < 6; i++) {
@@ -187,6 +202,7 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 60_000,
       });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       // Heartbeat for a while
       vi.advanceTimersByTime(15_000);
@@ -206,6 +222,7 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 40_000,
       });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       // Initially alive
       expect(monitor.getHealth().sessions[0]?.health).toBe('alive');
@@ -230,18 +247,33 @@ describe('heartbeat-monitor', () => {
       expect(monitor.getSessionHealth('nope')).toBeUndefined();
     });
 
-    it('returns alive with no transition for new session', () => {
+    // #4665: a new session starts at `unmeasured` — nothing has been observed
+    // yet — so its first health read is a real unmeasured → alive transition
+    // rather than a no-op. Only 'slow' and 'stalled' transitions are logged, so
+    // this is silent in production.
+    it('reports the first observation of a new session as unmeasured → alive', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
       const t = monitor.getSessionHealth(sid) as HealthTransition;
       expect(t.health).toBe('alive');
-      expect(t.previousHealth).toBe('alive');
+      expect(t.previousHealth).toBe('unmeasured');
+      expect(t.changed).toBe(true);
+    });
+
+    it('reports no transition on a second read with no change', () => {
+      const monitor = new HeartbeatMonitor();
+      const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
+      monitor.getSessionHealth(sid);
+      const t = monitor.getSessionHealth(sid) as HealthTransition;
       expect(t.changed).toBe(false);
     });
 
     it('detects alive → slow transition', () => {
       const monitor = new HeartbeatMonitor({ slowThresholdMs: 10_000 });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
       // First check — alive
       monitor.getSessionHealth(sid);
 
@@ -258,6 +290,7 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 20_000,
       });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(15_000);
       monitor.getSessionHealth(sid); // alive → slow
@@ -272,6 +305,7 @@ describe('heartbeat-monitor', () => {
     it('does not report change when health is stable', () => {
       const monitor = new HeartbeatMonitor({ slowThresholdMs: 10_000 });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(15_000);
       monitor.getSessionHealth(sid); // alive → slow
@@ -288,6 +322,7 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 20_000,
       });
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(25_000);
       monitor.getSessionHealth(sid); // alive → stalled
@@ -302,6 +337,7 @@ describe('heartbeat-monitor', () => {
     it('includes correct elapsedMs and heartbeatCount', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
+      monitor.markInstrumented(sid);
       monitor.heartbeat(sid);
       monitor.heartbeat(sid);
 
@@ -325,6 +361,79 @@ describe('heartbeat-monitor', () => {
       resetHeartbeatMonitor();
       const b = getHeartbeatMonitor();
       expect(a).not.toBe(b);
+    });
+  });
+
+  // #4665: the durable fix. Before this, NO caller could produce a session that
+  // reports `stalled` — the three monitored regions pet their own watchdog on a
+  // timer, so `timeSince` never exceeded the 15s tick. A test that the monitor
+  // CAN report a stall is what makes the thresholds mean something.
+  describe('progress-driven liveness (#4665)', () => {
+    it('reports stalled once a session that HAS reported progress goes silent', () => {
+      const monitor = new HeartbeatMonitor();
+      const sid = monitor.startSession('expert-stall');
+
+      monitor.heartbeat(sid); // real progress happened at least once
+      vi.advanceTimersByTime(130_000); // past the 120s stalled threshold
+
+      expect(monitor.isStalled(sid)).toBe(true);
+      expect(monitor.getHealth().stalledSessions).toBe(1);
+      expect(monitor.getSessionHealth(sid)?.health).toBe('stalled');
+    });
+
+    it('reports unmeasured, not stalled, when no progress was ever reported', () => {
+      // Silence only means something once something has spoken. Calling this
+      // `stalled` would blame a session for running on an uninstrumented path.
+      const monitor = new HeartbeatMonitor();
+      const sid = monitor.startSession('expert-quiet');
+
+      vi.advanceTimersByTime(130_000);
+
+      expect(monitor.getSessionHealth(sid)?.health).toBe('unmeasured');
+      expect(monitor.isStalled(sid)).toBe(false);
+      expect(monitor.getHealth().stalledSessions).toBe(0);
+    });
+
+    it('counts step activity inside the session scope as progress', async () => {
+      const monitor = getHeartbeatMonitor();
+      const sid = monitor.startSession('expert-progress');
+
+      await runInHeartbeatSession(sid, async () => {
+        stepBus.emit('step', {
+          event: 'step.completed',
+          stepId: 's1',
+          name: 'x',
+          kind: 'expert.exec',
+          durationMs: 1,
+          status: 'ok',
+        });
+        return Promise.resolve();
+      });
+
+      expect(monitor.getHealth().sessions[0]?.heartbeatCount).toBeGreaterThan(0);
+    });
+
+    it('does NOT credit step activity emitted outside the session scope', async () => {
+      // The correlation guarantee. Without it a busy session would pet a hung
+      // one, which is the same self-petting defect at process granularity.
+      const monitor = getHeartbeatMonitor();
+      const sid = monitor.startSession('expert-isolated');
+
+      stepBus.emit('step', {
+        event: 'step.completed',
+        stepId: 's2',
+        name: 'y',
+        kind: 'expert.exec',
+        durationMs: 1,
+        status: 'ok',
+      });
+      await Promise.resolve();
+
+      expect(monitor.getSessionHealth(sid)?.heartbeatCount).toBe(0);
+    });
+
+    it('exposes no ambient session outside a scope', () => {
+      expect(currentHeartbeatSession()).toBeUndefined();
     });
   });
 });

--- a/packages/nexus-agents/src/agents/heartbeat-monitor.test.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-monitor.test.ts
@@ -11,7 +11,6 @@ import {
   getHeartbeatMonitor,
   resetHeartbeatMonitor,
   runInHeartbeatSession,
-  currentHeartbeatSession,
   type HealthTransition,
 } from './heartbeat-monitor.js';
 import { stepBus } from '../core/step-bus.js';
@@ -430,10 +429,6 @@ describe('heartbeat-monitor', () => {
       await Promise.resolve();
 
       expect(monitor.getSessionHealth(sid)?.heartbeatCount).toBe(0);
-    });
-
-    it('exposes no ambient session outside a scope', () => {
-      expect(currentHeartbeatSession()).toBeUndefined();
     });
   });
 });

--- a/packages/nexus-agents/src/agents/heartbeat-monitor.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-monitor.ts
@@ -17,7 +17,13 @@ import { getTimeProvider } from '../core/index.js';
 // ============================================================================
 
 /** Health status of an expert session. */
-export type SessionHealth = 'alive' | 'slow' | 'stalled';
+/**
+ * `unmeasured` (#4665) is the empty case: nothing has claimed to report this
+ * session's progress, so its silence carries no information. Deliberately
+ * neither `alive` (the old self-petting lie) nor `stalled` (which would blame a
+ * session for running on an uninstrumented path).
+ */
+export type SessionHealth = 'unmeasured' | 'alive' | 'slow' | 'stalled';
 
 /** Snapshot of a single expert session. */
 export interface ExpertSessionSnapshot {
@@ -54,6 +60,8 @@ export interface HeartbeatConfig {
 
 // Canonical source: config/timeouts.ts (Issue #1046)
 import { HEARTBEAT_TIMEOUTS } from '../config/timeouts.js';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { stepBus } from '../core/step-bus.js';
 
 const DEFAULT_SLOW_THRESHOLD_MS = HEARTBEAT_TIMEOUTS.slowThresholdMs;
 const DEFAULT_STALLED_THRESHOLD_MS = HEARTBEAT_TIMEOUTS.stalledThresholdMs;
@@ -68,6 +76,8 @@ interface SessionEntry {
   readonly startedAt: number;
   lastHeartbeat: number;
   heartbeatCount: number;
+  /** Set once the session's work is running under a progress scope (#4665). */
+  instrumented: boolean;
   /** Previous health state for transition detection (Issue #1088 Phase 4). */
   previousHealth: SessionHealth;
 }
@@ -117,9 +127,25 @@ export class HeartbeatMonitor {
       startedAt: now,
       lastHeartbeat: now,
       heartbeatCount: 0,
-      previousHealth: 'alive',
+      instrumented: false,
+      previousHealth: 'unmeasured',
     });
     return sessionId;
+  }
+
+  /**
+   * Declares that this session's work runs under a progress scope (#4665), so
+   * silence from it is meaningful.
+   *
+   * This separates two facts that `heartbeatCount === 0` conflates: a session
+   * on an uninstrumented path (nothing is watching, so say `unmeasured`) and a
+   * session that hung BEFORE emitting its first step (the worst stall there is,
+   * and one an `unmeasured` verdict would hide forever).
+   */
+  markInstrumented(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (entry === undefined) return;
+    entry.instrumented = true;
   }
 
   /** Record a heartbeat for an active session. */
@@ -139,6 +165,10 @@ export class HeartbeatMonitor {
   isStalled(sessionId: string): boolean {
     const entry = this.sessions.get(sessionId);
     if (entry === undefined) return false;
+    // #4665: silence from an uninstrumented session means nothing — no scope
+    // ever claimed to report its progress. Silence from an instrumented one is
+    // the signal.
+    if (!entry.instrumented && entry.heartbeatCount === 0) return false;
     const elapsed = getTimeProvider().now() - entry.lastHeartbeat;
     return elapsed >= this.config.stalledThresholdMs;
   }
@@ -158,7 +188,7 @@ export class HeartbeatMonitor {
 
     for (const [sessionId, entry] of this.sessions) {
       const timeSince = now - entry.lastHeartbeat;
-      const health = this.classifyHealth(timeSince);
+      const health = this.classifyHealth(timeSince, entry.heartbeatCount, entry.instrumented);
       if (health === 'stalled') stalledCount++;
 
       sessions.push({
@@ -190,7 +220,7 @@ export class HeartbeatMonitor {
     if (entry === undefined) return undefined;
     const now = getTimeProvider().now();
     const timeSince = now - entry.lastHeartbeat;
-    const health = this.classifyHealth(timeSince);
+    const health = this.classifyHealth(timeSince, entry.heartbeatCount, entry.instrumented);
     const changed = health !== entry.previousHealth;
     const result: HealthTransition = {
       sessionId,
@@ -210,7 +240,16 @@ export class HeartbeatMonitor {
     return this.sessions.size;
   }
 
-  private classifyHealth(timeSinceMs: number): SessionHealth {
+  private classifyHealth(
+    timeSinceMs: number,
+    heartbeatCount: number,
+    instrumented: boolean
+  ): SessionHealth {
+    // Nothing ever claimed to report this session's progress, so `lastHeartbeat`
+    // is still just `startedAt` and the elapsed time measures the clock, not the
+    // work. An INSTRUMENTED session with no heartbeats is a different fact — it
+    // hung before its first step — and falls through to the thresholds.
+    if (!instrumented && heartbeatCount === 0) return 'unmeasured';
     if (timeSinceMs >= this.config.stalledThresholdMs) return 'stalled';
     if (timeSinceMs >= this.config.slowThresholdMs) return 'slow';
     return 'alive';
@@ -226,10 +265,60 @@ let globalMonitor: HeartbeatMonitor | undefined;
 /** Get or create the global heartbeat monitor singleton. */
 export function getHeartbeatMonitor(): HeartbeatMonitor {
   globalMonitor ??= new HeartbeatMonitor();
+  ensureProgressSubscription();
   return globalMonitor;
 }
 
 /** Reset global monitor (for testing). */
 export function resetHeartbeatMonitor(): void {
   globalMonitor = undefined;
+}
+
+// ============================================================================
+// Progress-driven heartbeats (#4665)
+// ============================================================================
+
+/**
+ * The session that owns the currently-executing async work.
+ *
+ * Progress has to pet the watchdog, not a timer. The three monitored regions
+ * each wrap a single opaque `await`, so there is no in-line place to call
+ * `heartbeat()` — but `withStep` emits on `stepBus` for every nested step
+ * INSIDE that await, and `EventEmitter` handlers run synchronously within
+ * `emit()`, so the emitting code's async context is still live in the handler.
+ * That is what lets one global subscriber pet exactly the right session, rather
+ * than every session crediting every other session's work.
+ */
+const sessionAls = new AsyncLocalStorage<string>();
+
+/**
+ * Runs `fn` attributed to `sessionId`, so step activity inside it counts as
+ * progress for that session.
+ */
+export function runInHeartbeatSession<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+  getHeartbeatMonitor().markInstrumented(sessionId);
+  return sessionAls.run(sessionId, fn);
+}
+
+/** The session owning the current async context, if any. Exported for tests. */
+export function currentHeartbeatSession(): string | undefined {
+  return sessionAls.getStore();
+}
+
+let subscribed = false;
+
+/**
+ * Subscribes the monitor to step activity. Idempotent, and called from
+ * `getHeartbeatMonitor` so any consumer of the singleton gets it. Reads
+ * `globalMonitor` at call time so a `resetHeartbeatMonitor()` in tests is
+ * followed correctly.
+ */
+function ensureProgressSubscription(): void {
+  if (subscribed) return;
+  subscribed = true;
+  stepBus.on('step', () => {
+    const sessionId = sessionAls.getStore();
+    if (sessionId === undefined) return;
+    globalMonitor?.heartbeat(sessionId);
+  });
 }

--- a/packages/nexus-agents/src/agents/heartbeat-monitor.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-monitor.ts
@@ -300,11 +300,6 @@ export function runInHeartbeatSession<T>(sessionId: string, fn: () => Promise<T>
   return sessionAls.run(sessionId, fn);
 }
 
-/** The session owning the current async context, if any. Exported for tests. */
-export function currentHeartbeatSession(): string | undefined {
-  return sessionAls.getStore();
-}
-
 let subscribed = false;
 
 /**

--- a/packages/nexus-agents/src/agents/heartbeat-self-petting.test.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-self-petting.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The watchdog must not pet itself (#4665).
+ *
+ * `heartbeat()` used to be called from the same `setInterval` that read the
+ * session's health, so `timeSince` could never exceed the tick and the 60s/120s
+ * thresholds were unreachable. Every behavioural test still passed, because a
+ * timer-driven heartbeat looks exactly like a healthy session.
+ *
+ * That is why this is a source-level guard rather than a behavioural one:
+ * restoring the timer pet leaves the whole suite green, so nothing behavioural
+ * can pin it. The invariant is about WHO calls `heartbeat()`.
+ *
+ * @module agents/heartbeat-self-petting.test
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { globSync } from 'node:fs';
+
+const SRC = join(process.cwd(), 'src');
+
+/** The one legitimate caller: the stepBus subscriber, which IS progress. */
+const PROGRESS_SUBSCRIBER = join('agents', 'heartbeat-monitor.ts');
+
+describe('heartbeat self-petting guard (#4665)', () => {
+  const files = globSync('**/*.ts', { cwd: SRC }).filter(
+    (f) => !f.endsWith('.test.ts') && !f.endsWith('.spec.ts')
+  );
+
+  it('finds source files to check', () => {
+    // Guard the guard: an empty file list would make the assertion below vacuous.
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it('only the progress subscriber calls heartbeat()', () => {
+    const callers = files.filter((f) => {
+      if (f === PROGRESS_SUBSCRIBER) return false;
+      return /\.heartbeat\(/.test(readFileSync(join(SRC, f), 'utf8'));
+    });
+
+    // A caller outside the subscriber is almost certainly a timer petting the
+    // session it is about to judge. If a new legitimate progress source appears,
+    // route it through `runInHeartbeatSession` instead of adding an exemption.
+    expect(callers).toEqual([]);
+  });
+
+  it('the health timers read but never write', () => {
+    // The three regions that own a heartbeat session. Each must call
+    // markInstrumented (via runInHeartbeatSession) and never heartbeat().
+    const monitored = [
+      join('mcp', 'tools', 'orchestrate.ts'),
+      join('mcp', 'tools', 'execute-expert.ts'),
+      join('agents', 'base-agent-execute-flow.ts'),
+    ];
+
+    for (const rel of monitored) {
+      const text = readFileSync(join(SRC, rel), 'utf8');
+      expect(text, `${rel} must scope its work for progress attribution`).toContain(
+        'runInHeartbeatSession'
+      );
+      expect(text, `${rel} must not pet its own watchdog`).not.toMatch(/\.heartbeat\(/);
+    }
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -70,7 +70,7 @@ import type { ICliDetectionCache } from '../../cli-adapters/cli-detection-cache.
 import { requireAdapterAvailable } from '../middleware/adapter-availability.js';
 import { getExpertPool } from '../../agents/expert-pool.js';
 import { withDepthGuard } from '../middleware/spawn-depth-guard.js';
-import { getHeartbeatMonitor } from '../../agents/heartbeat-monitor.js';
+import { getHeartbeatMonitor, runInHeartbeatSession } from '../../agents/heartbeat-monitor.js';
 import {
   getContextForTask,
   inferTaskCategory,
@@ -614,6 +614,39 @@ async function executeExpertUnderPolicy(
   );
 }
 
+/**
+ * Runs expert work under a heartbeat session whose liveness comes from progress
+ * (#4665).
+ *
+ * The timer only OBSERVES. It used to call `heartbeat()` on its own tick, which
+ * made the watchdog measure the clock rather than the work and left the
+ * stall thresholds unreachable. Step activity emitted inside
+ * `runInHeartbeatSession` is now the only thing that keeps the session alive.
+ */
+async function runExpertUnderHeartbeat<T>(
+  expertId: string,
+  logger: ILogger | undefined,
+  work: () => Promise<T>
+): Promise<T> {
+  const monitor = getHeartbeatMonitor();
+  const sessionId = monitor.startSession(expertId);
+  const heartbeatTimer = setInterval(() => {
+    if (monitor.isExpired(sessionId)) {
+      logger?.warn('Expert session expired', { expertId, sessionId });
+    }
+    if (monitor.isStalled(sessionId)) {
+      logger?.warn('Expert session stalled — no step activity', { expertId, sessionId });
+    }
+  }, HEARTBEAT_TIMEOUTS.heartbeatIntervalMs);
+
+  try {
+    return await runInHeartbeatSession(sessionId, work);
+  } finally {
+    clearInterval(heartbeatTimer);
+    monitor.endSession(sessionId);
+  }
+}
+
 /** Runs the expert task and records outcomes. Assumes permit is held. */
 async function runExpertTask(
   deps: ExecuteExpertDeps,
@@ -638,24 +671,10 @@ async function runExpertTask(
   return withStep(
     { name: `expert:${expert.role}`, kind: 'expert.exec', attrs: { expertId, role: expert.role } },
     async (ctx) => {
-      const monitor = getHeartbeatMonitor();
-      const sessionId = monitor.startSession(expertId);
       const startTime = getTimeProvider().now();
-
-      const heartbeatTimer = setInterval(() => {
-        if (monitor.isExpired(sessionId)) {
-          deps.logger?.warn('Expert session expired', { expertId, sessionId });
-        }
-        monitor.heartbeat(sessionId);
-      }, HEARTBEAT_TIMEOUTS.heartbeatIntervalMs);
-
-      let result;
-      try {
-        result = await executeExpertUnderPolicy(deps, expert, task, policyObjective);
-      } finally {
-        clearInterval(heartbeatTimer);
-        monitor.endSession(sessionId);
-      }
+      const result = await runExpertUnderHeartbeat(expertId, deps.logger, () =>
+        executeExpertUnderPolicy(deps, expert, task, policyObjective)
+      );
       const durationMs = getTimeProvider().now() - startTime;
       observeExpertContextIfOk(result, expert, task, durationMs, deps.logger);
       const classified = await classifyExpertResult({

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -9,7 +9,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ILogger, Result, Task, TaskContext } from '../../core/index.js';
 import { getErrorMessage } from '../../core/index.js';
 import { MCP_TIMEOUTS, HEARTBEAT_TIMEOUTS, getMcpSafeDeadlineMs } from '../../config/timeouts.js';
-import { getHeartbeatMonitor } from '../../agents/heartbeat-monitor.js';
+import { getHeartbeatMonitor, runInHeartbeatSession } from '../../agents/heartbeat-monitor.js';
 import { raceAgainstDeadline } from '../../core/race/race-against-deadline.js';
 import {
   createOrchestrationStateSnapshot,
@@ -518,16 +518,22 @@ function handleOrchestrationException(
 }
 
 /** Starts a heartbeat session with periodic stall detection (Issue #1087). */
-function startHeartbeatTracking(label: string, logger: ILogger): { cleanup: () => void } {
+function startHeartbeatTracking(
+  label: string,
+  logger: ILogger
+): { sessionId: string; cleanup: () => void } {
   const monitor = getHeartbeatMonitor();
   const sessionId = monitor.startSession(label);
+  // #4665: the timer OBSERVES. It used to pet the session on the line above
+  // this check, so `isStalled` compared `now` against a value it had just set
+  // to `now` and could never be true.
   const timer = setInterval(() => {
-    monitor.heartbeat(sessionId);
     if (monitor.isStalled(sessionId)) {
       logger.warn('Orchestration session stalled', { label, sessionId });
     }
   }, HEARTBEAT_TIMEOUTS.heartbeatIntervalMs);
   return {
+    sessionId,
     cleanup: (): void => {
       clearInterval(timer);
       monitor.endSession(sessionId);
@@ -641,6 +647,20 @@ interface ExecuteOrchestrationOpts {
   readonly taskId?: string;
 }
 
+/**
+ * Runs the orchestration attributed to its heartbeat session (#4665).
+ *
+ * Step activity emitted inside this scope is what keeps the session alive — the
+ * health timer only observes, so silence here is a real stall signal rather
+ * than a clock reading.
+ */
+function runTrackedOrchestration(
+  sessionId: string,
+  args: Parameters<typeof runOrchestratorWithStateTracking>[0]
+): Promise<Result<OrchestrateOutput, OrchestrationError>> {
+  return runInHeartbeatSession(sessionId, () => runOrchestratorWithStateTracking(args));
+}
+
 async function executeOrchestration(
   input: OrchestrateInput,
   deps: OrchestrateDeps,
@@ -675,7 +695,7 @@ async function executeOrchestration(
   // no-logger path so that path establishes no trail and stays byte-identical.
   const auditTrail = createDurableAuditTrail(deps.auditLogger);
   try {
-    return await runOrchestratorWithStateTracking({
+    return await runTrackedOrchestration(hb.sessionId, {
       taskId,
       taskInput: input.task,
       definition,

--- a/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report-types.ts
@@ -200,6 +200,19 @@ export interface ExpertPerformanceEntry {
 export interface AgentHealthSummary {
   readonly activeSessions: number;
   readonly stalledSessions: number;
+  /**
+   * Sessions that have reported no progress yet (#4665), so their silence
+   * carries no information either way. Counted rather than listed: the
+   * per-session `health` union below is reachable from the exported
+   * `generateWeatherReport` return type, so adding `'unmeasured'` to it would
+   * break downstream readers. Widening it is tracked with the other
+   * return-position unions in #4740.
+   *
+   * `activeSessions - unmeasuredSessions` is the number this report can
+   * actually speak to.
+   */
+  readonly unmeasuredSessions?: number;
+  /** Sessions with a measured health verdict. Excludes unmeasured ones. */
   readonly sessions: readonly AgentSessionEntry[];
 }
 

--- a/packages/nexus-agents/src/mcp/tools/weather-report.ts
+++ b/packages/nexus-agents/src/mcp/tools/weather-report.ts
@@ -46,7 +46,7 @@ import { computeAdaptiveThresholds } from '../../orchestration/outcomes/adaptive
 import { getRateLimitStats } from '../../adapters/rate-limit-detector.js';
 import { getToolStats } from '../middleware/tool-metrics.js';
 import { getHeartbeatMonitor } from '../../agents/heartbeat-monitor.js';
-import type { AgentHealthSummary, CostSection } from './weather-report-types.js';
+import type { AgentHealthSummary, AgentSessionEntry, CostSection } from './weather-report-types.js';
 import { isPersistenceEnabled } from '../../config/learning-persistence.js';
 import { aggregateDecisionCosts } from '../../observability/decision-cost-aggregate.js';
 import {
@@ -162,13 +162,19 @@ function buildAgentHealth(): AgentHealthSummary | undefined {
   const monitor = getHeartbeatMonitor();
   if (monitor.activeCount === 0) return undefined;
   const health = monitor.getHealth();
+  // #4665: an unmeasured session has no verdict to report. Report the count so
+  // the gap is visible, rather than picking one of the three declared values
+  // and calling a non-measurement a measurement.
+  const measured = health.sessions.filter((s) => s.health !== 'unmeasured');
+  const unmeasuredSessions = health.sessions.length - measured.length;
   return {
     activeSessions: health.activeSessions,
     stalledSessions: health.stalledSessions,
-    sessions: health.sessions.map((s) => ({
+    ...(unmeasuredSessions > 0 ? { unmeasuredSessions } : {}),
+    sessions: measured.map((s) => ({
       sessionId: s.sessionId,
       expertId: s.expertId,
-      health: s.health,
+      health: s.health as AgentSessionEntry['health'],
       elapsedMs: s.elapsedMs,
       timeSinceHeartbeatMs: s.timeSinceHeartbeatMs,
       heartbeatCount: s.heartbeatCount,


### PR DESCRIPTION
Resolves the reachability half of #4665. Panel chose this over deleting the liveness layer, 6-1 (5 of 6 approvers).

## The defect

`heartbeat()` was only ever called from the same `setInterval` that read the session's health. In `orchestrate.ts` the two were adjacent:

```ts
monitor.heartbeat(sessionId);          // lastHeartbeat = now
if (monitor.isStalled(sessionId)) {    // now - lastHeartbeat === 0
```

So `timeSinceHeartbeat` could never exceed the 15s tick, the 60s/120s thresholds were unreachable, `stalledSessions` was structurally `0`, and a session whose work had genuinely hung reported `alive` for the life of the process. #983 once raised a threshold from 90s to 120s "for slower CLIs" — someone tuning a sensor that read constant-healthy.

The 900s absolute cap **does** work (`isExpired` reads `startedAt`), which is what hid this: sessions eventually died, so nothing looked broken.

## Why the obvious fix wasn't available

All three monitored regions wrap a **single opaque `await`** — `executeExpertUnderPolicy`, `executeWithTimeout`, the orchestrator call. There is no "stage completion" to move `heartbeat()` to. Five of the six approvers described emitting at exactly such a boundary; none exists. That was the legitimate half of the contrarian's objection.

## What makes it work

`withStep` already emits `step.started`/`step.completed` on `stepBus` for every nested step *inside* those awaits. Naive subscription would be wrong — step events are global, so a busy session would pet a hung one, recreating the same defect at process granularity and harder to see.

`EventEmitter` handlers run **synchronously inside `emit()`**, so the emitting code's async context is still live in the handler. A session-scoped `AsyncLocalStorage` therefore attributes step activity to exactly the session that produced it, from **one** subscriber rather than per-surface instrumentation. That also answers the coupling half of the dissent.

The timers now only read.

## Naming the empty case, without hiding the worst case

`SessionHealth` gains `unmeasured`: nothing has claimed to report this session's progress, so its silence carries no information.

My first version made that `heartbeatCount === 0`, which was wrong — **a session that hangs before emitting its first step is the most severe stall**, and that rule would have hidden it behind a benign verdict forever. So instrumentation is declared explicitly at scope entry (`markInstrumented`), and an instrumented session with no heartbeats still falls through to the thresholds and reports `stalled`.

## The guard is source-level on purpose

I mutation-tested both guarantees. Dropping the ALS correlation fails a behavioural test. **Restoring the timer pet leaves the entire suite green** — a timer-driven heartbeat is indistinguishable from a healthy session, which is exactly why this survived.

So `heartbeat-self-petting.test.ts` asserts at source level that only the progress subscriber calls `heartbeat()`, and that the three monitored regions scope their work and never pet. Verified: it fails with the pet restored, passes without. It also immediately caught a file I had accidentally reverted mid-change.

## Public surface

`weather-report` gets an **additive** `unmeasuredSessions` count, not a widened union. `AgentSessionEntry.health` is reachable from the exported `generateWeatherReport`, so adding `'unmeasured'` would break downstream readers — the #4740 class, checked before writing it this time.

## Verification

Full suite **28381 passed, 0 failed**; the four directly affected suites 119 passing. Typecheck 0, lint clean (two functions extracted rather than exempted).

Nine pre-existing tests needed updating: they started a session, advanced time, and expected `slow`/`stalled` without ever reporting progress. Their intent is valid, so they now declare instrumentation rather than having their assertions weakened.

## Not in scope

Per-I/O `child_process` timeouts, raised by the contrarian as defence-in-depth. Worth its own issue, but not a substitute: it cannot see a process that is running and producing nothing, which is the case these thresholds exist for.