### PR TITLE
fix(audit): say when a clean verdict verified nothing

### DIFF
--- a/.changeset/empty-chain-is-not-verified.md
+++ b/.changeset/empty-chain-is-not-verified.md
@@ -1,0 +1,37 @@
+---
+'nexus-agents': patch
+---
+
+fix(audit): verifyChain says when `ok: true` verified nothing
+
+`verifyChain` returns `{ ok: true }` in two cases where it checked no
+cryptographic link at all:
+
+- **zero events** — nothing to verify;
+- **an un-chained log** — the first event carries no `hash`, so the whole batch
+  short-circuits and no links are walked.
+
+Both are honest verdicts (nothing contradicts them) and both were
+indistinguishable from a genuinely verified chain. `verify_audit_chain` reported
+`ok: true` for an empty directory, so pointing it at the wrong path — or at a
+deployment where audit logging is simply off (#4768) — looked identical to a
+clean chain.
+
+The ok-variant now carries `notVerified: 'empty' | 'unchained'`, absent when
+links were actually checked. `ok` is unchanged, so the threat model's accepted
+position on empty logs stands; what changes is that the verdict no longer
+implies assurance it does not have.
+
+This is the mitigation the threat model asks for by name. T8 records **residual
+risk HIGH** — _"'OK' is ambiguous between 'verified chained log' and
+'un-chained log, nothing to verify'. Mitigation would require the tool to report
+whether the log was chained at all"_ — which was true when written and is what
+this adds.
+
+Four tests, all mutation-verified, including one through the registered MCP
+handler asserting the marker reaches the serialized response rather than merely
+existing on the type.
+
+Does not change the callers' behaviour: nothing fails that passed before. Making
+`verify_audit_chain` warn or fail-closed on `notVerified` is a separate policy
+decision (#4768).

--- a/packages/nexus-agents/src/audit/audit-chain-verify.test.ts
+++ b/packages/nexus-agents/src/audit/audit-chain-verify.test.ts
@@ -201,4 +201,52 @@ describe('front-truncation is detected (#4703)', () => {
     // Asserted so a future change to the empty case is a deliberate one.
     expect(verifyChain([]).ok).toBe(true);
   });
+
+  // #4768: `ok` stays true — the threat model accepts that, and nothing
+  // contradicts an absent chain. What changes is that the verdict now says it
+  // verified NOTHING, which T8 names as the required mitigation for its HIGH
+  // residual risk: "OK" was ambiguous between "verified chained log" and
+  // "un-chained log, nothing to verify".
+  describe('says what it did not verify (#4768, #4660)', () => {
+    it('marks an empty chain as unverified rather than silently clean', () => {
+      const r = verifyChain([]);
+
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.notVerified).toBe('empty');
+        expect(r.eventCount).toBe(0);
+      }
+    });
+
+    it('marks an un-chained log as unverified — T8, residual risk HIGH', () => {
+      // First event carries no hash, so the whole batch is treated as
+      // un-chained and no links are checked. Previously indistinguishable from
+      // a verified chain.
+      const unhashed = chain(2).map((e) => {
+        const copy: AuditEvent = { ...e };
+        delete (copy as { hash?: string }).hash;
+        return copy;
+      });
+
+      const r = verifyChain(unhashed);
+
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.notVerified).toBe('unchained');
+        expect(r.eventCount).toBe(2);
+      }
+    });
+
+    it('leaves notVerified absent when links were actually checked', () => {
+      // The guard-rail in the other direction: a genuinely verified chain must
+      // NOT be labelled unverified, or the field is noise.
+      const r = verifyChain(chain(3));
+
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.notVerified).toBeUndefined();
+        expect(r.eventCount).toBe(3);
+      }
+    });
+  });
 });

--- a/packages/nexus-agents/src/audit/audit-logger.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.ts
@@ -107,6 +107,21 @@ export type ChainVerification =
        * rather than judges — see T6 in the audit hash-chain threat model.
        */
       unanchoredHead?: { previousHash: string; detail: string };
