### PR TITLE
docs(changeset): correct the workflow-budget removal note

### DIFF
--- a/.changeset/remove-workflow-budget-enforcement.md
+++ b/.changeset/remove-workflow-budget-enforcement.md
@@ -12,10 +12,21 @@ So `enforceStepBudgets` was structurally incapable of returning `err`,
 `budgetEvents` was permanently `[]`, and `getBudgetEvents` returned that empty
 list to nobody.
 
-Removed: `enableBudgetEnforcement`, `contextManagerConfig`,
-`budgetCircuitBreakerConfig`, `applyBudgetEnforcement`, `enforceStepBudgets`,
-`getBudgetEvents`, `getBudgetCircuitBreaker`, and `ExecutionContext.budgetEvents`
-/ `.budgetCircuitBreaker`.
+Removed from the workflow engine: `enableBudgetEnforcement`,
+`budgetCircuitBreakerConfig`, `enforceStepBudgets`, `getBudgetEvents`,
+`getBudgetCircuitBreaker`, and `ExecutionContext.budgetEvents` /
+`.budgetCircuitBreaker`.
+
+NOT removed, contrary to an earlier draft of this note: `applyBudgetEnforcement`
+still exists in `budget-enforcement.ts`, and `contextManagerConfig` is still a
+`WorkflowEngineConfig` field — the context manager is unrelated to budget
+enforcement and survives it.
+
+This removes ten types from the package's public surface — `IBudgetCircuitBreaker`,
+`BudgetCircuitState`, `BudgetEnforcementEvent` and siblings — which were
+reachable only through the two deleted `ExecutionContext` fields rather than by
+direct export. That makes this a BREAKING change despite the `minor` header
+above; the version decision is tracked in #4759.
 
 **`BudgetCircuitBreaker` itself is untouched** — `pipeline/budget-guard.ts`
 wraps it as "the single budget authority" for `agent-executor`, and that path


### PR DESCRIPTION
The #4755 changeset is still unconsumed, so it can be corrected before it becomes the CHANGELOG.

## Two inaccuracies

Its `Removed:` list names **`applyBudgetEnforcement`** and **`contextManagerConfig`**. Both survive:

```
applyBudgetEnforcement  -> still in budget-enforcement.ts (2 non-test refs)
contextManagerConfig    -> still a WorkflowEngineConfig field (3 non-test refs)
```

The context manager is unrelated to budget enforcement; I listed it because it appeared in the same constructor block I was deleting from.

## What the note now records

The ten public types that left with the two deleted `ExecutionContext` fields — `IBudgetCircuitBreaker`, `BudgetCircuitState`, `BudgetEnforcementEvent` and siblings. They were reachable only *through* those fields, never exported by name, which is why my grep missed them and why the change is breaking despite the `minor` header. Version decision tracked in **#4759**.

## Why this is worth a PR

A changeset is not a commit message — it is published verbatim into the CHANGELOG that downstream consumers read to decide whether to upgrade. A `Removed:` list naming symbols that still exist would send someone hunting for a migration they do not need, and omit the ten that actually went.

Found by an adversarial review of my own merged work.

## Not fixed here

Five symbols are now exported from `workflows/index.ts` with zero production callers: `applyBudgetEnforcement`, `enforceBudgetForStep`, `createWorkflowCircuitBreaker`, `copyBudgetEvents`, `resolveStepBudget`. They were live before #4755 removed their only caller.

Deleting them is a further public-surface removal, which belongs with the #4759 version decision rather than being slipped into a docs fix.