### PR TITLE
docs(routing): correct a correction about the capacity stage

### DIFF
--- a/.changeset/capacity-comment-accuracy.md
+++ b/.changeset/capacity-comment-accuracy.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+docs(routing): the capacity stage does run — correcting a correction
+
+The `#4658` wiring note claimed the capacity stage "is not part of the
+production routing chain" and that "neither the signal nor the exclusion runs
+today". Both are false, and false in the direction that invites deleting live
+code.
+
+`enableCapacityBalancing` defaults to `true`, `composite-router.ts` constructs
+`CapacityFilterStage` directly, and `composite-router-stages.ts` awaits
+`filterArms` in the pipeline. Every route is assessed. What does not run is the
+EXCLUSION, because `enforceHardLimits` stays at its `false` default via a
+hardcoded `{}` — so `excludedCount` really is structurally 0.
+
+The earlier note reasoned from `createCapacityStage`, the factory, having no
+non-test caller. That is true and remains true; production does not use the
+factory. "The factory is unused" is not "the stage is unused".
+
+Two tests now pin the claims — that the stage is default-on, and that an
+observed exhaustion is assessed but not excluded — so the comment cannot drift
+in either direction again without a failure.

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.test.ts
@@ -455,3 +455,33 @@ describe('#4456 follow-up: a throttled candidate is reported, not silently dropp
     expect(getRemainingCandidates(result.value.context)).toEqual(CLIS);
   });
 });
