### PR TITLE
fix(agents): a scope is not a measurement

### DIFF
--- a/.changeset/false-stall-regression.md
+++ b/.changeset/false-stall-regression.md
@@ -1,0 +1,39 @@
+---
+'nexus-agents': patch
+---
+
+fix(agents): stop reporting a false stall on every long expert task
+
+#4752 marked a heartbeat session "instrumented" when its scope opened, and let
+an instrumented session with no heartbeats fall through to the stall
+thresholds. The reasoning was that a scoped session emitting nothing must have
+hung before its first step. Two facts make that wrong:
+
+- **Nothing under `src/agents/` emits a `withStep`.** `SimpleAgent.executeTask`
+  is a bare model call, so no step event is ever published from the agent work
+  path and no heartbeat is ever credited.
+- **The sessions nest.** `execute-expert` opens a session, then
+  `base-agent-execute-flow` opens a second one inside it. The inner
+  `AsyncLocalStorage` store shadows the outer, so even once producers exist the
+  outer session receives no credit.
+
+Net effect: every expert or agent task running past 120s logged
+`Expert session stalled — no step activity` every 15s and inflated
+`stalledSessions`. #4752 traded "structurally 0" for "structurally stalled",
+which is not an improvement — the record was wrong in a new direction.
+
+A session is now measured only once a heartbeat is actually **credited**.
+Opening a scope is not evidence that anything will report progress. Nesting
+becomes benign: an outer session with no credit stays `unmeasured` rather than
+claiming a stall. An immediate hang remains covered by the 900s absolute cap
+(`isExpired`), which does work.
+
+Also fixes the same class in `measuredTrustTier` (#4751): it accepted `clientId`
+as a derivation input, but `deriveTrustTier` reads `clientId` only inside its
+`authenticated === true` branch — and `extractCallerInfo` returns exactly
+`{ clientId, sessionId }` on its CLAUDE_SESSION_ID path. Wiring that producer
+would have relabelled the `'3'` fallback as a measurement. `authenticated:
+false` still counts, because "we checked and they are not authenticated" is a
+measurement; only an absent field is not.
+
+Found by an adversarial review of my own merged work.

--- a/packages/nexus-agents/src/agents/heartbeat-monitor.test.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-monitor.test.ts
@@ -29,7 +29,6 @@ describe('heartbeat-monitor', () => {
     it('should start and end sessions', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
       expect(sid).toContain('expert-1');
       expect(monitor.activeCount).toBe(1);
 
@@ -48,7 +47,6 @@ describe('heartbeat-monitor', () => {
     it('should record heartbeats', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
       monitor.heartbeat(sid);
       monitor.heartbeat(sid);
       monitor.heartbeat(sid);
@@ -61,7 +59,6 @@ describe('heartbeat-monitor', () => {
     it('should classify session as alive when recent heartbeat', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
       monitor.heartbeat(sid);
 
       const health = monitor.getHealth();
@@ -72,7 +69,7 @@ describe('heartbeat-monitor', () => {
     it('should classify session as slow after threshold', () => {
       const monitor = new HeartbeatMonitor({ slowThresholdMs: 10_000 });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
+      monitor.heartbeat(sid); // progress must be credited before silence means anything
 
       vi.advanceTimersByTime(15_000);
 
@@ -84,7 +81,7 @@ describe('heartbeat-monitor', () => {
     it('should classify session as stalled after threshold', () => {
       const monitor = new HeartbeatMonitor({ stalledThresholdMs: 20_000 });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
+      monitor.heartbeat(sid);
 
       vi.advanceTimersByTime(25_000);
 
@@ -96,7 +93,6 @@ describe('heartbeat-monitor', () => {
     it('should reset stall timer on heartbeat', () => {
       const monitor = new HeartbeatMonitor({ stalledThresholdMs: 20_000 });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(15_000);
       monitor.heartbeat(sid);
@@ -108,7 +104,6 @@ describe('heartbeat-monitor', () => {
     it('should detect expired sessions', () => {
       const monitor = new HeartbeatMonitor({ absoluteMaxMs: 50_000 });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(60_000);
 
@@ -118,7 +113,6 @@ describe('heartbeat-monitor', () => {
     it('should not expire if within max', () => {
       const monitor = new HeartbeatMonitor({ absoluteMaxMs: 100_000 });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(50_000);
 
@@ -145,7 +139,6 @@ describe('heartbeat-monitor', () => {
     it('should include elapsed and timeSince in snapshot', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
 
       vi.advanceTimersByTime(5_000);
 
@@ -160,9 +153,9 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 10_000,
       });
       const sid1 = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid1);
+      monitor.heartbeat(sid1);
       const sid2 = monitor.startSession('expert-2');
-      monitor.markInstrumented(sid2);
+      monitor.heartbeat(sid2);
 
       vi.advanceTimersByTime(15_000);
       monitor.heartbeat(sid1); // expert-1 alive, expert-2 stalled
@@ -180,7 +173,6 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 60_000,
       });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
 
       // Simulate periodic heartbeats every 15s for 90s
       for (let i = 0; i < 6; i++) {
@@ -201,7 +193,6 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 60_000,
       });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
 
       // Heartbeat for a while
       vi.advanceTimersByTime(15_000);
@@ -221,7 +212,7 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 40_000,
       });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
+      monitor.heartbeat(sid);
 
       // Initially alive
       expect(monitor.getHealth().sessions[0]?.health).toBe('alive');
@@ -246,14 +237,12 @@ describe('heartbeat-monitor', () => {
       expect(monitor.getSessionHealth('nope')).toBeUndefined();
     });
 
-    // #4665: a new session starts at `unmeasured` — nothing has been observed
-    // yet — so its first health read is a real unmeasured → alive transition
-    // rather than a no-op. Only 'slow' and 'stalled' transitions are logged, so
-    // this is silent in production.
-    it('reports the first observation of a new session as unmeasured → alive', () => {
+    // #4665: a session starts `unmeasured` and stays there until progress is
+    // actually credited. The first credited heartbeat is what makes it `alive`.
+    it('reports unmeasured → alive once progress is credited', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
+      monitor.heartbeat(sid);
       const t = monitor.getSessionHealth(sid) as HealthTransition;
       expect(t.health).toBe('alive');
       expect(t.previousHealth).toBe('unmeasured');
@@ -263,7 +252,6 @@ describe('heartbeat-monitor', () => {
     it('reports no transition on a second read with no change', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
       monitor.getSessionHealth(sid);
       const t = monitor.getSessionHealth(sid) as HealthTransition;
       expect(t.changed).toBe(false);
@@ -272,7 +260,7 @@ describe('heartbeat-monitor', () => {
     it('detects alive → slow transition', () => {
       const monitor = new HeartbeatMonitor({ slowThresholdMs: 10_000 });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
+      monitor.heartbeat(sid);
       // First check — alive
       monitor.getSessionHealth(sid);
 
@@ -289,7 +277,7 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 20_000,
       });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
+      monitor.heartbeat(sid);
 
       vi.advanceTimersByTime(15_000);
       monitor.getSessionHealth(sid); // alive → slow
@@ -304,7 +292,7 @@ describe('heartbeat-monitor', () => {
     it('does not report change when health is stable', () => {
       const monitor = new HeartbeatMonitor({ slowThresholdMs: 10_000 });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
+      monitor.heartbeat(sid);
 
       vi.advanceTimersByTime(15_000);
       monitor.getSessionHealth(sid); // alive → slow
@@ -321,7 +309,7 @@ describe('heartbeat-monitor', () => {
         stalledThresholdMs: 20_000,
       });
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
+      monitor.heartbeat(sid); // credit progress so silence is meaningful
 
       vi.advanceTimersByTime(25_000);
       monitor.getSessionHealth(sid); // alive → stalled
@@ -336,7 +324,6 @@ describe('heartbeat-monitor', () => {
     it('includes correct elapsedMs and heartbeatCount', () => {
       const monitor = new HeartbeatMonitor();
       const sid = monitor.startSession('expert-1');
-      monitor.markInstrumented(sid);
       monitor.heartbeat(sid);
       monitor.heartbeat(sid);
 

--- a/packages/nexus-agents/src/agents/heartbeat-monitor.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-monitor.ts
@@ -76,8 +76,6 @@ interface SessionEntry {
   readonly startedAt: number;
   lastHeartbeat: number;
   heartbeatCount: number;
-  /** Set once the session's work is running under a progress scope (#4665). */
-  instrumented: boolean;
   /** Previous health state for transition detection (Issue #1088 Phase 4). */
   previousHealth: SessionHealth;
 }
@@ -127,25 +125,9 @@ export class HeartbeatMonitor {
       startedAt: now,
       lastHeartbeat: now,
       heartbeatCount: 0,
-      instrumented: false,
       previousHealth: 'unmeasured',
     });
     return sessionId;
-  }
-
-  /**
-   * Declares that this session's work runs under a progress scope (#4665), so
-   * silence from it is meaningful.
-   *
-   * This separates two facts that `heartbeatCount === 0` conflates: a session
-   * on an uninstrumented path (nothing is watching, so say `unmeasured`) and a
-   * session that hung BEFORE emitting its first step (the worst stall there is,
-   * and one an `unmeasured` verdict would hide forever).
-   */
-  markInstrumented(sessionId: string): void {
-    const entry = this.sessions.get(sessionId);
-    if (entry === undefined) return;
-    entry.instrumented = true;
   }
 
   /** Record a heartbeat for an active session. */
@@ -168,7 +150,7 @@ export class HeartbeatMonitor {
     // #4665: silence from an uninstrumented session means nothing — no scope
     // ever claimed to report its progress. Silence from an instrumented one is
     // the signal.
-    if (!entry.instrumented && entry.heartbeatCount === 0) return false;
+    if (entry.heartbeatCount === 0) return false;
     const elapsed = getTimeProvider().now() - entry.lastHeartbeat;
     return elapsed >= this.config.stalledThresholdMs;
   }
@@ -188,7 +170,7 @@ export class HeartbeatMonitor {
 
     for (const [sessionId, entry] of this.sessions) {
       const timeSince = now - entry.lastHeartbeat;
-      const health = this.classifyHealth(timeSince, entry.heartbeatCount, entry.instrumented);
+      const health = this.classifyHealth(timeSince, entry.heartbeatCount);
       if (health === 'stalled') stalledCount++;
 
       sessions.push({
@@ -220,7 +202,7 @@ export class HeartbeatMonitor {
     if (entry === undefined) return undefined;
     const now = getTimeProvider().now();
     const timeSince = now - entry.lastHeartbeat;
-    const health = this.classifyHealth(timeSince, entry.heartbeatCount, entry.instrumented);
+    const health = this.classifyHealth(timeSince, entry.heartbeatCount);
     const changed = health !== entry.previousHealth;
     const result: HealthTransition = {
       sessionId,
@@ -240,16 +222,19 @@ export class HeartbeatMonitor {
     return this.sessions.size;
   }
 
-  private classifyHealth(
-    timeSinceMs: number,
-    heartbeatCount: number,
-    instrumented: boolean
-  ): SessionHealth {
-    // Nothing ever claimed to report this session's progress, so `lastHeartbeat`
-    // is still just `startedAt` and the elapsed time measures the clock, not the
-    // work. An INSTRUMENTED session with no heartbeats is a different fact — it
-    // hung before its first step — and falls through to the thresholds.
-    if (!instrumented && heartbeatCount === 0) return 'unmeasured';
+  private classifyHealth(timeSinceMs: number, heartbeatCount: number): SessionHealth {
+    // No progress has ever been credited, so `lastHeartbeat` is still just
+    // `startedAt` and the elapsed time measures the clock, not the work.
+    //
+    // A first version marked a session "instrumented" when its scope opened and
+    // let that fall through to the thresholds, on the theory that a scoped
+    // session with no steps had hung before its first step. That was wrong:
+    // opening a scope is not evidence that anything will report progress, and
+    // nothing under `src/agents/` emits a step at all — so EVERY expert task
+    // over 120s reported `stalled`. Trading "structurally 0" for "structurally
+    // stalled" is not an improvement. An immediate hang is covered by the 900s
+    // absolute cap (`isExpired`), which does work.
+    if (heartbeatCount === 0) return 'unmeasured';
     if (timeSinceMs >= this.config.stalledThresholdMs) return 'stalled';
     if (timeSinceMs >= this.config.slowThresholdMs) return 'slow';
     return 'alive';
@@ -296,7 +281,6 @@ const sessionAls = new AsyncLocalStorage<string>();
  * progress for that session.
  */
 export function runInHeartbeatSession<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
-  getHeartbeatMonitor().markInstrumented(sessionId);
   return sessionAls.run(sessionId, fn);
 }
 

--- a/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
@@ -358,6 +358,20 @@ describe('measuredTrustTier (#4733)', () => {
     expect(measuredTrustTier(ctx)).toBe('1');
   });
 
+  // The exact shape `extractCallerInfo` returns on its CLAUDE_SESSION_ID path.
+  // A previous version of the guard accepted `clientId` as a derivation input,
+  // but `deriveTrustTier` reads it only inside `authenticated === true` — so
+  // this shape yields the '3' fallback and must NOT be reported as measured.
+  it('does not treat a clientId-only caller as measured', () => {
+    const context = createRequestContext({
+      toolName: 'run_pipeline',
+      caller: { clientId: 'claude-cli', sessionId: 'sess_abc' },
+    });
+
+    expect(context.trustTier).toBe('3');
+    expect(measuredTrustTier(context)).toBeUndefined();
+  });
+
   it('distinguishes a genuine tier 3 from the fallback tier 3', () => {
     // The case the raw field cannot express: an authenticated caller with an
     // unknown client is really tier 3, and must not be conflated with "we did

--- a/packages/nexus-agents/src/mcp/middleware/request-context.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.ts
@@ -284,9 +284,17 @@ export function measuredTrustTier(context: RequestContext): string | undefined {
   // a non-empty check would have called the '3' fallback a measurement as soon
   // as a producer supplied only those — reintroducing the constant this
   // function exists to prevent, in the function that prevents it.
+  // `clientId` is NOT sufficient, and including it was a bug in the previous
+  // version of this guard: `deriveTrustTier` reads `clientId` only INSIDE the
+  // `authenticated === true` branch, so `{ clientId: 'claude-cli' }` returns
+  // the same '3' fallback as `{}`. The one in-tree producer,
+  // `extractCallerInfo`, returns exactly that shape on its CLAUDE_SESSION_ID
+  // path — so wiring it would have relabelled the constant as a measurement,
+  // inside the function written to prevent exactly that.
   const info = caller as Partial<CallerInfo>;
-  const derivable =
-    info.transport !== undefined || info.authenticated !== undefined || info.clientId !== undefined;
+  // `authenticated: false` counts: it is a measured fact ("we checked, they
+  // are not authenticated"), which is different from the field being absent.
+  const derivable = info.transport !== undefined || info.authenticated !== undefined;
 
   return derivable ? context.trustTier : undefined;
 }


### PR DESCRIPTION
Fixes a regression **I merged this morning in #4752**. Found by an adversarial review of my own work, not by me.

## What I broke

#4752 marked a heartbeat session "instrumented" when its scope opened, then let an instrumented session with no heartbeats fall through to the stall thresholds. My reasoning: a scoped session emitting nothing must have hung before its first step, and treating that as `unmeasured` would hide the worst stall there is.

The reasoning is fine. The premise is false, twice over:

**Nothing under `src/agents/` emits a `withStep`.**

```
grep -rn "withStep" src/agents/ --include=*.ts | grep -v test   -> nothing
```

`SimpleAgent.executeTask` is a bare `this.complete(request)`. No step event is published from the agent work path, so no heartbeat is ever credited.

**The sessions nest.** `execute-expert` opens a session, then `base-agent-execute-flow` opens a second one inside it (`runInHeartbeatSession` at both `execute-expert.ts:643` and `base-agent-execute-flow.ts:158`). The inner `AsyncLocalStorage` store shadows the outer, so even once producers exist the outer session receives no credit.

Net effect: every expert or agent task past 120s logged `Expert session stalled — no step activity` every 15s and inflated `stalledSessions`.

**#4752 traded "structurally 0" for "structurally stalled."** That is not an improvement — I replaced a check that could not fire with one that could not stop firing, and the second is worse because it produces noise a reader must learn to ignore.

My changeset asserted that `withStep` "emits on `stepBus` for every nested step inside that await". I never verified that the agent path emits any.

## The fix

A session is measured only once a heartbeat is actually **credited** — `heartbeatCount > 0`. Opening a scope is not evidence that anything will report progress.

This is what my *first* version did, before I over-corrected. Nesting becomes benign: an outer session with no credit stays `unmeasured` rather than claiming a stall. The immediate-hang case remains covered by the 900s absolute cap (`isExpired`), which genuinely works.

The honest consequence: **every session reports `unmeasured` today**, because no producer exists. That is the true state, and it is what `unmeasured` is for. Making it vary needs step emission on the agent work path — the remaining half of #4665, and not something to fake.

## Second fix, same class

`measuredTrustTier` (from #4751) accepted `clientId` as a derivation input. But `deriveTrustTier` reads `clientId` **only inside** its `authenticated === true` branch, so `{ clientId: 'claude-cli' }` returns the same `'3'` fallback as `{}`. The one in-tree producer, `extractCallerInfo`, returns exactly that shape on its `CLAUDE_SESSION_ID` path — so wiring it would have relabelled the constant as a measurement, inside the function written to prevent that.

Now gated on `transport` or `authenticated`. Note `authenticated: false` still counts: "we checked and they are not authenticated" is a measurement; only an absent field is not. The review suggested `authenticated === true`, which would have discarded that — an existing test caught it.

## Verification

Both fixes mutation-verified: re-admitting `clientId` fails the new producer-shape test; the heartbeat tests now credit progress before asserting a threshold, and fail without the credit.

Full suite **28367 passed, 0 failed**. Typecheck 0, lint clean.