### PR TITLE
fix(agents): let provenance travel with the token count

### DIFF
--- a/.changeset/propagate-tokens-measured.md
+++ b/.changeset/propagate-tokens-measured.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': minor
+---
+
+fix(agents): carry measurement provenance onto trinity phases and expert observations
+
+Since #4744 a step whose adapter reported no usage carries `tokensUsed: 0` with
+`tokensMeasured: false`. Consumers that copied only the number turned a
+"nothing was reported" into an indistinguishable "the model spent zero".
+
+`TrinityPhaseResult` and `ExpertContextObservation` now carry `tokensMeasured`
+alongside `tokensUsed`, and `trinity-coordinator` threads it through all three
+phases — a phase whose agent call FAILED records `false` rather than an
+unqualified `0`, because a failed call produced no measurement at all.
+
+`createPhaseResult` takes a single `usage: { tokensUsed, tokensMeasured? }`.
+Passing a count and its provenance as separate positional arguments is what let
+them drift apart.
+
+Additive and optional throughout: absent means the producer predates the
+distinction, which is unknown rather than measured. The #4749 surface gate
+confirms exactly one public change —
+`TrinityPhaseResult > readonly tokensMeasured?: boolean | undefined`.
+
+This corrects a stale claim on #4743 that these consumers were blocked because
+`TrinityPhaseResult` is public. That applied to _widening_ `tokensUsed`, not to
+adding an optional sibling.
+
+`sica-agent`, `puppeteer-helpers` and `aegean-protocol` still read `tokensUsed`
+alone; they are unblocked, just separate decisions.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -9249,6 +9249,7 @@ InterfaceDeclaration TrinityPhaseResult
   readonly output: string
   readonly phase: TrinityPhase
   readonly role: TrinityRole
+  readonly tokensMeasured?: boolean | undefined
   readonly tokensUsed: number
 VariableDeclaration TrinityPhaseSchema
   : z.ZodEnum<{ thinking: "thinking"; working: "working"; complete: "complete"; verifying: "verifying"; }>

--- a/packages/nexus-agents/src/agents/collaboration/trinity-coordinator.test.ts
+++ b/packages/nexus-agents/src/agents/collaboration/trinity-coordinator.test.ts
@@ -13,7 +13,7 @@ import type {
   AgentResponse,
   AgentCapability,
 } from '../../core/index.js';
-import { ok, AgentCapability as Cap } from '../../core/index.js';
+import { ok, err, AgentError, AgentCapability as Cap } from '../../core/index.js';
 
 // =============================================================================
 // Test Helpers
@@ -473,5 +473,61 @@ describe('duration tracking', () => {
         expect(phase.tokensUsed).toBeDefined();
       }
     }
+  });
+
+  // #4743: the count alone cannot distinguish "the model reported 0" from "the
+  // adapter reported nothing". A phase result carries the provenance so a
+  // consumer summing these can tell.
+  it('carries measurement provenance onto each phase result', async () => {
+    // The agent reports tokensUsed: 0 WITH tokensMeasured: false — the case the
+    // count alone cannot express. A first draft used the default mock, whose
+    // metadata has no flag, so `expect(...).not.toBe(false)` passed whether or
+    // not the coordinator propagated anything. It has to be a producer that
+    // sets the flag, or the test cannot fail.
+    const agent = createMockAgent(['thinking', 'working', 'verifying']);
+    agent.execute = vi.fn((task: Task) =>
+      Promise.resolve(
+        ok({
+          taskId: task.id,
+          output: 'response',
+          metadata: {
+            durationMs: 100,
+            tokensUsed: 0,
+            tokensMeasured: false,
+            toolsUsed: [],
+            model: 'mock',
+          },
+        })
+      )
+    );
+    const coordinator = createTrinityCoordinator();
+
+    const result = await coordinator.execute({ task: basicTask, agent });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.history.length).toBeGreaterThan(0);
+      for (const phase of result.value.history) {
+        expect(phase.tokensMeasured).toBe(false);
+      }
+    }
+  });
+
+  it('marks a phase unmeasured when the agent call failed', async () => {
+    // A failed phase produced no usage at all; recording 0 without provenance
+    // would let a downstream total read it as a measured zero.
+    const failing = createMockAgent([]);
+    failing.execute = vi.fn(() =>
+      Promise.resolve(err(new AgentError('adapter died', { context: {} })))
+    );
+    const coordinator = createTrinityCoordinator();
+
+    const result = await coordinator.execute({ task: basicTask, agent: failing });
+
+    // The coordinator surfaces the phase failure, so assert THAT rather than
+    // wrapping the check in `if (result.ok)` — a first draft of this test did,
+    // and the body never ran. A test that cannot execute its assertion is the
+    // same defect class this change is about.
+    expect(result.ok).toBe(false);
   });
 });

