### PR TITLE
fix(agents): do not sum placeholder zeros into an aggregate total

### DIFF
--- a/.changeset/unmeasured-in-aggregates.md
+++ b/.changeset/unmeasured-in-aggregates.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': minor
+---
+
+fix(agents): aggregate token totals no longer absorb unmeasured contributors
+
+`AggregationMetadata.totalTokensUsed` summed `metadata.tokensUsed` across every
+contributor. Since #4744 a contributor whose adapter reported no usage carries a
+placeholder `0` with `tokensMeasured: false`, so those zeros were added in
+silently and the total read as a complete figure when it was a lower bound.
+
+The two aggregation sites (`result-aggregator.ts`, `session-helpers.ts`) now sum
+measured contributors only and report `unmeasuredResults` beside the total. The
+field is additive and optional — absent means the aggregate predates the
+distinction, which is unknown rather than zero.
+
+Confirmed non-breaking by the #4749 surface gate, which reported exactly one
+public change: `AggregationMetadata > unmeasuredResults?: number | undefined`.
+That is the first time a change here has been checked against the real API
+surface rather than a grep.
+
+Part of #4743. The propagating consumers (trinity, execute-expert, sica,
+puppeteer, aegean) still read `tokensUsed` alone and are unchanged.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -404,6 +404,7 @@ InterfaceDeclaration AggregationMetadata
   conflictCount: number
   resultCount: number
   totalTokensUsed: number
+  unmeasuredResults?: number | undefined
 TypeAliasDeclaration AggregationStrategy
   = 'merge' | 'select_best' | 'consensus' | 'sequential_chain'
 InterfaceDeclaration AggregatorInput

--- a/packages/nexus-agents/src/agents/collaboration/collaboration-types.ts
+++ b/packages/nexus-agents/src/agents/collaboration/collaboration-types.ts
@@ -253,6 +253,16 @@ export interface AggregationMetadata {
   conflictCount: number;
   averageConfidence: number;
   totalTokensUsed: number;
+  /**
+   * How many contributors reported no measured usage (#4743).
+   *
+   * `totalTokensUsed` sums what was measured. A contributor whose adapter
+   * reported nothing carries a placeholder `0` (`ResultMetadata.tokensMeasured
+   * === false`), so without this count the total reads as complete when it is a
+   * LOWER BOUND. Absent means the aggregate predates the distinction — unknown,
+   * not zero.
+   */
+  unmeasuredResults?: number;
   aggregatedAt: string;
 }
 

--- a/packages/nexus-agents/src/agents/collaboration/result-aggregator.test.ts
+++ b/packages/nexus-agents/src/agents/collaboration/result-aggregator.test.ts
@@ -124,6 +124,51 @@ describe('ResultAggregator', () => {
       }
     });
 
