### PR TITLE
chore(release): declare the workflow-budget removal as breaking

### DIFF
--- a/.changeset/declare-major-workflow-budget-removal.md
+++ b/.changeset/declare-major-workflow-budget-removal.md
@@ -1,0 +1,44 @@
+---
+'nexus-agents': major
+---
+
+BREAKING: the workflow engine's budget-enforcement types are no longer exported
+
+#4755 removed the workflow engine's dormant budget enforcement. That removal took
+ten types off the package's public surface, and shipped declared as `minor`. This
+changeset corrects the version level; it adds no further code change.
+
+Removed from the public API:
+
+- `IBudgetCircuitBreaker`
+- `BudgetCircuitBreakerConfig`
+- `BudgetCircuitSnapshot`
+- `BudgetCircuitState`
+- `BudgetCircuitStateChangeEvent`
+- `BudgetCircuitStateChangeListener`
+- `BudgetEnforcementEvent`
+- `BudgetEnforcementResult`
+- `BudgetUsageSnapshot`
+- `StepBudgetAllocation`
+
+plus the `ExecutionContext.budgetCircuitBreaker` and `.budgetEvents` fields.
+
+None was exported by name from `exports/workflows.ts` — they were reachable only
+_through_ `ExecutionContext`, which is why a name-based grep reported the change
+as internal. The AST surface gate added in #4749 caught it on its first real run,
+before publication.
+
+**Migration.** If you imported any of these, they still exist internally and the
+`BudgetCircuitBreaker` class itself is unchanged and still used by
+`pipeline/budget-guard.ts` — the pipeline's budget enforcement is unaffected.
+What is gone is the workflow engine's copy, which could never fire: it required
+`enableBudgetEnforcement` plus a `contextManagerConfig`, and no caller set either.
+Workflow runs had no budget enforcement before this change and have none after
+(#4754).
+
+Chosen over re-exporting the ten types to preserve the surface. Re-exporting
+would keep the version at `minor`, but it would commit the project to a public
+API that exists only by accident of type reachability, and export symbols with
+no consumer — which the export ratchet (#3024) exists to discourage.
+
+Resolves #4759.


### PR DESCRIPTION
Resolves #4759, on the owner's approval to proceed.

## What this is

A version-level correction, **no code change**. #4755 removed ten types from the package's public surface and declared the change `minor`. This adds a `major` changeset so the next release is versioned honestly.

## Why major rather than re-export

The two options in #4759 were:

1. **Declare it major** — accurate, costs a major version for types that were reachable only incidentally.
2. **Re-export the ten types** from `exports/workflows.ts` — keeps `minor` correct, at the cost of committing to a public API that exists only by accident of type reachability, and exporting symbols with no consumer (which the export ratchet, #3024, exists to discourage).

Taking 1, which was my recommendation. Under-declaring is the recurring error here — #4736 shipped a `number | null` widening as a patch, and this is the same class caught earlier.

## The types

`IBudgetCircuitBreaker`, `BudgetCircuitBreakerConfig`, `BudgetCircuitSnapshot`, `BudgetCircuitState`, `BudgetCircuitStateChangeEvent`, `BudgetCircuitStateChangeListener`, `BudgetEnforcementEvent`, `BudgetEnforcementResult`, `BudgetUsageSnapshot`, `StepBudgetAllocation`, plus `ExecutionContext.budgetCircuitBreaker` and `.budgetEvents`.

None was exported by name — they were reachable *through* `ExecutionContext`, which is exactly why my name-based grep called the removal internal. The #4749 AST surface gate caught it on its first real run, pre-publication.

## What is NOT affected

`BudgetCircuitBreaker` itself is unchanged and still load-bearing in `pipeline/budget-guard.ts`. The pipeline's budget enforcement works exactly as before. What was removed is the workflow engine's copy, which could never fire — it needed `enableBudgetEnforcement` plus a `contextManagerConfig` and no caller supplied either. Workflow runs were unbudgeted before and remain so (#4754).

## Effect on the release

The open release PR (#4756) will regenerate from 3.16.0 to **4.0.0** once this lands. I will verify that before merging it.