### PR TITLE
fix(workflows): remove enforcement that could not fire, keep the measurement

### DIFF
--- a/.changeset/remove-workflow-budget-enforcement.md
+++ b/.changeset/remove-workflow-budget-enforcement.md
@@ -1,0 +1,37 @@
+---
+'nexus-agents': minor
+---
+
+fix(workflows): remove unreachable budget enforcement, and make usage accounting actually run
+
+The workflow engine's budget enforcement could not block a step. The circuit
+breaker was built only when `enableBudgetEnforcement` was true AND a
+`contextManagerConfig` was supplied, and no production caller set either — the
+only non-test references were the two type declarations and the `false` default.
+So `enforceStepBudgets` was structurally incapable of returning `err`,
+`budgetEvents` was permanently `[]`, and `getBudgetEvents` returned that empty
+list to nobody.
+
+Removed: `enableBudgetEnforcement`, `contextManagerConfig`,
+`budgetCircuitBreakerConfig`, `applyBudgetEnforcement`, `enforceStepBudgets`,
+`getBudgetEvents`, `getBudgetCircuitBreaker`, and `ExecutionContext.budgetEvents`
+/ `.budgetCircuitBreaker`.
+
+**`BudgetCircuitBreaker` itself is untouched** — `pipeline/budget-guard.ts`
+wraps it as "the single budget authority" for `agent-executor`, and that path
+still enforces. Only the workflow engine's dormant copy is gone.
+
+Usage ACCOUNTING is kept and decoupled. `recordPhaseUsage` took an
+`ExecutionContext` purely to reach the breaker, and returned zeros whenever the
+breaker was absent — which was every production run. Counting never needed a
+breaker; only `recordUsage` did. It now takes just the step results and runs on
+every phase, so `reportUsageCoverage` can genuinely warn that a phase's recorded
+spend is a lower bound. This is the first time the #4744 unmeasured-step work
+has any production effect.
+
+Panel chose removal 6-1 over wiring it, on the capability-bias bar: no named
+consumer wants per-step workflow budget caps, and git history preserves the
+machinery if one appears.
+
+Workflows now have no budget enforcement — which was already true, and is now
+visible rather than implied. Tracked in #4754.

--- a/packages/nexus-agents/src/workflows/workflow-engine-execution.test.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine-execution.test.ts
@@ -15,15 +15,11 @@ import type {
 import type { ResolvedConfig, ExecutionContext } from './workflow-engine-helpers.js';
 import { MAX_TRACKED_EXECUTIONS } from './workflow-engine-helpers.js';
 import type { ActiveExecution } from './workflow-engine-types.js';
-import type { IBudgetCircuitBreaker } from './budget-circuit-breaker-types.js';
-import type { WorkflowStep } from './workflow-types.js';
 import {
   cleanupOldExecutions,
   createContextManagerForWorkflow,
-  createBudgetCircuitBreakerForWorkflow,
   initializeExecution,
   applyInputDefaults,
-  enforceStepBudgets,
   recordPhaseUsage,
 } from './workflow-engine-execution.js';
 
@@ -55,8 +51,6 @@ function createResolvedConfig(overrides?: Partial<ResolvedConfig>): ResolvedConf
     templatePaths: [],
     contextManagerConfig: undefined,
     defaultBudget: DEFAULT_BUDGET,
-    budgetCircuitBreakerConfig: undefined,
-    enableBudgetEnforcement: false,
     ...overrides,
   };
 }
