### PR TITLE
docs(agents): stop the wave budget implying precision it does not have

### DIFF
--- a/.changeset/name-the-wave-estimate.md
+++ b/.changeset/name-the-wave-estimate.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': patch
+---
+
+docs(agents): say that WaveScheduler's token budget enforces an estimate
+
+`WaveScheduler.maxTotalTokens` aborts the wave loop when a running total exceeds
+the configured budget. That total is `Math.ceil(outputChars / 4)` summed per
+task, which:
+
+- **omits input entirely** — prompt and context usually dominate an agent task's
+  spend, so a large prompt with a terse answer looks nearly free; and
+- **records a failed task as `0`**, however long it ran before throwing.
+
+Both errors run in the same direction: the budget believes it has more headroom
+than it does. Nothing in this repo is affected — `maxTotalTokens` defaults to `0`
+and no in-tree caller sets it — but `WaveScheduler` is public API, so a consumer
+who enables the documented budget gets a cap with no signal that the figure is
+approximate.
+
+No behaviour change. The estimate stays, because `WaveTaskExecutor` returns a
+bare string and real usage never reaches the scheduler. What changes is that it
+no longer implies precision: the field and config docs state what is excluded,
+and the caller-visible abort reason now reads "Estimated token budget exhausted
+… (estimate excludes input and failed tasks)".
+
+Replacing the estimate needs a wider executor contract — a public-type change
+tracked in #4761, alongside #4754 and #4743 as the same "measurement does not
+reach its consumer" thread.