+
+/**
+ * #4658: pins the two facts the file comment asserts, because that comment has
+ * now been wrong in both directions — first promising an opt-in no caller could
+ * set, then claiming the stage does not run at all. The second error is the
+ * dangerous one: it reads as permission to delete live code.
+ */
+describe('capacity stage wiring claims (#4658)', () => {
+  it('is default-on, so the assessment really does run on every route', async () => {
+    const { DEFAULT_COMPOSITE_CONFIG } = await import('../../composite-router-types.js');
+
+    expect(DEFAULT_COMPOSITE_CONFIG.enableCapacityBalancing).toBe(true);
+  });
+
+  it('assesses but cannot exclude, because enforceHardLimits is not settable in production', async () => {
+    // The production construction passes a hardcoded `{}`, so the default
+    // stands. If a caller ever supplies real config, this test should fail and
+    // be replaced by one that exercises the opt-in.
+    const stage = new CapacityFilterStage(adapters({ claude: capacity({ quotaExhausted: true }) }));
+
+    const outcome = await stage.filterArms(['claude'] as RoutingArmId[]);
+
+    // Exhaustion IS observed...
+    expect(outcome.eligible).toEqual(['claude']);
+    // ...and deliberately not acted on. `excludedCount` stays 0 while the
+    // exclusion is held pending a real quota signal (#4456).
+    expect(outcome.excluded.size).toBe(0);
+    expect(stage.getStats().excludedCount).toBe(0);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
@@ -77,18 +77,30 @@ export interface CapacityStageConfig {
  * is at least as exhausted") does not survive the correction. Enforcement is
  * therefore held until a real quota signal exists (#4456).
  *
- * WIRING, corrected (#4658). This previously said `enforceHardLimits: true`
- * "remains available for callers who have one". No caller can set it, and the
- * reason is broader than the flag: `createCapacityStage` has **no non-test
- * caller at all**. The stage is not part of the production routing chain
- * (`Task -> BudgetRouter -> ZeroRouter -> PreferenceRouter -> TopsisRouter ->
- * LinUCB`), so neither the signal nor the exclusion runs today, and
- * `excludedCount` is structurally 0.
+ * WIRING, corrected twice (#4658). The original text promised
+ * `enforceHardLimits: true` "remains available for callers who have one", which
+ * no caller can set. The first correction then over-shot, claiming the stage is
+ * not in the production routing chain and that neither the signal nor the
+ * exclusion runs. That is wrong, and wrong in the dangerous direction — it
+ * reads as an invitation to delete live code.
  *
- * Do not read a passing capacity check as evidence of available capacity —
- * nothing is measuring it. Making the flag settable without first wiring the
- * stage AND supplying a real quota producer would only relocate the hole #4456
- * deliberately left open.
+ * What is actually true:
+ *
+ * - The stage RUNS on every route. `enableCapacityBalancing` defaults to `true`
+ *   (`composite-router-types.ts`), `composite-router.ts` constructs this class
+ *   directly, and `composite-router-stages.ts` awaits `filterArms` in the
+ *   pipeline. Each arm is assessed and logged.
+ * - The EXCLUSION does not run. `filterArms` only drops an arm when
+ *   `enforceHardLimits` is true, and the sole production construction passes a
+ *   hardcoded `{}`, leaving the `false` default. So `excludedCount` is
+ *   structurally 0 and `outcome.excluded` is always empty.
+ * - `createCapacityStage` — the FACTORY — has no non-test caller. That is a
+ *   fact about the factory, not about the stage, and conflating the two is what
+ *   produced the previous error.
+ *
+ * So: a passing capacity check is a real assessment, but it can never exclude.
+ * Making the flag settable without a real quota producer would only relocate
+ * the hole #4456 deliberately left open.
  *
  * (`BudgetStageConfig.enforceHardLimits` is a different setting on a different
  * router and IS enforced — see `budget-router.ts`. The mirrored name here is


### PR DESCRIPTION
Closes the last live item on #4658.

## What was wrong

The `#4658` wiring note in `capacity-stage.ts` says:

> The stage is not part of the production routing chain … so neither the signal nor the exclusion runs today

Both claims are false:

```
composite-router-types.ts   enableCapacityBalancing: z.boolean().default(true)
composite-router-types.ts   DEFAULT_COMPOSITE_CONFIG.enableCapacityBalancing: true
composite-router.ts:383     if (this.config.enableCapacityBalancing) {
                              this.capacityFilterStage = new CapacityFilterStage(this.adapters, {}, this.logger);
composite-router-stages.ts  outcome = await deps.capacityFilterStage.filterArms(candidates);
```

Default-on. `filterArms` runs on every route and assesses every arm. What does **not** run is the exclusion — `enforceHardLimits` stays `false` via the hardcoded `{}` — so `excludedCount` is genuinely structurally 0. That part of the note was right.

## How the error happened

The note reasoned from `createCapacityStage` having no non-test caller. That is true, and still true — but production doesn't use the factory, it calls the constructor. **"The factory is unused" got generalised into "the stage is unused."**

## Why this is worth a PR rather than a wording tweak

The error points the wrong way. A comment saying *"nothing is measuring it"* and *"neither the signal nor the exclusion runs"* invites two bad moves: deleting a stage that runs on every route, or concluding that adding a quota producer requires wiring the stage in first when it is already wired.

`.rules/jsdoc-accuracy.md` calls this capability-revealing drift, and understating what code does is the direction that gets live code removed.

It is also the second time this comment has been wrong — first promising an opt-in no caller could set, then denying the stage runs at all. A comment with that history should be pinned by tests, not by more prose.

## The tests

Two, covering the two claims the comment makes:

- the stage is **default-on** (`DEFAULT_COMPOSITE_CONFIG.enableCapacityBalancing === true`)
- an observed exhaustion is **assessed but not excluded** — `eligible` still contains the arm, `excluded` is empty, `excludedCount` is 0

The second doubles as a tripwire: if someone ever makes `enforceHardLimits` settable in production, it fails and has to be replaced by a test exercising the opt-in.

## Unchanged, deliberately

The signal-only posture itself. #4456 held enforcement because no real quota signal exists, and that reasoning is sound — absence of a reading is not a reading. This PR corrects the description, not the behaviour.

Still open on #4658 and blocked on the same missing producer: `excludedCount` can only report 0, and the *"All routing candidates excluded — capacity_exhausted"* fail-closed branch in `composite-router-stages.ts` remains unreachable.

## Verification

`src/cli-adapters` 2672 passing, typecheck 0, lint clean.