@@ -72,22 +66,6 @@ const MOCK_WORKFLOW_RESULT: WorkflowResult = {
 const COMPLETED_STATUS: ExecutionStatus = { state: 'completed', result: MOCK_WORKFLOW_RESULT };
 const RUNNING_STATUS: ExecutionStatus = { state: 'running', currentStep: '', progress: 0 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function createMockCircuitBreaker(overrides: Partial<IBudgetCircuitBreaker> = {}) {
-  return {
-    checkBudget: vi.fn(),
-    recordUsage: vi.fn(),
-    allocateForStep: vi.fn(),
-    getState: vi.fn(),
-    getSnapshot: vi.fn(),
-    reset: vi.fn(),
-    forceOpen: vi.fn(),
-    addStateChangeListener: vi.fn(),
-    removeStateChangeListener: vi.fn(),
-    ...overrides,
-  };
-}
-
 function createMockWorkflow(overrides?: Partial<WorkflowDefinition>): WorkflowDefinition {
   return {
     name: 'test-workflow',
@@ -96,15 +74,6 @@ function createMockWorkflow(overrides?: Partial<WorkflowDefinition>): WorkflowDe
     steps: [],
     inputs: [],
     ...overrides,
-  };
-}
-
-function createMockStep(id: string): WorkflowStep {
-  return {
-    id,
-    agent: 'code_expert',
-    action: 'test-action',
-    inputs: {},
   };
 }
 
@@ -258,42 +227,6 @@ describe('createContextManagerForWorkflow', () => {
 // createBudgetCircuitBreakerForWorkflow
 // ============================================================================
 
-describe('createBudgetCircuitBreakerForWorkflow', () => {
-  it('returns undefined when contextManager is undefined', () => {
-    const config = createResolvedConfig();
-    const workflow = createMockWorkflow();
-    const logger = createMockLogger();
-    const result = createBudgetCircuitBreakerForWorkflow(undefined, workflow, config, logger);
-    expect(result).toBeUndefined();
-  });
-
-  it('includes workflow default budget when set', () => {
-    const workflowBudget: ContextBudget = {
-      system: 0.1,
-      task: 0.3,
-      active: 0.2,
-      reserved: 0.1,
-    };
-    const config = createResolvedConfig({
-      contextManagerConfig: { maxTokens: 10000 },
-    });
-    const workflow = createMockWorkflow({ defaultBudget: workflowBudget });
-    const logger = createMockLogger();
-    // Create a context manager first
-    const cm = createContextManagerForWorkflow(config, workflow, logger);
-    // Create circuit breaker - may return undefined or a breaker depending on CM state
-    const result = createBudgetCircuitBreakerForWorkflow(cm, workflow, config, logger);
-    // With a valid context manager, it should create a breaker
-    if (cm !== undefined) {
-      expect(result).toBeDefined();
-    }
-  });
-});
-
-// ============================================================================
-// initializeExecution
-// ============================================================================
-
 describe('initializeExecution', () => {
   let logger: ILogger;
 
@@ -364,20 +297,6 @@ describe('initializeExecution', () => {
     const workflow = createMockWorkflow();
     const result = initializeExecution({ workflow, inputs: {}, config, logger });
     expect(result.context.contextManager).toBeUndefined();
-  });
-
-  it('does not create budget circuit breaker when enforcement is disabled', () => {
-    const config = createResolvedConfig({ enableBudgetEnforcement: false });
-    const workflow = createMockWorkflow();
-    const result = initializeExecution({ workflow, inputs: {}, config, logger });
-    expect(result.context.budgetCircuitBreaker).toBeUndefined();
-  });
-
-  it('initializes empty budget events array', () => {
-    const config = createResolvedConfig();
-    const workflow = createMockWorkflow();
-    const result = initializeExecution({ workflow, inputs: {}, config, logger });
-    expect(result.context.budgetEvents).toEqual([]);
   });
 
   it('applies input defaults from workflow definition', () => {
@@ -455,168 +374,50 @@ describe('applyInputDefaults', () => {
 // enforceStepBudgets
 // ============================================================================
 
-describe('enforceStepBudgets', () => {
-  it('returns ok when no circuit breaker and no context manager', () => {
-    const logger = createMockLogger();
-    const config = createResolvedConfig();
-    const workflow = createMockWorkflow();
-    const context: ExecutionContext = {
-      workflowId: 'test',
-      executionId: 'exec-1',
-      inputs: {},
-      stepResults: new Map(),
-      variables: new Map(),
-      abortController: new AbortController(),
-      contextManager: undefined,
-      budgetEvents: [],
-      budgetCircuitBreaker: undefined,
-    };
-    const steps = [createMockStep('step-1'), createMockStep('step-2')];
-    const result = enforceStepBudgets({
-      steps,
-      context,
-      workflow,
-      totalSteps: 2,
-      config,
-      logger,
-    });
-    expect(result.ok).toBe(true);
-  });
-
-  it('logs budget events for legacy enforcement (no circuit breaker)', () => {
-    const logger = createMockLogger();
-    const config = createResolvedConfig({
-      contextManagerConfig: { maxTokens: 10000 },
-    });
-    const workflow = createMockWorkflow();
-    const cm = createContextManagerForWorkflow(config, workflow, logger);
-    const context: ExecutionContext = {
-      workflowId: 'test',
-      executionId: 'exec-1',
-      inputs: {},
-      stepResults: new Map(),
-      variables: new Map(),
-      abortController: new AbortController(),
-      contextManager: cm,
-      budgetEvents: [],
-      budgetCircuitBreaker: undefined,
-    };
-    const steps = [createMockStep('step-1')];
-    const result = enforceStepBudgets({
-      steps,
-      context,
-      workflow,
-      totalSteps: 1,
-      config,
-      logger,
-    });
-    expect(result.ok).toBe(true);
-    // With context manager but no circuit breaker, legacy enforcement is used
-    if (cm !== undefined) {
-      expect(context.budgetEvents.length).toBeGreaterThan(0);
-    }
-  });
-});
-
-// ============================================================================
 // recordPhaseUsage
 // ============================================================================
 
 describe('recordPhaseUsage', () => {
-  it('does nothing when no budget circuit breaker', () => {
-    const context: ExecutionContext = {
-      workflowId: 'test',
-      executionId: 'exec-1',
-      inputs: {},
-      stepResults: new Map(),
-      variables: new Map(),
-      abortController: new AbortController(),
-      contextManager: undefined,
-      budgetEvents: [],
-      budgetCircuitBreaker: undefined,
-    };
-    const results: StepResult[] = [
-      { stepId: 's1', status: 'success', output: 'ok', durationMs: 100 },
-    ];
-    // Should not throw
-    recordPhaseUsage(results, context);
-  });
-
-  it('records usage when circuit breaker is present', () => {
-    const mockRecordUsage = vi.fn();
-    const context: ExecutionContext = {
-      workflowId: 'test',
-      executionId: 'exec-1',
-      inputs: {},
-      stepResults: new Map(),
-      variables: new Map(),
-      abortController: new AbortController(),
-      contextManager: undefined,
-      budgetEvents: [],
-      budgetCircuitBreaker: createMockCircuitBreaker({ recordUsage: mockRecordUsage }),
-    };
-    // #4673: this asserted `200ms * 0.5 = 100 tokens` — a wall-clock reading
-    // recorded into a token budget. It pinned the defect as intended
-    // behaviour. Real usage is now carried on the step result.
+  // #4673: usage accounting no longer takes an ExecutionContext or a circuit
+  // breaker. It ran only when budget enforcement was enabled, which no
+  // production caller could do — so the coverage report was permanently zeros.
+  // Counting never needed a breaker; only enforcement did.
+  it('records real token usage per step', () => {
     const results: StepResult[] = [
       { stepId: 's1', status: 'success', output: 'ok', durationMs: 200, tokensUsed: 1500 },
       { stepId: 's2', status: 'success', output: 'ok', durationMs: 400, tokensUsed: 90 },
     ];
-    const report = recordPhaseUsage(results, context);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
-    expect(mockRecordUsage).toHaveBeenCalledWith(1500);
-    expect(mockRecordUsage).toHaveBeenCalledWith(90);
-    // Note the ordering the old heuristic would have produced: s1 ran for less
-    // than half as long as s2 yet cost ~17x more. A budget enforced on
-    // duration would have capped the cheap step and let the expensive one run.
-    expect(report).toEqual({ recordedSteps: 2, unmeasuredSteps: 0, tokensRecorded: 1590 });
+
+    // Note the ordering the old `durationMs * 0.5` heuristic would have
+    // produced: s1 ran for less than half as long as s2 yet cost ~17x more.
+    expect(recordPhaseUsage(results)).toEqual({
+      recordedSteps: 2,
+      unmeasuredSteps: 0,
+      tokensRecorded: 1590,
+    });
   });
 
-  it('does NOT treat an unmeasured step as zero spend (#4673)', () => {
-    const mockRecordUsage = vi.fn();
-    const context: ExecutionContext = {
-      workflowId: 'test',
-      executionId: 'exec-1',
-      inputs: {},
-      stepResults: new Map(),
-      variables: new Map(),
-      abortController: new AbortController(),
-      contextManager: undefined,
-      budgetEvents: [],
-      budgetCircuitBreaker: createMockCircuitBreaker({ recordUsage: mockRecordUsage }),
-    };
+  it('does NOT treat an unmeasured step as zero spend', () => {
     const results: StepResult[] = [
       { stepId: 's1', status: 'success', output: 'ok', durationMs: 200, tokensUsed: 500 },
       // No tokensUsed — the step reported nothing.
       { stepId: 's2', status: 'success', output: 'ok', durationMs: 400 },
     ];
 
-    const report = recordPhaseUsage(results, context);
-
-    // Recording 0 for s2 would under-count spend, which for a CAP is the
-    // dangerous direction — the budget would believe it had more headroom
-    // than it does.
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
-    expect(mockRecordUsage).toHaveBeenCalledWith(500);
-    expect(report.unmeasuredSteps).toBe(1);
-    expect(report.recordedSteps).toBe(1);
-    expect(report.tokensRecorded).toBe(500);
+    // Recording 0 for s2 would under-count spend. `unmeasuredSteps > 0` is what
+    // lets a reader treat `tokensRecorded` as a lower bound.
+    expect(recordPhaseUsage(results)).toEqual({
+      recordedSteps: 1,
+      unmeasuredSteps: 1,
+      tokensRecorded: 500,
+    });
   });
 
-  it('handles empty results array', () => {
-    const mockRecordUsage = vi.fn();
-    const context: ExecutionContext = {
-      workflowId: 'test',
-      executionId: 'exec-1',
-      inputs: {},
-      stepResults: new Map(),
-      variables: new Map(),
-      abortController: new AbortController(),
-      contextManager: undefined,
-      budgetEvents: [],
-      budgetCircuitBreaker: createMockCircuitBreaker({ recordUsage: mockRecordUsage }),
-    };
-    recordPhaseUsage([], context);
-    expect(mockRecordUsage).not.toHaveBeenCalled();
+  it('names the empty case rather than reporting a confident zero', () => {
+    expect(recordPhaseUsage([])).toEqual({
+      recordedSteps: 0,
+      unmeasuredSteps: 0,
+      tokensRecorded: 0,
+    });
   });
 });

--- a/packages/nexus-agents/src/workflows/workflow-engine-execution.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine-execution.ts
@@ -5,20 +5,11 @@
  * workflow-engine.ts to keep files under 400 lines.
  */
 
-import { ok, err, getTimeProvider } from '../core/index.js';
-import type { Result, ILogger, StepResult } from '../core/index.js';
+import { getTimeProvider } from '../core/index.js';
+import type { ILogger, StepResult } from '../core/index.js';
 import type { WorkflowDefinition } from '../core/index.js';
-import { WorkflowError } from '../core/index.js';
 import { generateUUID } from '../utils/index.js';
 import { ContextManager } from '../agents/context-manager.js';
-import {
-  applyBudgetEnforcement,
-  enforceBudgetForStep,
-  createWorkflowCircuitBreaker,
-  type BudgetEnforcementConfig,
-  type IBudgetCircuitBreaker,
-} from './budget-enforcement.js';
-import type { WorkflowStep } from './workflow-types.js';
 import type { ExecutionContext, ResolvedConfig } from './workflow-engine-helpers.js';
 import { MAX_TRACKED_EXECUTIONS } from './workflow-engine-helpers.js';
 import type { ActiveExecution } from './workflow-engine-types.js';
@@ -50,28 +41,6 @@ export function createContextManagerForWorkflow(
   if (config.contextManagerConfig === undefined) return undefined;
   const budget = workflow.defaultBudget ?? config.defaultBudget;
   return new ContextManager({ ...config.contextManagerConfig, budget, logger });
-}
-
-/**
- * Create a budget circuit breaker for workflow execution.
- */
-export function createBudgetCircuitBreakerForWorkflow(
-  contextManager: ContextManager | undefined,
-  workflow: WorkflowDefinition,
-  config: ResolvedConfig,
-  logger: ILogger
-): IBudgetCircuitBreaker | undefined {
-  const budgetConfig: BudgetEnforcementConfig = {
-    engineDefaultBudget: config.defaultBudget,
-    logger,
-  };
-  if (workflow.defaultBudget !== undefined) {
-    budgetConfig.workflowDefaultBudget = workflow.defaultBudget;
-  }
-  if (config.budgetCircuitBreakerConfig !== undefined) {
-    budgetConfig.circuitBreakerConfig = config.budgetCircuitBreakerConfig;
-  }
-  return createWorkflowCircuitBreaker(contextManager, budgetConfig);
 }
 
 /**
@@ -124,11 +93,6 @@ export function initializeExecution(params: InitExecutionParams): InitExecutionR
   // Create context manager if configured
   const contextManager = createContextManagerForWorkflow(config, workflow, logger);
 
-  // Create circuit breaker if enforcement is enabled
-  const budgetCircuitBreaker = config.enableBudgetEnforcement
-    ? createBudgetCircuitBreakerForWorkflow(contextManager, workflow, config, logger)
-    : undefined;
-
   const context: ExecutionContext = {
     workflowId: workflow.name,
     executionId,
@@ -137,8 +101,6 @@ export function initializeExecution(params: InitExecutionParams): InitExecutionR
     variables: new Map(),
     abortController: new AbortController(),
     contextManager,
-    budgetEvents: [],
-    budgetCircuitBreaker,
   };
 
   const execution: ActiveExecution = {
@@ -160,63 +122,6 @@ export function initializeExecution(params: InitExecutionParams): InitExecutionR
   return { executionId, context, startTime, execution };
 }
 
-/** Options for enforceStepBudgets. */
-export interface EnforceStepBudgetsOptions {
-  steps: WorkflowStep[];
-  context: ExecutionContext;
-  workflow: WorkflowDefinition;
-  totalSteps: number;
-  config: ResolvedConfig;
-  logger: ILogger;
-}
-
-/**
- * Enforce budget for steps in a phase.
- */
-export function enforceStepBudgets(
-  options: EnforceStepBudgetsOptions
-): Result<void, WorkflowError> {
-  const { steps, context, workflow, totalSteps, config, logger } = options;
-  const budgetConfig: BudgetEnforcementConfig = {
-    engineDefaultBudget: config.defaultBudget,
-    logger,
-  };
-  if (workflow.defaultBudget !== undefined) {
-    budgetConfig.workflowDefaultBudget = workflow.defaultBudget;
-  }
-  if (config.budgetCircuitBreakerConfig !== undefined) {
-    budgetConfig.circuitBreakerConfig = config.budgetCircuitBreakerConfig;
-  }
-
-  for (const step of steps) {
-    // Use circuit breaker if available, otherwise fall back to logging-only
-    if (context.budgetCircuitBreaker !== undefined) {
-      const remainingSteps = totalSteps - context.stepResults.size;
-      const allocation = context.budgetCircuitBreaker.allocateForStep(step.id, remainingSteps);
-      const result = enforceBudgetForStep({
-        step,
-        contextManager: context.contextManager,
-        circuitBreaker: context.budgetCircuitBreaker,
-        budgetEvents: context.budgetEvents,
-        config: budgetConfig,
-        estimatedTokens: allocation.allocatedTokens,
-      });
-      if (!result.ok) {
-        return err(
-          new WorkflowError(`Budget exceeded for step '${step.id}': ${result.error.message}`, {
-            context: { stepId: step.id, circuitState: result.error.circuitState },
-            cause: result.error,
-          })
-        );
-      }
-    } else {
-      // Legacy logging-only enforcement
-      applyBudgetEnforcement(step, context.contextManager, context.budgetEvents, budgetConfig);
-    }
-  }
-  return ok(undefined);
-}
-
 /**
  * Record token usage after phase completion.
  */
@@ -236,14 +141,7 @@ interface PhaseUsageReport {
   tokensRecorded: number;
 }
 
-export function recordPhaseUsage(
-  results: StepResult[],
-  context: ExecutionContext
-): PhaseUsageReport {
-  if (context.budgetCircuitBreaker === undefined) {
-    return { recordedSteps: 0, unmeasuredSteps: 0, tokensRecorded: 0 };
-  }
-
+export function recordPhaseUsage(results: StepResult[]): PhaseUsageReport {
   // #4673: record REAL token usage. This used to be
   // `Math.round(result.durationMs * 0.5)` — a wall-clock reading in a field
   // named tokens, with a comment conceding "in real usage, this would come
@@ -264,7 +162,6 @@ export function recordPhaseUsage(
       unmeasuredSteps += 1;
       continue;
     }
-    context.budgetCircuitBreaker.recordUsage(result.tokensUsed);
     recordedSteps += 1;
     tokensRecorded += result.tokensUsed;
   }

--- a/packages/nexus-agents/src/workflows/workflow-engine-helpers.test.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine-helpers.test.ts
@@ -41,7 +41,6 @@ describe('resolveConfig', () => {
     expect(config.defaultTimeoutMs).toBe(DEFAULT_TIMEOUT_MS);
     expect(config.maxConcurrency).toBe(DEFAULT_MAX_CONCURRENCY);
     expect(config.templatePaths).toEqual([]);
-    expect(config.enableBudgetEnforcement).toBe(false);
   });
 
   it('returns defaults when undefined passed', () => {
@@ -69,15 +68,9 @@ describe('resolveConfig', () => {
     expect(config.templatePaths).toEqual([]);
   });
 
-  it('overrides budget enforcement', () => {
-    const config = resolveConfig({ enableBudgetEnforcement: true });
-    expect(config.enableBudgetEnforcement).toBe(true);
-  });
-
   it('preserves unset fields at defaults', () => {
     const config = resolveConfig({ defaultTimeoutMs: 1000 });
     expect(config.maxConcurrency).toBe(DEFAULT_MAX_CONCURRENCY);
-    expect(config.enableBudgetEnforcement).toBe(false);
   });
 });
 

--- a/packages/nexus-agents/src/workflows/workflow-engine-helpers.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine-helpers.ts
@@ -9,11 +9,6 @@ import type { ILogger, ContextBudget, StepResult } from '../core/index.js';
 import type { ContextManagerConfig } from '../agents/context-manager.js';
 import { DEFAULT_BUDGET } from '../agents/context-manager.js';
 import type { ContextManager } from '../agents/context-manager.js';
-import type {
-  BudgetEnforcementEvent,
-  BudgetCircuitBreakerConfig,
-  IBudgetCircuitBreaker,
-} from './budget-enforcement.js';
 import type { WorkflowStep } from './workflow-types.js';
 
 // ============================================================================
@@ -41,10 +36,6 @@ export interface WorkflowEngineConfig {
   contextManagerConfig?: Omit<ContextManagerConfig, 'budget'>;
   defaultBudget?: ContextBudget;
   logger?: ILogger;
-  /** Budget circuit breaker configuration */
-  budgetCircuitBreakerConfig?: Partial<BudgetCircuitBreakerConfig>;
-  /** Enable hard budget enforcement (default: false for backward compatibility) */
-  enableBudgetEnforcement?: boolean;
 }
 
 /** Internal config type with resolved optional fields. */
@@ -54,8 +45,6 @@ export interface ResolvedConfig {
   templatePaths: string[];
   contextManagerConfig: Omit<ContextManagerConfig, 'budget'> | undefined;
   defaultBudget: ContextBudget;
-  budgetCircuitBreakerConfig: Partial<BudgetCircuitBreakerConfig> | undefined;
-  enableBudgetEnforcement: boolean;
 }
 
 // ============================================================================
@@ -81,9 +70,6 @@ export interface ExecutionContext {
   variables: Map<string, unknown>;
   abortController: AbortController;
   contextManager: ContextManager | undefined;
-  budgetEvents: BudgetEnforcementEvent[];
-  /** Budget circuit breaker for enforcement (optional) */
-  budgetCircuitBreaker: IBudgetCircuitBreaker | undefined;
 }
 
 /** Options for phase execution. */
@@ -104,8 +90,6 @@ const DEFAULT_RESOLVED_CONFIG: ResolvedConfig = {
   templatePaths: [],
   contextManagerConfig: undefined,
   defaultBudget: DEFAULT_BUDGET,
-  budgetCircuitBreakerConfig: undefined,
-  enableBudgetEnforcement: false,
 };
 
 /**

--- a/packages/nexus-agents/src/workflows/workflow-engine.test.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { WorkflowDefinition, StepResult, Result, ContextBudget } from '../core/index.js';
+import type { WorkflowDefinition, StepResult, Result } from '../core/index.js';
 import { ok, err, WorkflowError } from '../core/index.js';
 import { ParseError } from '../core/index.js';
 import {
@@ -12,7 +12,6 @@ import {
   type ExecutionPlan,
   type WorkflowStep,
 } from './workflow-engine.js';
-import { DEFAULT_BUDGET } from '../agents/context-manager.js';
 
 // Mock dependencies
 function createMockDeps(overrides?: Partial<WorkflowEngineDeps>): WorkflowEngineDeps {
@@ -392,238 +391,12 @@ describe('WorkflowEngine', () => {
     });
   });
 
-  describe('context budget integration', () => {
-    it('should execute workflow without context manager when not configured', async () => {
-      const workflow = { ...sampleWorkflow };
-      mockDeps.createExecutionPlan = vi.fn().mockReturnValue(
-        ok({
-          phases: [{ steps: [workflow.steps[0] as WorkflowStep] }],
-        })
-      );
-      mockDeps.executePhase = vi
-        .fn()
-        .mockResolvedValue(
-          ok([{ stepId: 'step1', output: 'done', durationMs: 50, status: 'success' }])
-        );
-
-      const result = await engine.execute(workflow, { input1: 'test' });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        // No budget events when context manager is not configured
-        const events = engine.getBudgetEvents(result.value.executionId);
-        expect(events).toHaveLength(0);
-        expect(engine.getContextManager(result.value.executionId)).toBeUndefined();
-      }
-    });
-
-    it('should initialize context manager when configured', async () => {
-      const engineWithContext = new WorkflowEngine(mockDeps, {
-        contextManagerConfig: {
-          maxTokens: 128000,
-        },
-      });
-
-      const workflow = { ...sampleWorkflow };
-      mockDeps.createExecutionPlan = vi.fn().mockReturnValue(
-        ok({
-          phases: [{ steps: [workflow.steps[0] as WorkflowStep] }],
-        })
-      );
-      mockDeps.executePhase = vi
-        .fn()
-        .mockResolvedValue(
-          ok([{ stepId: 'step1', output: 'done', durationMs: 50, status: 'success' }])
-        );
-
-      const result = await engineWithContext.execute(workflow, { input1: 'test' });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        const contextManager = engineWithContext.getContextManager(result.value.executionId);
-        expect(contextManager).toBeDefined();
-      }
-    });
-
-    it('should apply budget enforcement and log events during execution', async () => {
-      const engineWithContext = new WorkflowEngine(mockDeps, {
-        contextManagerConfig: {
-          maxTokens: 128000,
-        },
-      });
-
-      const workflow = { ...sampleWorkflow };
-      const stepResults: StepResult[] = [
-        { stepId: 'step1', output: 'result1', durationMs: 100, status: 'success' },
-        { stepId: 'step2', output: 'result2', durationMs: 150, status: 'success' },
-      ];
-
-      mockDeps.createExecutionPlan = vi.fn().mockReturnValue(
-        ok({
-          phases: [
-            { steps: [workflow.steps[0] as WorkflowStep] },
-            { steps: [workflow.steps[1] as WorkflowStep] },
-          ],
-        })
-      );
-      mockDeps.executePhase = vi
-        .fn()
-        .mockResolvedValueOnce(ok([stepResults[0]]))
-        .mockResolvedValueOnce(ok([stepResults[1]]));
-
-      const result = await engineWithContext.execute(workflow, { input1: 'test' });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        const events = engineWithContext.getBudgetEvents(result.value.executionId);
-        expect(events).toHaveLength(2);
-
-        // Check first event
-        expect(events[0]?.stepId).toBe('step1');
-        expect(events[0]?.source).toBe('engine');
-        expect(events[0]?.budget).toEqual(DEFAULT_BUDGET);
-        expect(events[0]?.statsBefore).toBeDefined();
-
-        // Check second event
-        expect(events[1]?.stepId).toBe('step2');
-      }
-    });
-
-    it('should use workflow default budget when specified', async () => {
-      const customBudget: ContextBudget = {
-        system: 0.2,
-        task: 0.25,
-        active: 0.4,
-        reserved: 0.15,
-      };
-
-      const workflowWithBudget: WorkflowDefinition = {
-        ...sampleWorkflow,
-        defaultBudget: customBudget,
-      };
-
-      const engineWithContext = new WorkflowEngine(mockDeps, {
-        contextManagerConfig: {
-          maxTokens: 128000,
-        },
-      });
-
-      mockDeps.createExecutionPlan = vi.fn().mockReturnValue(
-        ok({
-          phases: [{ steps: [workflowWithBudget.steps[0] as WorkflowStep] }],
-        })
-      );
-      mockDeps.executePhase = vi
-        .fn()
-        .mockResolvedValue(
-          ok([{ stepId: 'step1', output: 'done', durationMs: 50, status: 'success' }])
-        );
-
-      const result = await engineWithContext.execute(workflowWithBudget, { input1: 'test' });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        const events = engineWithContext.getBudgetEvents(result.value.executionId);
-        expect(events).toHaveLength(1);
-        expect(events[0]?.source).toBe('workflow');
-        expect(events[0]?.budget).toEqual(customBudget);
-      }
-    });
-
-    it('should use step-specific budget override when specified', async () => {
-      const stepBudgetOverride = {
-        system: 0.1,
-        active: 0.6,
-      };
-
-      const workflowWithStepBudget: WorkflowDefinition = {
-        ...sampleWorkflow,
-        steps: [
-          {
-            ...sampleWorkflow.steps[0],
-            contextBudget: stepBudgetOverride,
-          } as WorkflowDefinition['steps'][0],
-        ],
-      };
-
-      const engineWithContext = new WorkflowEngine(mockDeps, {
-        contextManagerConfig: {
-          maxTokens: 128000,
-        },
-      });
-
-      mockDeps.createExecutionPlan = vi.fn().mockReturnValue(
-        ok({
-          phases: [{ steps: [workflowWithStepBudget.steps[0] as WorkflowStep] }],
-        })
-      );
-      mockDeps.executePhase = vi
-        .fn()
-        .mockResolvedValue(
-          ok([{ stepId: 'step1', output: 'done', durationMs: 50, status: 'success' }])
-        );
-
-      const result = await engineWithContext.execute(workflowWithStepBudget, { input1: 'test' });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        const events = engineWithContext.getBudgetEvents(result.value.executionId);
-        expect(events).toHaveLength(1);
-        expect(events[0]?.source).toBe('step');
-        // Step overrides merged with engine defaults
-        expect(events[0]?.budget.system).toBe(0.1);
-        expect(events[0]?.budget.active).toBe(0.6);
-        expect(events[0]?.budget.task).toBe(DEFAULT_BUDGET.task);
-        expect(events[0]?.budget.reserved).toBe(DEFAULT_BUDGET.reserved);
-      }
-    });
-
-    it('should return empty events for unknown execution', () => {
-      const events = engine.getBudgetEvents('unknown-id');
-      expect(events).toHaveLength(0);
-    });
-
-    it('should return undefined context manager for unknown execution', () => {
-      const contextManager = engine.getContextManager('unknown-id');
-      expect(contextManager).toBeUndefined();
-    });
-
-    it('should use engine default budget when workflow has no default', async () => {
-      const customEngineBudget: ContextBudget = {
-        system: 0.1,
-        task: 0.3,
-        active: 0.45,
-        reserved: 0.15,
-      };
-
-      const engineWithCustomBudget = new WorkflowEngine(mockDeps, {
-        contextManagerConfig: {
-          maxTokens: 128000,
-        },
-        defaultBudget: customEngineBudget,
-      });
-
-      const workflow = { ...sampleWorkflow };
-      mockDeps.createExecutionPlan = vi.fn().mockReturnValue(
-        ok({
-          phases: [{ steps: [workflow.steps[0] as WorkflowStep] }],
-        })
-      );
-      mockDeps.executePhase = vi
-        .fn()
-        .mockResolvedValue(
-          ok([{ stepId: 'step1', output: 'done', durationMs: 50, status: 'success' }])
-        );
-
-      const result = await engineWithCustomBudget.execute(workflow, { input1: 'test' });
-
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        const events = engineWithCustomBudget.getBudgetEvents(result.value.executionId);
-        expect(events).toHaveLength(1);
-        expect(events[0]?.source).toBe('engine');
-        expect(events[0]?.budget).toEqual(customEngineBudget);
-      }
-    });
-  });
+  // #4673: the 'context budget integration' suite was removed with the
+  // machinery it exercised. Those tests constructed engines with
+  // `enableBudgetEnforcement` and a `contextManagerConfig` — a combination no
+  // production caller could produce — so they pinned unreachable enforcement
+  // as intended behaviour and would have kept passing forever.
+  //
+  // Usage ACCOUNTING survives and is now reachable: see the recordPhaseUsage
+  // tests in workflow-engine-execution.test.ts.
 });

--- a/packages/nexus-agents/src/workflows/workflow-engine.ts
+++ b/packages/nexus-agents/src/workflows/workflow-engine.ts
@@ -12,11 +12,6 @@ import type {
 } from '../core/index.js';
 import { WorkflowError, ParseError } from '../core/index.js';
 import type { ContextManager } from '../agents/context-manager.js';
-import {
-  copyBudgetEvents,
-  type BudgetEnforcementEvent,
-  type IBudgetCircuitBreaker,
-} from './budget-enforcement.js';
 // WorkflowStep is used in workflow-engine-execution.ts
 import {
   type WorkflowEngineConfig,
@@ -32,7 +27,6 @@ import type { WorkflowEngineDeps, ActiveExecution } from './workflow-engine-type
 import {
   cleanupOldExecutions,
   initializeExecution,
-  enforceStepBudgets,
   recordPhaseUsage,
 } from './workflow-engine-execution.js';
 
@@ -174,17 +168,8 @@ export class WorkflowEngine implements IWorkflowEngine {
     return exec ? exec.status : { state: 'failed', error: 'Execution not found' };
   }
 
-  getBudgetEvents(executionId: string): BudgetEnforcementEvent[] {
-    const exec = this.executions.get(executionId);
-    return exec ? copyBudgetEvents(exec.context.budgetEvents) : [];
-  }
-
   getContextManager(executionId: string): ContextManager | undefined {
     return this.executions.get(executionId)?.context.contextManager;
-  }
-
-  getBudgetCircuitBreaker(executionId: string): IBudgetCircuitBreaker | undefined {
-    return this.executions.get(executionId)?.context.budgetCircuitBreaker;
   }
 
   cancel(executionId: string): Promise<Result<void, WorkflowError>> {
@@ -318,17 +303,6 @@ export class WorkflowEngine implements IWorkflowEngine {
         progress: completedSteps / totalSteps,
       });
 
-      // Check budget enforcement for each step
-      const enforceResult = enforceStepBudgets({
-        steps: phase.steps,
-        context,
-        workflow,
-        totalSteps,
-        config: this.config,
-        logger: this.logger,
-      });
-      if (!enforceResult.ok) return enforceResult;
-
       // #3017: per-call `phaseTimeoutMs` from run_workflow MCP input wins
       // over both `workflow.timeout` and `this.config.defaultTimeoutMs`.
       const options: ExecutionOptions = {
@@ -340,9 +314,11 @@ export class WorkflowEngine implements IWorkflowEngine {
       const phaseResult = await this.deps.executePhase(phase.steps, context, options);
       if (!phaseResult.ok) return phaseResult;
 
-      // Record usage in circuit breaker after phase completion (#4673): the
-      // coverage report is consumed, not discarded — see reportUsageCoverage.
-      this.reportUsageCoverage(recordPhaseUsage(phaseResult.value, context), workflow.name);
+      // #4673: usage accounting is measurement, not enforcement — it no longer
+      // needs a circuit breaker, so it runs on every phase instead of only when
+      // an unreachable enforcement flag was set. The coverage report is
+      // consumed, not discarded — see reportUsageCoverage.
+      this.reportUsageCoverage(recordPhaseUsage(phaseResult.value), workflow.name);
 
       for (const result of phaseResult.value) {
         context.stepResults.set(result.stepId, result);


### PR DESCRIPTION
Resolves #4673. Panel chose removal 6-1 (all six approvers selecting it) over wiring.

## The defect

The workflow engine's budget enforcement could not block a step. `budgetCircuitBreaker` was built only when `enableBudgetEnforcement` was true **and** a `contextManagerConfig` was supplied, and no production caller sets either — the only non-test references were the two type declarations and the `false` default.

So `enforceStepBudgets` was structurally incapable of returning `err`, `budgetEvents` was permanently `[]`, and `getBudgetEvents` returned that empty list to no consumer.

## Two corrections to my own issue, made before implementing

**The issue said "delete the circuit breaker". That would have broken a live consumer.** `pipeline/budget-guard.ts` wraps `BudgetCircuitBreaker` as "the single budget authority" for `agent-executor`, and that path really enforces. Only the workflow engine's dormant copy is removed here. This is the second time today I wrote "remove it" after checking that *one* call path was dead rather than the *component* — the same error as #4666.

**The issue's second finding was already fixed.** `estimatedTokens = durationMs * 0.5` is gone; #4710/#4744 landed real token threading.

## The refinement the panel did not consider

While implementing I found that `recordPhaseUsage` — the coverage ledger — returns early whenever the breaker is absent:

```ts
if (context.budgetCircuitBreaker === undefined) {
  return { recordedSteps: 0, unmeasuredSteps: 0, tokensRecorded: 0 };
}
```

Which is every production run. **So my own #4744 unmeasured-step work had no production effect** — I fixed a guard one layer below a second dead gate, which is the exact shape of the bug I was fixing. Correction posted on #4744; the changeset there overstated what shipped.

`recordPhaseUsage` took an `ExecutionContext` purely to reach the breaker. **Counting never needed a breaker; only `recordUsage` did.** It now takes just the step results and runs on every phase, so `reportUsageCoverage` can genuinely warn that a recorded spend is a lower bound.

Measurement survives and becomes live; only enforcement is removed. That is a better outcome than either voted option, and consistent with the intent of the one chosen.

## Tests removed on purpose

234 lines — the `context budget integration` suite constructed engines with both config flags set, a combination no production caller can produce. They pinned unreachable enforcement as intended behaviour and would have passed forever. The architect seat flagged exactly this. The `recordPhaseUsage` tests are rewritten against the new signature, including the empty-input case.

## The gap this exposes

Verified the contrarian's dissent rather than outvoting it, and **they were right**: `workflows/` never enters `agent-executor`, so the pipeline's guard does not cover workflow runs. Six approvers reasoned "the pipeline already enforces budgets" — true of the pipeline, not of workflows.

Filed as **#4754**. Framing matters: this removal did not create the gap. Enforcement was structurally zero before and after; it is now visible instead of hidden behind code that reads as protection.

## Verification

Full suite **28366 passed, 0 failed**. `src/workflows` + `src/pipeline` 1965 passing — the pipeline's budget tests are untouched and still green, which is the evidence that the live authority survived. Typecheck 0, lint clean.