### PR TITLE
docs(consensus): pin that quorum eligibility screens nobody in production

### DIFF
--- a/.changeset/quorum-wiring-note.md
+++ b/.changeset/quorum-wiring-note.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': patch
+---
+
+docs(consensus): say that quorum eligibility screening never runs in production
+
+`QuorumValidator.isAgentEligible` has three exclusion branches —
+`byzantine_flagged`, `low_trust`, `insufficient_weight` — and none can fire from
+a real run. All require an `AgentRecord`, and the only production path in
+(`voting-protocol-helpers` → `validateQuorum` → `getQuorumBreakdown`) passes
+`{ votes, config }` with no `agentRecords`. With no record the method returns
+`{ eligible: true, weight: 1.0 }` immediately, so `eligibleAgents` is always
+every voter. `enableByzantineDetection` additionally has zero writers anywhere
+in `src/`.
+
+Deliberately NOT deleted. The behaviour is correct and covered by four tests, so
+this is unwired capability rather than dead code, and removing a working trust
+model is a decision about the resilience posture — tracked in #4666, not
+something to slip into a cleanup.
+
+What changes is that the code no longer implies screening happens: the method
+documents that a full eligible list is not evidence anything was screened, and a
+new test pins that production shape — Byzantine detection enabled, no records
+supplied, nobody excluded. If a producer for `AgentRecord` is ever wired, that
+test fails and should be replaced by one asserting the real screening.
+
+Severity is low and unchanged: this is `VotingProtocol`, not the live
+`consensus_vote` engine, so trust screening is not silently disabled on the path
+that decides real things.

--- a/packages/nexus-agents/src/consensus/quorum-validator.test.ts
+++ b/packages/nexus-agents/src/consensus/quorum-validator.test.ts
@@ -435,6 +435,26 @@ describe('QuorumValidator.getQuorumBreakdown', () => {
     expect(breakdown.eligibleAgents).not.toContain('a2');
   });
 
+  // #4666: the tests above prove exclusion WORKS when an AgentRecord is
+  // supplied. This one pins the production reality — no caller supplies one,
+  // so nothing is ever excluded. If a producer is wired, this test should fail
+  // and be replaced by one asserting the real screening.
+  it('excludes nobody when no agent records are supplied — the production shape', () => {
+    const breakdown = validator.getQuorumBreakdown({
+      votes: makeVotes([
+        ['a1', 'approve'],
+        ['a2', 'approve'],
+      ]),
+      config: makeConfig({ enableByzantineDetection: true }),
+    });
+
+    // Byzantine detection is ON and still excludes nothing: with no record the
+    // eligibility check returns early. A full eligible list is NOT evidence
+    // that screening ran.
+    expect(breakdown.eligibleAgents).toContain('a1');
+    expect(breakdown.eligibleAgents).toContain('a2');
+  });
+
   it('includes reasoning string', () => {
     const breakdown = validator.getQuorumBreakdown({
       votes: makeVotes([

--- a/packages/nexus-agents/src/consensus/quorum-validator.ts
+++ b/packages/nexus-agents/src/consensus/quorum-validator.ts
@@ -225,6 +225,29 @@ export class QuorumValidator implements IQuorumValidator {
     };
   }
 
+  /**
+   * Decides whether an agent's vote counts, and with what weight.
+   *
+   * WIRING (#4666): this works and is tested, but **nothing in production can
+   * reach an exclusion**. The three exclusion branches all require an
+   * `AgentRecord`, and `getQuorumBreakdown`'s only production caller
+   * (`voting-protocol-helpers`) passes `{ votes, config }` with no
+   * `agentRecords` — `grep -rn agentRecords src --include=*.ts`, excluding
+   * tests and this file, returns nothing. With no record the method returns
+   * `{ eligible: true, weight: 1.0 }` on the first line.
+   *
+   * `enableByzantineDetection` additionally has zero writers anywhere in
+   * `src/`: only this read and its declaration.
+   *
+   * So `eligibleAgents` is every voter, always. Do NOT read a full eligible
+   * list as evidence that trust or Byzantine screening ran — nothing screened.
+   * Wiring it needs a producer for `AgentRecord` (trust scores, Byzantine
+   * flags), which the engine does not currently maintain.
+   *
+   * Kept rather than deleted: the behaviour is correct and covered by tests, so
+   * this is unwired capability, not dead code. Removing a working trust model
+   * is a decision about the resilience posture, not a cleanup — see #4666.
+   */
   isAgentEligible(
     agentId: string,
     record: AgentRecord | undefined,


### PR DESCRIPTION
Addresses #4666 — with a different answer than the issue proposed, and than I proposed in my own comment on it.

## The finding stands

`QuorumValidator.isAgentEligible` has three exclusion branches — `byzantine_flagged`, `low_trust`, `insufficient_weight` — and none can fire from a real run. All require an `AgentRecord`; the only production path in (`voting-protocol-helpers` → `validateQuorum` → `getQuorumBreakdown`) passes `{ votes, config }` with no `agentRecords`. With no record the method returns `{ eligible: true, weight: 1.0 }` on its first line, so `eligibleAgents` is always every voter.

`enableByzantineDetection` additionally has **zero writers** anywhere in `src/` — only its declaration and the one read.

## Why I did not delete it

The issue leaned toward removal, and my own follow-up comment proposed "narrow it in place — delete the unreachable internals". I started that, and stopped when the tests told me something.

**Four tests exercise the exclusion, and they pass.** Supply an `AgentRecord` with a Byzantine flag and the agent really is excluded. So this is *unwired capability*, not dead code — the distinction that matters, and the one I have got wrong twice today already (#4666 itself, #4673).

Removing a working trust model is a decision about the resilience posture, not a cleanup. It also isn't the narrow change I framed it as: deleting only `enableByzantineDetection` would be arbitrary, since the `low_trust` and `insufficient_weight` branches are equally unreachable for the same reason. Either all of it goes or none does, and that belongs in #4666 with an explicit decision.

The surface gate confirms `QuorumValidationConfig` is not publicly reachable, so removal *would* have been non-breaking — the constraint here is judgement, not compatibility. Worth separating those.

## What this does instead

Makes the code stop implying screening happens:

- `isAgentEligible` documents that a full eligible list is **not** evidence anything was screened, names the missing `AgentRecord` producer, and records that `enableByzantineDetection` has no writers.
- A new test pins the production shape: Byzantine detection **enabled**, no records supplied, **nobody excluded**. If a producer is ever wired, that test fails and should be replaced by one asserting the real screening — so it is a tripwire, not just documentation.

## Severity, unchanged

This is `VotingProtocol`, not the live `consensus_vote` engine — neither `consensus/engine.ts` nor `mcp/tools/consensus-vote.ts` references it. Trust screening is not silently disabled on the path that decides real things.

## Verification

48 tests passing, typecheck 0, lint clean, surface gate unchanged.