### PR TITLE
fix(agents): average SICA cost over measured executions only

### DIFF
--- a/.changeset/sica-measured-tokens.md
+++ b/.changeset/sica-measured-tokens.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+fix(agents): SICA's cost metric no longer averages in unmeasured executions
+
+`SicaVersionManager.updateMetrics` averaged `tokensUsed` across all execution
+history. Since #4744 an execution whose adapter reported nothing carries a
+placeholder `0`, and a FAILED execution recorded `0` unconditionally — so both
+were averaged in as if the version had genuinely run for free.
+
+This is decision-affecting, not just telemetry. `sica-agent-helpers` gates the
+cost-focused improvement path on `metrics.avgTokensUsed > 2000`, so
+understating the average can suppress the improvement SICA would otherwise
+pursue. Two executions at 3000 and "unmeasured" averaged to 1500 and fell below
+the threshold; they now average to 3000 with `unmeasuredExecutions: 1` recorded
+beside it.
+
+Failed executions record `tokensMeasured: false` rather than a bare `0` — a
+failure produced no measurement, which is not the same as measuring zero.
+
+`avgQualityScore` in the same function already filtered absent values and
+returned `undefined`; the token average was the outlier. Internal types only,
+confirmed by the #4749 surface gate.

--- a/packages/nexus-agents/src/agents/self-improving/sica-agent.ts
+++ b/packages/nexus-agents/src/agents/self-improving/sica-agent.ts
@@ -213,6 +213,9 @@ export class SicaAgent {
       return {
         durationMs,
         tokensUsed: 0,
+        // #4743: a failed execution produced no measurement; this 0 is unknown,
+        // not a measured zero, and averaging it in understates cost.
+        tokensMeasured: false,
         success: false,
         errorType: result.error.message,
       };
@@ -221,6 +224,9 @@ export class SicaAgent {
     return {
       durationMs,
       tokensUsed: result.value.metadata.tokensUsed,
+      ...(result.value.metadata.tokensMeasured !== undefined && {
+        tokensMeasured: result.value.metadata.tokensMeasured,
+      }),
       success: true,
       qualityScore: estimateQuality(result.value),
     };

--- a/packages/nexus-agents/src/agents/self-improving/sica-types.ts
+++ b/packages/nexus-agents/src/agents/self-improving/sica-types.ts
@@ -61,8 +61,14 @@ export interface AgentVersion {
 export interface ExecutionMetrics {
   /** Time taken in milliseconds */
   readonly durationMs: number;
-  /** Tokens consumed */
+  /** Tokens consumed. Meaningful only when `tokensMeasured` is not `false`. */
   readonly tokensUsed: number;
+  /**
+   * Whether `tokensUsed` is a measurement (#4743). `false` means the adapter
+   * reported nothing — or the execution failed before reporting — so the number
+   * is a placeholder. Absent means the producer predates the distinction.
+   */
+  readonly tokensMeasured?: boolean;
   /** Whether the task succeeded */
   readonly success: boolean;
   /** Quality score if available (0-1) */
@@ -85,8 +91,17 @@ export interface VersionMetrics {
   readonly successRate: number;
   /** Average execution time in ms */
   readonly avgDurationMs: number;
-  /** Average tokens used per execution */
+  /**
+   * Average tokens per execution, over MEASURED executions only (#4743).
+   *
+   * Unmeasured executions used to be averaged in as zeros, which pulled this
+   * below the `> 2000` cost threshold in `sica-agent-helpers` and suppressed
+   * the cost-focused improvement path. `0` here now means either a genuine zero
+   * or no measured executions — read `unmeasuredExecutions` to tell.
+   */
   readonly avgTokensUsed: number;
+  /** How many executions in the window reported no measured usage (#4743). */
+  readonly unmeasuredExecutions?: number;
   /** Average quality score if available (0-1) */
   readonly avgQualityScore?: number;
   /** When metrics were last updated */

--- a/packages/nexus-agents/src/agents/self-improving/sica-version-manager.test.ts
+++ b/packages/nexus-agents/src/agents/self-improving/sica-version-manager.test.ts
@@ -112,6 +112,40 @@ describe('SicaVersionManager', () => {
       expect(metrics?.avgDurationMs).toBe(1000);
     });
 
+    // #4743: unmeasured executions were averaged in as zeros, which understates
+    // cost. `sica-agent-helpers` gates the cost-focused improvement path on
+    // `avgTokensUsed > 2000`, so the understatement could suppress it.
+    it('averages tokens over measured executions only', () => {
+      const version = manager.createInitialVersion(sampleConfig);
+
+      manager.recordExecution(version.id, { durationMs: 100, tokensUsed: 3000, success: true });
+      manager.recordExecution(version.id, {
+        durationMs: 100,
+        tokensUsed: 0,
+        tokensMeasured: false,
+        success: false,
+      });
+
+      const metrics = manager.getMetrics(version.id);
+
+      // Averaging both would give 1500 and drop below the 2000 cost threshold.
+      expect(metrics?.avgTokensUsed).toBe(3000);
+      expect(metrics?.unmeasuredExecutions).toBe(1);
+      // The execution still counts for every other metric.
+      expect(metrics?.executionCount).toBe(2);
+    });
+
+    it('omits the unmeasured count when every execution reported usage', () => {
+      const version = manager.createInitialVersion(sampleConfig);
+
+      manager.recordExecution(version.id, { durationMs: 100, tokensUsed: 500, success: true });
+
+      const metrics = manager.getMetrics(version.id);
+
+      expect(metrics?.avgTokensUsed).toBe(500);
+      expect(metrics?.unmeasuredExecutions).toBeUndefined();
+    });
+
     it('should calculate correct success rate over multiple executions', () => {
       const version = manager.createInitialVersion(sampleConfig);
 

--- a/packages/nexus-agents/src/agents/self-improving/sica-version-manager.ts
+++ b/packages/nexus-agents/src/agents/self-improving/sica-version-manager.ts
@@ -256,7 +256,15 @@ export class SicaVersionManager {
     const successes = history.filter((e) => e.success).length;
 
     const avgDuration = history.reduce((s, e) => s + e.durationMs, 0) / count;
-    const avgTokens = history.reduce((s, e) => s + e.tokensUsed, 0) / count;
+    // #4743: average over measured executions only. Averaging placeholder
+    // zeros in understated cost and could suppress the cost-focused
+    // improvement path. Mirrors how avgQuality below already handles absence.
+    const measuredTokens = history.filter((e) => e.tokensMeasured !== false);
+    const avgTokens =
+      measuredTokens.length > 0
+        ? measuredTokens.reduce((s, e) => s + e.tokensUsed, 0) / measuredTokens.length
+        : 0;
+    const unmeasuredExecutions = count - measuredTokens.length;
 
     const qualityScores = history.filter((e) => e.qualityScore !== undefined);
     const avgQuality =
@@ -271,6 +279,7 @@ export class SicaVersionManager {
       successRate: count > 0 ? successes / count : 0,
       avgDurationMs: avgDuration,
       avgTokensUsed: avgTokens,
+      ...(unmeasuredExecutions > 0 && { unmeasuredExecutions }),
       ...(avgQuality !== undefined && { avgQualityScore: avgQuality }),
       lastUpdatedAt: new Date(getTimeProvider().now()),
     };


### PR DESCRIPTION
Part of #4743, and the first consumer in that set where the flag changes a **decision** rather than a report.

## The defect

`SicaVersionManager.updateMetrics` averaged `tokensUsed` over all execution history:

```ts
const avgTokens = history.reduce((s, e) => s + e.tokensUsed, 0) / count;
```

Two kinds of zero were averaged in as if the version had run for free:

- an execution whose adapter reported no usage (placeholder `0` since #4744), and
- a **failed** execution, which recorded `tokensUsed: 0` unconditionally.

## Why it matters more than the other consumers

`sica-agent-helpers.ts:154` gates the cost-focused improvement path on the result:

```ts
if (focus === 'cost' && metrics.avgTokensUsed > 2000) {
  return 'Reduce token usage while maintaining quality';
}
```

Understating the average can suppress an improvement SICA would otherwise pursue. Concretely: one execution at 3000 tokens plus one unmeasured averaged to **1500** and fell under the threshold. It now averages to **3000**, with `unmeasuredExecutions: 1` recorded beside it.

This is why I checked for a consumer before propagating rather than doing all five sites mechanically — SICA had one, and it feeds the self-improvement loop.

## The sibling was already right

`avgQualityScore`, computed six lines below in the same function, already filters absent values and returns `undefined` when none qualify. The token average was the outlier, so this matches an existing local convention rather than inventing one.

## Verification

Mutation-verified: removing the `tokensMeasured !== false` filter fails the new test with 1500 vs 3000.

Two tests, both directions — a mixed history reports the measured average with the unmeasured count, and a fully-measured history omits the count rather than reporting a confident `0`.

Surface gate: **unchanged** — SICA's types are internal, confirmed rather than grepped for.

Full suite **28374 passed, 0 failed**. Typecheck 0, lint clean.

## Still open

`puppeteer-helpers` and `aegean-protocol` read `tokensUsed` alone. I will apply the same test before touching them: if nothing reads the number in a way the flag would change, propagating adds a field with no reader, which the export ratchet exists to discourage. Consistency alone is not sufficient reason.