--- a/packages/nexus-agents/src/agents/wave-scheduler-types.ts
+++ b/packages/nexus-agents/src/agents/wave-scheduler-types.ts
@@ -21,7 +21,15 @@ export interface WaveSchedulerConfig {
   readonly maxConcurrency: number;
   /** Maximum output length (chars) per task result. Default: 2000. */
   readonly maxOutputChars: number;
-  /** Maximum total token budget across all waves. 0 = unlimited. Default: 0. */
+  /**
+   * Maximum total token budget across all waves. 0 = unlimited. Default: 0.
+   *
+   * Enforced against the SUM OF ESTIMATES described on
+   * `WaveTaskResult.estimatedTokens`, which excludes input tokens and counts a
+   * failed task as zero. Both errors run in the same direction: the budget
+   * believes it has more headroom than it does, so enabling this does not give
+   * you a reliable spend cap (#4761).
+   */
   readonly maxTotalTokens: number;
   /** Whether to abort remaining waves on first task failure. Default: false. */
   readonly abortOnFailure: boolean;
@@ -79,7 +87,19 @@ export interface WaveTaskResult {
   readonly truncated: boolean;
   /** Original output length before truncation. */
   readonly originalLength: number;
-  /** Estimated tokens consumed by this task. */
+  /**
+   * Rough token estimate for this task, derived as `outputChars / 4` (#4761).
+   *
+   * NOT a measurement, and specifically NOT comparable to
+   * `ResultMetadata.tokensUsed`:
+   * - **Input is not counted.** Prompt and context usually dominate an agent
+   *   task's spend, so a large prompt with a terse answer looks nearly free.
+   * - **A failed task reports 0**, however long it ran before throwing.
+   *
+   * Real usage is not available here: `WaveTaskExecutor` returns a bare string,
+   * so the scheduler has nothing better to sum. Treat this as a coarse
+   * output-size signal, not a spend figure.
+   */
   readonly estimatedTokens: number;
   /** Duration of this task in ms. */
   readonly durationMs: number;

--- a/packages/nexus-agents/src/agents/wave-scheduler.test.ts
+++ b/packages/nexus-agents/src/agents/wave-scheduler.test.ts
@@ -177,7 +177,25 @@ describe('WaveScheduler.execute', () => {
 
     // First wave executes, second wave aborted due to budget
     expect(result.aborted).toBe(true);
-    expect(result.abortReason).toContain('Token budget exhausted');
+    expect(result.abortReason).toContain('Estimated token budget exhausted');
+    // #4761: the caller-visible reason must say the figure is an estimate.
+    // The sum ignores input tokens and counts failed tasks as zero, so actual
+    // spend at the abort point is higher than the number quoted.
+    expect(result.abortReason).toContain('excludes input and failed tasks');
+  });
+
+  it('reports zero estimated tokens for a task that threw, and says so', async () => {
+    // Not a claim that the task was free — there is no usable number once the
+    // executor throws. The budget summing this under-counts, which is why the
+    // abort reason is worded as an estimate (#4761).
+    const scheduler = createWaveScheduler({ maxConcurrency: 1 });
+    const tasks = [createTask('boom')];
+    const executor: WaveTaskExecutor<string> = () => Promise.reject(new Error('adapter died'));
+
+    const result = await scheduler.execute(tasks, executor);
+
+    expect(result.allResults[0]?.success).toBe(false);
+    expect(result.allResults[0]?.estimatedTokens).toBe(0);
   });
 
   it('should estimate tokens from output length', async () => {

--- a/packages/nexus-agents/src/agents/wave-scheduler.ts
+++ b/packages/nexus-agents/src/agents/wave-scheduler.ts
@@ -183,7 +183,10 @@ export class WaveScheduler {
 
       if (this.isTokenBudgetExhausted(totalTokensUsed)) {
         aborted = true;
-        abortReason = `Token budget exhausted: ${String(totalTokensUsed)}/${String(this.config.maxTotalTokens)}`;
+        // #4761: "estimated" is load-bearing. The figure sums outputChars/4,
+        // ignores input, and counts failed tasks as zero, so actual spend at
+        // the abort point is higher than the number quoted here.
+        abortReason = `Estimated token budget exhausted: ${String(totalTokensUsed)}/${String(this.config.maxTotalTokens)} (estimate excludes input and failed tasks)`;
         break;
       }
 
@@ -225,9 +228,13 @@ export class WaveScheduler {
     if (this.config.maxTotalTokens <= 0 || totalTokensUsed < this.config.maxTotalTokens) {
       return false;
     }
-    this.logger.warn('Wave execution aborted: token budget exhausted', {
+    this.logger.warn('Wave execution aborted: estimated token budget exhausted', {
       totalTokensUsed,
       maxTotalTokens: this.config.maxTotalTokens,
+      // #4761: say what the figure is. It sums output-char estimates, ignores
+      // input, and counts failed tasks as zero — so the real spend at the point
+      // of abort is HIGHER than the number that triggered it.
+      basis: 'sum of outputChars/4 estimates; excludes input and failed tasks',
     });
     return true;
   }
@@ -286,7 +293,10 @@ export class WaveScheduler {
         ? truncateWithInfo(rawOutput, this.config.maxOutputChars)
         : rawOutput;
 
-      // Estimate tokens as ~4 chars per token (rough approximation)
+      // #4761: OUTPUT chars only — input is not counted, so this understates
+      // spend for a large prompt with a terse answer. Kept because
+      // `WaveTaskExecutor` returns a bare string and real usage never reaches
+      // the scheduler; named honestly on the type rather than dressed up.
       const estimatedTokens = Math.ceil(originalLength / 4);
       const durationMs = getTimeProvider().now() - taskStart;
 
@@ -319,6 +329,10 @@ export class WaveScheduler {
         output: '',
         truncated: false,
         originalLength: 0,
+        // #4761: a task that ran and then threw did not cost nothing — this 0
+        // is "unknown", and it under-counts any budget summing it. There is no
+        // better number available: the executor threw instead of returning
+        // output, and it reports no usage.
         estimatedTokens: 0,
         durationMs,
         error: message,


### PR DESCRIPTION
Addresses #4761 options 2+3. **No behaviour change** — the estimate stays; it stops pretending.

## What the budget actually enforces

`WaveScheduler.maxTotalTokens` aborts the wave loop on a running total of `Math.ceil(outputChars / 4)` per task. That figure:

- **omits input entirely.** Prompt and context usually dominate an agent task's spend, so a large prompt with a terse answer reads as nearly free.
- **records a failed task as `0`** (`wave-scheduler.ts` catch block), however long it ran before throwing.

Both errors point the same way: the budget believes it has more headroom than it does. For a cap, under-counting is the dangerous direction.

## Severity, stated precisely

Nothing here is being mis-capped. `maxTotalTokens` defaults to `0`, `isTokenBudgetExhausted` returns false when it is `<= 0`, and **no in-tree caller sets it** — verified by grep excluding tests.

But `WaveScheduler` and `WaveSchedulerConfig` are public API (`exports/agents.ts:298-302`) and the field is documented, so a downstream consumer who switches the budget on gets a cap with no indication the number is approximate. Footgun, not live bug.

## Why the estimate stays

`WaveTaskExecutor<T>` returns a bare string. Real usage — available since #4744 as `ResultMetadata.tokensUsed` / `tokensMeasured` — never reaches the scheduler. There is no better number to sum without widening a public contract, which is a #4759-class change and belongs with the broader thread (#4754, #4743): measurement exists at the adapter layer and does not travel to the components enforcing budgets.

Swapping in a *different* wrong number would have been worse than labelling the current one.

## What changed

- `WaveTaskResult.estimatedTokens` docs: says it is `outputChars / 4`, that input is excluded, that a failed task reports `0`, and that it is not comparable to `ResultMetadata.tokensUsed`.
- `maxTotalTokens` docs: says what it enforces against and which direction the error runs.
- The caller-visible `abortReason` now reads `Estimated token budget exhausted: X/Y (estimate excludes input and failed tasks)` — previously it said "Token budget exhausted", which reads as a measured overrun.
- The failure path's `0` is annotated as "unknown", not "free".

## Verification

Surface gate: **unchanged** — confirming this is docs-and-strings only, rather than me asserting it.

Two tests: the abort reason must contain both `Estimated token budget exhausted` and `excludes input and failed tasks`; and a task that throws reports `estimatedTokens: 0` — pinned deliberately, so the under-count is visible in the suite rather than incidental.

19 passing in the scheduler suite, typecheck 0, lint clean.