+    // #4743: a contributor whose adapter reported nothing carries a placeholder
+    // zero. Summing it in silently made the total look complete when it is a
+    // lower bound.
+    it('excludes unmeasured contributors from the total and counts them', () => {
+      const aggregator = createResultAggregator();
+      const unmeasured = createExpertResult('e2', 'output2');
+      const input: AggregatorInput = {
+        pattern: 'parallel',
+        results: [
+          createExpertResult('e1', 'output1'),
+          {
+            ...unmeasured,
+            result: {
+              ...unmeasured.result,
+              metadata: { ...unmeasured.result.metadata, tokensUsed: 0, tokensMeasured: false },
+            },
+          },
+        ],
+      };
+
+      const result = aggregator.aggregate(input);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.metadata.totalTokensUsed).toBe(50);
+        expect(result.value.metadata.unmeasuredResults).toBe(1);
+      }
+    });
+
+    it('omits the unmeasured count when every contributor reported usage', () => {
+      const aggregator = createResultAggregator();
+      const input: AggregatorInput = {
+        pattern: 'parallel',
+        results: [createExpertResult('e1', 'output1'), createExpertResult('e2', 'output2')],
+      };
+
+      const result = aggregator.aggregate(input);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.metadata.totalTokensUsed).toBe(100);
+        expect(result.value.metadata.unmeasuredResults).toBeUndefined();
+      }
+    });
+
     it('should calculate quality score', () => {
       const aggregator = createResultAggregator();
       const input: AggregatorInput = {

--- a/packages/nexus-agents/src/agents/collaboration/result-aggregator.ts
+++ b/packages/nexus-agents/src/agents/collaboration/result-aggregator.ts
@@ -136,7 +136,11 @@ export class ResultAggregator {
     conflicts: ResultConflict[],
     qualityScore: number
   ): AggregatedResult {
-    const totalTokensUsed = results.reduce((s, r) => s + r.result.metadata.tokensUsed, 0);
+    // #4743: sum what was measured, and say how much was not. Adding the
+    // placeholder zeros in silently would make the total look complete.
+    const measured = results.filter((r) => r.result.metadata.tokensMeasured !== false);
+    const totalTokensUsed = measured.reduce((s, r) => s + r.result.metadata.tokensUsed, 0);
+    const unmeasuredResults = results.length - measured.length;
     const avgConfidence = results.reduce((s, r) => s + (r.confidence ?? 0.5), 0) / results.length;
 
     return {
@@ -149,6 +153,7 @@ export class ResultAggregator {
         conflictCount: conflicts.length,
         averageConfidence: Math.round(avgConfidence * 100) / 100,
         totalTokensUsed,
+        ...(unmeasuredResults > 0 ? { unmeasuredResults } : {}),
         aggregatedAt: getTimeProvider().nowIso(),
       },
     };

--- a/packages/nexus-agents/src/agents/collaboration/session-helpers.ts
+++ b/packages/nexus-agents/src/agents/collaboration/session-helpers.ts
@@ -288,7 +288,14 @@ export function buildAggregatedResult(input: AggregatedResultInput): AggregatedR
       resultCount: results.length,
       conflictCount: 0,
       averageConfidence: 1.0,
-      totalTokensUsed: results.reduce((sum, r) => sum + r.metadata.tokensUsed, 0),
+      // #4743: measured contributors only; the count of the rest sits beside it
+      // so the total is readable as a lower bound rather than a complete figure.
+      totalTokensUsed: results
+        .filter((r) => r.metadata.tokensMeasured !== false)
+        .reduce((sum, r) => sum + r.metadata.tokensUsed, 0),
+      ...(results.some((r) => r.metadata.tokensMeasured === false)
+        ? { unmeasuredResults: results.filter((r) => r.metadata.tokensMeasured === false).length }
+        : {}),
       aggregatedAt: endTime.toISOString(),
     },
   };


### PR DESCRIPTION
Part of #4743.

## The defect

`AggregationMetadata.totalTokensUsed` summed `metadata.tokensUsed` across every contributor:

```ts
results.reduce((s, r) => s + r.result.metadata.tokensUsed, 0)
```

Since #4744, a contributor whose adapter reported no usage carries a placeholder `0` with `tokensMeasured: false`. Those zeros were added in silently, so the total read as a complete figure when it was a lower bound — the same "absence renders as a measurement" shape, one layer up from where #4744 fixed it.

## The fix

Both aggregation sites — `result-aggregator.ts` and `session-helpers.ts` — sum measured contributors only, and report `unmeasuredResults` beside the total. Additive and optional: absent means the aggregate predates the distinction, which is unknown rather than zero.

## Non-breaking, confirmed rather than asserted

This is the first change here checked against the real API surface. The #4749 gate reported exactly one public change:

```
ADDED: InterfaceDeclaration AggregationMetadata >  unmeasuredResults?: number | undefined
```

An additive optional field, so `minor` is correct. Previously I would have grepped `src/exports/` for `AggregationMetadata`, found nothing, and called it internal — the mistake that produced #4736, #4740, #4744 and #4759.

## Verification

Mutation-verified: removing the `tokensMeasured !== false` filter fails the new test. Two tests cover both directions — a mixed batch reports `totalTokensUsed: 50` with `unmeasuredResults: 1`, and a fully-measured batch omits the field entirely rather than reporting a confident `0`.

Typecheck 0, lint clean, aggregator suite 30 passing.

## Not in scope

The propagating consumers (`trinity-coordinator`, `execute-expert`, `sica-agent`, `puppeteer-helpers`, `aegean-protocol`) still read `tokensUsed` alone. They need per-site decisions about carrying the flag onward, and #4743 tracks them.