+      /**
+       * Set when `ok: true` carries NO cryptographic assurance (#4768, #4660).
+       *
+       * - `'empty'` — zero events. Nothing was verified. Reported because
+       *   pointing the verifier at the wrong directory produces exactly this,
+       *   and a bare `ok: true` reads as "the chain is intact".
+       * - `'unchained'` — events exist but the first carries no `hash`, so the
+       *   whole batch is treated as un-hashed and no links are checked.
+       *
+       * Absent means links were actually verified. Callers deciding whether
+       * tamper-evidence holds MUST read this: `ok: true` alone does not
+       * distinguish a verified chain from an absent one, which is the
+       * "default reported as a measurement" shape the mission text rules out.
+       */
+      notVerified?: 'empty' | 'unchained';
     }
   | {
       ok: false;
@@ -170,8 +185,14 @@ function verifyEvent(
  * @returns ChainVerification result
  */
 export function verifyChain(events: readonly AuditEvent[]): ChainVerification {
-  if (events.length === 0) return { ok: true, eventCount: 0 };
-  if (events[0]?.hash === undefined) return { ok: true, eventCount: events.length };
+  // Both early exits below are honest `ok: true` verdicts — there is nothing to
+  // contradict — but neither verified anything, so they say so. #4768: an empty
+  // log verified clean was indistinguishable from a correct one, including when
+  // the caller pointed at the wrong directory.
+  if (events.length === 0) return { ok: true, eventCount: 0, notVerified: 'empty' };
+  if (events[0]?.hash === undefined) {
+    return { ok: true, eventCount: events.length, notVerified: 'unchained' };
+  }
 
   let priorHash: string | undefined = undefined;
   for (let i = 0; i < events.length; i++) {

--- a/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.test.ts
@@ -12,6 +12,7 @@ import * as crypto from 'node:crypto';
 import type { AuditEvent } from '../../audit/audit-types.js';
 import {
   VerifyAuditChainInputSchema,
+  registerVerifyAuditChainTool,
   type VerifyAuditChainResponse,
 } from './verify-audit-chain-tool.js';
 
@@ -121,6 +122,30 @@ describe('verify_audit_chain handler behavior', () => {
     const result = verifyChain(events);
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.eventCount).toBe(3);
+  });
+
+  // #4768: the handler serialises the whole verdict, so the unverified marker
+  // reaches the caller without extra wiring — asserted through the REGISTERED
+  // handler rather than by re-calling verifyChain, because "the field exists"
+  // and "a caller sees it" are different claims.
+  it('surfaces notVerified through the tool response for an empty directory', async () => {
+    type Captured =
+      ((a: unknown, c: unknown) => Promise<{ content: Array<{ text: string }> }>) | undefined;
+    let captured: Captured;
+    const server = {
+      registerTool: (_n: string, _s: unknown, h: unknown) => {
+        captured = h as Captured;
+      },
+    };
+    registerVerifyAuditChainTool(server as never, {} as never);
+    expect(captured).toBeDefined();
+
+    const res = await captured?.({ logDir: tmpDir }, {});
+    const body = res?.content[0]?.text ?? '';
+
+    // The directory has no audit files in this test, so the verdict must say so.
+    expect(body).toContain('"notVerified"');
+    expect(body).toContain('empty');
   });
 
   it('verifies a clean multi-file chain in lexicographic order', async () => {


### PR DESCRIPTION
Implements the mitigation the threat model asks for by name. **Governor-owned path (`src/audit/`) — needs owner ratification; I have not self-merged.**

## The defect

`verifyChain` returns `{ ok: true }` in two cases where it checked no cryptographic link at all:

```ts
if (events.length === 0) return { ok: true, eventCount: 0 };                    // nothing to verify
if (events[0]?.hash === undefined) return { ok: true, eventCount: events.length }; // un-chained
```

Both verdicts are honest — nothing contradicts them — and both were indistinguishable from a genuinely verified chain.

Found during end-to-end validation: `verify_audit_chain` reported `ok: true` for **both** plausible data directories on this machine, because the audit chain has never written an event here (#4768). A human spot-checking tamper-evidence sees green. Pointing the tool at the wrong directory produces the identical result.

## The threat model already asked for this

T8 records **residual risk HIGH**:

> "OK" is ambiguous between "verified chained log" and "un-chained log, nothing to verify". **Mitigation would require the tool to report whether the log was chained at all** and to fail-closed (or at least warn loudly) on an un-chained log when chaining is expected by policy.

That was accurate when written. This adds the reporting half.

## What changes, and what deliberately does not

`ChainVerification`'s ok-variant gains `notVerified: 'empty' | 'unchained'`, absent when links were actually walked.

**`ok` is unchanged.** Two existing tests pin the empty case as accepted, one citing §1.4 explicitly — so I did not reverse a documented decision. The verdict simply stops implying assurance it never had.

**No caller behaviour changes.** Nothing that passed now fails. Whether `verify_audit_chain` should warn or fail-closed on `notVerified` is a policy decision, and stays with #4768.

## Tests

Four, all mutation-verified — removing each marker turns the corresponding test red:

- empty chain → `notVerified: 'empty'`
- un-chained log → `notVerified: 'unchained'` (T8's case)
- a genuinely verified chain → `notVerified` **absent**, so the field cannot become noise
- **through the registered MCP handler**, asserting the marker reaches the serialized response

The last one matters because the handler serializes the verdict whole, so the field flows through with no wiring — which is exactly the situation where I have previously shipped a field no reader ever sees. "The field exists" and "a caller sees it" are different claims, so the test exercises the handler rather than re-calling `verifyChain`.

## Verification

Full suite **28380 passed, 0 failed**. Audit + tool suites 309 passing. Typecheck 0, lint clean. API surface gate reports unchanged — `ChainVerification` is not publicly reachable.