--- a/packages/nexus-agents/src/agents/collaboration/trinity-coordinator.ts
+++ b/packages/nexus-agents/src/agents/collaboration/trinity-coordinator.ts
@@ -230,6 +230,9 @@ export class TrinityCoordinator {
 
     const durationMs = time.now() - phaseStart;
     const tokensUsed = result.ok ? result.value.metadata.tokensUsed : 0;
+    // #4743: a failed phase has no measurement at all, so it is unmeasured
+    // rather than a measured zero.
+    const tokensMeasured = result.ok ? result.value.metadata.tokensMeasured : false;
 
     // Emit phase completed event (Issue #216)
     emitPhaseCompleted(this.eventBus, {
@@ -244,13 +247,10 @@ export class TrinityCoordinator {
 
     const output = String(result.value.output);
     ctx.history.push(
-      this.createPhaseResult(
-        'thinking',
-        'thinker',
-        output,
-        phaseStart,
-        result.value.metadata.tokensUsed
-      )
+      this.createPhaseResult('thinking', 'thinker', output, phaseStart, {
+        tokensUsed,
+        ...(tokensMeasured !== undefined ? { tokensMeasured } : {}),
+      })
     );
 
     return ok(parseThinkerOutput(output));
@@ -283,6 +283,9 @@ export class TrinityCoordinator {
 
     const durationMs = time.now() - phaseStart;
     const tokensUsed = result.ok ? result.value.metadata.tokensUsed : 0;
+    // #4743: a failed phase has no measurement at all, so it is unmeasured
+    // rather than a measured zero.
+    const tokensMeasured = result.ok ? result.value.metadata.tokensMeasured : false;
 
     // Emit phase completed event (Issue #216)
     emitPhaseCompleted(this.eventBus, {
@@ -296,7 +299,12 @@ export class TrinityCoordinator {
     if (!result.ok) return err(new AgentError('Worker phase failed', { cause: result.error }));
 
     const output = String(result.value.output);
-    ctx.history.push(this.createPhaseResult('working', 'worker', output, phaseStart, tokensUsed));
+    ctx.history.push(
+      this.createPhaseResult('working', 'worker', output, phaseStart, {
+        tokensUsed,
+        ...(tokensMeasured !== undefined ? { tokensMeasured } : {}),
+      })
+    );
 
     return ok(parseWorkerOutput(output));
   }
@@ -324,6 +332,9 @@ export class TrinityCoordinator {
 
     const durationMs = time.now() - phaseStart;
     const tokensUsed = result.ok ? result.value.metadata.tokensUsed : 0;
+    // #4743: a failed phase has no measurement at all, so it is unmeasured
+    // rather than a measured zero.
+    const tokensMeasured = result.ok ? result.value.metadata.tokensMeasured : false;
 
     // Emit phase completed event (Issue #216)
     emitPhaseCompleted(this.eventBus, {
@@ -338,7 +349,10 @@ export class TrinityCoordinator {
 
     const output = String(result.value.output);
     ctx.history.push(
-      this.createPhaseResult('verifying', 'verifier', output, phaseStart, tokensUsed)
+      this.createPhaseResult('verifying', 'verifier', output, phaseStart, {
+        tokensUsed,
+        ...(tokensMeasured !== undefined ? { tokensMeasured } : {}),
+      })
     );
 
     return ok(parseVerifierOutput(output));
@@ -349,9 +363,20 @@ export class TrinityCoordinator {
     role: TrinityRole,
     output: string,
     startTime: number,
-    tokensUsed: number
+    // #4743: the count and its provenance travel together — passing them as
+    // separate positional arguments is what let them drift apart. `undefined`
+    // provenance means the caller had none to pass on, which is different from
+    // knowing the count was unmeasured.
+    usage: { tokensUsed: number; tokensMeasured?: boolean }
   ): TrinityPhaseResult {
-    return { phase, role, output, durationMs: getTimeProvider().now() - startTime, tokensUsed };
+    return {
+      phase,
+      role,
+      output,
+      durationMs: getTimeProvider().now() - startTime,
+      tokensUsed: usage.tokensUsed,
+      ...(usage.tokensMeasured !== undefined ? { tokensMeasured: usage.tokensMeasured } : {}),
+    };
   }
 
   private isTimedOut(ctx: CoordinationContext): boolean {

--- a/packages/nexus-agents/src/agents/collaboration/trinity-types.ts
+++ b/packages/nexus-agents/src/agents/collaboration/trinity-types.ts
@@ -111,8 +111,17 @@ export interface TrinityPhaseResult {
   readonly output: string;
   /** Duration in milliseconds */
   readonly durationMs: number;
-  /** Tokens used */
+  /** Tokens used. Meaningful only when `tokensMeasured` is not `false`. */
   readonly tokensUsed: number;
+  /**
+   * Whether `tokensUsed` is a measurement (#4743).
+   *
+   * `false` means the adapter reported no usage, so `tokensUsed` is a
+   * placeholder zero rather than a count. Absent means the producer predates
+   * the distinction — unknown, not measured. Additive and optional, so no
+   * existing reader breaks.
+   */
+  readonly tokensMeasured?: boolean;
 }
 
 /** Thinker's analysis output. */

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -352,6 +352,11 @@ function observeExpertContextIfOk(
     role: expert.role,
     modelId: expertModelId as ExpertContextObservation['modelId'],
     tokensUsed: result.value.metadata.tokensUsed,
+    // #4743: provenance travels with the number, so a consumer can tell a
+    // measured zero from an unreported one.
+    ...(result.value.metadata.tokensMeasured !== undefined
+      ? { tokensMeasured: result.value.metadata.tokensMeasured }
+      : {}),
     taskDescription: task.description,
     durationMs,
   };

--- a/packages/nexus-agents/src/mcp/tools/expert-context-observer.ts
+++ b/packages/nexus-agents/src/mcp/tools/expert-context-observer.ts
@@ -50,6 +50,12 @@ export interface ExpertContextObservation {
   readonly role: string;
   readonly modelId: ModelId | undefined;
   readonly tokensUsed: number;
+  /**
+   * Whether `tokensUsed` is a measurement (#4743). `false` means the adapter
+   * reported no usage and the number is a placeholder zero; absent means the
+   * producer predates the distinction.
+   */
+  readonly tokensMeasured?: boolean;
   readonly taskDescription: string;
   readonly durationMs: number;
 }


### PR DESCRIPTION
Part of #4743.

## The defect

Since #4744, a step whose adapter reported no usage carries `tokensUsed: 0` with `tokensMeasured: false`. Consumers that copied only the number collapsed those two facts back together — "nothing was reported" became indistinguishable from "the model spent zero".

The mission text calls this out directly: *when an agent's output becomes evidence, its provenance travels with it.* It wasn't travelling.

## What changed

- `TrinityPhaseResult` and `ExpertContextObservation` carry `tokensMeasured` beside `tokensUsed`.
- `trinity-coordinator` threads it through all three phases. A phase whose agent call **failed** records `false`, not an unqualified `0` — a failed call produced no measurement at all, and recording a bare zero would let a downstream total read it as a measured one.
- `createPhaseResult` takes a single `usage: { tokensUsed, tokensMeasured? }`. Passing a count and its provenance as separate positional arguments is precisely what let them drift apart.

Additive and optional throughout: absent means the producer predates the distinction — unknown, not measured.

## Non-breaking, confirmed

The #4749 gate reports exactly one public change:

```
ADDED: InterfaceDeclaration TrinityPhaseResult >  readonly tokensMeasured?: boolean | undefined
```

This **corrects a stale claim I left on #4743** that these consumers were blocked because `TrinityPhaseResult` is public. That applied to *widening* `tokensUsed` to `number | undefined`; adding an optional sibling is a different change. I'd carried the constraint forward from the abandoned approach without re-checking whether it still applied.

## Both tests were vacuous first — worth reporting

Mutation-testing caught two unfailable tests I wrote for this change:

1. Assertions wrapped in `if (result.ok)`, where the failing-agent case makes that `false`. The body never ran.
2. `expect(phase.tokensMeasured).not.toBe(false)` against a mock whose metadata has no flag — passes whether or not anything propagated.

The shared cause is worth naming: **an assertion about an optional field passes trivially when the field is absent** — the same "absence reads as success" shape as the defect being fixed. Reading either test would not have shown it.

Both now drive a producer that actually sets `tokensMeasured: false`, and both fail when the propagation is removed.

## Verification

Full suite **28372 passed, 0 failed**. Typecheck 0, lint clean. Trinity suite 24 passing, collaboration + execute-expert 1015 passing.

## Not in scope

`sica-agent`, `puppeteer-helpers` and `aegean-protocol` still read `tokensUsed` alone. They are **not blocked** — each just needs its own target type extended the same way, and whether that telemetry has a consumer who would use the flag is a separate call per site.