### PR TITLE
fix(pipeline): stop returning the prompt when the planner fails

### DIFF
--- a/.changeset/planner-failure-signal.md
+++ b/.changeset/planner-failure-signal.md
@@ -1,0 +1,33 @@
+---
+'nexus-agents': minor
+---
+
+fix(pipeline): a failed planner no longer looks like a successful one
+
+`agent-executor.ts` returned `r.text || prompt` from the plan stage, so when the
+model produced nothing the stage handed back **the prompt as the plan**. The
+vote then ran against the input text, and — outside a dry run — decompose would
+have too. `runExpert` already returns `{ success: false, text: '' }`, so the
+failure was known one line earlier and discarded in favour of a fallback that
+looked like output.
+
+Found by running the same dry run twice: one planned well, one's planner
+returned empty five times, and both produced identical result envelopes
+(`completed: false, securityPassed: false, voteIterations: 1, tasks: []`).
+
+- The plan stage returns the empty string on failure instead of the prompt.
+- `planVoteLoop` stops before voting on an empty plan — a panel convened on no
+  proposal wastes seven voters and yields a verdict about nothing.
+- `DevPipelineResult.planStatus?: 'empty'` says why there is no plan.
+- `DevPipelineResult.securityRan?: boolean` separates "the gate rejected this"
+  from "the gate never ran". A dry run stops after plan+vote by design, so its
+  `securityPassed: false` was reporting absence as a verdict.
+
+Both new fields are additive and optional. Resolves #4772.
+
+Also fixes a defect in the #4749 API-surface gate found while doing this:
+TypeScript's type printer does not guarantee member order, so adding these two
+fields reordered a zod enum in an untouched module and produced a spurious diff.
+A gate that cries wolf on unrelated code teaches people to regenerate the
+snapshot without reading it. Printed types are now canonically sorted;
+determinism and real-change detection both re-verified.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -29,7 +29,7 @@ ClassDeclaration ActionCacheImpl
   clear() => number
   evictExpired() => number
   get(input: unknown) => ActionCacheEntry | null
-  getStats() => { entries: number; hits: number; hitRate: number; timeSavedMs: number; }
+  getStats() => { entries: number; hitRate: number; hits: number; timeSavedMs: number; }
   recordHit(entryId: string) => void
 InterfaceDeclaration ActionContext
   readonly existingLabels?: ReadonlySet<string> | undefined
@@ -51,7 +51,7 @@ InterfaceDeclaration ActionStep
   readonly parameters: Record<string, unknown>
   readonly success: boolean
 TypeAliasDeclaration ActionValidationResult
-  = { ok: true; value: AgentAction } | { ok: false; error: string }
+  = { ok: true; value: AgentAction; } | { error: string; ok: false; }
 InterfaceDeclaration ActivationOptions
   readonly ensureTreeCoverage: boolean
   readonly maxActive: number
@@ -60,7 +60,7 @@ InterfaceDeclaration ActivationOptions
 TypeAliasDeclaration ActivationStrategy
   = 'ucb' | 'greedy' | 'diverse' | 'adaptive'
 VariableDeclaration ActivationStrategySchema
-  : z.ZodEnum<{ adaptive: "adaptive"; ucb: "ucb"; greedy: "greedy"; diverse: "diverse"; }>
+  : z.ZodEnum<{ adaptive: "adaptive"; diverse: "diverse"; greedy: "greedy"; ucb: "ucb"; }>
 InterfaceDeclaration ActivityItem
   readonly agentId: string
   readonly eventType: import("src/observability/swarm-observer-core-types").EventType
@@ -77,7 +77,7 @@ InterfaceDeclaration AdapterAttemptStats
 TypeAliasDeclaration AdapterConfig
   = z.infer<typeof AdapterConfigSchema>
 VariableDeclaration AdapterConfigSchema
-  : z.ZodObject<{ providerId: z.ZodString; modelId: z.ZodString; apiKey: z.ZodOptional<z.ZodString>; baseUrl: z.ZodOptional<z.ZodURL>; timeout: z.ZodOptional<z.ZodNumber>; maxRetries: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ apiKey: z.ZodOptional<z.ZodString>; baseUrl: z.ZodOptional<z.ZodURL>; maxRetries: z.ZodOptional<z.ZodNumber>; modelId: z.ZodString; providerId: z.ZodString; timeout: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 TypeAliasDeclaration AdapterCreator
   = (config: AdapterConfig) => IModelAdapter
 ClassDeclaration AdapterFactory
@@ -137,11 +137,11 @@ InterfaceDeclaration AdaptiveProtocolConfig
   readonly classifierConfig?: { readonly minConfidence?: number; } | undefined
   readonly logDecisions?: boolean | undefined
   readonly logger?: ILogger | undefined
-  readonly protocolMapping?: { readonly reasoning?: CollaborationPattern; readonly knowledge?: CollaborationPattern; readonly unknown?: CollaborationPattern; } | undefined
+  readonly protocolMapping?: { readonly knowledge?: CollaborationPattern; readonly reasoning?: CollaborationPattern; readonly unknown?: CollaborationPattern; } | undefined
   readonly protocolOptions?: ProtocolOptions | undefined
 ClassDeclaration AdaptiveProtocolSelector
   execute(config: CollaborationConfig, agents: Map<string, IAgent>) => Promise<Result<CollaborationResult, AgentError>>
-  getRecommendation(config: CollaborationConfig) => { recommendedPattern: CollaborationPattern; taskType: TaskType; confidence: number; reasoning: string; }
+  getRecommendation(config: CollaborationConfig) => { confidence: number; reasoning: string; recommendedPattern: CollaborationPattern; taskType: TaskType; }
   selectProtocol(config: CollaborationConfig) => SelectionResult
 InterfaceDeclaration AdaptiveThresholdResult
   readonly baseline: number
@@ -155,14 +155,14 @@ InterfaceDeclaration AdjacencyEntry
 TypeAliasDeclaration AgentAction
   = z.infer<typeof AgentActionSchema>
 VariableDeclaration AgentActionSchema
-  : z.ZodDiscriminatedUnion<[z.ZodObject<{ type: z.ZodLiteral<"SummarizeIssue">; summary: z.ZodString; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ type: z.ZodLiteral<"issueBody">; issueNumber: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"repoFile">; path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; commit: z.ZodOptional<z.ZodString>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"issueComment">; issueNumber: z.ZodNumber; commentId: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ciResult">; runId: z.ZodNumber; status: z.ZodEnum<{ pass: "pass"; fail: "fail"; }>; job: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"policyDoc">; path: z.ZodString; section: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; commentId: z.ZodNumber; }, z.core.$strip>], "type">>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ProposeLabels">; labels: z.ZodArray<z.ZodString>; reason: z.ZodString; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ type: z.ZodLiteral<"issueBody">; issueNumber: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"repoFile">; path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; commit: z.ZodOptional<z.ZodString>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"issueComment">; issueNumber: z.ZodNumber; commentId: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ciResult">; runId: z.ZodNumber; status: z.ZodEnum<{ pass: "pass"; fail: "fail"; }>; job: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"policyDoc">; path: z.ZodString; section: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; commentId: z.ZodNumber; }, z.core.$strip>], "type">>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"DraftReply">; body: z.ZodString; requiresApproval: z.ZodLiteral<true>; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ type: z.ZodLiteral<"issueBody">; issueNumber: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"repoFile">; path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; commit: z.ZodOptional<z.ZodString>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"issueComment">; issueNumber: z.ZodNumber; commentId: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ciResult">; runId: z.ZodNumber; status: z.ZodEnum<{ pass: "pass"; fail: "fail"; }>; job: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"policyDoc">; path: z.ZodString; section: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; commentId: z.ZodNumber; }, z.core.$strip>], "type">>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"RequestHumanApproval">; reason: z.ZodString; context: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"GeneratePatchPlan">; files: z.ZodArray<z.ZodObject<{ path: z.ZodString; operation: z.ZodEnum<{ modify: "modify"; create: "create"; delete: "delete"; }>; description: z.ZodString; }, z.core.$strip>>; rationale: z.ZodString; requiresApproval: z.ZodLiteral<true>; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ type: z.ZodLiteral<"issueBody">; issueNumber: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"repoFile">; path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; commit: z.ZodOptional<z.ZodString>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"issueComment">; issueNumber: z.ZodNumber; commentId: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ciResult">; runId: z.ZodNumber; status: z.ZodEnum<{ pass: "pass"; fail: "fail"; }>; job: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"policyDoc">; path: z.ZodString; section: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; commentId: z.ZodNumber; }, z.core.$strip>], "type">>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ClassifyIssue">; category: z.ZodEnum<{ security: "security"; documentation: "documentation"; bug: "bug"; feature: "feature"; question: "question"; performance: "performance"; }>; confidence: z.ZodNumber; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ type: z.ZodLiteral<"issueBody">; issueNumber: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"repoFile">; path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; commit: z.ZodOptional<z.ZodString>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"issueComment">; issueNumber: z.ZodNumber; commentId: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ciResult">; runId: z.ZodNumber; status: z.ZodEnum<{ pass: "pass"; fail: "fail"; }>; job: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"policyDoc">; path: z.ZodString; section: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; commentId: z.ZodNumber; }, z.core.$strip>], "type">>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"IdentifyDuplicates">; candidates: z.ZodArray<z.ZodNumber>; similarity: z.ZodArray<z.ZodNumber>; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ type: z.ZodLiteral<"issueBody">; issueNumber: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"repoFile">; path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; commit: z.ZodOptional<z.ZodString>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"issueComment">; issueNumber: z.ZodNumber; commentId: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ciResult">; runId: z.ZodNumber; status: z.ZodEnum<{ pass: "pass"; fail: "fail"; }>; job: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"policyDoc">; path: z.ZodString; section: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; commentId: z.ZodNumber; }, z.core.$strip>], "type">>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"RefuseAction">; reason: z.ZodString; escalateTo: z.ZodEnum<{ security: "security"; maintainer: "maintainer"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"HandoffMessage">; targetCapability: z.ZodString; reason: z.ZodString; inputTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ type: z.ZodLiteral<"issueBody">; issueNumber: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"repoFile">; path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; commit: z.ZodOptional<z.ZodString>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"issueComment">; issueNumber: z.ZodNumber; commentId: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ciResult">; runId: z.ZodNumber; status: z.ZodEnum<{ pass: "pass"; fail: "fail"; }>; job: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"policyDoc">; path: z.ZodString; section: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; commentId: z.ZodNumber; }, z.core.$strip>], "type">>; }, z.core.$strip>], "type">
+  : z.ZodDiscriminatedUnion<[z.ZodObject<{ sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueBody">; }, z.core.$strip>, z.ZodObject<{ commit: z.ZodOptional<z.ZodString>; line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; type: z.ZodLiteral<"repoFile">; }, z.core.$strip>, z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; commentId: z.ZodNumber; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueComment">; }, z.core.$strip>, z.ZodObject<{ job: z.ZodString; runId: z.ZodNumber; status: z.ZodEnum<{ fail: "fail"; pass: "pass"; }>; type: z.ZodLiteral<"ciResult">; }, z.core.$strip>, z.ZodObject<{ path: z.ZodString; section: z.ZodString; type: z.ZodLiteral<"policyDoc">; }, z.core.$strip>, z.ZodObject<{ commentId: z.ZodNumber; type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; }, z.core.$strip>], "type">>; summary: z.ZodString; type: z.ZodLiteral<"SummarizeIssue">; }, z.core.$strip>, z.ZodObject<{ labels: z.ZodArray<z.ZodString>; reason: z.ZodString; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueBody">; }, z.core.$strip>, z.ZodObject<{ commit: z.ZodOptional<z.ZodString>; line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; type: z.ZodLiteral<"repoFile">; }, z.core.$strip>, z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; commentId: z.ZodNumber; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueComment">; }, z.core.$strip>, z.ZodObject<{ job: z.ZodString; runId: z.ZodNumber; status: z.ZodEnum<{ fail: "fail"; pass: "pass"; }>; type: z.ZodLiteral<"ciResult">; }, z.core.$strip>, z.ZodObject<{ path: z.ZodString; section: z.ZodString; type: z.ZodLiteral<"policyDoc">; }, z.core.$strip>, z.ZodObject<{ commentId: z.ZodNumber; type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; }, z.core.$strip>], "type">>; type: z.ZodLiteral<"ProposeLabels">; }, z.core.$strip>, z.ZodObject<{ body: z.ZodString; requiresApproval: z.ZodLiteral<true>; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueBody">; }, z.core.$strip>, z.ZodObject<{ commit: z.ZodOptional<z.ZodString>; line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; type: z.ZodLiteral<"repoFile">; }, z.core.$strip>, z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; commentId: z.ZodNumber; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueComment">; }, z.core.$strip>, z.ZodObject<{ job: z.ZodString; runId: z.ZodNumber; status: z.ZodEnum<{ fail: "fail"; pass: "pass"; }>; type: z.ZodLiteral<"ciResult">; }, z.core.$strip>, z.ZodObject<{ path: z.ZodString; section: z.ZodString; type: z.ZodLiteral<"policyDoc">; }, z.core.$strip>, z.ZodObject<{ commentId: z.ZodNumber; type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; }, z.core.$strip>], "type">>; type: z.ZodLiteral<"DraftReply">; }, z.core.$strip>, z.ZodObject<{ context: z.ZodString; reason: z.ZodString; type: z.ZodLiteral<"RequestHumanApproval">; }, z.core.$strip>, z.ZodObject<{ files: z.ZodArray<z.ZodObject<{ description: z.ZodString; operation: z.ZodEnum<{ create: "create"; delete: "delete"; modify: "modify"; }>; path: z.ZodString; }, z.core.$strip>>; rationale: z.ZodString; requiresApproval: z.ZodLiteral<true>; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueBody">; }, z.core.$strip>, z.ZodObject<{ commit: z.ZodOptional<z.ZodString>; line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; type: z.ZodLiteral<"repoFile">; }, z.core.$strip>, z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; commentId: z.ZodNumber; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueComment">; }, z.core.$strip>, z.ZodObject<{ job: z.ZodString; runId: z.ZodNumber; status: z.ZodEnum<{ fail: "fail"; pass: "pass"; }>; type: z.ZodLiteral<"ciResult">; }, z.core.$strip>, z.ZodObject<{ path: z.ZodString; section: z.ZodString; type: z.ZodLiteral<"policyDoc">; }, z.core.$strip>, z.ZodObject<{ commentId: z.ZodNumber; type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; }, z.core.$strip>], "type">>; type: z.ZodLiteral<"GeneratePatchPlan">; }, z.core.$strip>, z.ZodObject<{ category: z.ZodEnum<{ bug: "bug"; documentation: "documentation"; feature: "feature"; performance: "performance"; question: "question"; security: "security"; }>; confidence: z.ZodNumber; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueBody">; }, z.core.$strip>, z.ZodObject<{ commit: z.ZodOptional<z.ZodString>; line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; type: z.ZodLiteral<"repoFile">; }, z.core.$strip>, z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; commentId: z.ZodNumber; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueComment">; }, z.core.$strip>, z.ZodObject<{ job: z.ZodString; runId: z.ZodNumber; status: z.ZodEnum<{ fail: "fail"; pass: "pass"; }>; type: z.ZodLiteral<"ciResult">; }, z.core.$strip>, z.ZodObject<{ path: z.ZodString; section: z.ZodString; type: z.ZodLiteral<"policyDoc">; }, z.core.$strip>, z.ZodObject<{ commentId: z.ZodNumber; type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; }, z.core.$strip>], "type">>; type: z.ZodLiteral<"ClassifyIssue">; }, z.core.$strip>, z.ZodObject<{ candidates: z.ZodArray<z.ZodNumber>; similarity: z.ZodArray<z.ZodNumber>; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueBody">; }, z.core.$strip>, z.ZodObject<{ commit: z.ZodOptional<z.ZodString>; line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; type: z.ZodLiteral<"repoFile">; }, z.core.$strip>, z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; commentId: z.ZodNumber; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueComment">; }, z.core.$strip>, z.ZodObject<{ job: z.ZodString; runId: z.ZodNumber; status: z.ZodEnum<{ fail: "fail"; pass: "pass"; }>; type: z.ZodLiteral<"ciResult">; }, z.core.$strip>, z.ZodObject<{ path: z.ZodString; section: z.ZodString; type: z.ZodLiteral<"policyDoc">; }, z.core.$strip>, z.ZodObject<{ commentId: z.ZodNumber; type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; }, z.core.$strip>], "type">>; type: z.ZodLiteral<"IdentifyDuplicates">; }, z.core.$strip>, z.ZodObject<{ escalateTo: z.ZodEnum<{ maintainer: "maintainer"; security: "security"; }>; reason: z.ZodString; type: z.ZodLiteral<"RefuseAction">; }, z.core.$strip>, z.ZodObject<{ inputTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; reason: z.ZodString; sources: z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueBody">; }, z.core.$strip>, z.ZodObject<{ commit: z.ZodOptional<z.ZodString>; line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; type: z.ZodLiteral<"repoFile">; }, z.core.$strip>, z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; commentId: z.ZodNumber; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueComment">; }, z.core.$strip>, z.ZodObject<{ job: z.ZodString; runId: z.ZodNumber; status: z.ZodEnum<{ fail: "fail"; pass: "pass"; }>; type: z.ZodLiteral<"ciResult">; }, z.core.$strip>, z.ZodObject<{ path: z.ZodString; section: z.ZodString; type: z.ZodLiteral<"policyDoc">; }, z.core.$strip>, z.ZodObject<{ commentId: z.ZodNumber; type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; }, z.core.$strip>], "type">>; targetCapability: z.ZodString; type: z.ZodLiteral<"HandoffMessage">; }, z.core.$strip>], "type">
 TypeAliasDeclaration AgentActionType
   = AgentAction['type']
 InterfaceDeclaration AgentBudgetConfig
   readonly criticalThreshold?: number | undefined
   readonly maxTokens: number
 TypeAliasDeclaration|VariableDeclaration AgentCapability
-  : { readonly TASK_EXECUTION: "task_execution"; readonly DELEGATION: "delegation"; readonly COLLABORATION: "collaboration"; readonly TOOL_USE: "tool_use"; readonly CODE_GENERATION: "code_generation"; readonly CODE_REVIEW: "code_review"; readonly RESEARCH: "research"; }
+  : { readonly CODE_GENERATION: "code_generation"; readonly CODE_REVIEW: "code_review"; readonly COLLABORATION: "collaboration"; readonly DELEGATION: "delegation"; readonly RESEARCH: "research"; readonly TASK_EXECUTION: "task_execution"; readonly TOOL_USE: "tool_use"; }
   = (typeof AgentCapability)[keyof typeof AgentCapability]
 InterfaceDeclaration AgentCluster
   readonly agents: string[]
@@ -213,7 +213,7 @@ InterfaceDeclaration AgentEvent
   readonly timestamp: string
   readonly traceId: string
 VariableDeclaration AgentEventSchema
-  : z.ZodObject<{ eventId: z.ZodString; timestamp: z.ZodISODateTime; agentId: z.ZodString; eventType: z.ZodEnum<{ error: "error"; state_change: "state_change"; message_sent: "message_sent"; message_received: "message_received"; tool_invoked: "tool_invoked"; tool_completed: "tool_completed"; memory_read: "memory_read"; memory_write: "memory_write"; task_started: "task_started"; task_completed: "task_completed"; }>; traceId: z.ZodString; spanId: z.ZodString; parentSpanId: z.ZodOptional<z.ZodString>; payload: z.ZodRecord<z.ZodString, z.ZodUnknown>; durationMs: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ agentId: z.ZodString; durationMs: z.ZodOptional<z.ZodNumber>; eventId: z.ZodString; eventType: z.ZodEnum<{ error: "error"; memory_read: "memory_read"; memory_write: "memory_write"; message_received: "message_received"; message_sent: "message_sent"; state_change: "state_change"; task_completed: "task_completed"; task_started: "task_started"; tool_completed: "tool_completed"; tool_invoked: "tool_invoked"; }>; parentSpanId: z.ZodOptional<z.ZodString>; payload: z.ZodRecord<z.ZodString, z.ZodUnknown>; spanId: z.ZodString; timestamp: z.ZodISODateTime; traceId: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration AgentExecutorConfig
   readonly budget?: AgentBudgetConfig | undefined
   readonly issueNumber?: number | undefined
@@ -227,7 +227,7 @@ InterfaceDeclaration AgentExecutorConfig
 TypeAliasDeclaration AgentFinding
   = z.infer<typeof AgentFindingSchema>
 VariableDeclaration AgentFindingSchema
-  : z.ZodObject<{ agentId: z.ZodString; category: z.ZodEnum<{ security: "security"; documentation: "documentation"; bug: "bug"; performance: "performance"; style: "style"; design: "design"; other: "other"; }>; severity: z.ZodEnum<{ critical: "critical"; major: "major"; minor: "minor"; suggestion: "suggestion"; }>; description: z.ZodString; location: z.ZodOptional<z.ZodString>; suggestion: z.ZodOptional<z.ZodString>; confidence: z.ZodNumber; timestamp: z.ZodOptional<z.ZodISODateTime>; }, z.core.$strip>
+  : z.ZodObject<{ agentId: z.ZodString; category: z.ZodEnum<{ bug: "bug"; design: "design"; documentation: "documentation"; other: "other"; performance: "performance"; security: "security"; style: "style"; }>; confidence: z.ZodNumber; description: z.ZodString; location: z.ZodOptional<z.ZodString>; severity: z.ZodEnum<{ critical: "critical"; major: "major"; minor: "minor"; suggestion: "suggestion"; }>; suggestion: z.ZodOptional<z.ZodString>; timestamp: z.ZodOptional<z.ZodISODateTime>; }, z.core.$strip>
 InterfaceDeclaration AgentHealthSummary
   readonly activeSessions: number
   readonly sessions: readonly AgentSessionEntry[]
@@ -279,11 +279,11 @@ InterfaceDeclaration AgentMessage
   to: string
   type: AgentMessageType
 VariableDeclaration AgentMessageSchema
-  : z.ZodObject<{ id: z.ZodString; from: z.ZodString; to: z.ZodString; type: z.ZodEnum<{ task: "task"; status: "status"; result: "result"; query: "query"; feedback: "feedback"; }>; payload: z.ZodUnknown; timestamp: z.ZodString; }, z.core.$strip>
+  : z.ZodObject<{ from: z.ZodString; id: z.ZodString; payload: z.ZodUnknown; timestamp: z.ZodString; to: z.ZodString; type: z.ZodEnum<{ feedback: "feedback"; query: "query"; result: "result"; status: "status"; task: "task"; }>; }, z.core.$strip>
 TypeAliasDeclaration AgentMessageType
   = 'task' | 'result' | 'query' | 'feedback' | 'status'
 TypeAliasDeclaration AgentPairKey
-  = `${string}:${string}`
+  = `${ string; }:${ string; }`
 InterfaceDeclaration AgentPerformance
   agentId: string
   correctVotes: number
@@ -291,7 +291,7 @@ InterfaceDeclaration AgentPerformance
   successRate: number
   totalVotes: number
 VariableDeclaration AgentPerformanceSchema
-  : z.ZodObject<{ agentId: z.ZodString; totalVotes: z.ZodNumber; correctVotes: z.ZodNumber; successRate: z.ZodNumber; lastUpdated: z.ZodISODateTime; }, z.core.$strip>
+  : z.ZodObject<{ agentId: z.ZodString; correctVotes: z.ZodNumber; lastUpdated: z.ZodISODateTime; successRate: z.ZodNumber; totalVotes: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration AgentQueueMetrics
   agentId: string
   lastMessageTime: number
@@ -306,7 +306,7 @@ InterfaceDeclaration AgentResponse
 TypeAliasDeclaration AgentRole
   = | 'orchestrator' // Coordinates multi-agent workflows (Issue #759) | 'code_expert' | 'architecture_expert' | 'security_expert' | 'documentation_expert' | 'testing_expert' | 'devops_expert' | 'research_expert' | 'pm_expert' // Product manager: requirements, user stories, acceptance criteria (Issue #902) | 'ux_expert' // UX designer: interaction design, usability, user journeys (Issue #902) | 'infrastructure_expert' // Physical server, bare metal, OOB management (Issue #1082) | 'qa_expert' // Quality assurance: code review, standards compliance, regression (#1684) | 'data_visualization_expert' // Data analysis, chart design, interactive visualizations | 'thinker' // TRINITY: High-level reasoning (arXiv:2512.04695) | 'worker' // TRINITY: Task execution | 'verifier' // TRINITY: Output validation | 'custom'
 VariableDeclaration AgentRoleSchema
-  : z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; research_expert: "research_expert"; infrastructure_expert: "infrastructure_expert"; thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>
+  : z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; research_expert: "research_expert"; security_expert: "security_expert"; testing_expert: "testing_expert"; thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>
 TypeAliasDeclaration AgentRoleType
   = z.infer<typeof AgentRoleSchema>
 InterfaceDeclaration AgentRunResult
@@ -377,7 +377,7 @@ InterfaceDeclaration AgentVoteResult
   readonly role: VoterRole
   readonly selectedOption?: string | undefined
   readonly source: "error" | "llm" | "simulation"
-  readonly vote: { decision: "approve" | "reject" | "abstain"; reasoning: string; confidence: number; conditions?: string[] | undefined; rejectionCategories?: ("YAGNI" | "DRY_VIOLATION" | "OVER_ENGINEERING" | "SCOPE_CREEP" | "SECURITY_RISK" | "MISALIGNED" | "INSUFFICIENT_EVIDENCE")[] | undefined; findings?: { summary: string; location: string; severity: "critical" | "high" | "medium" | "low"; gate: { reread_cited_line: "failed" | "skipped" | "passed"; traced_call_path: "failed" | "skipped" | "passed"; named_assertion: string; ruled_out_language_non_issue: "failed" | "skipped" | "passed"; }; claim: string; }[] | undefined; selectedOption?: string | undefined; timestamp?: string | undefined; }
+  readonly vote: { conditions?: string[] | undefined; confidence: number; decision: "approve" | "reject" | "abstain"; findings?: { claim: string; gate: { named_assertion: string; reread_cited_line: "failed" | "skipped" | "passed"; ruled_out_language_non_issue: "failed" | "skipped" | "passed"; traced_call_path: "failed" | "skipped" | "passed"; }; location: string; severity: "critical" | "high" | "medium" | "low"; summary: string; }[] | undefined; reasoning: string; rejectionCategories?: ("YAGNI" | "DRY_VIOLATION" | "OVER_ENGINEERING" | "SCOPE_CREEP" | "SECURITY_RISK" | "MISALIGNED" | "INSUFFICIENT_EVIDENCE")[] | undefined; selectedOption?: string | undefined; timestamp?: string | undefined; }
 InterfaceDeclaration AgentVoteSummary
   confidence: number
   decision: "approve" | "reject" | "abstain"
@@ -437,7 +437,7 @@ FunctionDeclaration analyzeGitHubRepo
 FunctionDeclaration analyzeRepo
   : typeof analyzeRepo
 TypeAliasDeclaration ApiArmId
-  = `api:${ApiVendor}`
+  = `api:${ ApiVendor; }`
 InterfaceDeclaration ApiDocumentation
   endpoints: ApiEndpoint[]
   types: ApiType[]
@@ -445,8 +445,8 @@ InterfaceDeclaration ApiEndpoint
   description: string
   example?: string | undefined
   name: string
-  parameters: { name: string; type: string; description: string; required: boolean; }[]
-  returns: { type: string; description: string; }
+  parameters: { description: string; name: string; required: boolean; type: string; }[]
+  returns: { description: string; type: string; }
 InterfaceDeclaration ApiErrorView
   readonly code?: string | null | undefined
   readonly error?: unknown
@@ -458,13 +458,13 @@ InterfaceDeclaration ApiErrorView
 InterfaceDeclaration ApiType
   description: string
   name: string
-  properties: { name: string; type: string; description: string; optional: boolean; }[]
+  properties: { description: string; name: string; optional: boolean; type: string; }[]
 TypeAliasDeclaration ApiVendor
   = 'anthropic' | 'openai' | 'google' | 'custom-openai'
 TypeAliasDeclaration AppConfig
   = z.infer<typeof AppConfigSchema>
 VariableDeclaration AppConfigSchema
-  : z.ZodObject<{ models: z.ZodObject<{ default: z.ZodString; tiers: z.ZodObject<{ fast: z.ZodArray<z.ZodString>; balanced: z.ZodArray<z.ZodString>; powerful: z.ZodArray<z.ZodString>; }, z.core.$strip>; providers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ apiKey: z.ZodOptional<z.ZodString>; baseUrl: z.ZodOptional<z.ZodURL>; timeout: z.ZodDefault<z.ZodNumber>; maxRetries: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; }, z.core.$strip>; experts: z.ZodOptional<z.ZodObject<{ builtin: z.ZodDefault<z.ZodBoolean>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ systemPrompt: z.ZodString; tier: z.ZodDefault<z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>>; domain: z.ZodDefault<z.ZodEnum<{ general: "general"; security: "security"; code: "code"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; }>>; secondaryDomains: z.ZodOptional<z.ZodArray<z.ZodEnum<{ general: "general"; security: "security"; code: "code"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; }>>>; capabilities: z.ZodDefault<z.ZodArray<z.ZodString>>; temperature: z.ZodDefault<z.ZodNumber>; tools: z.ZodOptional<z.ZodArray<z.ZodString>>; description: z.ZodOptional<z.ZodString>; weight: z.ZodDefault<z.ZodNumber>; available: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>>; }, z.core.$strip>>; workflows: z.ZodOptional<z.ZodObject<{ templatesDir: z.ZodDefault<z.ZodString>; timeout: z.ZodDefault<z.ZodNumber>; maxParallel: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; security: z.ZodOptional<z.ZodObject<{ allowedPaths: z.ZodDefault<z.ZodArray<z.ZodString>>; blockedPatterns: z.ZodDefault<z.ZodArray<z.ZodString>>; rateLimit: z.ZodDefault<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; requestsPerMinute: z.ZodDefault<z.ZodNumber>; perTool: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ capacity: z.ZodDefault<z.ZodNumber>; refillRate: z.ZodDefault<z.ZodNumber>; refillIntervalMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; }, z.core.$strip>>; secretsFile: z.ZodOptional<z.ZodString>; policy: z.ZodOptional<z.ZodObject<{ defaultMode: z.ZodDefault<z.ZodEnum<{ "read-only": "read-only"; "read-write": "read-write"; }>>; policyMode: z.ZodDefault<z.ZodEnum<{ warn: "warn"; enforce: "enforce"; }>>; }, z.core.$strip>>; sandbox: z.ZodOptional<z.ZodObject<{ mode: z.ZodDefault<z.ZodEnum<{ none: "none"; policy: "policy"; container: "container"; }>>; fallbackToPolicy: z.ZodDefault<z.ZodBoolean>; dockerImage: z.ZodOptional<z.ZodString>; networkEnabled: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; timeout: z.ZodOptional<z.ZodObject<{ defaultTimeoutMs: z.ZodDefault<z.ZodNumber>; maxTimeoutMs: z.ZodDefault<z.ZodNumber>; enableLogging: z.ZodDefault<z.ZodBoolean>; uriValidation: z.ZodDefault<z.ZodBoolean>; perToolTimeout: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; }, z.core.$strip>>; toolAllowlist: z.ZodOptional<z.ZodArray<z.ZodString>>; audit: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; logDir: z.ZodOptional<z.ZodString>; minSeverity: z.ZodDefault<z.ZodEnum<{ info: "info"; warning: "warning"; critical: "critical"; }>>; enableHashChain: z.ZodDefault<z.ZodBoolean>; maxFileSizeBytes: z.ZodDefault<z.ZodNumber>; maxFiles: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; auth: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; method: z.ZodDefault<z.ZodEnum<{ token: "token"; oauth2: "oauth2"; }>>; tokenHeader: z.ZodDefault<z.ZodString>; tokenFile: z.ZodOptional<z.ZodString>; }, z.core.$strip>>; }, z.core.$strip>>; logging: z.ZodOptional<z.ZodObject<{ level: z.ZodDefault<z.ZodEnum<{ debug: "debug"; info: "info"; warn: "warn"; error: "error"; }>>; format: z.ZodDefault<z.ZodEnum<{ json: "json"; pretty: "pretty"; }>>; destination: z.ZodDefault<z.ZodEnum<{ stdout: "stdout"; stderr: "stderr"; file: "file"; }>>; filePath: z.ZodOptional<z.ZodString>; }, z.core.$strip>>; observability: z.ZodOptional<z.ZodObject<{ eventBus: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; maxHistorySize: z.ZodDefault<z.ZodNumber>; subscriptions: z.ZodDefault<z.ZodObject<{ consensus: z.ZodDefault<z.ZodBoolean>; agent: z.ZodDefault<z.ZodBoolean>; protocol: z.ZodDefault<z.ZodBoolean>; session: z.ZodDefault<z.ZodBoolean>; message: z.ZodDefault<z.ZodBoolean>; byzantine: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; logging: z.ZodDefault<z.ZodObject<{ frequentEventLevel: z.ZodDefault<z.ZodEnum<{ debug: "debug"; info: "info"; }>>; importantEventLevel: z.ZodDefault<z.ZodEnum<{ debug: "debug"; info: "info"; }>>; }, z.core.$strip>>; }, z.core.$strip>>; swarmObserverMaxEvents: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; routing: z.ZodOptional<z.ZodObject<{ stages: z.ZodOptional<z.ZodObject<{ budgetFilter: z.ZodDefault<z.ZodBoolean>; zeroRouter: z.ZodDefault<z.ZodBoolean>; preferenceRouting: z.ZodDefault<z.ZodBoolean>; topsisRanking: z.ZodDefault<z.ZodBoolean>; linucbSelection: z.ZodDefault<z.ZodBoolean>; latencyTracking: z.ZodDefault<z.ZodBoolean>; routingMemory: z.ZodDefault<z.ZodBoolean>; confidenceCascade: z.ZodDefault<z.ZodBoolean>; capabilityMatch: z.ZodDefault<z.ZodBoolean>; qualityConstraint: z.ZodDefault<z.ZodBoolean>; resourceStrategy: z.ZodDefault<z.ZodBoolean>; strategyDistillation: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; budget: z.ZodOptional<z.ZodObject<{ maxTokens: z.ZodOptional<z.ZodNumber>; maxCostUsd: z.ZodOptional<z.ZodNumber>; maxLatencyMs: z.ZodOptional<z.ZodNumber>; taskClassMaxCostUsd: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ research: "research"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; devops: "devops"; planning: "planning"; code_generation: "code_generation"; code_review: "code_review"; security_review: "security_review"; exploration: "exploration"; }> & z.core.$partial, z.ZodNumber>>; }, z.core.$strip>>; topsis: z.ZodOptional<z.ZodObject<{ criteria: z.ZodOptional<z.ZodArray<z.ZodObject<{ name: z.ZodString; weight: z.ZodNumber; beneficial: z.ZodBoolean; }, z.core.$strip>>>; minQualityThreshold: z.ZodDefault<z.ZodNumber>; maxLatencyMs: z.ZodOptional<z.ZodNumber>; maxCostPerRequest: z.ZodOptional<z.ZodNumber>; verbose: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; zeroRouter: z.ZodOptional<z.ZodObject<{ thresholds: z.ZodOptional<z.ZodObject<{ easyUpperBound: z.ZodDefault<z.ZodNumber>; hardLowerBound: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; weights: z.ZodOptional<z.ZodObject<{ reasoning: z.ZodDefault<z.ZodNumber>; knowledge: z.ZodDefault<z.ZodNumber>; creativity: z.ZodDefault<z.ZodNumber>; precision: z.ZodDefault<z.ZodNumber>; context_length: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; difficultyToTier: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ medium: "medium"; hard: "hard"; easy: "easy"; }>, z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>>>; tierToClis: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>, z.ZodArray<z.ZodEnum<{ claude: "claude"; gemini: "gemini"; codex: "codex"; opencode: "opencode"; }>>>>; enableCalibration: z.ZodDefault<z.ZodBoolean>; maxCalibrationOutcomes: z.ZodDefault<z.ZodNumber>; minCalibrationOutcomes: z.ZodDefault<z.ZodNumber>; verbose: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; latencyTracker: z.ZodOptional<z.ZodObject<{ windowSize: z.ZodDefault<z.ZodNumber>; decayFactor: z.ZodDefault<z.ZodNumber>; maxSampleAgeMs: z.ZodDefault<z.ZodNumber>; percentiles: z.ZodDefault<z.ZodArray<z.ZodNumber>>; }, z.core.$strip>>; routingMemory: z.ZodOptional<z.ZodObject<{ minObservations: z.ZodDefault<z.ZodNumber>; confidenceThreshold: z.ZodDefault<z.ZodNumber>; successRateThreshold: z.ZodDefault<z.ZodNumber>; actionCacheMaxAgeMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; linucb: z.ZodOptional<z.ZodObject<{ alpha: z.ZodDefault<z.ZodNumber>; maxDecisionTimeMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; preference: z.ZodOptional<z.ZodObject<{ minDataPoints: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; latencyScoreWeight: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; skills: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; maxSkills: z.ZodDefault<z.ZodNumber>; minSuccessRateForRetention: z.ZodDefault<z.ZodNumber>; executionsBeforeEvaluation: z.ZodDefault<z.ZodNumber>; enablePruning: z.ZodDefault<z.ZodBoolean>; trackExecutionHistory: z.ZodDefault<z.ZodBoolean>; maxHistoryPerSkill: z.ZodDefault<z.ZodNumber>; externalPacks: z.ZodOptional<z.ZodArray<z.ZodObject<{ name: z.ZodString; source: z.ZodString; enabled: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>>; }, z.core.$strip>>; sica: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; minExecutionsForImprovement: z.ZodDefault<z.ZodNumber>; improvementThreshold: z.ZodDefault<z.ZodNumber>; maxActiveVersions: z.ZodDefault<z.ZodNumber>; autoSelectBest: z.ZodDefault<z.ZodBoolean>; improvementCooldownMs: z.ZodDefault<z.ZodNumber>; enableObservability: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; gateway: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; tierOverrides: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodEnum<{ DIRECT: "DIRECT"; ANALYZED: "ANALYZED"; ORCHESTRATED: "ORCHESTRATED"; }>>>; upstreamServers: z.ZodOptional<z.ZodArray<z.ZodObject<{ name: z.ZodString; command: z.ZodEnum<{ python: "python"; node: "node"; npx: "npx"; python3: "python3"; uvx: "uvx"; docker: "docker"; }>; args: z.ZodDefault<z.ZodArray<z.ZodString>>; env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>; lazy: z.ZodDefault<z.ZodBoolean>; timeoutMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ experts: z.ZodOptional<z.ZodObject<{ builtin: z.ZodDefault<z.ZodBoolean>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ available: z.ZodDefault<z.ZodBoolean>; capabilities: z.ZodDefault<z.ZodArray<z.ZodString>>; description: z.ZodOptional<z.ZodString>; domain: z.ZodDefault<z.ZodEnum<{ architecture: "architecture"; code: "code"; documentation: "documentation"; general: "general"; security: "security"; testing: "testing"; }>>; secondaryDomains: z.ZodOptional<z.ZodArray<z.ZodEnum<{ architecture: "architecture"; code: "code"; documentation: "documentation"; general: "general"; security: "security"; testing: "testing"; }>>>; systemPrompt: z.ZodString; temperature: z.ZodDefault<z.ZodNumber>; tier: z.ZodDefault<z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>>; tools: z.ZodOptional<z.ZodArray<z.ZodString>>; weight: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; }, z.core.$strip>>; gateway: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; tierOverrides: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodEnum<{ ANALYZED: "ANALYZED"; DIRECT: "DIRECT"; ORCHESTRATED: "ORCHESTRATED"; }>>>; upstreamServers: z.ZodOptional<z.ZodArray<z.ZodObject<{ args: z.ZodDefault<z.ZodArray<z.ZodString>>; command: z.ZodEnum<{ docker: "docker"; node: "node"; npx: "npx"; python: "python"; python3: "python3"; uvx: "uvx"; }>; env: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>; lazy: z.ZodDefault<z.ZodBoolean>; name: z.ZodString; timeoutMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; }, z.core.$strip>>; logging: z.ZodOptional<z.ZodObject<{ destination: z.ZodDefault<z.ZodEnum<{ file: "file"; stderr: "stderr"; stdout: "stdout"; }>>; filePath: z.ZodOptional<z.ZodString>; format: z.ZodDefault<z.ZodEnum<{ json: "json"; pretty: "pretty"; }>>; level: z.ZodDefault<z.ZodEnum<{ debug: "debug"; error: "error"; info: "info"; warn: "warn"; }>>; }, z.core.$strip>>; models: z.ZodObject<{ default: z.ZodString; providers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ apiKey: z.ZodOptional<z.ZodString>; baseUrl: z.ZodOptional<z.ZodURL>; maxRetries: z.ZodDefault<z.ZodNumber>; timeout: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; tiers: z.ZodObject<{ balanced: z.ZodArray<z.ZodString>; fast: z.ZodArray<z.ZodString>; powerful: z.ZodArray<z.ZodString>; }, z.core.$strip>; }, z.core.$strip>; observability: z.ZodOptional<z.ZodObject<{ eventBus: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; logging: z.ZodDefault<z.ZodObject<{ frequentEventLevel: z.ZodDefault<z.ZodEnum<{ debug: "debug"; info: "info"; }>>; importantEventLevel: z.ZodDefault<z.ZodEnum<{ debug: "debug"; info: "info"; }>>; }, z.core.$strip>>; maxHistorySize: z.ZodDefault<z.ZodNumber>; subscriptions: z.ZodDefault<z.ZodObject<{ agent: z.ZodDefault<z.ZodBoolean>; byzantine: z.ZodDefault<z.ZodBoolean>; consensus: z.ZodDefault<z.ZodBoolean>; message: z.ZodDefault<z.ZodBoolean>; protocol: z.ZodDefault<z.ZodBoolean>; session: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; }, z.core.$strip>>; swarmObserverMaxEvents: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; routing: z.ZodOptional<z.ZodObject<{ budget: z.ZodOptional<z.ZodObject<{ maxCostUsd: z.ZodOptional<z.ZodNumber>; maxLatencyMs: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; taskClassMaxCostUsd: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ architecture: "architecture"; code_generation: "code_generation"; code_review: "code_review"; devops: "devops"; documentation: "documentation"; exploration: "exploration"; planning: "planning"; research: "research"; security_review: "security_review"; testing: "testing"; }> & z.core.$partial, z.ZodNumber>>; }, z.core.$strip>>; latencyScoreWeight: z.ZodDefault<z.ZodNumber>; latencyTracker: z.ZodOptional<z.ZodObject<{ decayFactor: z.ZodDefault<z.ZodNumber>; maxSampleAgeMs: z.ZodDefault<z.ZodNumber>; percentiles: z.ZodDefault<z.ZodArray<z.ZodNumber>>; windowSize: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; linucb: z.ZodOptional<z.ZodObject<{ alpha: z.ZodDefault<z.ZodNumber>; maxDecisionTimeMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; preference: z.ZodOptional<z.ZodObject<{ minDataPoints: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; routingMemory: z.ZodOptional<z.ZodObject<{ actionCacheMaxAgeMs: z.ZodDefault<z.ZodNumber>; confidenceThreshold: z.ZodDefault<z.ZodNumber>; minObservations: z.ZodDefault<z.ZodNumber>; successRateThreshold: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; stages: z.ZodOptional<z.ZodObject<{ budgetFilter: z.ZodDefault<z.ZodBoolean>; capabilityMatch: z.ZodDefault<z.ZodBoolean>; confidenceCascade: z.ZodDefault<z.ZodBoolean>; latencyTracking: z.ZodDefault<z.ZodBoolean>; linucbSelection: z.ZodDefault<z.ZodBoolean>; preferenceRouting: z.ZodDefault<z.ZodBoolean>; qualityConstraint: z.ZodDefault<z.ZodBoolean>; resourceStrategy: z.ZodDefault<z.ZodBoolean>; routingMemory: z.ZodDefault<z.ZodBoolean>; strategyDistillation: z.ZodDefault<z.ZodBoolean>; topsisRanking: z.ZodDefault<z.ZodBoolean>; zeroRouter: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; topsis: z.ZodOptional<z.ZodObject<{ criteria: z.ZodOptional<z.ZodArray<z.ZodObject<{ beneficial: z.ZodBoolean; name: z.ZodString; weight: z.ZodNumber; }, z.core.$strip>>>; maxCostPerRequest: z.ZodOptional<z.ZodNumber>; maxLatencyMs: z.ZodOptional<z.ZodNumber>; minQualityThreshold: z.ZodDefault<z.ZodNumber>; verbose: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; zeroRouter: z.ZodOptional<z.ZodObject<{ difficultyToTier: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ easy: "easy"; hard: "hard"; medium: "medium"; }>, z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>>>; enableCalibration: z.ZodDefault<z.ZodBoolean>; maxCalibrationOutcomes: z.ZodDefault<z.ZodNumber>; minCalibrationOutcomes: z.ZodDefault<z.ZodNumber>; thresholds: z.ZodOptional<z.ZodObject<{ easyUpperBound: z.ZodDefault<z.ZodNumber>; hardLowerBound: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; tierToClis: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>, z.ZodArray<z.ZodEnum<{ claude: "claude"; codex: "codex"; gemini: "gemini"; opencode: "opencode"; }>>>>; verbose: z.ZodDefault<z.ZodBoolean>; weights: z.ZodOptional<z.ZodObject<{ context_length: z.ZodDefault<z.ZodNumber>; creativity: z.ZodDefault<z.ZodNumber>; knowledge: z.ZodDefault<z.ZodNumber>; precision: z.ZodDefault<z.ZodNumber>; reasoning: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; }, z.core.$strip>>; }, z.core.$strip>>; security: z.ZodOptional<z.ZodObject<{ allowedPaths: z.ZodDefault<z.ZodArray<z.ZodString>>; audit: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; enableHashChain: z.ZodDefault<z.ZodBoolean>; logDir: z.ZodOptional<z.ZodString>; maxFiles: z.ZodDefault<z.ZodNumber>; maxFileSizeBytes: z.ZodDefault<z.ZodNumber>; minSeverity: z.ZodDefault<z.ZodEnum<{ critical: "critical"; info: "info"; warning: "warning"; }>>; }, z.core.$strip>>; auth: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; method: z.ZodDefault<z.ZodEnum<{ oauth2: "oauth2"; token: "token"; }>>; tokenFile: z.ZodOptional<z.ZodString>; tokenHeader: z.ZodDefault<z.ZodString>; }, z.core.$strip>>; blockedPatterns: z.ZodDefault<z.ZodArray<z.ZodString>>; policy: z.ZodOptional<z.ZodObject<{ defaultMode: z.ZodDefault<z.ZodEnum<{ "read-only": "read-only"; "read-write": "read-write"; }>>; policyMode: z.ZodDefault<z.ZodEnum<{ enforce: "enforce"; warn: "warn"; }>>; }, z.core.$strip>>; rateLimit: z.ZodDefault<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; perTool: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ capacity: z.ZodDefault<z.ZodNumber>; refillIntervalMs: z.ZodDefault<z.ZodNumber>; refillRate: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; requestsPerMinute: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; sandbox: z.ZodOptional<z.ZodObject<{ dockerImage: z.ZodOptional<z.ZodString>; fallbackToPolicy: z.ZodDefault<z.ZodBoolean>; mode: z.ZodDefault<z.ZodEnum<{ container: "container"; none: "none"; policy: "policy"; }>>; networkEnabled: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; secretsFile: z.ZodOptional<z.ZodString>; timeout: z.ZodOptional<z.ZodObject<{ defaultTimeoutMs: z.ZodDefault<z.ZodNumber>; enableLogging: z.ZodDefault<z.ZodBoolean>; maxTimeoutMs: z.ZodDefault<z.ZodNumber>; perToolTimeout: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; uriValidation: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; toolAllowlist: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>>; sica: z.ZodOptional<z.ZodObject<{ autoSelectBest: z.ZodDefault<z.ZodBoolean>; enabled: z.ZodDefault<z.ZodBoolean>; enableObservability: z.ZodDefault<z.ZodBoolean>; improvementCooldownMs: z.ZodDefault<z.ZodNumber>; improvementThreshold: z.ZodDefault<z.ZodNumber>; maxActiveVersions: z.ZodDefault<z.ZodNumber>; minExecutionsForImprovement: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; skills: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; enablePruning: z.ZodDefault<z.ZodBoolean>; executionsBeforeEvaluation: z.ZodDefault<z.ZodNumber>; externalPacks: z.ZodOptional<z.ZodArray<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; name: z.ZodString; source: z.ZodString; }, z.core.$strip>>>; maxHistoryPerSkill: z.ZodDefault<z.ZodNumber>; maxSkills: z.ZodDefault<z.ZodNumber>; minSuccessRateForRetention: z.ZodDefault<z.ZodNumber>; trackExecutionHistory: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; workflows: z.ZodOptional<z.ZodObject<{ maxParallel: z.ZodDefault<z.ZodNumber>; templatesDir: z.ZodDefault<z.ZodString>; timeout: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; }, z.core.$strip>
 FunctionDeclaration append
   : typeof append
 InterfaceDeclaration ArchitectureAnalysisResult
@@ -490,7 +490,7 @@ InterfaceDeclaration ArchitecturePattern
   applicability: number
   category: string
   name: string
-  tradeoffs: { pros: string[]; cons: string[]; }
+  tradeoffs: { cons: string[]; pros: string[]; }
 TypeAliasDeclaration ArchitectureStyle
   = 'layered' | 'microservices' | 'event_driven' | 'hexagonal' | 'clean' | 'cqrs' | 'ddd'
 FunctionDeclaration areStepsCompleted
@@ -526,7 +526,7 @@ InterfaceDeclaration ArtifactFilter
 TypeAliasDeclaration ArtifactRef
   = z.infer<typeof ArtifactRefSchema>
 VariableDeclaration ArtifactRefSchema
-  : z.ZodObject<{ id: z.ZodString; type: z.ZodEnum<{ review: "review"; plan: "plan"; vote: "vote"; code: "code"; test: "test"; report: "report"; spec: "spec"; analysis: "analysis"; }>; }, z.core.$strip>
+  : z.ZodObject<{ id: z.ZodString; type: z.ZodEnum<{ analysis: "analysis"; code: "code"; plan: "plan"; report: "report"; review: "review"; spec: "spec"; test: "test"; vote: "vote"; }>; }, z.core.$strip>
 ClassDeclaration ArtifactStore
   get size(): number
   get(ref: ArtifactRef) => Artifact | undefined
@@ -576,11 +576,11 @@ VariableDeclaration AUDIT_PIPELINE_TEMPLATE
 TypeAliasDeclaration AuditActor
   = z.infer<typeof AuditActorSchema>
 VariableDeclaration AuditActorSchema
-  : z.ZodObject<{ type: z.ZodEnum<{ system: "system"; user: "user"; agent: "agent"; external: "external"; }>; id: z.ZodString; name: z.ZodOptional<z.ZodString>; ip: z.ZodOptional<z.ZodString>; userAgent: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ id: z.ZodString; ip: z.ZodOptional<z.ZodString>; name: z.ZodOptional<z.ZodString>; type: z.ZodEnum<{ agent: "agent"; external: "external"; system: "system"; user: "user"; }>; userAgent: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 TypeAliasDeclaration AuditCategory
   = z.infer<typeof AuditCategorySchema>
 VariableDeclaration AuditCategorySchema
-  : z.ZodEnum<{ security: "security"; authentication: "authentication"; authorization: "authorization"; tool_invocation: "tool_invocation"; data_access: "data_access"; data_modification: "data_modification"; configuration: "configuration"; system: "system"; governance: "governance"; }>
+  : z.ZodEnum<{ authentication: "authentication"; authorization: "authorization"; configuration: "configuration"; data_access: "data_access"; data_modification: "data_modification"; governance: "governance"; security: "security"; system: "system"; tool_invocation: "tool_invocation"; }>
 ClassDeclaration AuditError
   readonly cause: Error | undefined
   readonly code: "AUDIT_ERROR"
@@ -591,16 +591,16 @@ TypeAliasDeclaration AuditEvent
 TypeAliasDeclaration AuditEventInput
   = z.infer<typeof AuditEventInputSchema>
 VariableDeclaration AuditEventInputSchema
-  : z.ZodObject<{ category: z.ZodEnum<{ security: "security"; authentication: "authentication"; authorization: "authorization"; tool_invocation: "tool_invocation"; data_access: "data_access"; data_modification: "data_modification"; configuration: "configuration"; system: "system"; governance: "governance"; }>; severity: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ info: "info"; warning: "warning"; critical: "critical"; }>>>; outcome: z.ZodEnum<{ success: "success"; failure: "failure"; error: "error"; denied: "denied"; }>; action: z.ZodString; description: z.ZodOptional<z.ZodString>; actor: z.ZodObject<{ type: z.ZodEnum<{ system: "system"; user: "user"; agent: "agent"; external: "external"; }>; id: z.ZodString; name: z.ZodOptional<z.ZodString>; ip: z.ZodOptional<z.ZodString>; userAgent: z.ZodOptional<z.ZodString>; }, z.core.$strip>; resource: z.ZodOptional<z.ZodObject<{ type: z.ZodString; id: z.ZodString; name: z.ZodOptional<z.ZodString>; path: z.ZodOptional<z.ZodString>; }, z.core.$strip>>; requestId: z.ZodOptional<z.ZodString>; traceId: z.ZodOptional<z.ZodString>; sessionId: z.ZodOptional<z.ZodString>; toolName: z.ZodOptional<z.ZodString>; durationMs: z.ZodOptional<z.ZodNumber>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; policyName: z.ZodOptional<z.ZodString>; policyDecision: z.ZodOptional<z.ZodString>; violationType: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ action: z.ZodString; actor: z.ZodObject<{ id: z.ZodString; ip: z.ZodOptional<z.ZodString>; name: z.ZodOptional<z.ZodString>; type: z.ZodEnum<{ agent: "agent"; external: "external"; system: "system"; user: "user"; }>; userAgent: z.ZodOptional<z.ZodString>; }, z.core.$strip>; category: z.ZodEnum<{ authentication: "authentication"; authorization: "authorization"; configuration: "configuration"; data_access: "data_access"; data_modification: "data_modification"; governance: "governance"; security: "security"; system: "system"; tool_invocation: "tool_invocation"; }>; description: z.ZodOptional<z.ZodString>; durationMs: z.ZodOptional<z.ZodNumber>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; outcome: z.ZodEnum<{ denied: "denied"; error: "error"; failure: "failure"; success: "success"; }>; policyDecision: z.ZodOptional<z.ZodString>; policyName: z.ZodOptional<z.ZodString>; requestId: z.ZodOptional<z.ZodString>; resource: z.ZodOptional<z.ZodObject<{ id: z.ZodString; name: z.ZodOptional<z.ZodString>; path: z.ZodOptional<z.ZodString>; type: z.ZodString; }, z.core.$strip>>; sessionId: z.ZodOptional<z.ZodString>; severity: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ critical: "critical"; info: "info"; warning: "warning"; }>>>; toolName: z.ZodOptional<z.ZodString>; traceId: z.ZodOptional<z.ZodString>; violationType: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 VariableDeclaration AuditEventSchema
-  : z.ZodObject<{ id: z.ZodString; version: z.ZodLiteral<"1.0">; timestamp: z.ZodString; timestampMs: z.ZodNumber; category: z.ZodEnum<{ security: "security"; authentication: "authentication"; authorization: "authorization"; tool_invocation: "tool_invocation"; data_access: "data_access"; data_modification: "data_modification"; configuration: "configuration"; system: "system"; governance: "governance"; }>; severity: z.ZodEnum<{ info: "info"; warning: "warning"; critical: "critical"; }>; outcome: z.ZodEnum<{ success: "success"; failure: "failure"; error: "error"; denied: "denied"; }>; action: z.ZodString; description: z.ZodOptional<z.ZodString>; actor: z.ZodObject<{ type: z.ZodEnum<{ system: "system"; user: "user"; agent: "agent"; external: "external"; }>; id: z.ZodString; name: z.ZodOptional<z.ZodString>; ip: z.ZodOptional<z.ZodString>; userAgent: z.ZodOptional<z.ZodString>; }, z.core.$strip>; resource: z.ZodOptional<z.ZodObject<{ type: z.ZodString; id: z.ZodString; name: z.ZodOptional<z.ZodString>; path: z.ZodOptional<z.ZodString>; }, z.core.$strip>>; requestId: z.ZodOptional<z.ZodString>; traceId: z.ZodOptional<z.ZodString>; sessionId: z.ZodOptional<z.ZodString>; toolName: z.ZodOptional<z.ZodString>; durationMs: z.ZodOptional<z.ZodNumber>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; policyName: z.ZodOptional<z.ZodString>; policyDecision: z.ZodOptional<z.ZodString>; violationType: z.ZodOptional<z.ZodString>; previousHash: z.ZodOptional<z.ZodString>; hash: z.ZodOptional<z.ZodString>; hashVersion: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ action: z.ZodString; actor: z.ZodObject<{ id: z.ZodString; ip: z.ZodOptional<z.ZodString>; name: z.ZodOptional<z.ZodString>; type: z.ZodEnum<{ agent: "agent"; external: "external"; system: "system"; user: "user"; }>; userAgent: z.ZodOptional<z.ZodString>; }, z.core.$strip>; category: z.ZodEnum<{ authentication: "authentication"; authorization: "authorization"; configuration: "configuration"; data_access: "data_access"; data_modification: "data_modification"; governance: "governance"; security: "security"; system: "system"; tool_invocation: "tool_invocation"; }>; description: z.ZodOptional<z.ZodString>; durationMs: z.ZodOptional<z.ZodNumber>; hash: z.ZodOptional<z.ZodString>; hashVersion: z.ZodOptional<z.ZodNumber>; id: z.ZodString; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; outcome: z.ZodEnum<{ denied: "denied"; error: "error"; failure: "failure"; success: "success"; }>; policyDecision: z.ZodOptional<z.ZodString>; policyName: z.ZodOptional<z.ZodString>; previousHash: z.ZodOptional<z.ZodString>; requestId: z.ZodOptional<z.ZodString>; resource: z.ZodOptional<z.ZodObject<{ id: z.ZodString; name: z.ZodOptional<z.ZodString>; path: z.ZodOptional<z.ZodString>; type: z.ZodString; }, z.core.$strip>>; sessionId: z.ZodOptional<z.ZodString>; severity: z.ZodEnum<{ critical: "critical"; info: "info"; warning: "warning"; }>; timestamp: z.ZodString; timestampMs: z.ZodNumber; toolName: z.ZodOptional<z.ZodString>; traceId: z.ZodOptional<z.ZodString>; version: z.ZodLiteral<"1.0">; violationType: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 InterfaceDeclaration AuditHandlerConfig
   auditLogger: IAuditLogger
-  defaultActor?: { type: "system" | "user" | "agent" | "external"; id: string; name?: string | undefined; ip?: string | undefined; userAgent?: string | undefined; } | undefined
+  defaultActor?: { id: string; ip?: string | undefined; name?: string | undefined; type: "system" | "user" | "agent" | "external"; userAgent?: string | undefined; } | undefined
 TypeAliasDeclaration AuditLogConfig
   = z.infer<typeof AuditLogConfigSchema>
 VariableDeclaration AuditLogConfigSchema
-  : z.ZodObject<{ logDir: z.ZodString; filePrefix: z.ZodDefault<z.ZodOptional<z.ZodString>>; maxFileSizeBytes: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; maxFiles: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; enableHashChain: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; enableCompression: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; flushIntervalMs: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; maxQueueDepth: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; minSeverity: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ info: "info"; warning: "warning"; critical: "critical"; }>>>; categories: z.ZodOptional<z.ZodArray<z.ZodEnum<{ security: "security"; authentication: "authentication"; authorization: "authorization"; tool_invocation: "tool_invocation"; data_access: "data_access"; data_modification: "data_modification"; configuration: "configuration"; system: "system"; governance: "governance"; }>>>; }, z.core.$strip>
+  : z.ZodObject<{ categories: z.ZodOptional<z.ZodArray<z.ZodEnum<{ authentication: "authentication"; authorization: "authorization"; configuration: "configuration"; data_access: "data_access"; data_modification: "data_modification"; governance: "governance"; security: "security"; system: "system"; tool_invocation: "tool_invocation"; }>>>; enableCompression: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; enableHashChain: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; filePrefix: z.ZodDefault<z.ZodOptional<z.ZodString>>; flushIntervalMs: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; logDir: z.ZodString; maxFiles: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; maxFileSizeBytes: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; maxQueueDepth: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; minSeverity: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ critical: "critical"; info: "info"; warning: "warning"; }>>>; }, z.core.$strip>
 ClassDeclaration AuditLogger
   close() => Promise<void>
   flush() => Promise<void>
@@ -616,7 +616,7 @@ ClassDeclaration AuditLogger
 TypeAliasDeclaration AuditOutcome
   = z.infer<typeof AuditOutcomeSchema>
 VariableDeclaration AuditOutcomeSchema
-  : z.ZodEnum<{ success: "success"; failure: "failure"; error: "error"; denied: "denied"; }>
+  : z.ZodEnum<{ denied: "denied"; error: "error"; failure: "failure"; success: "success"; }>
 InterfaceDeclaration AuditQuery
   readonly actionType?: "SummarizeIssue" | "ProposeLabels" | "DraftReply" | "RequestHumanApproval" | "GeneratePatchPlan" | "ClassifyIssue" | "IdentifyDuplicates" | "RefuseAction" | "HandoffMessage" | undefined
   readonly actor?: string | undefined
@@ -629,15 +629,15 @@ InterfaceDeclaration AuditQuery
 TypeAliasDeclaration AuditQueryCriteria
   = z.infer<typeof AuditQueryCriteriaSchema>
 VariableDeclaration AuditQueryCriteriaSchema
-  : z.ZodObject<{ startTime: z.ZodOptional<z.ZodDate>; endTime: z.ZodOptional<z.ZodDate>; categories: z.ZodOptional<z.ZodArray<z.ZodEnum<{ security: "security"; authentication: "authentication"; authorization: "authorization"; tool_invocation: "tool_invocation"; data_access: "data_access"; data_modification: "data_modification"; configuration: "configuration"; system: "system"; governance: "governance"; }>>>; severities: z.ZodOptional<z.ZodArray<z.ZodEnum<{ info: "info"; warning: "warning"; critical: "critical"; }>>>; outcomes: z.ZodOptional<z.ZodArray<z.ZodEnum<{ success: "success"; failure: "failure"; error: "error"; denied: "denied"; }>>>; actorId: z.ZodOptional<z.ZodString>; resourceId: z.ZodOptional<z.ZodString>; requestId: z.ZodOptional<z.ZodString>; traceId: z.ZodOptional<z.ZodString>; limit: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; offset: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; }, z.core.$strip>
+  : z.ZodObject<{ actorId: z.ZodOptional<z.ZodString>; categories: z.ZodOptional<z.ZodArray<z.ZodEnum<{ authentication: "authentication"; authorization: "authorization"; configuration: "configuration"; data_access: "data_access"; data_modification: "data_modification"; governance: "governance"; security: "security"; system: "system"; tool_invocation: "tool_invocation"; }>>>; endTime: z.ZodOptional<z.ZodDate>; limit: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; offset: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; outcomes: z.ZodOptional<z.ZodArray<z.ZodEnum<{ denied: "denied"; error: "error"; failure: "failure"; success: "success"; }>>>; requestId: z.ZodOptional<z.ZodString>; resourceId: z.ZodOptional<z.ZodString>; severities: z.ZodOptional<z.ZodArray<z.ZodEnum<{ critical: "critical"; info: "info"; warning: "warning"; }>>>; startTime: z.ZodOptional<z.ZodDate>; traceId: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 TypeAliasDeclaration AuditResource
   = z.infer<typeof AuditResourceSchema>
 VariableDeclaration AuditResourceSchema
-  : z.ZodObject<{ type: z.ZodString; id: z.ZodString; name: z.ZodOptional<z.ZodString>; path: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ id: z.ZodString; name: z.ZodOptional<z.ZodString>; path: z.ZodOptional<z.ZodString>; type: z.ZodString; }, z.core.$strip>
 TypeAliasDeclaration AuditSeverity
   = z.infer<typeof AuditSeveritySchema>
 VariableDeclaration AuditSeveritySchema
-  : z.ZodEnum<{ info: "info"; warning: "warning"; critical: "critical"; }>
+  : z.ZodEnum<{ critical: "critical"; info: "info"; warning: "warning"; }>
 ClassDeclaration AuditTrail
   append(event: Omit<AuditEvent, "id" | "timestamp">) => string
   clear() => void
@@ -650,7 +650,7 @@ InterfaceDeclaration AuthenticatedUser
 TypeAliasDeclaration AuthorizationMethod
   = 'role' | 'explicit' | 'inherited'
 VariableDeclaration AuthorizationMethodSchema
-  : z.ZodEnum<{ explicit: "explicit"; role: "role"; inherited: "inherited"; }>
+  : z.ZodEnum<{ explicit: "explicit"; inherited: "inherited"; role: "role"; }>
 ClassDeclaration AvailabilityCache
   clear() => void
   entries() => ReadonlyArray<ProbeResult>
@@ -754,7 +754,7 @@ InterfaceDeclaration BaseAgentOptions
   temperature?: number | undefined
   tokenBudget?: TokenBudgetConfig | undefined
 VariableDeclaration BaseAgentOptionsSchema
-  : z.ZodObject<{ id: z.ZodString; role: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; research_expert: "research_expert"; pm_expert: "pm_expert"; ux_expert: "ux_expert"; infrastructure_expert: "infrastructure_expert"; qa_expert: "qa_expert"; data_visualization_expert: "data_visualization_expert"; thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>; capabilities: z.ZodArray<z.ZodEnum<{ research: "research"; code_generation: "code_generation"; code_review: "code_review"; tool_use: "tool_use"; task_execution: "task_execution"; delegation: "delegation"; collaboration: "collaboration"; }>>; systemPrompt: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; contextPruning: z.ZodOptional<z.ZodObject<{ enabled: z.ZodOptional<z.ZodBoolean>; strategy: z.ZodOptional<z.ZodEnum<{ semantic: "semantic"; oldest_first: "oldest_first"; lowest_priority: "lowest_priority"; priority_weighted_age: "priority_weighted_age"; summarize: "summarize"; sliding_window: "sliding_window"; hierarchical: "hierarchical"; }>>; maxTokens: z.ZodOptional<z.ZodNumber>; reserveTokens: z.ZodOptional<z.ZodNumber>; triggerThreshold: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ capabilities: z.ZodArray<z.ZodEnum<{ code_generation: "code_generation"; code_review: "code_review"; collaboration: "collaboration"; delegation: "delegation"; research: "research"; task_execution: "task_execution"; tool_use: "tool_use"; }>>; contextPruning: z.ZodOptional<z.ZodObject<{ enabled: z.ZodOptional<z.ZodBoolean>; maxTokens: z.ZodOptional<z.ZodNumber>; reserveTokens: z.ZodOptional<z.ZodNumber>; strategy: z.ZodOptional<z.ZodEnum<{ hierarchical: "hierarchical"; lowest_priority: "lowest_priority"; oldest_first: "oldest_first"; priority_weighted_age: "priority_weighted_age"; semantic: "semantic"; sliding_window: "sliding_window"; summarize: "summarize"; }>>; triggerThreshold: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; id: z.ZodString; maxTokens: z.ZodOptional<z.ZodNumber>; role: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; data_visualization_expert: "data_visualization_expert"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; pm_expert: "pm_expert"; qa_expert: "qa_expert"; research_expert: "research_expert"; security_expert: "security_expert"; testing_expert: "testing_expert"; thinker: "thinker"; ux_expert: "ux_expert"; verifier: "verifier"; worker: "worker"; }>; systemPrompt: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 ClassDeclaration BaseCliAdapter
   dispose() => Promise<void>
   execute(task: CliTask, options?: ExecutionOptions) => Promise<Result<CliResponse, CliError>>
@@ -771,7 +771,7 @@ ClassDeclaration BaseCliAdapter
 InterfaceDeclaration BaseMcpToolDeps
   logger?: ILogger | undefined
   rateLimiter: RateLimiter
-  security?: { allowedPaths: string[]; blockedPatterns: string[]; rateLimit: { enabled: boolean; requestsPerMinute: number; perTool?: Record<string, { capacity: number; refillRate: number; refillIntervalMs: number; }> | undefined; }; secretsFile?: string | undefined; policy?: { defaultMode: "read-only" | "read-write"; policyMode: "warn" | "enforce"; } | undefined; sandbox?: { mode: "none" | "policy" | "container"; fallbackToPolicy: boolean; networkEnabled: boolean; dockerImage?: string | undefined; } | undefined; timeout?: { defaultTimeoutMs: number; maxTimeoutMs: number; enableLogging: boolean; uriValidation: boolean; perToolTimeout?: Record<string, number> | undefined; } | undefined; toolAllowlist?: string[] | undefined; audit?: { enabled: boolean; minSeverity: "info" | "warning" | "critical"; enableHashChain: boolean; maxFileSizeBytes: number; maxFiles: number; logDir?: string | undefined; } | undefined; auth?: { enabled: boolean; method: "token" | "oauth2"; tokenHeader: string; tokenFile?: string | undefined; } | undefined; } | undefined
+  security?: { allowedPaths: string[]; audit?: { enabled: boolean; enableHashChain: boolean; logDir?: string | undefined; maxFiles: number; maxFileSizeBytes: number; minSeverity: "info" | "warning" | "critical"; } | undefined; auth?: { enabled: boolean; method: "token" | "oauth2"; tokenFile?: string | undefined; tokenHeader: string; } | undefined; blockedPatterns: string[]; policy?: { defaultMode: "read-only" | "read-write"; policyMode: "warn" | "enforce"; } | undefined; rateLimit: { enabled: boolean; perTool?: Record<string, { capacity: number; refillIntervalMs: number; refillRate: number; }> | undefined; requestsPerMinute: number; }; sandbox?: { dockerImage?: string | undefined; fallbackToPolicy: boolean; mode: "none" | "policy" | "container"; networkEnabled: boolean; } | undefined; secretsFile?: string | undefined; timeout?: { defaultTimeoutMs: number; enableLogging: boolean; maxTimeoutMs: number; perToolTimeout?: Record<string, number> | undefined; uriValidation: boolean; } | undefined; toolAllowlist?: string[] | undefined; } | undefined
 InterfaceDeclaration Belief
   readonly beliefId: string
   readonly confidence: BeliefConfidence
@@ -789,7 +789,7 @@ InterfaceDeclaration Belief
   readonly updatedAt: Date
   readonly version: number
 VariableDeclaration|TypeAliasDeclaration BeliefConfidence
-  : { readonly HIGH: "high"; readonly MEDIUM: "medium"; readonly LOW: "low"; readonly SPECULATIVE: "speculative"; }
+  : { readonly HIGH: "high"; readonly LOW: "low"; readonly MEDIUM: "medium"; readonly SPECULATIVE: "speculative"; }
   = (typeof BeliefConfidence)[keyof typeof BeliefConfidence]
 InterfaceDeclaration BeliefMemoryStats
   readonly activeBeliefs: number
@@ -813,7 +813,7 @@ InterfaceDeclaration BeliefQuery
   readonly sourceType?: BeliefSourceType | undefined
   readonly subject?: string | undefined
 VariableDeclaration|TypeAliasDeclaration BeliefSourceType
-  : { readonly OBSERVATION: "observation"; readonly INFERENCE: "inference"; readonly EXTERNAL: "external"; readonly USER_INPUT: "user_input"; readonly HINDSIGHT: "hindsight"; readonly PRIOR: "prior"; }
+  : { readonly EXTERNAL: "external"; readonly HINDSIGHT: "hindsight"; readonly INFERENCE: "inference"; readonly OBSERVATION: "observation"; readonly PRIOR: "prior"; readonly USER_INPUT: "user_input"; }
   = (typeof BeliefSourceType)[keyof typeof BeliefSourceType]
 InterfaceDeclaration BeliefStats
   available: boolean
@@ -829,7 +829,7 @@ InterfaceDeclaration BeliefUpdate
   readonly updateType: BeliefUpdateType
   readonly updatedBy?: string | undefined
 TypeAliasDeclaration|VariableDeclaration BeliefUpdateType
-  : { readonly RETAIN: "retain"; readonly REVISE: "revise"; readonly SUPERSEDE: "supersede"; readonly CORRECT: "correct"; readonly REINFORCE: "reinforce"; readonly WEAKEN: "weaken"; }
+  : { readonly CORRECT: "correct"; readonly REINFORCE: "reinforce"; readonly RETAIN: "retain"; readonly REVISE: "revise"; readonly SUPERSEDE: "supersede"; readonly WEAKEN: "weaken"; }
   = (typeof BeliefUpdateType)[keyof typeof BeliefUpdateType]
 InterfaceDeclaration BenchmarkAdapter
   evaluate(instance: TInstance, prediction: TPrediction) => Promise<TEvalResult>
@@ -915,7 +915,7 @@ InterfaceDeclaration BestSolution
   readonly qualityScore: number
   readonly treeId: string
 VariableDeclaration BestSolutionSchema
-  : z.ZodObject<{ treeId: z.ZodString; path: z.ZodArray<z.ZodString>; conclusionNode: z.ZodObject<{ id: z.ZodString; treeId: z.ZodString; parentId: z.ZodNullable<z.ZodString>; children: z.ZodArray<z.ZodString>; depth: z.ZodNumber; stepType: z.ZodEnum<{ inference: "inference"; hypothesis: "hypothesis"; decomposition: "decomposition"; synthesis: "synthesis"; verification: "verification"; conclusion: "conclusion"; }>; content: z.ZodString; metadata: z.ZodObject<{ source: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodOptional<z.ZodNumber>; generationTimeMs: z.ZodOptional<z.ZodNumber>; crossReferences: z.ZodOptional<z.ZodArray<z.ZodString>>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>; state: z.ZodEnum<{ pending: "pending"; completed: "completed"; error: "error"; active: "active"; pruned: "pruned"; }>; isActive: z.ZodBoolean; activationScore: z.ZodNumber; confidence: z.ZodNumber; qualityScore: z.ZodNumber; estimatedValue: z.ZodNumber; createdAt: z.ZodNumber; updatedAt: z.ZodNumber; }, z.core.$strip>; confidence: z.ZodNumber; qualityScore: z.ZodNumber; combinedScore: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ combinedScore: z.ZodNumber; conclusionNode: z.ZodObject<{ activationScore: z.ZodNumber; children: z.ZodArray<z.ZodString>; confidence: z.ZodNumber; content: z.ZodString; createdAt: z.ZodNumber; depth: z.ZodNumber; estimatedValue: z.ZodNumber; id: z.ZodString; isActive: z.ZodBoolean; metadata: z.ZodObject<{ crossReferences: z.ZodOptional<z.ZodArray<z.ZodString>>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; generationTimeMs: z.ZodOptional<z.ZodNumber>; source: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>; parentId: z.ZodNullable<z.ZodString>; qualityScore: z.ZodNumber; state: z.ZodEnum<{ active: "active"; completed: "completed"; error: "error"; pending: "pending"; pruned: "pruned"; }>; stepType: z.ZodEnum<{ conclusion: "conclusion"; decomposition: "decomposition"; hypothesis: "hypothesis"; inference: "inference"; synthesis: "synthesis"; verification: "verification"; }>; treeId: z.ZodString; updatedAt: z.ZodNumber; }, z.core.$strip>; confidence: z.ZodNumber; path: z.ZodArray<z.ZodString>; qualityScore: z.ZodNumber; treeId: z.ZodString; }, z.core.$strip>
 VariableDeclaration BIAS_CATEGORY
   : SafetyCategory
 TypeAliasDeclaration BillingMode
@@ -953,13 +953,13 @@ ClassDeclaration BudgetRouter
   getSessionBudget() => SessionBudget
   resetBudget() => void
   routeWithBudget(task: CliTask, budget?: BudgetConstraint) => Promise<Result<BudgetRoutingResult, BudgetExceededError>>
-  updateBudget(usage: { tokens?: number; costUsd?: number; }) => void
+  updateBudget(usage: { costUsd?: number; tokens?: number; }) => void
 InterfaceDeclaration BudgetRouterOptions
   readonly defaultConstraints?: BudgetConstraint | undefined
   readonly enforceHardLimits?: boolean | undefined
-  readonly sessionBudget?: { readonly tokenBudget?: number; readonly costBudgetUsd?: number; readonly resetIntervalMs?: number; } | undefined
+  readonly sessionBudget?: { readonly costBudgetUsd?: number; readonly resetIntervalMs?: number; readonly tokenBudget?: number; } | undefined
   readonly taskClassCostCeilings?: Readonly<Partial<Record<"research" | "architecture" | "documentation" | "testing" | "devops" | "planning" | "code_generation" | "code_review" | "security_review" | "exploration", number>>> | undefined
-  readonly warningThresholds?: { readonly info?: number; readonly warning?: number; readonly critical?: number; } | undefined
+  readonly warningThresholds?: { readonly critical?: number; readonly info?: number; readonly warning?: number; } | undefined
 InterfaceDeclaration BudgetRoutingResult
   readonly adapter: ICliAdapter | null
   readonly estimatedCostUsd: number
@@ -1042,7 +1042,7 @@ VariableDeclaration BUILT_IN_TEMPLATES
 TypeAliasDeclaration BuiltInExpertType
   = | 'code' | 'architecture' | 'security' | 'documentation' | 'testing' | 'devops' | 'research' | 'pm' | 'ux' | 'infrastructure' | 'qa' | 'data-visualization'
 VariableDeclaration BuiltInExpertTypeSchema
-  : z.ZodEnum<{ research: "research"; pm: "pm"; qa: "qa"; security: "security"; code: "code"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; devops: "devops"; ux: "ux"; infrastructure: "infrastructure"; "data-visualization": "data-visualization"; }>
+  : z.ZodEnum<{ "data-visualization": "data-visualization"; architecture: "architecture"; code: "code"; devops: "devops"; documentation: "documentation"; infrastructure: "infrastructure"; pm: "pm"; qa: "qa"; research: "research"; security: "security"; testing: "testing"; ux: "ux"; }>
 TypeAliasDeclaration BuiltInTemplateName
   = (typeof BUILT_IN_TEMPLATES)[number]
 TypeAliasDeclaration BuiltInType
@@ -1244,7 +1244,7 @@ InterfaceDeclaration Checkpoint
 VariableDeclaration CHECKPOINT_SCHEMA_VERSION
   : 1
 InterfaceDeclaration CheckpointInterrupt
-  readonly additionalInterrupts?: readonly { readonly nodeId: string; readonly interruptId: string; readonly value: unknown; }[] | undefined
+  readonly additionalInterrupts?: readonly { readonly interruptId: string; readonly nodeId: string; readonly value: unknown; }[] | undefined
   readonly consumedAt?: string | undefined
   readonly createdAt: string
   readonly interruptId: string
@@ -1275,9 +1275,9 @@ ClassDeclaration ChildProcess
   readonly spawnfile: string
   readonly stdio: [Stream.Writable | null, Readable | null, Readable | null, Stream.Writable | Readable | null | undefined, Stream.Writable | Readable | null | undefined]
   ref() => void
-  send{ (message: Serializable, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, options?: MessageOptions, callback?: (error: Error | null) => void): boolean; }
-  send{ (message: Serializable, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, options?: MessageOptions, callback?: (error: Error | null) => void): boolean; }
-  send{ (message: Serializable, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, options?: MessageOptions, callback?: (error: Error | null) => void): boolean; }
+  send{ (message: Serializable, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, options?: MessageOptions, callback?: (error: Error | null) => void): boolean;; }
+  send{ (message: Serializable, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, options?: MessageOptions, callback?: (error: Error | null) => void): boolean;; }
+  send{ (message: Serializable, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, callback?: (error: Error | null) => void): boolean; (message: Serializable, sendHandle?: SendHandle, options?: MessageOptions, callback?: (error: Error | null) => void): boolean;; }
   stderr: Readable | null
   stdin: Stream.Writable | null
   stdout: Readable | null
@@ -1318,7 +1318,7 @@ ClassDeclaration CircuitError
   readonly cliName: "claude" | "gemini" | "codex" | "opencode"
   readonly failureCategory?: FailureCategory | undefined
 TypeAliasDeclaration|VariableDeclaration CircuitErrorCode
-  : { readonly CIRCUIT_OPEN: "CIRCUIT_OPEN"; readonly CIRCUIT_HALF_OPEN_REJECTED: "CIRCUIT_HALF_OPEN_REJECTED"; readonly EXECUTION_FAILED: "EXECUTION_FAILED"; }
+  : { readonly CIRCUIT_HALF_OPEN_REJECTED: "CIRCUIT_HALF_OPEN_REJECTED"; readonly CIRCUIT_OPEN: "CIRCUIT_OPEN"; readonly EXECUTION_FAILED: "EXECUTION_FAILED"; }
   = (typeof CircuitErrorCode)[keyof typeof CircuitErrorCode]
 InterfaceDeclaration CircuitProtectedResult
   readonly executedBy: "claude" | "gemini" | "codex" | "opencode"
@@ -1360,7 +1360,7 @@ FunctionDeclaration classifyExpertFailure
 InterfaceDeclaration ClassifyInput
   readonly authorAssociation: string
   readonly config?: Partial<{ allowlistedMaintainers: string[]; failOpen: boolean; maxInputLength: number; }> | undefined
-  readonly sanitizedInput?: { content: string; originalLength: number; trustTier: "1" | "2" | "3" | "4"; userRole: "unknown" | "maintainer" | "owner" | "collaborator" | "contributor" | "member"; injectionFlags: ("authority_claim" | "instruction_pattern" | "system_prompt_manipulation" | "hidden_content" | "urgency_manipulation" | "fake_conversation" | "base64_encoded" | "external_link_instruction")[]; strippedElements: { tag: string; reason: string; startIndex: number; length: number; }[]; wasModified: boolean; sanitizedAt: string; } | undefined
+  readonly sanitizedInput?: { content: string; injectionFlags: ("authority_claim" | "instruction_pattern" | "system_prompt_manipulation" | "hidden_content" | "urgency_manipulation" | "fake_conversation" | "base64_encoded" | "external_link_instruction")[]; originalLength: number; sanitizedAt: string; strippedElements: { length: number; reason: string; startIndex: number; tag: string; }[]; trustTier: "1" | "2" | "3" | "4"; userRole: "unknown" | "maintainer" | "owner" | "collaborator" | "contributor" | "member"; wasModified: boolean; } | undefined
   readonly username: string
 InterfaceDeclaration ClassifyResult
   readonly isAllowlisted: boolean
@@ -1375,7 +1375,7 @@ FunctionDeclaration classifyTrust
 VariableDeclaration CLAUDE_MODEL_ALIASES
   : Record<string, string>
 VariableDeclaration CLAUDE_MODELS
-  : { readonly OPUS_4: string; readonly SONNET_4: string; readonly HAIKU_4: string; }
+  : { readonly HAIKU_4: string; readonly OPUS_4: string; readonly SONNET_4: string; }
 ClassDeclaration ClaudeAdapter
   complete(request: CompletionRequest) => Promise<Result<CompletionResponse, ModelError>>
   countTokens(text: string) => Promise<number>
@@ -1395,13 +1395,13 @@ ClassDeclaration ClaudeCliAdapter
 InterfaceDeclaration ClaudeCliResponse
   readonly duration_ms?: number | undefined
   readonly is_error: boolean
-  readonly modelUsage?: Record<string, { readonly inputTokens: number; readonly outputTokens: number; readonly cacheReadInputTokens?: number; readonly cacheCreationInputTokens?: number; readonly costUSD?: number; readonly contextWindow?: number; }> | undefined
+  readonly modelUsage?: Record<string, { readonly cacheCreationInputTokens?: number; readonly cacheReadInputTokens?: number; readonly contextWindow?: number; readonly costUSD?: number; readonly inputTokens: number; readonly outputTokens: number; }> | undefined
   readonly result: string
   readonly session_id?: string | undefined
   readonly subtype?: "success" | "error" | undefined
   readonly total_cost_usd?: number | undefined
   readonly type: "result"
-  readonly usage?: { readonly input_tokens: number; readonly output_tokens: number; readonly cache_creation_input_tokens?: number; readonly cache_read_input_tokens?: number; } | undefined
+  readonly usage?: { readonly cache_creation_input_tokens?: number; readonly cache_read_input_tokens?: number; readonly input_tokens: number; readonly output_tokens: number; } | undefined
 ClassDeclaration ClaudeResponseParser
   extractResponse(raw: string) => string | null
   extractSessionId(raw: string) => string | null
@@ -1427,7 +1427,7 @@ VariableDeclaration CLI_DEFAULT_CACHE_CONFIG
 VariableDeclaration CLI_DEFAULT_CAPABILITIES
   : Record<"claude" | "gemini" | "codex" | "opencode", CapabilityProfile>
 VariableDeclaration CLI_DEFAULT_COMPOSITE_CONFIG
-  : { enableConfidenceCascade: boolean; enableBudgetFilter: boolean; enableCapabilityMatch: boolean; enableZeroRouter: boolean; enablePreferenceRouting: boolean; enableTopsisRanking: boolean; enableLinUCBSelection: boolean; enableQualityConstraint: boolean; enableResourceStrategy: boolean; enableStrategyDistillation: boolean; enableLatencyTracking: boolean; enableRoutingMemory: boolean; enableKnnRouting: boolean; latencyScoreWeight: number; linucbAlpha: number; billingMode: "plan" | "api"; enableCapacityBalancing: boolean; maxDecisionTimeMs: number; preferenceMinDataPoints: number; budgetConstraints?: { maxTokens?: number | undefined; maxCostUsd?: number | undefined; maxLatencyMs?: number | undefined; taskClassMaxCostUsd?: Partial<Record<"research" | "architecture" | "documentation" | "testing" | "devops" | "planning" | "code_generation" | "code_review" | "security_review" | "exploration", number>> | undefined; } | undefined; }
+  : { billingMode: "plan" | "api"; budgetConstraints?: { maxCostUsd?: number | undefined; maxLatencyMs?: number | undefined; maxTokens?: number | undefined; taskClassMaxCostUsd?: Partial<Record<"research" | "architecture" | "documentation" | "testing" | "devops" | "planning" | "code_generation" | "code_review" | "security_review" | "exploration", number>> | undefined; } | undefined; enableBudgetFilter: boolean; enableCapabilityMatch: boolean; enableCapacityBalancing: boolean; enableConfidenceCascade: boolean; enableKnnRouting: boolean; enableLatencyTracking: boolean; enableLinUCBSelection: boolean; enablePreferenceRouting: boolean; enableQualityConstraint: boolean; enableResourceStrategy: boolean; enableRoutingMemory: boolean; enableStrategyDistillation: boolean; enableTopsisRanking: boolean; enableZeroRouter: boolean; latencyScoreWeight: number; linucbAlpha: number; maxDecisionTimeMs: number; preferenceMinDataPoints: number; }
 VariableDeclaration CLI_TIMEOUT_PROFILES
   : Record<string, TimeoutProfile>
 VariableDeclaration CLI_VERSION_REQUIREMENTS
@@ -1469,7 +1469,7 @@ ClassDeclaration CliCircuitBreakerIntegration
   resetAllCircuits() => void
   resetCircuit(cliName: CliName) => void
 InterfaceDeclaration CliCircuitHealthStatus
-  readonly clis: readonly { readonly name: CliName; readonly healthy: boolean; readonly circuitState: "closed" | "open" | "half-open"; readonly failureCount: number; readonly lastFailureTime: number | null; }[]
+  readonly clis: readonly { readonly circuitState: "closed" | "open" | "half-open"; readonly failureCount: number; readonly healthy: boolean; readonly lastFailureTime: number | null; readonly name: CliName; }[]
   readonly healthyCount: number
   readonly systemHealthy: boolean
   readonly timestamp: number
@@ -1490,26 +1490,26 @@ InterfaceDeclaration CliDetectionCacheConfig
 VariableDeclaration CliDetectionCacheConfigSchema
   : z.ZodObject<{ ttlMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 ClassDeclaration Client
-  callTool(params: CallToolRequest["params"], resultSchema?: typeof CallToolResultSchema | typeof CompatibilityCallToolResultSchema, options?: RequestOptions) => Promise<{ [x: string]: unknown; content: ({ type: "text"; text: string; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: Record<string, unknown> | undefined; } | { type: "image"; data: string; mimeType: string; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: Record<string, unknown> | undefined; } | { type: "audio"; data: string; mimeType: string; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: Record<string, unknown> | undefined; } | { type: "resource"; resource: { uri: string; text: string; mimeType?: string | undefined; _meta?: Record<string, unknown> | undefined; } | { uri: string; blob: string; mimeType?: string | undefined; _meta?: Record<string, unknown> | undefined; }; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: Record<string, unknown> | undefined; } | { uri: string; name: string; type: "resource_link"; description?: string | undefined; mimeType?: string | undefined; size?: number | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: { [x: string]: unknown; } | undefined; icons?: { src: string; mimeType?: string | undefined; sizes?: string[] | undefined; theme?: "light" | "dark" | undefined; }[] | undefined; title?: string | undefined; })[]; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; structuredContent?: Record<string, unknown> | undefined; isError?: boolean | undefined; } | { [x: string]: unknown; toolResult: unknown; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; }>
-  complete(params: CompleteRequest["params"], options?: RequestOptions) => Promise<{ [x: string]: unknown; completion: { [x: string]: unknown; values: string[]; total?: number | undefined; hasMore?: boolean | undefined; }; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; }>
+  callTool(params: CallToolRequest["params"], resultSchema?: typeof CallToolResultSchema | typeof CompatibilityCallToolResultSchema, options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; content: ({ _meta?: Record<string, unknown> | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; text: string; type: "text"; } | { _meta?: Record<string, unknown> | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; data: string; mimeType: string; type: "image"; } | { _meta?: Record<string, unknown> | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; data: string; mimeType: string; type: "audio"; } | { _meta?: Record<string, unknown> | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; resource: { _meta?: Record<string, unknown> | undefined; mimeType?: string | undefined; text: string; uri: string; } | { _meta?: Record<string, unknown> | undefined; blob: string; mimeType?: string | undefined; uri: string; }; type: "resource"; } | { _meta?: { [x: string]: unknown; } | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; description?: string | undefined; icons?: { mimeType?: string | undefined; sizes?: string[] | undefined; src: string; theme?: "light" | "dark" | undefined; }[] | undefined; mimeType?: string | undefined; name: string; size?: number | undefined; title?: string | undefined; type: "resource_link"; uri: string; })[]; isError?: boolean | undefined; structuredContent?: Record<string, unknown> | undefined; } | { _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; toolResult: unknown; }>
+  complete(params: CompleteRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; completion: { [x: string]: unknown; hasMore?: boolean | undefined; total?: number | undefined; values: string[]; }; }>
   connect(transport: Transport, options?: RequestOptions) => Promise<void>
   get experimental(): { tasks: ExperimentalClientTasks<RequestT, NotificationT, ResultT>; }
   getInstructions() => string | undefined
-  getPrompt(params: GetPromptRequest["params"], options?: RequestOptions) => Promise<{ [x: string]: unknown; messages: { role: "user" | "assistant"; content: { type: "text"; text: string; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: Record<string, unknown> | undefined; } | { type: "image"; data: string; mimeType: string; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: Record<string, unknown> | undefined; } | { type: "audio"; data: string; mimeType: string; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: Record<string, unknown> | undefined; } | { type: "resource"; resource: { uri: string; text: string; mimeType?: string | undefined; _meta?: Record<string, unknown> | undefined; } | { uri: string; blob: string; mimeType?: string | undefined; _meta?: Record<string, unknown> | undefined; }; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: Record<string, unknown> | undefined; } | { uri: string; name: string; type: "resource_link"; description?: string | undefined; mimeType?: string | undefined; size?: number | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: { [x: string]: unknown; } | undefined; icons?: { src: string; mimeType?: string | undefined; sizes?: string[] | undefined; theme?: "light" | "dark" | undefined; }[] | undefined; title?: string | undefined; }; }[]; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; description?: string | undefined; }>
+  getPrompt(params: GetPromptRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; description?: string | undefined; messages: { content: { _meta?: Record<string, unknown> | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; text: string; type: "text"; } | { _meta?: Record<string, unknown> | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; data: string; mimeType: string; type: "image"; } | { _meta?: Record<string, unknown> | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; data: string; mimeType: string; type: "audio"; } | { _meta?: Record<string, unknown> | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; resource: { _meta?: Record<string, unknown> | undefined; mimeType?: string | undefined; text: string; uri: string; } | { _meta?: Record<string, unknown> | undefined; blob: string; mimeType?: string | undefined; uri: string; }; type: "resource"; } | { _meta?: { [x: string]: unknown; } | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; description?: string | undefined; icons?: { mimeType?: string | undefined; sizes?: string[] | undefined; src: string; theme?: "light" | "dark" | undefined; }[] | undefined; mimeType?: string | undefined; name: string; size?: number | undefined; title?: string | undefined; type: "resource_link"; uri: string; }; role: "user" | "assistant"; }[]; }>
   getServerCapabilities() => ServerCapabilities | undefined
   getServerVersion() => Implementation | undefined
-  listPrompts(params?: ListPromptsRequest["params"], options?: RequestOptions) => Promise<{ [x: string]: unknown; prompts: { name: string; description?: string | undefined; arguments?: { name: string; description?: string | undefined; required?: boolean | undefined; }[] | undefined; _meta?: { [x: string]: unknown; } | undefined; icons?: { src: string; mimeType?: string | undefined; sizes?: string[] | undefined; theme?: "light" | "dark" | undefined; }[] | undefined; title?: string | undefined; }[]; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; nextCursor?: string | undefined; }>
-  listResourceTemplates(params?: ListResourceTemplatesRequest["params"], options?: RequestOptions) => Promise<{ [x: string]: unknown; resourceTemplates: { uriTemplate: string; name: string; description?: string | undefined; mimeType?: string | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: { [x: string]: unknown; } | undefined; icons?: { src: string; mimeType?: string | undefined; sizes?: string[] | undefined; theme?: "light" | "dark" | undefined; }[] | undefined; title?: string | undefined; }[]; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; nextCursor?: string | undefined; }>
-  listResources(params?: ListResourcesRequest["params"], options?: RequestOptions) => Promise<{ [x: string]: unknown; resources: { uri: string; name: string; description?: string | undefined; mimeType?: string | undefined; size?: number | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; priority?: number | undefined; lastModified?: string | undefined; } | undefined; _meta?: { [x: string]: unknown; } | undefined; icons?: { src: string; mimeType?: string | undefined; sizes?: string[] | undefined; theme?: "light" | "dark" | undefined; }[] | undefined; title?: string | undefined; }[]; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; nextCursor?: string | undefined; }>
-  listTools(params?: ListToolsRequest["params"], options?: RequestOptions) => Promise<{ [x: string]: unknown; tools: { inputSchema: { [x: string]: unknown; type: "object"; properties?: Record<string, object> | undefined; required?: string[] | undefined; }; name: string; description?: string | undefined; outputSchema?: { [x: string]: unknown; type: "object"; properties?: Record<string, object> | undefined; required?: string[] | undefined; } | undefined; annotations?: { title?: string | undefined; readOnlyHint?: boolean | undefined; destructiveHint?: boolean | undefined; idempotentHint?: boolean | undefined; openWorldHint?: boolean | undefined; } | undefined; execution?: { taskSupport?: "optional" | "required" | "forbidden" | undefined; } | undefined; _meta?: Record<string, unknown> | undefined; icons?: { src: string; mimeType?: string | undefined; sizes?: string[] | undefined; theme?: "light" | "dark" | undefined; }[] | undefined; title?: string | undefined; }[]; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; nextCursor?: string | undefined; }>
-  ping(options?: RequestOptions) => Promise<{ _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; }>
-  readResource(params: ReadResourceRequest["params"], options?: RequestOptions) => Promise<{ [x: string]: unknown; contents: ({ uri: string; text: string; mimeType?: string | undefined; _meta?: Record<string, unknown> | undefined; } | { uri: string; blob: string; mimeType?: string | undefined; _meta?: Record<string, unknown> | undefined; })[]; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; }>
+  listPrompts(params?: ListPromptsRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; nextCursor?: string | undefined; prompts: { _meta?: { [x: string]: unknown; } | undefined; arguments?: { description?: string | undefined; name: string; required?: boolean | undefined; }[] | undefined; description?: string | undefined; icons?: { mimeType?: string | undefined; sizes?: string[] | undefined; src: string; theme?: "light" | "dark" | undefined; }[] | undefined; name: string; title?: string | undefined; }[]; }>
+  listResourceTemplates(params?: ListResourceTemplatesRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; nextCursor?: string | undefined; resourceTemplates: { _meta?: { [x: string]: unknown; } | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; description?: string | undefined; icons?: { mimeType?: string | undefined; sizes?: string[] | undefined; src: string; theme?: "light" | "dark" | undefined; }[] | undefined; mimeType?: string | undefined; name: string; title?: string | undefined; uriTemplate: string; }[]; }>
+  listResources(params?: ListResourcesRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; nextCursor?: string | undefined; resources: { _meta?: { [x: string]: unknown; } | undefined; annotations?: { audience?: ("user" | "assistant")[] | undefined; lastModified?: string | undefined; priority?: number | undefined; } | undefined; description?: string | undefined; icons?: { mimeType?: string | undefined; sizes?: string[] | undefined; src: string; theme?: "light" | "dark" | undefined; }[] | undefined; mimeType?: string | undefined; name: string; size?: number | undefined; title?: string | undefined; uri: string; }[]; }>
+  listTools(params?: ListToolsRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; nextCursor?: string | undefined; tools: { _meta?: Record<string, unknown> | undefined; annotations?: { destructiveHint?: boolean | undefined; idempotentHint?: boolean | undefined; openWorldHint?: boolean | undefined; readOnlyHint?: boolean | undefined; title?: string | undefined; } | undefined; description?: string | undefined; execution?: { taskSupport?: "optional" | "required" | "forbidden" | undefined; } | undefined; icons?: { mimeType?: string | undefined; sizes?: string[] | undefined; src: string; theme?: "light" | "dark" | undefined; }[] | undefined; inputSchema: { [x: string]: unknown; properties?: Record<string, object> | undefined; required?: string[] | undefined; type: "object"; }; name: string; outputSchema?: { [x: string]: unknown; properties?: Record<string, object> | undefined; required?: string[] | undefined; type: "object"; } | undefined; title?: string | undefined; }[]; }>
+  ping(options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; }>
+  readResource(params: ReadResourceRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; contents: ({ _meta?: Record<string, unknown> | undefined; mimeType?: string | undefined; text: string; uri: string; } | { _meta?: Record<string, unknown> | undefined; blob: string; mimeType?: string | undefined; uri: string; })[]; }>
   registerCapabilities(capabilities: ClientCapabilities) => void
   sendRootsListChanged() => Promise<void>
-  setLoggingLevel(level: LoggingLevel, options?: RequestOptions) => Promise<{ _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; }>
+  setLoggingLevel(level: LoggingLevel, options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; }>
   setRequestHandler<T extends AnyObjectSchema>(requestSchema: T, handler: (request: SchemaOutput<T>, extra: RequestHandlerExtra<ClientRequest | RequestT, ClientNotification | NotificationT>) => ClientResult | ResultT | Promise<ClientResult | ResultT>) => void
-  subscribeResource(params: SubscribeRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; }>
-  unsubscribeResource(params: UnsubscribeRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; }>
+  subscribeResource(params: SubscribeRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; }>
+  unsubscribeResource(params: UnsubscribeRequest["params"], options?: RequestOptions) => Promise<{ _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; }>
 InterfaceDeclaration CliError
   readonly cause?: Error | undefined
   readonly cli: "claude" | "gemini" | "codex" | "opencode"
@@ -1579,11 +1579,11 @@ InterfaceDeclaration CodeAnalysisResult
 InterfaceDeclaration CodeChange
   description: string
   file: string
-  lineRange?: { start: number; end: number; } | undefined
+  lineRange?: { end: number; start: number; } | undefined
   modified: string
   original?: string | undefined
 VariableDeclaration CodeChangeSchema
-  : z.ZodObject<{ file: z.ZodString; lineRange: z.ZodOptional<z.ZodObject<{ start: z.ZodNumber; end: z.ZodNumber; }, z.core.$strip>>; original: z.ZodOptional<z.ZodString>; modified: z.ZodString; description: z.ZodString; }, z.core.$strip>
+  : z.ZodObject<{ description: z.ZodString; file: z.ZodString; lineRange: z.ZodOptional<z.ZodObject<{ end: z.ZodNumber; start: z.ZodNumber; }, z.core.$strip>>; modified: z.ZodString; original: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 ClassDeclaration CodeExpert
   getExpertOptions() => Readonly<CodeExpertOptions>
 InterfaceDeclaration CodeExpertOptions
@@ -1624,7 +1624,7 @@ InterfaceDeclaration CollaborationConfig
   task: Task
   timeout?: number | undefined
 VariableDeclaration CollaborationConfigSchema
-  : z.ZodObject<{ sessionId: z.ZodString; pattern: z.ZodEnum<{ review: "review"; consensus: "consensus"; sequential: "sequential"; parallel: "parallel"; reflexion: "reflexion"; aegean: "aegean"; "self-refine": "self-refine"; "self-debug": "self-debug"; }>; experts: z.ZodArray<z.ZodString>; task: z.ZodObject<{ id: z.ZodString; description: z.ZodString; context: z.ZodRecord<z.ZodString, z.ZodUnknown>; constraints: z.ZodOptional<z.ZodObject<{ maxDuration: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; outputFormat: z.ZodOptional<z.ZodEnum<{ json: "json"; text: "text"; markdown: "markdown"; }>>; allowedTools: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>>; priority: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>; timeout: z.ZodOptional<z.ZodNumber>; minVotes: z.ZodOptional<z.ZodNumber>; requireUnanimous: z.ZodOptional<z.ZodBoolean>; maxRetries: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ experts: z.ZodArray<z.ZodString>; maxRetries: z.ZodOptional<z.ZodNumber>; minVotes: z.ZodOptional<z.ZodNumber>; pattern: z.ZodEnum<{ "self-debug": "self-debug"; "self-refine": "self-refine"; aegean: "aegean"; consensus: "consensus"; parallel: "parallel"; reflexion: "reflexion"; review: "review"; sequential: "sequential"; }>; requireUnanimous: z.ZodOptional<z.ZodBoolean>; sessionId: z.ZodString; task: z.ZodObject<{ constraints: z.ZodOptional<z.ZodObject<{ allowedTools: z.ZodOptional<z.ZodArray<z.ZodString>>; maxDuration: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; outputFormat: z.ZodOptional<z.ZodEnum<{ json: "json"; markdown: "markdown"; text: "text"; }>>; }, z.core.$strip>>; context: z.ZodRecord<z.ZodString, z.ZodUnknown>; description: z.ZodString; id: z.ZodString; priority: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>; timeout: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 TypeAliasDeclaration CollaborationMessage
   = | TaskAssignmentMessage | ResultSubmissionMessage | ReviewRequestMessage | ReviewResponseMessage | FeedbackMessage | VoteMessage | StatusUpdateMessage
 InterfaceDeclaration CollaborationMetadata
@@ -1635,7 +1635,7 @@ InterfaceDeclaration CollaborationMetadata
 TypeAliasDeclaration CollaborationPattern
   = | 'sequential' | 'parallel' | 'review' | 'consensus' | 'reflexion' | 'aegean' | 'self-refine' | 'self-debug'
 VariableDeclaration CollaborationPatternSchema
-  : z.ZodEnum<{ review: "review"; consensus: "consensus"; sequential: "sequential"; parallel: "parallel"; reflexion: "reflexion"; aegean: "aegean"; "self-refine": "self-refine"; "self-debug": "self-debug"; }>
+  : z.ZodEnum<{ "self-debug": "self-debug"; "self-refine": "self-refine"; aegean: "aegean"; consensus: "consensus"; parallel: "parallel"; reflexion: "reflexion"; review: "review"; sequential: "sequential"; }>
 InterfaceDeclaration CollaborationResult
   aggregatedResult: AggregatedResult
   durationMs: number
@@ -1713,7 +1713,7 @@ InterfaceDeclaration CompiledGraph
   readonly stateSchema: Readonly<StateSchema>
 InterfaceDeclaration CompiledPipeline
   readonly graph: CompiledGraph
-  readonly plan: { taskId: string; stages: { id: string; type: "analyze" | "route" | "execute" | "validate" | "aggregate" | "gate"; pluginId: string; inputArtifacts: string[]; outputArtifacts: string[]; dependencies: string[]; config: Record<string, unknown>; preferredCli?: string | undefined; maxRetries?: number | undefined; timeoutMs?: number | undefined; }[]; policyGates: { id: string; afterStage: string; beforeStage: string; rules: string[]; }[]; estimatedCost: { totalTokensIn: number; totalTokensOut: number; estimatedCostUsd: number; modelCalls: number; }; approvalRequired: boolean; maxIterations: number; timeoutMs: number; }
+  readonly plan: { approvalRequired: boolean; estimatedCost: { estimatedCostUsd: number; modelCalls: number; totalTokensIn: number; totalTokensOut: number; }; maxIterations: number; policyGates: { afterStage: string; beforeStage: string; id: string; rules: string[]; }[]; stages: { config: Record<string, unknown>; dependencies: string[]; id: string; inputArtifacts: string[]; maxRetries?: number | undefined; outputArtifacts: string[]; pluginId: string; preferredCli?: string | undefined; timeoutMs?: number | undefined; type: "analyze" | "route" | "execute" | "validate" | "aggregate" | "gate"; }[]; taskId: string; timeoutMs: number; }
 InterfaceDeclaration CompileOptions
   readonly handlerFactory?: NodeHandlerFactory | undefined
 FunctionDeclaration compilePipelineGraph
@@ -1722,8 +1722,8 @@ FunctionDeclaration compilePlan
   : typeof compilePlan
 TypeAliasDeclaration CompileResult
   = Result<CompiledGraph, GraphCompileError>
-  = | { readonly ok: true; readonly value: CompiledGraph } | { readonly ok: false; readonly error: string }
-  = | { readonly ok: true; readonly value: CompiledPipeline } | { readonly ok: false; readonly error: string }
+  = | { readonly ok: true; readonly value: CompiledGraph; } | { readonly error: string; readonly ok: false; }
+  = | { readonly ok: true; readonly value: CompiledPipeline; } | { readonly error: string; readonly ok: false; }
 FunctionDeclaration compileSpecToGraph
   : typeof compileSpecToGraph
 InterfaceDeclaration CompletionRequest
@@ -1748,7 +1748,7 @@ TypeAliasDeclaration ComplexityLevel
   = 'simple' | 'moderate' | 'complex' | 'expert'
   = z.infer<typeof ComplexityLevelSchema>
 VariableDeclaration ComplexityLevelSchema
-  : z.ZodEnum<{ simple: "simple"; moderate: "moderate"; complex: "complex"; expert: "expert"; }>
+  : z.ZodEnum<{ complex: "complex"; expert: "expert"; moderate: "moderate"; simple: "simple"; }>
 InterfaceDeclaration ComplianceStatus
   findings: string[]
   framework: string
@@ -1770,27 +1770,27 @@ ClassDeclaration CompositeRouter
 TypeAliasDeclaration CompositeRouterConfig
   = z.infer<typeof CompositeRouterConfigSchema>
 VariableDeclaration CompositeRouterConfigSchema
-  : z.ZodObject<{ enableConfidenceCascade: z.ZodDefault<z.ZodBoolean>; enableBudgetFilter: z.ZodDefault<z.ZodBoolean>; enableCapabilityMatch: z.ZodDefault<z.ZodBoolean>; enableZeroRouter: z.ZodDefault<z.ZodBoolean>; enablePreferenceRouting: z.ZodDefault<z.ZodBoolean>; enableTopsisRanking: z.ZodDefault<z.ZodBoolean>; enableLinUCBSelection: z.ZodDefault<z.ZodBoolean>; enableQualityConstraint: z.ZodDefault<z.ZodBoolean>; enableResourceStrategy: z.ZodDefault<z.ZodBoolean>; enableStrategyDistillation: z.ZodDefault<z.ZodBoolean>; enableLatencyTracking: z.ZodDefault<z.ZodBoolean>; enableRoutingMemory: z.ZodDefault<z.ZodBoolean>; enableKnnRouting: z.ZodDefault<z.ZodBoolean>; latencyScoreWeight: z.ZodDefault<z.ZodNumber>; budgetConstraints: z.ZodOptional<z.ZodObject<{ maxTokens: z.ZodOptional<z.ZodNumber>; maxCostUsd: z.ZodOptional<z.ZodNumber>; maxLatencyMs: z.ZodOptional<z.ZodNumber>; taskClassMaxCostUsd: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ research: "research"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; devops: "devops"; planning: "planning"; code_generation: "code_generation"; code_review: "code_review"; security_review: "security_review"; exploration: "exploration"; }> & z.core.$partial, z.ZodNumber>>; }, z.core.$strip>>; linucbAlpha: z.ZodDefault<z.ZodNumber>; billingMode: z.ZodDefault<z.ZodEnum<{ plan: "plan"; api: "api"; }>>; enableCapacityBalancing: z.ZodDefault<z.ZodBoolean>; maxDecisionTimeMs: z.ZodDefault<z.ZodNumber>; preferenceMinDataPoints: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ billingMode: z.ZodDefault<z.ZodEnum<{ api: "api"; plan: "plan"; }>>; budgetConstraints: z.ZodOptional<z.ZodObject<{ maxCostUsd: z.ZodOptional<z.ZodNumber>; maxLatencyMs: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; taskClassMaxCostUsd: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ architecture: "architecture"; code_generation: "code_generation"; code_review: "code_review"; devops: "devops"; documentation: "documentation"; exploration: "exploration"; planning: "planning"; research: "research"; security_review: "security_review"; testing: "testing"; }> & z.core.$partial, z.ZodNumber>>; }, z.core.$strip>>; enableBudgetFilter: z.ZodDefault<z.ZodBoolean>; enableCapabilityMatch: z.ZodDefault<z.ZodBoolean>; enableCapacityBalancing: z.ZodDefault<z.ZodBoolean>; enableConfidenceCascade: z.ZodDefault<z.ZodBoolean>; enableKnnRouting: z.ZodDefault<z.ZodBoolean>; enableLatencyTracking: z.ZodDefault<z.ZodBoolean>; enableLinUCBSelection: z.ZodDefault<z.ZodBoolean>; enablePreferenceRouting: z.ZodDefault<z.ZodBoolean>; enableQualityConstraint: z.ZodDefault<z.ZodBoolean>; enableResourceStrategy: z.ZodDefault<z.ZodBoolean>; enableRoutingMemory: z.ZodDefault<z.ZodBoolean>; enableStrategyDistillation: z.ZodDefault<z.ZodBoolean>; enableTopsisRanking: z.ZodDefault<z.ZodBoolean>; enableZeroRouter: z.ZodDefault<z.ZodBoolean>; latencyScoreWeight: z.ZodDefault<z.ZodNumber>; linucbAlpha: z.ZodDefault<z.ZodNumber>; maxDecisionTimeMs: z.ZodDefault<z.ZodNumber>; preferenceMinDataPoints: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration CompositeRouterConfigWithPreference
   availableModelsCache?: import("src/config/available-models-cache").AvailableModelsCache | undefined
   capabilityMatchConfig?: Partial<CapabilityMatchConfig> | undefined
   confidenceCascadeConfig?: Partial<ConfidenceCascadeConfig> | undefined
   distilledRuleStageConfig?: Partial<DistilledRuleStageConfig> | undefined
-  latencyTrackerConfig?: Partial<{ windowSize: number; decayFactor: number; maxSampleAgeMs: number; percentiles: number[]; }> | undefined
+  latencyTrackerConfig?: Partial<{ decayFactor: number; maxSampleAgeMs: number; percentiles: number[]; windowSize: number; }> | undefined
   metricsCollector?: IRoutingMetricsCollector | undefined
   orchestrationObserver?: IOrchestrationObserver | undefined
   preferenceRouterConfig?: Partial<PreferenceRouterConfig> | undefined
   qualityConstraintConfig?: Partial<QualityConstraintConfig> | undefined
   resourceStrategyConfig?: Partial<ResourceStrategyConfig> | undefined
   routingMemoryConfig?: Partial<RoutingMemoryConfig> | undefined
-  zeroRouterConfig?: Partial<{ thresholds: { easyUpperBound: number; hardLowerBound: number; }; weights: { reasoning: number; knowledge: number; creativity: number; precision: number; context_length: number; }; difficultyToTier: Record<"medium" | "hard" | "easy", "balanced" | "fast" | "powerful">; tierToClis: Record<"balanced" | "fast" | "powerful", ("claude" | "gemini" | "codex" | "opencode")[]>; enableCalibration: boolean; maxCalibrationOutcomes: number; minCalibrationOutcomes: number; verbose: boolean; }> | undefined
+  zeroRouterConfig?: Partial<{ difficultyToTier: Record<"medium" | "hard" | "easy", "balanced" | "fast" | "powerful">; enableCalibration: boolean; maxCalibrationOutcomes: number; minCalibrationOutcomes: number; thresholds: { easyUpperBound: number; hardLowerBound: number; }; tierToClis: Record<"balanced" | "fast" | "powerful", ("claude" | "gemini" | "codex" | "opencode")[]>; verbose: boolean; weights: { context_length: number; creativity: number; knowledge: number; precision: number; reasoning: number; }; }> | undefined
 InterfaceDeclaration CompositeRouterStats
   readonly avgDecisionTimeMs: number
-  readonly banditStats: readonly { name: string; pullCount: number; avgReward: number; }[]
+  readonly banditStats: readonly { avgReward: number; name: string; pullCount: number; }[]
   readonly budgetRejectionRate: number
   readonly decisionsPerCli: Readonly<Record<"claude" | "gemini" | "codex" | "opencode", number>>
   readonly latencyStats?: LatencyTrackerStats | undefined
-  readonly preferenceStats?: { readonly enabled: boolean; readonly hasSufficientData: boolean; readonly dataPointCount: number; readonly strongModelPreferenceRate: number; } | undefined
+  readonly preferenceStats?: { readonly dataPointCount: number; readonly enabled: boolean; readonly hasSufficientData: boolean; readonly strongModelPreferenceRate: number; } | undefined
   readonly routingMemoryStats?: RoutingMemoryStats | undefined
   readonly totalDecisions: number
 InterfaceDeclaration CompositeRoutingDecision
@@ -1826,7 +1826,7 @@ InterfaceDeclaration CompositionValidation
 FunctionDeclaration computeAdaptiveThresholds
   : typeof computeAdaptiveThresholds
 InterfaceDeclaration ComputedReward
-  readonly components: { readonly baseReward: number; readonly qualityBonus: number; readonly speedBonus: number; readonly efficiencyBonus: number; readonly retryPenalty: number; }
+  readonly components: { readonly baseReward: number; readonly efficiencyBonus: number; readonly qualityBonus: number; readonly retryPenalty: number; readonly speedBonus: number; }
   readonly explanation: string
   readonly reward: number
 FunctionDeclaration computeOutcomeReward
@@ -1855,11 +1855,11 @@ ClassDeclaration ConfigError
 TypeAliasDeclaration ConfigExpertConfig
   = z.infer<typeof ExpertConfigSchema>
 VariableDeclaration ConfigExpertConfigSchema
-  : z.ZodObject<{ builtin: z.ZodDefault<z.ZodBoolean>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ systemPrompt: z.ZodString; tier: z.ZodDefault<z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>>; domain: z.ZodDefault<z.ZodEnum<{ general: "general"; security: "security"; code: "code"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; }>>; secondaryDomains: z.ZodOptional<z.ZodArray<z.ZodEnum<{ general: "general"; security: "security"; code: "code"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; }>>>; capabilities: z.ZodDefault<z.ZodArray<z.ZodString>>; temperature: z.ZodDefault<z.ZodNumber>; tools: z.ZodOptional<z.ZodArray<z.ZodString>>; description: z.ZodOptional<z.ZodString>; weight: z.ZodDefault<z.ZodNumber>; available: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>>; }, z.core.$strip>
+  : z.ZodObject<{ builtin: z.ZodDefault<z.ZodBoolean>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ available: z.ZodDefault<z.ZodBoolean>; capabilities: z.ZodDefault<z.ZodArray<z.ZodString>>; description: z.ZodOptional<z.ZodString>; domain: z.ZodDefault<z.ZodEnum<{ architecture: "architecture"; code: "code"; documentation: "documentation"; general: "general"; security: "security"; testing: "testing"; }>>; secondaryDomains: z.ZodOptional<z.ZodArray<z.ZodEnum<{ architecture: "architecture"; code: "code"; documentation: "documentation"; general: "general"; security: "security"; testing: "testing"; }>>>; systemPrompt: z.ZodString; temperature: z.ZodDefault<z.ZodNumber>; tier: z.ZodDefault<z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>>; tools: z.ZodOptional<z.ZodArray<z.ZodString>>; weight: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; }, z.core.$strip>
 TypeAliasDeclaration ConfigExpertDefinition
   = z.infer<typeof ExpertDefinitionSchema>
 VariableDeclaration ConfigExpertDefinitionSchema
-  : z.ZodObject<{ prompt: z.ZodString; tier: z.ZodDefault<z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>>; temperature: z.ZodDefault<z.ZodNumber>; tools: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>
+  : z.ZodObject<{ prompt: z.ZodString; temperature: z.ZodDefault<z.ZodNumber>; tier: z.ZodDefault<z.ZodEnum<{ balanced: "balanced"; fast: "fast"; powerful: "powerful"; }>>; tools: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>
 InterfaceDeclaration Conflict
   description: string
   resolution: string
@@ -1876,7 +1876,7 @@ FunctionDeclaration connectTransport
 TypeAliasDeclaration ConsensusAlgorithm
   = z.infer<typeof ConsensusAlgorithmSchema>
 VariableDeclaration ConsensusAlgorithmSchema
-  : z.ZodEnum<{ simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; proof_of_learning: "proof_of_learning"; higher_order: "higher_order"; opinion_wise: "opinion_wise"; }>
+  : z.ZodEnum<{ higher_order: "higher_order"; opinion_wise: "opinion_wise"; proof_of_learning: "proof_of_learning"; simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; }>
 ClassDeclaration ConsensusEngine
   clearCache() => void
   close(proposalId: ProposalId) => Promise<Result<ConsensusResult, ConsensusError>>
@@ -1898,7 +1898,7 @@ InterfaceDeclaration ConsensusEngineConfig
   minVotersForQuorum: number
   proposalCache?: ProposalCacheConfig | undefined
 VariableDeclaration ConsensusEngineConfigSchema
-  : z.ZodObject<{ defaultTimeout: z.ZodDefault<z.ZodNumber>; minVotersForQuorum: z.ZodDefault<z.ZodNumber>; maxActiveProposals: z.ZodDefault<z.ZodNumber>; enablePerformanceTracking: z.ZodDefault<z.ZodBoolean>; maxClosedProposals: z.ZodDefault<z.ZodNumber>; proposalCache: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; ttlMs: z.ZodDefault<z.ZodNumber>; maxEntries: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ defaultTimeout: z.ZodDefault<z.ZodNumber>; enablePerformanceTracking: z.ZodDefault<z.ZodBoolean>; maxActiveProposals: z.ZodDefault<z.ZodNumber>; maxClosedProposals: z.ZodDefault<z.ZodNumber>; minVotersForQuorum: z.ZodDefault<z.ZodNumber>; proposalCache: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; maxEntries: z.ZodDefault<z.ZodNumber>; ttlMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; }, z.core.$strip>
 ClassDeclaration ConsensusError
 InterfaceDeclaration ConsensusGateNodeOptions
   readonly proposalFrom: (state: Readonly<GraphState>) => ConsensusProposalInput
@@ -1921,7 +1921,7 @@ InterfaceDeclaration ConsensusMetrics
   timedOutProposals: number
   totalProposals: number
 VariableDeclaration ConsensusMetricsSchema
-  : z.ZodObject<{ totalProposals: z.ZodNumber; approvedProposals: z.ZodNumber; rejectedProposals: z.ZodNumber; timedOutProposals: z.ZodNumber; averageDurationMs: z.ZodNumber; averageVotesPerProposal: z.ZodNumber; algorithmUsage: z.ZodRecord<z.ZodEnum<{ simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; proof_of_learning: "proof_of_learning"; higher_order: "higher_order"; opinion_wise: "opinion_wise"; }>, z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ algorithmUsage: z.ZodRecord<z.ZodEnum<{ higher_order: "higher_order"; opinion_wise: "opinion_wise"; proof_of_learning: "proof_of_learning"; simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; }>, z.ZodNumber>; approvedProposals: z.ZodNumber; averageDurationMs: z.ZodNumber; averageVotesPerProposal: z.ZodNumber; rejectedProposals: z.ZodNumber; timedOutProposals: z.ZodNumber; totalProposals: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration ConsensusProposalInput
   readonly context?: string | undefined
   readonly proposal: string
@@ -1930,25 +1930,25 @@ ClassDeclaration ConsensusProtocol
   execute(config: CollaborationConfig, agents: Map<string, IAgent>) => Promise<Result<CollaborationResult, AgentError>>
   readonly pattern: "consensus"
 InterfaceDeclaration ConsensusReachedEvent
-  readonly payload: { readonly proposalId: string; readonly decision: VoteDecision; readonly voteCount: number; readonly unanimity: boolean; }
+  readonly payload: { readonly decision: VoteDecision; readonly proposalId: string; readonly unanimity: boolean; readonly voteCount: number; }
   readonly topic: "consensus.reached"
 InterfaceDeclaration ConsensusResult
   approvalPercentage: number
   closedAt: string
   durationMs: number
   outcome: "pending" | "approved" | "closed" | "rejected" | "timeout" | "voting"
-  proposal: { title: string; description: string; algorithm: "simple_majority" | "supermajority" | "unanimous" | "proof_of_learning" | "higher_order" | "opinion_wise"; id?: string | undefined; timeout?: number | undefined; requiredVoters?: string[] | undefined; metadata?: Record<string, unknown> | undefined; createdAt?: string | undefined; }
+  proposal: { algorithm: "simple_majority" | "supermajority" | "unanimous" | "proof_of_learning" | "higher_order" | "opinion_wise"; createdAt?: string | undefined; description: string; id?: string | undefined; metadata?: Record<string, unknown> | undefined; requiredVoters?: string[] | undefined; timeout?: number | undefined; title: string; }
   proposalId: string
   quorumReached: boolean
   startedAt: string
   voteCounts: VoteCounts
-  votes: Map<string, { decision: "approve" | "reject" | "abstain"; reasoning: string; confidence: number; conditions?: string[] | undefined; rejectionCategories?: ("YAGNI" | "DRY_VIOLATION" | "OVER_ENGINEERING" | "SCOPE_CREEP" | "SECURITY_RISK" | "MISALIGNED" | "INSUFFICIENT_EVIDENCE")[] | undefined; findings?: { summary: string; location: string; severity: "critical" | "high" | "medium" | "low"; gate: { reread_cited_line: "failed" | "skipped" | "passed"; traced_call_path: "failed" | "skipped" | "passed"; named_assertion: string; ruled_out_language_non_issue: "failed" | "skipped" | "passed"; }; claim: string; }[] | undefined; selectedOption?: string | undefined; timestamp?: string | undefined; }>
+  votes: Map<string, { conditions?: string[] | undefined; confidence: number; decision: "approve" | "reject" | "abstain"; findings?: { claim: string; gate: { named_assertion: string; reread_cited_line: "failed" | "skipped" | "passed"; ruled_out_language_non_issue: "failed" | "skipped" | "passed"; traced_call_path: "failed" | "skipped" | "passed"; }; location: string; severity: "critical" | "high" | "medium" | "low"; summary: string; }[] | undefined; reasoning: string; rejectionCategories?: ("YAGNI" | "DRY_VIOLATION" | "OVER_ENGINEERING" | "SCOPE_CREEP" | "SECURITY_RISK" | "MISALIGNED" | "INSUFFICIENT_EVIDENCE")[] | undefined; selectedOption?: string | undefined; timestamp?: string | undefined; }>
   weightedCounts?: WeightedVoteCounts | undefined
 VariableDeclaration ConsensusResultSchema
-  : z.ZodObject<{ proposalId: z.ZodString; proposal: z.ZodObject<{ id: z.ZodOptional<z.ZodString>; title: z.ZodString; description: z.ZodString; algorithm: z.ZodEnum<{ simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; proof_of_learning: "proof_of_learning"; higher_order: "higher_order"; opinion_wise: "opinion_wise"; }>; timeout: z.ZodOptional<z.ZodNumber>; requiredVoters: z.ZodOptional<z.ZodArray<z.ZodString>>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; createdAt: z.ZodOptional<z.ZodISODateTime>; }, z.core.$strip>; outcome: z.ZodEnum<{ pending: "pending"; approved: "approved"; closed: "closed"; rejected: "rejected"; timeout: "timeout"; voting: "voting"; }>; votes: z.ZodMap<z.ZodString, z.ZodObject<{ decision: z.ZodEnum<{ approve: "approve"; reject: "reject"; abstain: "abstain"; }>; reasoning: z.ZodString; confidence: z.ZodNumber; conditions: z.ZodOptional<z.ZodArray<z.ZodString>>; rejectionCategories: z.ZodOptional<z.ZodArray<z.ZodEnum<{ YAGNI: "YAGNI"; DRY_VIOLATION: "DRY_VIOLATION"; OVER_ENGINEERING: "OVER_ENGINEERING"; SCOPE_CREEP: "SCOPE_CREEP"; SECURITY_RISK: "SECURITY_RISK"; MISALIGNED: "MISALIGNED"; INSUFFICIENT_EVIDENCE: "INSUFFICIENT_EVIDENCE"; }>>>; findings: z.ZodOptional<z.ZodArray<z.ZodObject<{ summary: z.ZodString; location: z.ZodString; severity: z.ZodDefault<z.ZodEnum<{ critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>>; gate: z.ZodObject<{ reread_cited_line: z.ZodDefault<z.ZodEnum<{ failed: "failed"; skipped: "skipped"; passed: "passed"; }>>; traced_call_path: z.ZodDefault<z.ZodEnum<{ failed: "failed"; skipped: "skipped"; passed: "passed"; }>>; named_assertion: z.ZodDefault<z.ZodString>; ruled_out_language_non_issue: z.ZodDefault<z.ZodEnum<{ failed: "failed"; skipped: "skipped"; passed: "passed"; }>>; }, z.core.$strip>; claim: z.ZodString; }, z.core.$strip>>>; selectedOption: z.ZodOptional<z.ZodString>; timestamp: z.ZodOptional<z.ZodISODateTime>; }, z.core.$strip>>; voteCounts: z.ZodObject<{ approve: z.ZodNumber; reject: z.ZodNumber; abstain: z.ZodNumber; total: z.ZodNumber; }, z.core.$strip>; weightedCounts: z.ZodOptional<z.ZodObject<{ approve: z.ZodNumber; reject: z.ZodNumber; abstain: z.ZodNumber; totalWeight: z.ZodNumber; }, z.core.$strip>>; approvalPercentage: z.ZodNumber; quorumReached: z.ZodBoolean; startedAt: z.ZodISODateTime; closedAt: z.ZodISODateTime; durationMs: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ approvalPercentage: z.ZodNumber; closedAt: z.ZodISODateTime; durationMs: z.ZodNumber; outcome: z.ZodEnum<{ approved: "approved"; closed: "closed"; pending: "pending"; rejected: "rejected"; timeout: "timeout"; voting: "voting"; }>; proposal: z.ZodObject<{ algorithm: z.ZodEnum<{ higher_order: "higher_order"; opinion_wise: "opinion_wise"; proof_of_learning: "proof_of_learning"; simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; }>; createdAt: z.ZodOptional<z.ZodISODateTime>; description: z.ZodString; id: z.ZodOptional<z.ZodString>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; requiredVoters: z.ZodOptional<z.ZodArray<z.ZodString>>; timeout: z.ZodOptional<z.ZodNumber>; title: z.ZodString; }, z.core.$strip>; proposalId: z.ZodString; quorumReached: z.ZodBoolean; startedAt: z.ZodISODateTime; voteCounts: z.ZodObject<{ abstain: z.ZodNumber; approve: z.ZodNumber; reject: z.ZodNumber; total: z.ZodNumber; }, z.core.$strip>; votes: z.ZodMap<z.ZodString, z.ZodObject<{ conditions: z.ZodOptional<z.ZodArray<z.ZodString>>; confidence: z.ZodNumber; decision: z.ZodEnum<{ abstain: "abstain"; approve: "approve"; reject: "reject"; }>; findings: z.ZodOptional<z.ZodArray<z.ZodObject<{ claim: z.ZodString; gate: z.ZodObject<{ named_assertion: z.ZodDefault<z.ZodString>; reread_cited_line: z.ZodDefault<z.ZodEnum<{ failed: "failed"; passed: "passed"; skipped: "skipped"; }>>; ruled_out_language_non_issue: z.ZodDefault<z.ZodEnum<{ failed: "failed"; passed: "passed"; skipped: "skipped"; }>>; traced_call_path: z.ZodDefault<z.ZodEnum<{ failed: "failed"; passed: "passed"; skipped: "skipped"; }>>; }, z.core.$strip>; location: z.ZodString; severity: z.ZodDefault<z.ZodEnum<{ critical: "critical"; high: "high"; low: "low"; medium: "medium"; }>>; summary: z.ZodString; }, z.core.$strip>>>; reasoning: z.ZodString; rejectionCategories: z.ZodOptional<z.ZodArray<z.ZodEnum<{ DRY_VIOLATION: "DRY_VIOLATION"; INSUFFICIENT_EVIDENCE: "INSUFFICIENT_EVIDENCE"; MISALIGNED: "MISALIGNED"; OVER_ENGINEERING: "OVER_ENGINEERING"; SCOPE_CREEP: "SCOPE_CREEP"; SECURITY_RISK: "SECURITY_RISK"; YAGNI: "YAGNI"; }>>>; selectedOption: z.ZodOptional<z.ZodString>; timestamp: z.ZodOptional<z.ZodISODateTime>; }, z.core.$strip>>; weightedCounts: z.ZodOptional<z.ZodObject<{ abstain: z.ZodNumber; approve: z.ZodNumber; reject: z.ZodNumber; totalWeight: z.ZodNumber; }, z.core.$strip>>; }, z.core.$strip>
 InterfaceDeclaration ConsensusStats
   consensusReached: number
-  decisions: { approved: number; rejected: number; abstained: number; }
+  decisions: { abstained: number; approved: number; rejected: number; }
   unanimityRate: number
   votesCast: number
   votesRequested: number
@@ -1957,7 +1957,7 @@ InterfaceDeclaration ConsensusVerdict
   readonly feedback: string
   readonly outcome: "approved" | "rejected" | "no_quorum"
 InterfaceDeclaration ConsensusVoteCastEvent
-  readonly payload: { readonly proposalId: string; readonly voterId: string; readonly decision: VoteDecision; readonly reasoning: string; }
+  readonly payload: { readonly decision: VoteDecision; readonly proposalId: string; readonly reasoning: string; readonly voterId: string; }
   readonly topic: "consensus.vote_cast"
 InterfaceDeclaration ConsensusVoteDeps
   gatewayAdapters?: readonly IModelAdapter[] | undefined
@@ -1965,11 +1965,11 @@ InterfaceDeclaration ConsensusVoteDeps
 TypeAliasDeclaration ConsensusVoteInput
   = z.infer<typeof ConsensusVoteInputSchema>
 VariableDeclaration ConsensusVoteInputSchema
-  : z.ZodObject<{ proposal: z.ZodString; options: z.ZodOptional<z.ZodArray<z.ZodString>>; threshold: z.ZodOptional<z.ZodEnum<{ supermajority: "supermajority"; unanimous: "unanimous"; majority: "majority"; }>>; strategy: z.ZodOptional<z.ZodEnum<{ simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; proof_of_learning: "proof_of_learning"; higher_order: "higher_order"; opinion_wise: "opinion_wise"; }>>; errorPolicy: z.ZodOptional<z.ZodEnum<{ reduce_denominator: "reduce_denominator"; count_as_abstain: "count_as_abstain"; fail_closed: "fail_closed"; absolute_quorum: "absolute_quorum"; }>>; quickMode: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; simulateVotes: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; mode: z.ZodOptional<z.ZodEnum<{ sync: "sync"; async: "async"; }>>; idempotencyKey: z.ZodOptional<z.ZodString>; ratifies: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ errorPolicy: z.ZodOptional<z.ZodEnum<{ absolute_quorum: "absolute_quorum"; count_as_abstain: "count_as_abstain"; fail_closed: "fail_closed"; reduce_denominator: "reduce_denominator"; }>>; idempotencyKey: z.ZodOptional<z.ZodString>; mode: z.ZodOptional<z.ZodEnum<{ async: "async"; sync: "sync"; }>>; options: z.ZodOptional<z.ZodArray<z.ZodString>>; proposal: z.ZodString; quickMode: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; ratifies: z.ZodOptional<z.ZodString>; simulateVotes: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; strategy: z.ZodOptional<z.ZodEnum<{ higher_order: "higher_order"; opinion_wise: "opinion_wise"; proof_of_learning: "proof_of_learning"; simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; }>>; threshold: z.ZodOptional<z.ZodEnum<{ majority: "majority"; supermajority: "supermajority"; unanimous: "unanimous"; }>>; }, z.core.$strip>
 TypeAliasDeclaration ConsensusVoter
   = (input: ConsensusProposalInput) => Promise<ConsensusVerdict>
 InterfaceDeclaration ConsensusVoteRequestedEvent
-  readonly payload: { readonly proposalId: string; readonly proposal: string; readonly voters: readonly string[]; readonly deadline?: string; }
+  readonly payload: { readonly deadline?: string; readonly proposal: string; readonly proposalId: string; readonly voters: readonly string[]; }
   readonly topic: "consensus.vote_requested"
 InterfaceDeclaration ConsensusVoteResponse
   approvalPercentage: number
@@ -1977,14 +1977,14 @@ InterfaceDeclaration ConsensusVoteResponse
   decision: "pending" | "approved" | "rejected" | "timeout" | "no_quorum"
   durationMs: number
   higherOrderMetadata?: HigherOrderMetadata | undefined
-  optionOutcome?: { tally: ReadonlyArray<{ option: string; count: number; }>; leadingOption?: string; leadingShare: number; approverCount: number; selectedCount: number; unattributedApprovals: number; thresholdMet: boolean; vetoReason?: string; } | undefined
+  optionOutcome?: { approverCount: number; leadingOption?: string; leadingShare: number; selectedCount: number; tally: ReadonlyArray<{ count: number; option: string; }>; thresholdMet: boolean; unattributedApprovals: number; vetoReason?: string; } | undefined
   panelWarning?: string | undefined
   policyReason?: string | undefined
   proposal: string
   simulateVotes: boolean
   strategy: VotingStrategy
   threshold?: "supermajority" | "unanimous" | "majority" | undefined
-  voteCounts: { approve: number; reject: number; abstain: number; error: number; }
+  voteCounts: { abstain: number; approve: number; error: number; reject: number; }
   voteRecordNote?: string | undefined
   voteRecordPersisted: boolean
   votes: AgentVoteSummary[]
@@ -1994,7 +1994,7 @@ InterfaceDeclaration ConsolidatedFinding
   description: string
   id: string
   location?: string | undefined
-  originalFindings: { agentId: string; category: "security" | "documentation" | "bug" | "performance" | "style" | "design" | "other"; severity: "critical" | "major" | "minor" | "suggestion"; description: string; confidence: number; location?: string | undefined; suggestion?: string | undefined; timestamp?: string | undefined; }[]
+  originalFindings: { agentId: string; category: "security" | "documentation" | "bug" | "performance" | "style" | "design" | "other"; confidence: number; description: string; location?: string | undefined; severity: "critical" | "major" | "minor" | "suggestion"; suggestion?: string | undefined; timestamp?: string | undefined; }[]
   severity: "critical" | "major" | "minor" | "suggestion"
   suggestion?: string | undefined
   supportingAgents: string[]
@@ -2010,9 +2010,9 @@ InterfaceDeclaration Content
   parts?: Part[] | undefined
   role?: string | undefined
 TypeAliasDeclaration ContentBlock
-  = | { type: 'text'; text: string } | { type: 'tool_use'; id: string; name: string; input: unknown } | { type: 'tool_result'; tool_use_id: string; content: string; is_error?: boolean } | { type: 'image'; source: { type: 'base64'; media_type: string; data: string } }
+  = | { text: string; type: 'text'; } | { id: string; input: unknown; name: string; type: 'tool_use'; } | { content: string; is_error?: boolean; tool_use_id: string; type: 'tool_result'; } | { source: { data: string; media_type: string; type: 'base64'; }; type: 'image'; }
 TypeAliasDeclaration|VariableDeclaration ContentPriority
-  : { readonly SYSTEM: 100; readonly TASK: 80; readonly ACTIVE: 60; readonly HISTORY: 40; readonly EPHEMERAL: 20; }
+  : { readonly ACTIVE: 60; readonly EPHEMERAL: 20; readonly HISTORY: 40; readonly SYSTEM: 100; readonly TASK: 80; }
   = (typeof ContentPriority)[keyof typeof ContentPriority]
 InterfaceDeclaration ContextBudget
   active: number
@@ -2024,14 +2024,14 @@ InterfaceDeclaration ContextBudget
   task: number
   task: number
 VariableDeclaration ContextBudgetSchema
-  : z.ZodObject<{ system: z.ZodNumber; task: z.ZodNumber; active: z.ZodNumber; reserved: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ active: z.ZodNumber; reserved: z.ZodNumber; system: z.ZodNumber; task: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration ContextFilter
   includeHistory: boolean
   maxTokens: number
   pruneStrategy: ContextPruneStrategy
   relevanceThreshold: number
 VariableDeclaration ContextFilterSchema
-  : z.ZodObject<{ maxTokens: z.ZodNumber; relevanceThreshold: z.ZodNumber; includeHistory: z.ZodBoolean; pruneStrategy: z.ZodEnum<{ importance: "importance"; recency: "recency"; hybrid: "hybrid"; }>; }, z.core.$strip>
+  : z.ZodObject<{ includeHistory: z.ZodBoolean; maxTokens: z.ZodNumber; pruneStrategy: z.ZodEnum<{ hybrid: "hybrid"; importance: "importance"; recency: "recency"; }>; relevanceThreshold: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration ContextItem
   addedAt: number
   category: "task" | "system" | "active"
@@ -2064,7 +2064,7 @@ InterfaceDeclaration ContextManagerConfig
   maxTokens: number
   warningThreshold?: number | undefined
 VariableDeclaration ContextManagerConfigSchema
-  : z.ZodObject<{ maxTokens: z.ZodNumber; budget: z.ZodOptional<z.ZodObject<{ system: z.ZodNumber; task: z.ZodNumber; active: z.ZodNumber; reserved: z.ZodNumber; }, z.core.$strip>>; warningThreshold: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ budget: z.ZodOptional<z.ZodObject<{ active: z.ZodNumber; reserved: z.ZodNumber; system: z.ZodNumber; task: z.ZodNumber; }, z.core.$strip>>; maxTokens: z.ZodNumber; warningThreshold: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 ClassDeclaration ContextPruner
   estimateFreeableTokens(categories: Array<keyof Omit<ContextBudget, "reserved">>) => number
   getPruneCandidates(categories: Array<keyof Omit<ContextBudget, "reserved">>) => ContextItem[]
@@ -2086,11 +2086,11 @@ InterfaceDeclaration ContextPrunerConfig
   minItemsPerCategory?: number | undefined
   protectedPriority?: ContentPriority | undefined
 VariableDeclaration ContextPrunerConfigSchema
-  : z.ZodObject<{ defaultStrategy: z.ZodOptional<z.ZodEnum<{ semantic: "semantic"; oldest_first: "oldest_first"; lowest_priority: "lowest_priority"; priority_weighted_age: "priority_weighted_age"; summarize: "summarize"; sliding_window: "sliding_window"; hierarchical: "hierarchical"; }>>; minItemsPerCategory: z.ZodOptional<z.ZodNumber>; protectedPriority: z.ZodOptional<z.ZodNumber>; autoTriggerThreshold: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ autoTriggerThreshold: z.ZodOptional<z.ZodNumber>; defaultStrategy: z.ZodOptional<z.ZodEnum<{ hierarchical: "hierarchical"; lowest_priority: "lowest_priority"; oldest_first: "oldest_first"; priority_weighted_age: "priority_weighted_age"; semantic: "semantic"; sliding_window: "sliding_window"; summarize: "summarize"; }>>; minItemsPerCategory: z.ZodOptional<z.ZodNumber>; protectedPriority: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 TypeAliasDeclaration ContextPruneStrategy
   = 'recency' | 'importance' | 'hybrid'
 VariableDeclaration ContextPruneStrategySchema
-  : z.ZodEnum<{ importance: "importance"; recency: "recency"; hybrid: "hybrid"; }>
+  : z.ZodEnum<{ hybrid: "hybrid"; importance: "importance"; recency: "recency"; }>
 InterfaceDeclaration ContextPruningMetrics
   lastPruningItemsRemoved: number
   lastPruningTargetReached: boolean
@@ -2106,7 +2106,7 @@ InterfaceDeclaration ContextStats
   totalTokens: number
   usagePercentage: number
 TypeAliasDeclaration ContextUnavailableEvent
-  = { readonly type: 'context_unavailable'; /** Inferred task category whose context could not be retrieved. */ readonly category: string; /** Sanitized failure message — message string only, no stack/paths/secrets. */ readonly error: string; /** Correlation id when the execution was given one. */ readonly executionId?: string; readonly timestamp: number; }
+  = { /** Correlation id when the execution was given one. */ readonly executionId?: string; /** Inferred task category whose context could not be retrieved. */ readonly category: string; /** Sanitized failure message — message string only, no stack/paths/secrets. */ readonly error: string; readonly timestamp: number; readonly type: 'context_unavailable'; }
 InterfaceDeclaration ContributionScore
   readonly activeTimeMs: number
   readonly agentId: string
@@ -2158,7 +2158,7 @@ InterfaceDeclaration CorrelationTrackerStats
   readonly totalObservations: number
   readonly trackedPairs: number
 VariableDeclaration CorrelationTrackerStatsSchema
-  : z.ZodObject<{ totalAgents: z.ZodNumber; trackedPairs: z.ZodNumber; totalObservations: z.ZodNumber; averageCorrelation: z.ZodNumber; independentSubsetCount: z.ZodNumber; pairsWithSufficientData: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ averageCorrelation: z.ZodNumber; independentSubsetCount: z.ZodNumber; pairsWithSufficientData: z.ZodNumber; totalAgents: z.ZodNumber; totalObservations: z.ZodNumber; trackedPairs: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration CorroborationEvent
   readonly actionType: "SummarizeIssue" | "ProposeLabels" | "DraftReply" | "RequestHumanApproval" | "GeneratePatchPlan" | "ClassifyIssue" | "IdentifyDuplicates" | "RefuseAction" | "HandoffMessage"
   readonly missingRequirements: readonly string[]
@@ -2167,7 +2167,7 @@ InterfaceDeclaration CorroborationEvent
   readonly type: "corroboration"
 InterfaceDeclaration CorroborationResult
   readonly actionType: "SummarizeIssue" | "ProposeLabels" | "DraftReply" | "RequestHumanApproval" | "GeneratePatchPlan" | "ClassifyIssue" | "IdentifyDuplicates" | "RefuseAction" | "HandoffMessage"
-  readonly corroboratingSources: readonly ({ type: "issueBody"; issueNumber: number; author: string; authorTrustTier: "1" | "2" | "3" | "4"; } | { type: "repoFile"; path: string; line?: number | undefined; commit?: string | undefined; } | { type: "issueComment"; issueNumber: number; commentId: number; author: string; authorTrustTier: "1" | "2" | "3" | "4"; } | { type: "ciResult"; runId: number; status: "pass" | "fail"; job: string; } | { type: "policyDoc"; path: string; section: string; } | { type: "maintainerCommand"; username: string; commentId: number; })[]
+  readonly corroboratingSources: readonly ({ author: string; authorTrustTier: "1" | "2" | "3" | "4"; issueNumber: number; type: "issueBody"; } | { commit?: string | undefined; line?: number | undefined; path: string; type: "repoFile"; } | { author: string; authorTrustTier: "1" | "2" | "3" | "4"; commentId: number; issueNumber: number; type: "issueComment"; } | { job: string; runId: number; status: "pass" | "fail"; type: "ciResult"; } | { path: string; section: string; type: "policyDoc"; } | { commentId: number; type: "maintainerCommand"; username: string; })[]
   readonly missing: readonly string[]
   readonly satisfied: boolean
 InterfaceDeclaration CorroborationRule
@@ -2176,7 +2176,7 @@ InterfaceDeclaration CorroborationRule
 TypeAliasDeclaration CostEstimate
   = z.infer<typeof CostEstimateSchema>
 VariableDeclaration CostEstimateSchema
-  : z.ZodObject<{ totalTokensIn: z.ZodNumber; totalTokensOut: z.ZodNumber; estimatedCostUsd: z.ZodNumber; modelCalls: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ estimatedCostUsd: z.ZodNumber; modelCalls: z.ZodNumber; totalTokensIn: z.ZodNumber; totalTokensOut: z.ZodNumber; }, z.core.$strip>
 TypeAliasDeclaration CostProfile
   = z.infer<typeof CostProfileSchema>
 InterfaceDeclaration CostSection
@@ -2204,7 +2204,7 @@ InterfaceDeclaration CoverageMetrics
   statement: number
   uncoveredAreas?: string[] | undefined
 VariableDeclaration CoverageMetricsSchema
-  : z.ZodObject<{ line: z.ZodNumber; branch: z.ZodNumber; function: z.ZodNumber; statement: z.ZodNumber; uncoveredAreas: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>
+  : z.ZodObject<{ branch: z.ZodNumber; function: z.ZodNumber; line: z.ZodNumber; statement: z.ZodNumber; uncoveredAreas: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>
 FunctionDeclaration createAbTestTracker
   : typeof createAbTestTracker
 FunctionDeclaration createAgenticAdapter
@@ -2299,7 +2299,7 @@ InterfaceDeclaration CreateExpertDeps
 TypeAliasDeclaration CreateExpertInput
   = z.infer<typeof CreateExpertInputSchema>
 VariableDeclaration CreateExpertInputSchema
-  : z.ZodObject<{ role: z.ZodEnum<{ code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; research_expert: "research_expert"; pm_expert: "pm_expert"; ux_expert: "ux_expert"; infrastructure_expert: "infrastructure_expert"; qa_expert: "qa_expert"; data_visualization_expert: "data_visualization_expert"; }>; modelPreference: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ modelPreference: z.ZodOptional<z.ZodString>; role: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; data_visualization_expert: "data_visualization_expert"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; pm_expert: "pm_expert"; qa_expert: "qa_expert"; research_expert: "research_expert"; security_expert: "security_expert"; testing_expert: "testing_expert"; ux_expert: "ux_expert"; }>; }, z.core.$strip>
 InterfaceDeclaration CreateExpertOptions
   adapter?: IModelAdapter | undefined
   additionalCapabilities?: AgentCapability[] | undefined
@@ -2492,11 +2492,11 @@ InterfaceDeclaration CriterionFailure
 TypeAliasDeclaration CriterionResult
   = z.infer<typeof CriterionResultSchema>
 VariableDeclaration CriterionResultSchema
-  : z.ZodObject<{ criterion: z.ZodString; met: z.ZodBoolean; matchedResults: z.ZodArray<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ criterion: z.ZodString; matchedResults: z.ZodArray<z.ZodString>; met: z.ZodBoolean; }, z.core.$strip>
 VariableDeclaration CriterionType
-  : { readonly BINARY: "binary"; readonly SCALED: "scaled"; readonly THRESHOLD: "threshold"; readonly CATEGORICAL: "categorical"; }
+  : { readonly BINARY: "binary"; readonly CATEGORICAL: "categorical"; readonly SCALED: "scaled"; readonly THRESHOLD: "threshold"; }
 VariableDeclaration CriterionTypeSchema
-  : z.ZodEnum<{ binary: "binary"; scaled: "scaled"; threshold: "threshold"; categorical: "categorical"; }>
+  : z.ZodEnum<{ binary: "binary"; categorical: "categorical"; scaled: "scaled"; threshold: "threshold"; }>
 TypeAliasDeclaration CriterionTypeType
   = (typeof CriterionType)[keyof typeof CriterionType]
 InterfaceDeclaration CrossTreeInfo
@@ -2504,11 +2504,11 @@ InterfaceDeclaration CrossTreeInfo
   readonly sharedConclusions: readonly SharedConclusion[]
   readonly sharedInsights: readonly SharedInsight[]
 VariableDeclaration CrossTreeInfoSchema
-  : z.ZodObject<{ sharedConclusions: z.ZodArray<z.ZodObject<{ sourceTreeId: z.ZodString; sourceNodeId: z.ZodString; content: z.ZodString; confidence: z.ZodNumber; qualityScore: z.ZodNumber; }, z.core.$strip>>; sharedInsights: z.ZodArray<z.ZodObject<{ sourceTreeId: z.ZodString; sourceNodeId: z.ZodString; content: z.ZodString; relevance: z.ZodNumber; }, z.core.$strip>>; failurePatterns: z.ZodArray<z.ZodObject<{ pattern: z.ZodString; occurrences: z.ZodNumber; avgFailureScore: z.ZodNumber; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ failurePatterns: z.ZodArray<z.ZodObject<{ avgFailureScore: z.ZodNumber; occurrences: z.ZodNumber; pattern: z.ZodString; }, z.core.$strip>>; sharedConclusions: z.ZodArray<z.ZodObject<{ confidence: z.ZodNumber; content: z.ZodString; qualityScore: z.ZodNumber; sourceNodeId: z.ZodString; sourceTreeId: z.ZodString; }, z.core.$strip>>; sharedInsights: z.ZodArray<z.ZodObject<{ content: z.ZodString; relevance: z.ZodNumber; sourceNodeId: z.ZodString; sourceTreeId: z.ZodString; }, z.core.$strip>>; }, z.core.$strip>
 TypeAliasDeclaration CrossTreeStrategy
   = 'none' | 'conclusions' | 'insights' | 'full'
 VariableDeclaration CrossTreeStrategySchema
-  : z.ZodEnum<{ full: "full"; none: "none"; conclusions: "conclusions"; insights: "insights"; }>
+  : z.ZodEnum<{ conclusions: "conclusions"; full: "full"; insights: "insights"; none: "none"; }>
 FunctionDeclaration curateContext
   : typeof curateContext
 InterfaceDeclaration CuratedContextItem
@@ -2552,7 +2552,7 @@ InterfaceDeclaration DashboardConfig
   readonly timeWindowMs: number
   readonly width: number
 VariableDeclaration DashboardConfigSchema
-  : z.ZodObject<{ format: z.ZodDefault<z.ZodEnum<{ json: "json"; text: "text"; markdown: "markdown"; compact: "compact"; }>>; maxAgentsShown: z.ZodDefault<z.ZodNumber>; maxEventsShown: z.ZodDefault<z.ZodNumber>; showGraph: z.ZodDefault<z.ZodBoolean>; showBottlenecks: z.ZodDefault<z.ZodBoolean>; showClusters: z.ZodDefault<z.ZodBoolean>; showContributions: z.ZodDefault<z.ZodBoolean>; timeWindowMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ format: z.ZodDefault<z.ZodEnum<{ compact: "compact"; json: "json"; markdown: "markdown"; text: "text"; }>>; maxAgentsShown: z.ZodDefault<z.ZodNumber>; maxEventsShown: z.ZodDefault<z.ZodNumber>; showBottlenecks: z.ZodDefault<z.ZodBoolean>; showClusters: z.ZodDefault<z.ZodBoolean>; showContributions: z.ZodDefault<z.ZodBoolean>; showGraph: z.ZodDefault<z.ZodBoolean>; timeWindowMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration DashboardFilter
   readonly minSampleSize?: number | undefined
   readonly models?: readonly string[] | undefined
@@ -2690,7 +2690,7 @@ VariableDeclaration DEFAULT_MAX_RETRIES
 VariableDeclaration DEFAULT_MEMORY_BENCHMARK_CONFIG
   : MemoryBenchmarkConfig
 VariableDeclaration DEFAULT_OUTCOME_STORAGE_CONFIG
-  : { readonly maxRecords: 100000; readonly autoPruneInterval: 3600000; }
+  : { readonly autoPruneInterval: 3600000; readonly maxRecords: 100000; }
 VariableDeclaration DEFAULT_PATH_SCORING_OPTIONS
   : PathScoringOptions
 VariableDeclaration DEFAULT_PERMISSIONS
@@ -2720,7 +2720,7 @@ VariableDeclaration DEFAULT_SWARM_OBSERVER_CONFIG
 VariableDeclaration DEFAULT_TIMEOUT_PROFILE
   : TimeoutProfile
 VariableDeclaration DEFAULT_TIMEOUTS
-  : { readonly sequential: number; readonly parallel: number; readonly review: number; readonly consensus: number; readonly reflexion: number; readonly aegean: number; readonly 'self-refine': number; readonly 'self-debug': number; }
+  : { readonly 'self-debug': number; readonly 'self-refine': number; readonly aegean: number; readonly consensus: number; readonly parallel: number; readonly reflexion: number; readonly review: number; readonly sequential: number; }
 VariableDeclaration DEFAULT_TRINITY_CONFIG
   : Required<TrinityConfig>
 VariableDeclaration DEFAULT_VOTING_PROTOCOL_CONFIG
@@ -2730,7 +2730,7 @@ VariableDeclaration DEFAULT_WAVE_CONFIG
 VariableDeclaration DEFAULT_WEIGHTED_VOTING_CONFIG
   : WeightedVotingConfig
 VariableDeclaration defaultConfig
-  : Partial<{ models: { default: string; tiers: { fast: string[]; balanced: string[]; powerful: string[]; }; providers?: Record<string, { timeout: number; maxRetries: number; apiKey?: string | undefined; baseUrl?: string | undefined; }> | undefined; }; experts?: { builtin: boolean; custom?: Record<string, { systemPrompt: string; tier: "balanced" | "fast" | "powerful"; domain: "general" | "security" | "code" | "architecture" | "documentation" | "testing"; capabilities: string[]; temperature: number; weight: number; available: boolean; secondaryDomains?: ("general" | "security" | "code" | "architecture" | "documentation" | "testing")[] | undefined; tools?: string[] | undefined; description?: string | undefined; }> | undefined; } | undefined; workflows?: { templatesDir: string; timeout: number; maxParallel: number; } | undefined; security?: { allowedPaths: string[]; blockedPatterns: string[]; rateLimit: { enabled: boolean; requestsPerMinute: number; perTool?: Record<string, { capacity: number; refillRate: number; refillIntervalMs: number; }> | undefined; }; secretsFile?: string | undefined; policy?: { defaultMode: "read-only" | "read-write"; policyMode: "warn" | "enforce"; } | undefined; sandbox?: { mode: "none" | "policy" | "container"; fallbackToPolicy: boolean; networkEnabled: boolean; dockerImage?: string | undefined; } | undefined; timeout?: { defaultTimeoutMs: number; maxTimeoutMs: number; enableLogging: boolean; uriValidation: boolean; perToolTimeout?: Record<string, number> | undefined; } | undefined; toolAllowlist?: string[] | undefined; audit?: { enabled: boolean; minSeverity: "info" | "warning" | "critical"; enableHashChain: boolean; maxFileSizeBytes: number; maxFiles: number; logDir?: string | undefined; } | undefined; auth?: { enabled: boolean; method: "token" | "oauth2"; tokenHeader: string; tokenFile?: string | undefined; } | undefined; } | undefined; logging?: { level: "debug" | "info" | "warn" | "error"; format: "json" | "pretty"; destination: "stdout" | "stderr" | "file"; filePath?: string | undefined; } | undefined; observability?: { swarmObserverMaxEvents: number; eventBus?: { enabled: boolean; maxHistorySize: number; subscriptions: { consensus: boolean; agent: boolean; protocol: boolean; session: boolean; message: boolean; byzantine: boolean; }; logging: { frequentEventLevel: "debug" | "info"; importantEventLevel: "debug" | "info"; }; } | undefined; } | undefined; routing?: { latencyScoreWeight: number; stages?: { budgetFilter: boolean; zeroRouter: boolean; preferenceRouting: boolean; topsisRanking: boolean; linucbSelection: boolean; latencyTracking: boolean; routingMemory: boolean; confidenceCascade: boolean; capabilityMatch: boolean; qualityConstraint: boolean; resourceStrategy: boolean; strategyDistillation: boolean; } | undefined; budget?: { maxTokens?: number | undefined; maxCostUsd?: number | undefined; maxLatencyMs?: number | undefined; taskClassMaxCostUsd?: Partial<Record<"research" | "architecture" | "documentation" | "testing" | "devops" | "planning" | "code_generation" | "code_review" | "security_review" | "exploration", number>> | undefined; } | undefined; topsis?: { minQualityThreshold: number; verbose: boolean; criteria?: { name: string; weight: number; beneficial: boolean; }[] | undefined; maxLatencyMs?: number | undefined; maxCostPerRequest?: number | undefined; } | undefined; zeroRouter?: { enableCalibration: boolean; maxCalibrationOutcomes: number; minCalibrationOutcomes: number; verbose: boolean; thresholds?: { easyUpperBound: number; hardLowerBound: number; } | undefined; weights?: { reasoning: number; knowledge: number; creativity: number; precision: number; context_length: number; } | undefined; difficultyToTier?: Record<"medium" | "hard" | "easy", "balanced" | "fast" | "powerful"> | undefined; tierToClis?: Record<"balanced" | "fast" | "powerful", ("claude" | "gemini" | "codex" | "opencode")[]> | undefined; } | undefined; latencyTracker?: { windowSize: number; decayFactor: number; maxSampleAgeMs: number; percentiles: number[]; } | undefined; routingMemory?: { minObservations: number; confidenceThreshold: number; successRateThreshold: number; actionCacheMaxAgeMs: number; } | undefined; linucb?: { alpha: number; maxDecisionTimeMs: number; } | undefined; preference?: { minDataPoints: number; } | undefined; } | undefined; skills?: { enabled: boolean; maxSkills: number; minSuccessRateForRetention: number; executionsBeforeEvaluation: number; enablePruning: boolean; trackExecutionHistory: boolean; maxHistoryPerSkill: number; externalPacks?: { name: string; source: string; enabled: boolean; }[] | undefined; } | undefined; sica?: { enabled: boolean; minExecutionsForImprovement: number; improvementThreshold: number; maxActiveVersions: number; autoSelectBest: boolean; improvementCooldownMs: number; enableObservability: boolean; } | undefined; gateway?: { enabled: boolean; tierOverrides?: Record<string, "DIRECT" | "ANALYZED" | "ORCHESTRATED"> | undefined; upstreamServers?: { name: string; command: "python" | "node" | "npx" | "python3" | "uvx" | "docker"; args: string[]; lazy: boolean; timeoutMs: number; env?: Record<string, string> | undefined; }[] | undefined; } | undefined; }>
+  : Partial<{ experts?: { builtin: boolean; custom?: Record<string, { available: boolean; capabilities: string[]; description?: string | undefined; domain: "general" | "security" | "code" | "architecture" | "documentation" | "testing"; secondaryDomains?: ("general" | "security" | "code" | "architecture" | "documentation" | "testing")[] | undefined; systemPrompt: string; temperature: number; tier: "balanced" | "fast" | "powerful"; tools?: string[] | undefined; weight: number; }> | undefined; } | undefined; gateway?: { enabled: boolean; tierOverrides?: Record<string, "DIRECT" | "ANALYZED" | "ORCHESTRATED"> | undefined; upstreamServers?: { args: string[]; command: "python" | "node" | "npx" | "python3" | "uvx" | "docker"; env?: Record<string, string> | undefined; lazy: boolean; name: string; timeoutMs: number; }[] | undefined; } | undefined; logging?: { destination: "stdout" | "stderr" | "file"; filePath?: string | undefined; format: "json" | "pretty"; level: "debug" | "info" | "warn" | "error"; } | undefined; models: { default: string; providers?: Record<string, { apiKey?: string | undefined; baseUrl?: string | undefined; maxRetries: number; timeout: number; }> | undefined; tiers: { balanced: string[]; fast: string[]; powerful: string[]; }; }; observability?: { eventBus?: { enabled: boolean; logging: { frequentEventLevel: "debug" | "info"; importantEventLevel: "debug" | "info"; }; maxHistorySize: number; subscriptions: { agent: boolean; byzantine: boolean; consensus: boolean; message: boolean; protocol: boolean; session: boolean; }; } | undefined; swarmObserverMaxEvents: number; } | undefined; routing?: { budget?: { maxCostUsd?: number | undefined; maxLatencyMs?: number | undefined; maxTokens?: number | undefined; taskClassMaxCostUsd?: Partial<Record<"research" | "architecture" | "documentation" | "testing" | "devops" | "planning" | "code_generation" | "code_review" | "security_review" | "exploration", number>> | undefined; } | undefined; latencyScoreWeight: number; latencyTracker?: { decayFactor: number; maxSampleAgeMs: number; percentiles: number[]; windowSize: number; } | undefined; linucb?: { alpha: number; maxDecisionTimeMs: number; } | undefined; preference?: { minDataPoints: number; } | undefined; routingMemory?: { actionCacheMaxAgeMs: number; confidenceThreshold: number; minObservations: number; successRateThreshold: number; } | undefined; stages?: { budgetFilter: boolean; capabilityMatch: boolean; confidenceCascade: boolean; latencyTracking: boolean; linucbSelection: boolean; preferenceRouting: boolean; qualityConstraint: boolean; resourceStrategy: boolean; routingMemory: boolean; strategyDistillation: boolean; topsisRanking: boolean; zeroRouter: boolean; } | undefined; topsis?: { criteria?: { beneficial: boolean; name: string; weight: number; }[] | undefined; maxCostPerRequest?: number | undefined; maxLatencyMs?: number | undefined; minQualityThreshold: number; verbose: boolean; } | undefined; zeroRouter?: { difficultyToTier?: Record<"medium" | "hard" | "easy", "balanced" | "fast" | "powerful"> | undefined; enableCalibration: boolean; maxCalibrationOutcomes: number; minCalibrationOutcomes: number; thresholds?: { easyUpperBound: number; hardLowerBound: number; } | undefined; tierToClis?: Record<"balanced" | "fast" | "powerful", ("claude" | "gemini" | "codex" | "opencode")[]> | undefined; verbose: boolean; weights?: { context_length: number; creativity: number; knowledge: number; precision: number; reasoning: number; } | undefined; } | undefined; } | undefined; security?: { allowedPaths: string[]; audit?: { enabled: boolean; enableHashChain: boolean; logDir?: string | undefined; maxFiles: number; maxFileSizeBytes: number; minSeverity: "info" | "warning" | "critical"; } | undefined; auth?: { enabled: boolean; method: "token" | "oauth2"; tokenFile?: string | undefined; tokenHeader: string; } | undefined; blockedPatterns: string[]; policy?: { defaultMode: "read-only" | "read-write"; policyMode: "warn" | "enforce"; } | undefined; rateLimit: { enabled: boolean; perTool?: Record<string, { capacity: number; refillIntervalMs: number; refillRate: number; }> | undefined; requestsPerMinute: number; }; sandbox?: { dockerImage?: string | undefined; fallbackToPolicy: boolean; mode: "none" | "policy" | "container"; networkEnabled: boolean; } | undefined; secretsFile?: string | undefined; timeout?: { defaultTimeoutMs: number; enableLogging: boolean; maxTimeoutMs: number; perToolTimeout?: Record<string, number> | undefined; uriValidation: boolean; } | undefined; toolAllowlist?: string[] | undefined; } | undefined; sica?: { autoSelectBest: boolean; enabled: boolean; enableObservability: boolean; improvementCooldownMs: number; improvementThreshold: number; maxActiveVersions: number; minExecutionsForImprovement: number; } | undefined; skills?: { enabled: boolean; enablePruning: boolean; executionsBeforeEvaluation: number; externalPacks?: { enabled: boolean; name: string; source: string; }[] | undefined; maxHistoryPerSkill: number; maxSkills: number; minSuccessRateForRetention: number; trackExecutionHistory: boolean; } | undefined; workflows?: { maxParallel: number; templatesDir: string; timeout: number; } | undefined; }>
 InterfaceDeclaration DelegateContractOpts
   readonly trustTier?: string | undefined
 InterfaceDeclaration DelegateDeps
@@ -2745,15 +2745,15 @@ InterfaceDeclaration DelegateInputLike
   readonly preferred_capability?: string | undefined
   readonly task: string
 VariableDeclaration DelegateInputSchema
-  : z.ZodObject<{ task: z.ZodString; preferred_capability: z.ZodOptional<z.ZodEnum<{ code: "code"; context: "context"; reasoning: "reasoning"; speed: "speed"; }>>; model_hint: z.ZodOptional<z.ZodString>; billing_mode: z.ZodOptional<z.ZodEnum<{ plan: "plan"; api: "api"; }>>; }, z.core.$strip>
+  : z.ZodObject<{ billing_mode: z.ZodOptional<z.ZodEnum<{ api: "api"; plan: "plan"; }>>; model_hint: z.ZodOptional<z.ZodString>; preferred_capability: z.ZodOptional<z.ZodEnum<{ code: "code"; context: "context"; reasoning: "reasoning"; speed: "speed"; }>>; task: z.ZodString; }, z.core.$strip>
 FunctionDeclaration delegateInputToTaskContract
   : typeof delegateInputToTaskContract
 TypeAliasDeclaration DelegateOutput
   = z.infer<typeof DelegateOutputSchema>
 VariableDeclaration DelegateOutputSchema
-  : z.ZodObject<{ recommended_model: z.ZodString; reasoning: z.ZodString; capabilities: z.ZodObject<{ reasoning: z.ZodNumber; contextWindow: z.ZodNumber; codeGeneration: z.ZodNumber; speed: z.ZodNumber; cost: z.ZodNumber; }, z.core.$strip>; estimated_tokens: z.ZodNumber; alternatives: z.ZodArray<z.ZodObject<{ model: z.ZodString; score: z.ZodNumber; tradeoff: z.ZodString; }, z.core.$strip>>; governance: z.ZodOptional<z.ZodObject<{ domain: z.ZodString; votingThreshold: z.ZodString; promotionReason: z.ZodString; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ alternatives: z.ZodArray<z.ZodObject<{ model: z.ZodString; score: z.ZodNumber; tradeoff: z.ZodString; }, z.core.$strip>>; capabilities: z.ZodObject<{ codeGeneration: z.ZodNumber; contextWindow: z.ZodNumber; cost: z.ZodNumber; reasoning: z.ZodNumber; speed: z.ZodNumber; }, z.core.$strip>; estimated_tokens: z.ZodNumber; governance: z.ZodOptional<z.ZodObject<{ domain: z.ZodString; promotionReason: z.ZodString; votingThreshold: z.ZodString; }, z.core.$strip>>; reasoning: z.ZodString; recommended_model: z.ZodString; }, z.core.$strip>
 TypeAliasDeclaration DelegatePipelineResult
-  = | { readonly ok: true; readonly value: CompiledPipeline } | { readonly ok: false; readonly error: string }
+  = | { readonly ok: true; readonly value: CompiledPipeline; } | { readonly error: string; readonly ok: false; }
 VariableDeclaration denyMutationsWithoutModeRule
   : PolicyRule
 InterfaceDeclaration DependencyError
@@ -2763,9 +2763,9 @@ InterfaceDeclaration DependencyError
 TypeAliasDeclaration DependencyErrorCode
   = | 'CIRCULAR_DEPENDENCY' | 'MISSING_DEPENDENCY' | 'VERSION_MISMATCH' | 'SELF_DEPENDENCY' | 'SKILL_NOT_FOUND'
 VariableDeclaration DependencyErrorCodeSchema
-  : z.ZodEnum<{ CIRCULAR_DEPENDENCY: "CIRCULAR_DEPENDENCY"; MISSING_DEPENDENCY: "MISSING_DEPENDENCY"; VERSION_MISMATCH: "VERSION_MISMATCH"; SELF_DEPENDENCY: "SELF_DEPENDENCY"; SKILL_NOT_FOUND: "SKILL_NOT_FOUND"; }>
+  : z.ZodEnum<{ CIRCULAR_DEPENDENCY: "CIRCULAR_DEPENDENCY"; MISSING_DEPENDENCY: "MISSING_DEPENDENCY"; SELF_DEPENDENCY: "SELF_DEPENDENCY"; SKILL_NOT_FOUND: "SKILL_NOT_FOUND"; VERSION_MISMATCH: "VERSION_MISMATCH"; }>
 VariableDeclaration DependencyErrorSchema
-  : z.ZodObject<{ code: z.ZodEnum<{ CIRCULAR_DEPENDENCY: "CIRCULAR_DEPENDENCY"; MISSING_DEPENDENCY: "MISSING_DEPENDENCY"; VERSION_MISMATCH: "VERSION_MISMATCH"; SELF_DEPENDENCY: "SELF_DEPENDENCY"; SKILL_NOT_FOUND: "SKILL_NOT_FOUND"; }>; message: z.ZodString; context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>
+  : z.ZodObject<{ code: z.ZodEnum<{ CIRCULAR_DEPENDENCY: "CIRCULAR_DEPENDENCY"; MISSING_DEPENDENCY: "MISSING_DEPENDENCY"; SELF_DEPENDENCY: "SELF_DEPENDENCY"; SKILL_NOT_FOUND: "SKILL_NOT_FOUND"; VERSION_MISMATCH: "VERSION_MISMATCH"; }>; context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; message: z.ZodString; }, z.core.$strip>
 ClassDeclaration DependencyGraph
   addStep(step: WorkflowStep) => void
   buildReverseLinks() => void
@@ -2802,7 +2802,7 @@ InterfaceDeclaration DetectionInput
   readonly taskDescription?: string | undefined
   readonly toolCalls?: readonly ToolCallRecord[] | undefined
 InterfaceDeclaration DetectionResult
-  readonly analysisMetadata: { readonly durationMs: number; readonly checksPerformed: number; readonly contentAnalyzed: number; }
+  readonly analysisMetadata: { readonly checksPerformed: number; readonly contentAnalyzed: number; readonly durationMs: number; }
   readonly failures: readonly DetectedFailure[]
   readonly hasFailure: boolean
 FunctionDeclaration detectLatencyPatterns
@@ -2833,8 +2833,10 @@ InterfaceDeclaration DevPipelineOptions
 InterfaceDeclaration DevPipelineResult
   readonly completed: boolean
   readonly plan: string
+  readonly planStatus?: "empty" | undefined
   readonly qaIterations: number
   readonly securityPassed: boolean
+  readonly securityRan?: boolean | undefined
   readonly tasks: readonly PipelineTask[]
   readonly voteIterations: number
 InterfaceDeclaration DevPipelineStages
@@ -2842,16 +2844,16 @@ InterfaceDeclaration DevPipelineStages
   implement(task: PipelineTask) => Promise<string>
   plan(task: string, research: string, priorFeedback?: string) => Promise<string>
   qaReview(task: PipelineTask, implementation: string) => Promise<QaReviewResult>
-  qualityGate(() => Promise<{ passed: boolean; feedback: string; }>) | undefined
+  qualityGate(() => Promise<{ feedback: string; passed: boolean; }>) | undefined
   research(task: string) => Promise<ResearchContext>
-  securityScan() => Promise<{ passed: boolean; feedback: string; }>
+  securityScan() => Promise<{ feedback: string; passed: boolean; }>
   vote(plan: string, research: string) => Promise<VoteResult>
 TypeAliasDeclaration DifficultyDimension
   = z.infer<typeof DifficultyDimensionSchema>
 InterfaceDeclaration DifficultyEstimate
   readonly aggregateScore: number
   readonly confidence: number
-  readonly dimensions: { reasoning: number; knowledge: number; creativity: number; precision: number; context_length: number; }
+  readonly dimensions: { context_length: number; creativity: number; knowledge: number; precision: number; reasoning: number; }
   readonly dominantDimension: "reasoning" | "knowledge" | "creativity" | "precision" | "context_length"
   readonly level: DifficultyLevel
   readonly recommendedTier: ModelTier
@@ -2934,7 +2936,7 @@ InterfaceDeclaration DistributionStats
   readonly median: number
   readonly min: number
   readonly n: number
-  readonly percentiles: { readonly p5: number; readonly p25: number; readonly p50: number; readonly p75: number; readonly p95: number; }
+  readonly percentiles: { readonly p25: number; readonly p5: number; readonly p50: number; readonly p75: number; readonly p95: number; }
   readonly stdDev: number
   readonly variance: number
 ClassDeclaration DocumentationExpert
@@ -3029,7 +3031,7 @@ FunctionDeclaration err
 TypeAliasDeclaration ErrorCategory
   = z.infer<typeof ErrorCategorySchema>
 VariableDeclaration|TypeAliasDeclaration ErrorCode
-  : { readonly VALIDATION_ERROR: "VALIDATION_ERROR"; readonly INVALID_INPUT: "INVALID_INPUT"; readonly MISSING_REQUIRED: "MISSING_REQUIRED"; readonly SCHEMA_ERROR: "SCHEMA_ERROR"; readonly CONFIG_ERROR: "CONFIG_ERROR"; readonly CONFIG_NOT_FOUND: "CONFIG_NOT_FOUND"; readonly CONFIG_INVALID: "CONFIG_INVALID"; readonly MODEL_ERROR: "MODEL_ERROR"; readonly MODEL_UNAVAILABLE: "MODEL_UNAVAILABLE"; readonly MODEL_NOT_FOUND: "MODEL_NOT_FOUND"; readonly MODEL_RATE_LIMITED: "MODEL_RATE_LIMITED"; readonly MODEL_TIMEOUT: "MODEL_TIMEOUT"; readonly MODEL_PARAMETER_UNSUPPORTED: "MODEL_PARAMETER_UNSUPPORTED"; readonly AGENT_ERROR: "AGENT_ERROR"; readonly AGENT_NOT_FOUND: "AGENT_NOT_FOUND"; readonly AGENT_EXECUTION_FAILED: "AGENT_EXECUTION_FAILED"; readonly AGENT_MEMORY_FAILURE: "AGENT_MEMORY_FAILURE"; readonly AGENT_REFLECTION_FAILURE: "AGENT_REFLECTION_FAILURE"; readonly AGENT_PLANNING_FAILURE: "AGENT_PLANNING_FAILURE"; readonly AGENT_ACTION_FAILURE: "AGENT_ACTION_FAILURE"; readonly WORKFLOW_ERROR: "WORKFLOW_ERROR"; readonly WORKFLOW_NOT_FOUND: "WORKFLOW_NOT_FOUND"; readonly WORKFLOW_PARSE_ERROR: "WORKFLOW_PARSE_ERROR"; readonly WORKFLOW_EXECUTION_FAILED: "WORKFLOW_EXECUTION_FAILED"; readonly SECURITY_ERROR: "SECURITY_ERROR"; readonly PATH_TRAVERSAL: "PATH_TRAVERSAL"; readonly UNAUTHORIZED: "UNAUTHORIZED"; readonly TIMEOUT_ERROR: "TIMEOUT_ERROR"; readonly RATE_LIMIT_ERROR: "RATE_LIMIT_ERROR"; readonly INTERNAL_ERROR: "INTERNAL_ERROR"; }
+  : { readonly AGENT_ACTION_FAILURE: "AGENT_ACTION_FAILURE"; readonly AGENT_ERROR: "AGENT_ERROR"; readonly AGENT_EXECUTION_FAILED: "AGENT_EXECUTION_FAILED"; readonly AGENT_MEMORY_FAILURE: "AGENT_MEMORY_FAILURE"; readonly AGENT_NOT_FOUND: "AGENT_NOT_FOUND"; readonly AGENT_PLANNING_FAILURE: "AGENT_PLANNING_FAILURE"; readonly AGENT_REFLECTION_FAILURE: "AGENT_REFLECTION_FAILURE"; readonly CONFIG_ERROR: "CONFIG_ERROR"; readonly CONFIG_INVALID: "CONFIG_INVALID"; readonly CONFIG_NOT_FOUND: "CONFIG_NOT_FOUND"; readonly INTERNAL_ERROR: "INTERNAL_ERROR"; readonly INVALID_INPUT: "INVALID_INPUT"; readonly MISSING_REQUIRED: "MISSING_REQUIRED"; readonly MODEL_ERROR: "MODEL_ERROR"; readonly MODEL_NOT_FOUND: "MODEL_NOT_FOUND"; readonly MODEL_PARAMETER_UNSUPPORTED: "MODEL_PARAMETER_UNSUPPORTED"; readonly MODEL_RATE_LIMITED: "MODEL_RATE_LIMITED"; readonly MODEL_TIMEOUT: "MODEL_TIMEOUT"; readonly MODEL_UNAVAILABLE: "MODEL_UNAVAILABLE"; readonly PATH_TRAVERSAL: "PATH_TRAVERSAL"; readonly RATE_LIMIT_ERROR: "RATE_LIMIT_ERROR"; readonly SCHEMA_ERROR: "SCHEMA_ERROR"; readonly SECURITY_ERROR: "SECURITY_ERROR"; readonly TIMEOUT_ERROR: "TIMEOUT_ERROR"; readonly UNAUTHORIZED: "UNAUTHORIZED"; readonly VALIDATION_ERROR: "VALIDATION_ERROR"; readonly WORKFLOW_ERROR: "WORKFLOW_ERROR"; readonly WORKFLOW_EXECUTION_FAILED: "WORKFLOW_EXECUTION_FAILED"; readonly WORKFLOW_NOT_FOUND: "WORKFLOW_NOT_FOUND"; readonly WORKFLOW_PARSE_ERROR: "WORKFLOW_PARSE_ERROR"; }
   = (typeof ErrorCode)[keyof typeof ErrorCode]
 InterfaceDeclaration ErrorPayload
   readonly errorCode: string
@@ -3065,7 +3067,7 @@ InterfaceDeclaration EvaluationCriterion
   readonly type: CriterionTypeType
   readonly weight: number
 VariableDeclaration EvaluationCriterionSchema
-  : z.ZodObject<{ id: z.ZodString; name: z.ZodString; description: z.ZodString; type: z.ZodEnum<{ binary: "binary"; scaled: "scaled"; threshold: "threshold"; categorical: "categorical"; }>; weight: z.ZodNumber; passThreshold: z.ZodOptional<z.ZodNumber>; categories: z.ZodOptional<z.ZodReadonly<z.ZodArray<z.ZodString>>>; }, z.core.$strip>
+  : z.ZodObject<{ categories: z.ZodOptional<z.ZodReadonly<z.ZodArray<z.ZodString>>>; description: z.ZodString; id: z.ZodString; name: z.ZodString; passThreshold: z.ZodOptional<z.ZodNumber>; type: z.ZodEnum<{ binary: "binary"; categorical: "categorical"; scaled: "scaled"; threshold: "threshold"; }>; weight: z.ZodNumber; }, z.core.$strip>
 ClassDeclaration EventBus
   emit(event: PipelineEvent) => void
   get bufferSize(): number
@@ -3123,7 +3125,7 @@ InterfaceDeclaration ExecuteExpertDeps
 TypeAliasDeclaration ExecuteExpertInput
   = z.infer<typeof ExecuteExpertInputSchema>
 VariableDeclaration ExecuteExpertInputSchema
-  : z.ZodObject<{ expertId: z.ZodString; task: z.ZodString; context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; timeoutMs: z.ZodOptional<z.ZodNumber>; previousExpertSummary: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; expertId: z.ZodString; previousExpertSummary: z.ZodOptional<z.ZodString>; task: z.ZodString; timeoutMs: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration ExecuteExpertResponse
   confidence?: number | undefined
   durationMs: number
@@ -3141,7 +3143,7 @@ FunctionDeclaration executeOrchestratePipeline
 FunctionDeclaration executeParallel
   : typeof executeParallel
 TypeAliasDeclaration ExecuteResult
-  = | { readonly ok: true; readonly value: PipelineResult } | { readonly ok: false; readonly error: string }
+  = | { readonly ok: true; readonly value: PipelineResult; } | { readonly error: string; readonly ok: false; }
 FunctionDeclaration executeSpec
   : typeof executeSpec
 TypeAliasDeclaration ExecuteSpecDeps
@@ -3149,7 +3151,7 @@ TypeAliasDeclaration ExecuteSpecDeps
 TypeAliasDeclaration ExecuteSpecInput
   = z.infer<typeof ExecuteSpecInputSchema>
 VariableDeclaration ExecuteSpecInputSchema
-  : z.ZodObject<{ spec: z.ZodString; dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; dispatch: z.ZodDefault<z.ZodEnum<{ sync: "sync"; async: "async"; }>>; }, z.core.$strip>
+  : z.ZodObject<{ dispatch: z.ZodDefault<z.ZodEnum<{ async: "async"; sync: "sync"; }>>; dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; spec: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration ExecutionContext
   abortController: AbortController
   allResults: NodeResult[]
@@ -3159,7 +3161,7 @@ InterfaceDeclaration ExecutionContext
   executionId: string
   inputs: Record<string, unknown>
   inputs: Record<string, unknown>
-  pendingInterrupt: { readonly nodeId: string; readonly interrupt: Interrupt; readonly additional: readonly { readonly nodeId: string; readonly interrupt: Interrupt; }[]; } | undefined
+  pendingInterrupt: { readonly additional: readonly { readonly interrupt: Interrupt; readonly nodeId: string; }[]; readonly interrupt: Interrupt; readonly nodeId: string; } | undefined
   resumeValues: Readonly<Record<string, unknown>>
   runnableIds: string[]
   signal?: AbortSignal | undefined
@@ -3197,20 +3199,20 @@ InterfaceDeclaration ExecutionPattern
 InterfaceDeclaration ExecutionPhase
   phaseIndex: number
   steps: WorkflowStep[]
-  steps: { id: string; agent: "custom" | "orchestrator" | "code_expert" | "architecture_expert" | "security_expert" | "documentation_expert" | "testing_expert" | "infrastructure_expert"; action: string; inputs: Record<string, unknown>; dependsOn?: string[] | undefined; parallel?: boolean | undefined; retries?: number | undefined; timeout?: number | undefined; condition?: string | undefined; contextBudget?: { system?: number | undefined; task?: number | undefined; active?: number | undefined; reserved?: number | undefined; } | undefined; }[]
+  steps: { action: string; agent: "custom" | "orchestrator" | "code_expert" | "architecture_expert" | "security_expert" | "documentation_expert" | "testing_expert" | "infrastructure_expert"; condition?: string | undefined; contextBudget?: { active?: number | undefined; reserved?: number | undefined; system?: number | undefined; task?: number | undefined; } | undefined; dependsOn?: string[] | undefined; id: string; inputs: Record<string, unknown>; parallel?: boolean | undefined; retries?: number | undefined; timeout?: number | undefined; }[]
 InterfaceDeclaration ExecutionPlan
   asWorkflowDefinition(options?: PlanConversionOptions) => WorkflowDefinition
   phases: ExecutionPhase[]
 TypeAliasDeclaration ExecutionStage
   = 'parse' | 'decompose' | 'compile' | 'execute' | 'validate'
 TypeAliasDeclaration ExecutionStatus
-  = | { state: 'pending' } | { state: 'running'; currentStep: string; progress: number } | { state: 'completed'; result: WorkflowResult } | { state: 'failed'; error: string; failedStep?: string } | { state: 'cancelled'; cancelledAt: string }
+  = | { state: 'pending'; } | { currentStep: string; progress: number; state: 'running'; } | { result: WorkflowResult; state: 'completed'; } | { error: string; failedStep?: string; state: 'failed'; } | { cancelledAt: string; state: 'cancelled'; }
 TypeAliasDeclaration ExecutionStrategy
   = | 'single-shot' /** Code change with the dev gate (test/lint/typecheck) → `run_dev_pipeline`. */ | 'dev-pipeline' /** Multi-stage templated work (audit/general) → `run_pipeline`. */ | 'pipeline' /** DAG / conditional-edge workflow → `run_graph_workflow`. */ | 'graph-workflow' /** Pattern-based multi-agent orchestration (wave/aflow/puppeteer) → `orchestrate`. */ | 'orchestrate' /** Multi-perspective decision → `consensus_vote`. */ | 'consensus' /** Greenfield project from a spec → `execute_spec`. */ | 'spec' /** Research-heavy work → the research pipeline. */ | 'research'
 VariableDeclaration ExpectedOutcome
-  : { readonly REFUSE: "refuse"; readonly CAUTION: "caution"; readonly CLARIFY: "clarify"; readonly ESCALATE: "escalate"; readonly PROCEED: "proceed"; readonly DETECT: "detect"; }
+  : { readonly CAUTION: "caution"; readonly CLARIFY: "clarify"; readonly DETECT: "detect"; readonly ESCALATE: "escalate"; readonly PROCEED: "proceed"; readonly REFUSE: "refuse"; }
 VariableDeclaration ExpectedOutcomeSchema
-  : z.ZodEnum<{ refuse: "refuse"; caution: "caution"; clarify: "clarify"; escalate: "escalate"; proceed: "proceed"; detect: "detect"; }>
+  : z.ZodEnum<{ caution: "caution"; clarify: "clarify"; detect: "detect"; escalate: "escalate"; proceed: "proceed"; refuse: "refuse"; }>
 TypeAliasDeclaration ExpectedOutcomeType
   = (typeof ExpectedOutcome)[keyof typeof ExpectedOutcome]
 InterfaceDeclaration ExperienceEntry
@@ -3320,7 +3322,7 @@ InterfaceDeclaration ExpertAssignment
   selectionReason: string
   subtaskId: string
 VariableDeclaration ExpertAssignmentSchema
-  : z.ZodObject<{ subtaskId: z.ZodString; expertRole: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; research_expert: "research_expert"; pm_expert: "pm_expert"; ux_expert: "ux_expert"; infrastructure_expert: "infrastructure_expert"; }>; selectionReason: z.ZodString; confidence: z.ZodNumber; ictmConfig: z.ZodOptional<z.ZodObject<{ instructions: z.ZodString; context: z.ZodObject<{ maxTokens: z.ZodNumber; relevanceThreshold: z.ZodNumber; includeHistory: z.ZodBoolean; pruneStrategy: z.ZodEnum<{ importance: "importance"; recency: "recency"; hybrid: "hybrid"; }>; }, z.core.$strip>; tools: z.ZodObject<{ capabilities: z.ZodArray<z.ZodString>; restrictions: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>; model: z.ZodObject<{ provider: z.ZodOptional<z.ZodString>; modelId: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; reasoning: z.ZodOptional<z.ZodEnum<{ standard: "standard"; minimal: "minimal"; extended: "extended"; }>>; }, z.core.$strip>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ confidence: z.ZodNumber; expertRole: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; pm_expert: "pm_expert"; research_expert: "research_expert"; security_expert: "security_expert"; testing_expert: "testing_expert"; ux_expert: "ux_expert"; }>; ictmConfig: z.ZodOptional<z.ZodObject<{ context: z.ZodObject<{ includeHistory: z.ZodBoolean; maxTokens: z.ZodNumber; pruneStrategy: z.ZodEnum<{ hybrid: "hybrid"; importance: "importance"; recency: "recency"; }>; relevanceThreshold: z.ZodNumber; }, z.core.$strip>; instructions: z.ZodString; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; model: z.ZodObject<{ maxTokens: z.ZodOptional<z.ZodNumber>; modelId: z.ZodOptional<z.ZodString>; provider: z.ZodOptional<z.ZodString>; reasoning: z.ZodOptional<z.ZodEnum<{ extended: "extended"; minimal: "minimal"; standard: "standard"; }>>; temperature: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>; tools: z.ZodObject<{ capabilities: z.ZodArray<z.ZodString>; restrictions: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>; }, z.core.$strip>>; selectionReason: z.ZodString; subtaskId: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration ExpertBridgeResult
   readonly cli?: "claude" | "gemini" | "codex" | "opencode" | undefined
   readonly durationMs: number
@@ -3333,7 +3335,7 @@ InterfaceDeclaration ExpertBridgeResult
   readonly tokensOut?: number | undefined
   readonly tokensUsed?: number | undefined
 VariableDeclaration ExpertCollaborationPattern
-  : { readonly SEQUENTIAL: "sequential"; readonly PARALLEL: "parallel"; readonly REVIEW_CHAIN: "review_chain"; readonly PAIR: "pair"; }
+  : { readonly PAIR: "pair"; readonly PARALLEL: "parallel"; readonly REVIEW_CHAIN: "review_chain"; readonly SEQUENTIAL: "sequential"; }
 TypeAliasDeclaration ExpertCollaborationPatternType
   = (typeof ExpertCollaborationPattern)[keyof typeof ExpertCollaborationPattern]
 InterfaceDeclaration ExpertConfig
@@ -3346,7 +3348,7 @@ InterfaceDeclaration ExpertConfig
   systemPrompt: string
   toolRestrictions?: { allowedTools?: string[] | undefined; deniedTools?: string[] | undefined; } | undefined
 VariableDeclaration ExpertConfigSchema
-  : z.ZodObject<{ id: z.ZodString; name: z.ZodString; role: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; research_expert: "research_expert"; pm_expert: "pm_expert"; ux_expert: "ux_expert"; infrastructure_expert: "infrastructure_expert"; qa_expert: "qa_expert"; data_visualization_expert: "data_visualization_expert"; }>; systemPrompt: z.ZodString; capabilities: z.ZodArray<z.ZodEnum<{ research: "research"; code_generation: "code_generation"; code_review: "code_review"; tool_use: "tool_use"; task_execution: "task_execution"; delegation: "delegation"; collaboration: "collaboration"; }>>; modelPreference: z.ZodOptional<z.ZodObject<{ provider: z.ZodOptional<z.ZodString>; modelId: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; toolRestrictions: z.ZodOptional<z.ZodObject<{ allowedTools: z.ZodOptional<z.ZodArray<z.ZodString>>; deniedTools: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>
+  : z.ZodObject<{ capabilities: z.ZodArray<z.ZodEnum<{ code_generation: "code_generation"; code_review: "code_review"; collaboration: "collaboration"; delegation: "delegation"; research: "research"; task_execution: "task_execution"; tool_use: "tool_use"; }>>; id: z.ZodString; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; modelPreference: z.ZodOptional<z.ZodObject<{ maxTokens: z.ZodOptional<z.ZodNumber>; modelId: z.ZodOptional<z.ZodString>; provider: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; name: z.ZodString; role: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; data_visualization_expert: "data_visualization_expert"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; pm_expert: "pm_expert"; qa_expert: "qa_expert"; research_expert: "research_expert"; security_expert: "security_expert"; testing_expert: "testing_expert"; ux_expert: "ux_expert"; }>; systemPrompt: z.ZodString; toolRestrictions: z.ZodOptional<z.ZodObject<{ allowedTools: z.ZodOptional<z.ZodArray<z.ZodString>>; deniedTools: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>>; }, z.core.$strip>
 InterfaceDeclaration ExpertDefinition
   available: boolean
   capabilities: string[]
@@ -3360,9 +3362,9 @@ InterfaceDeclaration ExpertDefinition
 TypeAliasDeclaration ExpertDomain
   = 'code' | 'security' | 'architecture' | 'testing' | 'documentation'
 VariableDeclaration ExpertDomainSchema
-  : z.ZodEnum<{ security: "security"; code: "code"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; }>
+  : z.ZodEnum<{ architecture: "architecture"; code: "code"; documentation: "documentation"; security: "security"; testing: "testing"; }>
 VariableDeclaration ExpertFactory
-  : { readonly create: typeof createExpert; readonly createBuiltIn: typeof createBuiltInExpert; readonly createMany: typeof createManyExperts; readonly createAllBuiltIn: typeof createAllBuiltInExperts; readonly validate: typeof validateExpertConfigStrict; readonly getBuiltInConfig: typeof getBuiltInExpertConfig; readonly createFromICTM: typeof createFromICTM; }
+  : { readonly create: typeof createExpert; readonly createAllBuiltIn: typeof createAllBuiltInExperts; readonly createBuiltIn: typeof createBuiltInExpert; readonly createFromICTM: typeof createFromICTM; readonly createMany: typeof createManyExperts; readonly getBuiltInConfig: typeof getBuiltInExpertConfig; readonly validate: typeof validateExpertConfigStrict; }
 ClassDeclaration ExpertFactoryAdapter
   createForRole(role: AgentRole) => Result<Expert, Error>
 InterfaceDeclaration ExpertInfo
@@ -3377,7 +3379,7 @@ InterfaceDeclaration ExpertMatch
   score: number
   scoreBreakdown: ScoreBreakdown
 VariableDeclaration ExpertMatchSchema
-  : z.ZodObject<{ expertId: z.ZodString; score: z.ZodNumber; matchedCapabilities: z.ZodArray<z.ZodString>; reasoning: z.ZodString; scoreBreakdown: z.ZodObject<{ capabilityScore: z.ZodNumber; domainScore: z.ZodNumber; weightScore: z.ZodNumber; finalScore: z.ZodNumber; }, z.core.$strip>; }, z.core.$strip>
+  : z.ZodObject<{ expertId: z.ZodString; matchedCapabilities: z.ZodArray<z.ZodString>; reasoning: z.ZodString; score: z.ZodNumber; scoreBreakdown: z.ZodObject<{ capabilityScore: z.ZodNumber; domainScore: z.ZodNumber; finalScore: z.ZodNumber; weightScore: z.ZodNumber; }, z.core.$strip>; }, z.core.$strip>
 InterfaceDeclaration ExpertOptions
   additionalCapabilities?: AgentCapability[] | undefined
   enableHeuristics?: boolean | undefined
@@ -3385,7 +3387,7 @@ InterfaceDeclaration ExpertOptions
   systemPromptOverride?: string | undefined
   temperature?: number | undefined
 VariableDeclaration ExpertOptionsSchema
-  : z.ZodObject<{ systemPromptOverride: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; enableHeuristics: z.ZodOptional<z.ZodBoolean>; additionalCapabilities: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>
+  : z.ZodObject<{ additionalCapabilities: z.ZodOptional<z.ZodArray<z.ZodString>>; enableHeuristics: z.ZodOptional<z.ZodBoolean>; maxTokens: z.ZodOptional<z.ZodNumber>; systemPromptOverride: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration ExpertOutput
   confidence: number
   content: string
@@ -3394,7 +3396,7 @@ InterfaceDeclaration ExpertOutput
   structuredData?: Record<string, unknown> | undefined
   warnings?: string[] | undefined
 VariableDeclaration ExpertOutputSchema
-  : z.ZodObject<{ content: z.ZodString; structuredData: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; recommendations: z.ZodOptional<z.ZodArray<z.ZodString>>; warnings: z.ZodOptional<z.ZodArray<z.ZodString>>; confidence: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ confidence: z.ZodNumber; content: z.ZodString; recommendations: z.ZodOptional<z.ZodArray<z.ZodString>>; structuredData: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; warnings: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>
 InterfaceDeclaration ExpertParticipation
   expertId: string
   joinedAt: string
@@ -3403,7 +3405,7 @@ InterfaceDeclaration ExpertParticipation
   status: "pending" | "failed" | "working" | "submitted" | "reviewing" | "voted"
   submittedAt?: string | undefined
 VariableDeclaration ExpertParticipationSchema
-  : z.ZodObject<{ expertId: z.ZodString; role: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; }>; joinedAt: z.ZodISODateTime; status: z.ZodEnum<{ pending: "pending"; failed: "failed"; working: "working"; submitted: "submitted"; reviewing: "reviewing"; voted: "voted"; }>; submittedAt: z.ZodOptional<z.ZodISODateTime>; retryCount: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ expertId: z.ZodString; joinedAt: z.ZodISODateTime; retryCount: z.ZodNumber; role: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; documentation_expert: "documentation_expert"; orchestrator: "orchestrator"; security_expert: "security_expert"; testing_expert: "testing_expert"; }>; status: z.ZodEnum<{ failed: "failed"; pending: "pending"; reviewing: "reviewing"; submitted: "submitted"; voted: "voted"; working: "working"; }>; submittedAt: z.ZodOptional<z.ZodISODateTime>; }, z.core.$strip>
 InterfaceDeclaration ExpertPerformanceEntry
   readonly avgDurationMs: number
   readonly consecutiveFailures: number
@@ -3463,11 +3465,11 @@ InterfaceDeclaration ExplorationEvent
   readonly timestamp: number
   readonly treeId?: string | undefined
 VariableDeclaration ExplorationEventSchema
-  : z.ZodObject<{ timestamp: z.ZodNumber; eventType: z.ZodEnum<{ tree_created: "tree_created"; node_created: "node_created"; node_activated: "node_activated"; node_deactivated: "node_deactivated"; node_completed: "node_completed"; node_pruned: "node_pruned"; path_scored: "path_scored"; cross_tree_share: "cross_tree_share"; conclusion_reached: "conclusion_reached"; tree_completed: "tree_completed"; forest_converging: "forest_converging"; forest_completed: "forest_completed"; }>; treeId: z.ZodOptional<z.ZodString>; nodeId: z.ZodOptional<z.ZodString>; details: z.ZodRecord<z.ZodString, z.ZodUnknown>; }, z.core.$strip>
+  : z.ZodObject<{ details: z.ZodRecord<z.ZodString, z.ZodUnknown>; eventType: z.ZodEnum<{ conclusion_reached: "conclusion_reached"; cross_tree_share: "cross_tree_share"; forest_completed: "forest_completed"; forest_converging: "forest_converging"; node_activated: "node_activated"; node_completed: "node_completed"; node_created: "node_created"; node_deactivated: "node_deactivated"; node_pruned: "node_pruned"; path_scored: "path_scored"; tree_completed: "tree_completed"; tree_created: "tree_created"; }>; nodeId: z.ZodOptional<z.ZodString>; timestamp: z.ZodNumber; treeId: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 TypeAliasDeclaration ExplorationEventType
   = | 'tree_created' | 'node_created' | 'node_activated' | 'node_deactivated' | 'node_completed' | 'node_pruned' | 'path_scored' | 'cross_tree_share' | 'conclusion_reached' | 'tree_completed' | 'forest_converging' | 'forest_completed'
 VariableDeclaration ExplorationEventTypeSchema
-  : z.ZodEnum<{ tree_created: "tree_created"; node_created: "node_created"; node_activated: "node_activated"; node_deactivated: "node_deactivated"; node_completed: "node_completed"; node_pruned: "node_pruned"; path_scored: "path_scored"; cross_tree_share: "cross_tree_share"; conclusion_reached: "conclusion_reached"; tree_completed: "tree_completed"; forest_converging: "forest_converging"; forest_completed: "forest_completed"; }>
+  : z.ZodEnum<{ conclusion_reached: "conclusion_reached"; cross_tree_share: "cross_tree_share"; forest_completed: "forest_completed"; forest_converging: "forest_converging"; node_activated: "node_activated"; node_completed: "node_completed"; node_created: "node_created"; node_deactivated: "node_deactivated"; node_pruned: "node_pruned"; path_scored: "path_scored"; tree_completed: "tree_completed"; tree_created: "tree_created"; }>
 TypeAliasDeclaration ExpressionType
   = 'inputs' | 'steps' | 'variables'
 FunctionDeclaration extractBooleanField
@@ -3489,7 +3491,7 @@ FunctionDeclaration extractStringField
 TypeAliasDeclaration ExtractSymbolsDeps
   = BaseMcpToolDeps
 VariableDeclaration ExtractSymbolsInputSchema
-  : z.ZodObject<{ filePath: z.ZodString; mode: z.ZodOptional<z.ZodEnum<{ full: "full"; index: "index"; }>>; maxChars: z.ZodOptional<z.ZodNumber>; maxSymbols: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ filePath: z.ZodString; maxChars: z.ZodOptional<z.ZodNumber>; maxSymbols: z.ZodOptional<z.ZodNumber>; mode: z.ZodOptional<z.ZodEnum<{ full: "full"; index: "index"; }>>; }, z.core.$strip>
 TypeParameter F
 ClassDeclaration FactoryError
 InterfaceDeclaration FailureAnalysis
@@ -3506,7 +3508,7 @@ InterfaceDeclaration FailureBreakdownEntry
   readonly count: number
   readonly percentage: number
 TypeAliasDeclaration FailureClassification
-  = { kind: 'transient' | 'permanent'; source: 'transport' | 'archetype' | 'default'; archetype?: FailureArchetype; confidence?: number; }
+  = { archetype?: FailureArchetype; confidence?: number; kind: 'transient' | 'permanent'; source: 'transport' | 'archetype' | 'default'; }
 ClassDeclaration FailureDetector
   detect(input: DetectionInput) => DetectionResult
 InterfaceDeclaration FailurePattern
@@ -3514,7 +3516,7 @@ InterfaceDeclaration FailurePattern
   readonly occurrences: number
   readonly pattern: string
 VariableDeclaration FailurePatternSchema
-  : z.ZodObject<{ pattern: z.ZodString; occurrences: z.ZodNumber; avgFailureScore: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ avgFailureScore: z.ZodNumber; occurrences: z.ZodNumber; pattern: z.ZodString; }, z.core.$strip>
 TypeAliasDeclaration FailureSeverity
   = 'low' | 'medium' | 'high' | 'critical'
 TypeAliasDeclaration FailureType
@@ -3538,7 +3540,7 @@ InterfaceDeclaration FeedbackCollectorConfig
   readonly targetDurationMs: number
   readonly targetTokenUsage: number
 VariableDeclaration FeedbackCollectorConfigSchema
-  : z.ZodObject<{ maxPendingDecisions: z.ZodDefault<z.ZodNumber>; pendingTimeoutMs: z.ZodDefault<z.ZodNumber>; enableAutoReward: z.ZodDefault<z.ZodBoolean>; qualityWeight: z.ZodDefault<z.ZodNumber>; speedWeight: z.ZodDefault<z.ZodNumber>; efficiencyWeight: z.ZodDefault<z.ZodNumber>; retryPenalty: z.ZodDefault<z.ZodNumber>; targetDurationMs: z.ZodDefault<z.ZodNumber>; targetTokenUsage: z.ZodDefault<z.ZodNumber>; maxHistorySize: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ efficiencyWeight: z.ZodDefault<z.ZodNumber>; enableAutoReward: z.ZodDefault<z.ZodBoolean>; maxHistorySize: z.ZodDefault<z.ZodNumber>; maxPendingDecisions: z.ZodDefault<z.ZodNumber>; pendingTimeoutMs: z.ZodDefault<z.ZodNumber>; qualityWeight: z.ZodDefault<z.ZodNumber>; retryPenalty: z.ZodDefault<z.ZodNumber>; speedWeight: z.ZodDefault<z.ZodNumber>; targetDurationMs: z.ZodDefault<z.ZodNumber>; targetTokenUsage: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 ClassDeclaration FeedbackIntegration
   evictStaleEntries() => number
   getDecisionMapSize() => number
@@ -3574,7 +3576,7 @@ InterfaceDeclaration FeedbackMessage
   targetExpertId?: string | undefined
   type: "feedback"
 VariableDeclaration FeedbackRoutingDecisionSchema
-  : z.ZodObject<{ id: z.ZodUUID; timestamp: z.ZodISODateTime; query: z.ZodString; routerType: z.ZodEnum<{ quality: "quality"; linucb: "linucb"; preference: "preference"; cascade: "cascade"; topsis: "topsis"; }>; selectedModel: z.ZodString; selectedTier: z.ZodOptional<z.ZodEnum<{ strong: "strong"; weak: "weak"; }>>; armIndex: z.ZodOptional<z.ZodNumber>; banditContext: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; queryFeatures: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; ucbScore: z.ZodOptional<z.ZodNumber>; confidence: z.ZodOptional<z.ZodNumber>; traceId: z.ZodString; domain: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ armIndex: z.ZodOptional<z.ZodNumber>; banditContext: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; confidence: z.ZodOptional<z.ZodNumber>; domain: z.ZodOptional<z.ZodString>; id: z.ZodUUID; query: z.ZodString; queryFeatures: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; routerType: z.ZodEnum<{ cascade: "cascade"; linucb: "linucb"; preference: "preference"; quality: "quality"; topsis: "topsis"; }>; selectedModel: z.ZodString; selectedTier: z.ZodOptional<z.ZodEnum<{ strong: "strong"; weak: "weak"; }>>; timestamp: z.ZodISODateTime; traceId: z.ZodString; ucbScore: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 ClassDeclaration FileAuditStorage
   close() => Promise<void>
   createtypeof FileAuditStorage.create
@@ -3586,7 +3588,7 @@ InterfaceDeclaration FileAuditStorageConfig
 TypeAliasDeclaration FileReference
   = z.infer<typeof FileReferenceSchema>
 VariableDeclaration FileReferenceSchema
-  : z.ZodObject<{ path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; }, z.core.$strip>
 FunctionDeclaration filterAvailableModels
   : typeof filterAvailableModels
 FunctionDeclaration filterStream
@@ -3605,16 +3607,16 @@ TypeAliasDeclaration FindingSeverity
 TypeAliasDeclaration FindingVote
   = z.infer<typeof FindingVoteSchema>
 VariableDeclaration FindingVoteSchema
-  : z.ZodObject<{ agentId: z.ZodString; findingId: z.ZodString; agree: z.ZodBoolean; reasoning: z.ZodOptional<z.ZodString>; amendedSeverity: z.ZodOptional<z.ZodEnum<{ critical: "critical"; major: "major"; minor: "minor"; suggestion: "suggestion"; }>>; }, z.core.$strip>
+  : z.ZodObject<{ agentId: z.ZodString; agree: z.ZodBoolean; amendedSeverity: z.ZodOptional<z.ZodEnum<{ critical: "critical"; major: "major"; minor: "minor"; suggestion: "suggestion"; }>>; findingId: z.ZodString; reasoning: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 FunctionDeclaration findMissingDependencies
   : typeof findMissingDependencies
 InterfaceDeclaration FirewallConfig
   readonly adapter: ISourceAdapter
   readonly allowlistedMaintainers?: readonly string[] | undefined
   readonly auditLogger?: IAuditLogger | undefined
-  readonly context?: { readonly hasWriteAccess?: boolean; readonly hasSecretAccess?: boolean; } | undefined
+  readonly context?: { readonly hasSecretAccess?: boolean; readonly hasWriteAccess?: boolean; } | undefined
   readonly maxInputLength?: number | undefined
-  readonly stages?: Partial<{ sanitization: boolean; trustClassification: boolean; reputationAssessment: boolean; policyEnforcement: boolean; corroboration: boolean; audit: boolean; }> | undefined
+  readonly stages?: Partial<{ audit: boolean; corroboration: boolean; policyEnforcement: boolean; reputationAssessment: boolean; sanitization: boolean; trustClassification: boolean; }> | undefined
 InterfaceDeclaration FirewallError
   readonly code: FirewallErrorCode
   readonly message: string
@@ -3627,8 +3629,8 @@ InterfaceDeclaration FirewallResult
   readonly durationMs: number
   readonly effectiveTrustTier: "1" | "2" | "3" | "4"
   readonly reputation?: ReputationAssessment | undefined
-  readonly ruleOfTwoViolation?: { rule: string; message: string; severity: "warn" | "block"; } | undefined
-  readonly sanitized: { content: string; originalLength: number; trustTier: "1" | "2" | "3" | "4"; userRole: "unknown" | "maintainer" | "owner" | "collaborator" | "contributor" | "member"; injectionFlags: ("authority_claim" | "instruction_pattern" | "system_prompt_manipulation" | "hidden_content" | "urgency_manipulation" | "fake_conversation" | "base64_encoded" | "external_link_instruction")[]; strippedElements: { tag: string; reason: string; startIndex: number; length: number; }[]; wasModified: boolean; sanitizedAt: string; }
+  readonly ruleOfTwoViolation?: { message: string; rule: string; severity: "warn" | "block"; } | undefined
+  readonly sanitized: { content: string; injectionFlags: ("authority_claim" | "instruction_pattern" | "system_prompt_manipulation" | "hidden_content" | "urgency_manipulation" | "fake_conversation" | "base64_encoded" | "external_link_instruction")[]; originalLength: number; sanitizedAt: string; strippedElements: { length: number; reason: string; startIndex: number; tag: string; }[]; trustTier: "1" | "2" | "3" | "4"; userRole: "unknown" | "maintainer" | "owner" | "collaborator" | "contributor" | "member"; wasModified: boolean; }
   readonly trust: ClassifyResult
 TypeAliasDeclaration FirewallStages
   = z.infer<typeof FirewallStagesSchema>
@@ -3674,13 +3676,13 @@ InterfaceDeclaration ForestConfig
   readonly sparsityRatio: number
   readonly temperature: number
 VariableDeclaration ForestConfigSchema
-  : z.ZodObject<{ maxTrees: z.ZodDefault<z.ZodNumber>; maxDepth: z.ZodDefault<z.ZodNumber>; maxNodesPerTree: z.ZodDefault<z.ZodNumber>; activationBudget: z.ZodDefault<z.ZodNumber>; sparsityRatio: z.ZodDefault<z.ZodNumber>; activationStrategy: z.ZodDefault<z.ZodEnum<{ adaptive: "adaptive"; ucb: "ucb"; greedy: "greedy"; diverse: "diverse"; }>>; explorationConstant: z.ZodDefault<z.ZodNumber>; crossTreeStrategy: z.ZodDefault<z.ZodEnum<{ full: "full"; none: "none"; conclusions: "conclusions"; insights: "insights"; }>>; pruningStrategy: z.ZodDefault<z.ZodEnum<{ none: "none"; score: "score"; depth: "depth"; combined: "combined"; }>>; minScoreThreshold: z.ZodDefault<z.ZodNumber>; confidenceThreshold: z.ZodDefault<z.ZodNumber>; earlyTerminationThreshold: z.ZodDefault<z.ZodNumber>; maxExplorationTimeMs: z.ZodDefault<z.ZodNumber>; nodeTimeoutMs: z.ZodDefault<z.ZodNumber>; maxTokensPerTree: z.ZodDefault<z.ZodNumber>; enableParallelExploration: z.ZodDefault<z.ZodBoolean>; parallelThreads: z.ZodDefault<z.ZodNumber>; enableEarlyTermination: z.ZodDefault<z.ZodBoolean>; enableCrossTreeSharing: z.ZodDefault<z.ZodBoolean>; temperature: z.ZodDefault<z.ZodNumber>; seed: z.ZodDefault<z.ZodNullable<z.ZodNumber>>; }, z.core.$strip>
+  : z.ZodObject<{ activationBudget: z.ZodDefault<z.ZodNumber>; activationStrategy: z.ZodDefault<z.ZodEnum<{ adaptive: "adaptive"; diverse: "diverse"; greedy: "greedy"; ucb: "ucb"; }>>; confidenceThreshold: z.ZodDefault<z.ZodNumber>; crossTreeStrategy: z.ZodDefault<z.ZodEnum<{ conclusions: "conclusions"; full: "full"; insights: "insights"; none: "none"; }>>; earlyTerminationThreshold: z.ZodDefault<z.ZodNumber>; enableCrossTreeSharing: z.ZodDefault<z.ZodBoolean>; enableEarlyTermination: z.ZodDefault<z.ZodBoolean>; enableParallelExploration: z.ZodDefault<z.ZodBoolean>; explorationConstant: z.ZodDefault<z.ZodNumber>; maxDepth: z.ZodDefault<z.ZodNumber>; maxExplorationTimeMs: z.ZodDefault<z.ZodNumber>; maxNodesPerTree: z.ZodDefault<z.ZodNumber>; maxTokensPerTree: z.ZodDefault<z.ZodNumber>; maxTrees: z.ZodDefault<z.ZodNumber>; minScoreThreshold: z.ZodDefault<z.ZodNumber>; nodeTimeoutMs: z.ZodDefault<z.ZodNumber>; parallelThreads: z.ZodDefault<z.ZodNumber>; pruningStrategy: z.ZodDefault<z.ZodEnum<{ combined: "combined"; depth: "depth"; none: "none"; score: "score"; }>>; seed: z.ZodDefault<z.ZodNullable<z.ZodNumber>>; sparsityRatio: z.ZodDefault<z.ZodNumber>; temperature: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 TypeAliasDeclaration ForestId
   = string
 TypeAliasDeclaration ForestPruningStrategy
   = 'none' | 'score' | 'depth' | 'combined'
 VariableDeclaration ForestPruningStrategySchema
-  : z.ZodEnum<{ none: "none"; score: "score"; depth: "depth"; combined: "combined"; }>
+  : z.ZodEnum<{ combined: "combined"; depth: "depth"; none: "none"; score: "score"; }>
 InterfaceDeclaration ForestResult
   readonly bestSolution: BestSolution | null
   readonly conclusions: readonly ReasoningNode[]
@@ -3694,11 +3696,11 @@ InterfaceDeclaration ForestResult
   readonly topPaths: readonly PathScore[]
   readonly totalTokensUsed: number
 VariableDeclaration ForestResultSchema
-  : z.ZodObject<{ forestId: z.ZodString; problem: z.ZodString; bestSolution: z.ZodNullable<z.ZodObject<{ treeId: z.ZodString; path: z.ZodArray<z.ZodString>; conclusionNode: z.ZodObject<{ id: z.ZodString; treeId: z.ZodString; parentId: z.ZodNullable<z.ZodString>; children: z.ZodArray<z.ZodString>; depth: z.ZodNumber; stepType: z.ZodEnum<{ inference: "inference"; hypothesis: "hypothesis"; decomposition: "decomposition"; synthesis: "synthesis"; verification: "verification"; conclusion: "conclusion"; }>; content: z.ZodString; metadata: z.ZodObject<{ source: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodOptional<z.ZodNumber>; generationTimeMs: z.ZodOptional<z.ZodNumber>; crossReferences: z.ZodOptional<z.ZodArray<z.ZodString>>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>; state: z.ZodEnum<{ pending: "pending"; completed: "completed"; error: "error"; active: "active"; pruned: "pruned"; }>; isActive: z.ZodBoolean; activationScore: z.ZodNumber; confidence: z.ZodNumber; qualityScore: z.ZodNumber; estimatedValue: z.ZodNumber; createdAt: z.ZodNumber; updatedAt: z.ZodNumber; }, z.core.$strip>; confidence: z.ZodNumber; qualityScore: z.ZodNumber; combinedScore: z.ZodNumber; }, z.core.$strip>>; topPaths: z.ZodArray<z.ZodObject<{ treeId: z.ZodString; path: z.ZodArray<z.ZodString>; targetNodeId: z.ZodString; score: z.ZodNumber; breakdown: z.ZodObject<{ confidenceScore: z.ZodNumber; qualityScore: z.ZodNumber; coherenceScore: z.ZodNumber; depthFactor: z.ZodNumber; conclusionBonus: z.ZodNumber; }, z.core.$strip>; reachesConclusion: z.ZodBoolean; length: z.ZodNumber; }, z.core.$strip>>; finalState: z.ZodEnum<{ completed: "completed"; timeout: "timeout"; initializing: "initializing"; exploring: "exploring"; converging: "converging"; }>; terminationReason: z.ZodEnum<{ error: "error"; max_tokens: "max_tokens"; solution_found: "solution_found"; convergence: "convergence"; max_time: "max_time"; max_depth: "max_depth"; no_progress: "no_progress"; }>; statistics: z.ZodObject<{ totalTrees: z.ZodNumber; activeTrees: z.ZodNumber; totalNodes: z.ZodNumber; totalActiveNodes: z.ZodNumber; maxDepth: z.ZodNumber; bestPathScore: z.ZodNumber; avgTreeScore: z.ZodNumber; totalTokensUsed: z.ZodNumber; totalExplorationTimeMs: z.ZodNumber; activationRatio: z.ZodNumber; }, z.core.$strip>; durationMs: z.ZodNumber; totalTokensUsed: z.ZodNumber; explorationHistory: z.ZodOptional<z.ZodArray<z.ZodObject<{ timestamp: z.ZodNumber; eventType: z.ZodEnum<{ tree_created: "tree_created"; node_created: "node_created"; node_activated: "node_activated"; node_deactivated: "node_deactivated"; node_completed: "node_completed"; node_pruned: "node_pruned"; path_scored: "path_scored"; cross_tree_share: "cross_tree_share"; conclusion_reached: "conclusion_reached"; tree_completed: "tree_completed"; forest_converging: "forest_converging"; forest_completed: "forest_completed"; }>; treeId: z.ZodOptional<z.ZodString>; nodeId: z.ZodOptional<z.ZodString>; details: z.ZodRecord<z.ZodString, z.ZodUnknown>; }, z.core.$strip>>>; }, z.core.$strip>
+  : z.ZodObject<{ bestSolution: z.ZodNullable<z.ZodObject<{ combinedScore: z.ZodNumber; conclusionNode: z.ZodObject<{ activationScore: z.ZodNumber; children: z.ZodArray<z.ZodString>; confidence: z.ZodNumber; content: z.ZodString; createdAt: z.ZodNumber; depth: z.ZodNumber; estimatedValue: z.ZodNumber; id: z.ZodString; isActive: z.ZodBoolean; metadata: z.ZodObject<{ crossReferences: z.ZodOptional<z.ZodArray<z.ZodString>>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; generationTimeMs: z.ZodOptional<z.ZodNumber>; source: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>; parentId: z.ZodNullable<z.ZodString>; qualityScore: z.ZodNumber; state: z.ZodEnum<{ active: "active"; completed: "completed"; error: "error"; pending: "pending"; pruned: "pruned"; }>; stepType: z.ZodEnum<{ conclusion: "conclusion"; decomposition: "decomposition"; hypothesis: "hypothesis"; inference: "inference"; synthesis: "synthesis"; verification: "verification"; }>; treeId: z.ZodString; updatedAt: z.ZodNumber; }, z.core.$strip>; confidence: z.ZodNumber; path: z.ZodArray<z.ZodString>; qualityScore: z.ZodNumber; treeId: z.ZodString; }, z.core.$strip>>; durationMs: z.ZodNumber; explorationHistory: z.ZodOptional<z.ZodArray<z.ZodObject<{ details: z.ZodRecord<z.ZodString, z.ZodUnknown>; eventType: z.ZodEnum<{ conclusion_reached: "conclusion_reached"; cross_tree_share: "cross_tree_share"; forest_completed: "forest_completed"; forest_converging: "forest_converging"; node_activated: "node_activated"; node_completed: "node_completed"; node_created: "node_created"; node_deactivated: "node_deactivated"; node_pruned: "node_pruned"; path_scored: "path_scored"; tree_completed: "tree_completed"; tree_created: "tree_created"; }>; nodeId: z.ZodOptional<z.ZodString>; timestamp: z.ZodNumber; treeId: z.ZodOptional<z.ZodString>; }, z.core.$strip>>>; finalState: z.ZodEnum<{ completed: "completed"; converging: "converging"; exploring: "exploring"; initializing: "initializing"; timeout: "timeout"; }>; forestId: z.ZodString; problem: z.ZodString; statistics: z.ZodObject<{ activationRatio: z.ZodNumber; activeTrees: z.ZodNumber; avgTreeScore: z.ZodNumber; bestPathScore: z.ZodNumber; maxDepth: z.ZodNumber; totalActiveNodes: z.ZodNumber; totalExplorationTimeMs: z.ZodNumber; totalNodes: z.ZodNumber; totalTokensUsed: z.ZodNumber; totalTrees: z.ZodNumber; }, z.core.$strip>; terminationReason: z.ZodEnum<{ convergence: "convergence"; error: "error"; max_depth: "max_depth"; max_time: "max_time"; max_tokens: "max_tokens"; no_progress: "no_progress"; solution_found: "solution_found"; }>; topPaths: z.ZodArray<z.ZodObject<{ breakdown: z.ZodObject<{ coherenceScore: z.ZodNumber; conclusionBonus: z.ZodNumber; confidenceScore: z.ZodNumber; depthFactor: z.ZodNumber; qualityScore: z.ZodNumber; }, z.core.$strip>; length: z.ZodNumber; path: z.ZodArray<z.ZodString>; reachesConclusion: z.ZodBoolean; score: z.ZodNumber; targetNodeId: z.ZodString; treeId: z.ZodString; }, z.core.$strip>>; totalTokensUsed: z.ZodNumber; }, z.core.$strip>
 TypeAliasDeclaration ForestState
   = 'initializing' | 'exploring' | 'converging' | 'completed' | 'timeout'
 VariableDeclaration ForestStateSchema
-  : z.ZodEnum<{ completed: "completed"; timeout: "timeout"; initializing: "initializing"; exploring: "exploring"; converging: "converging"; }>
+  : z.ZodEnum<{ completed: "completed"; converging: "converging"; exploring: "exploring"; initializing: "initializing"; timeout: "timeout"; }>
 InterfaceDeclaration ForestStatistics
   readonly activationRatio: number
   readonly activeTrees: number
@@ -3711,7 +3713,7 @@ InterfaceDeclaration ForestStatistics
   readonly totalTokensUsed: number
   readonly totalTrees: number
 VariableDeclaration ForestStatisticsSchema
-  : z.ZodObject<{ totalTrees: z.ZodNumber; activeTrees: z.ZodNumber; totalNodes: z.ZodNumber; totalActiveNodes: z.ZodNumber; maxDepth: z.ZodNumber; bestPathScore: z.ZodNumber; avgTreeScore: z.ZodNumber; totalTokensUsed: z.ZodNumber; totalExplorationTimeMs: z.ZodNumber; activationRatio: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ activationRatio: z.ZodNumber; activeTrees: z.ZodNumber; avgTreeScore: z.ZodNumber; bestPathScore: z.ZodNumber; maxDepth: z.ZodNumber; totalActiveNodes: z.ZodNumber; totalExplorationTimeMs: z.ZodNumber; totalNodes: z.ZodNumber; totalTokensUsed: z.ZodNumber; totalTrees: z.ZodNumber; }, z.core.$strip>
 FunctionDeclaration formatAdapterLatencyReport
   : typeof formatAdapterLatencyReport
 FunctionDeclaration formatBenchmarkReport
@@ -3754,7 +3756,7 @@ InterfaceDeclaration GatePolicyEnforcement
 VariableDeclaration GEMINI_MODEL_ALIASES
   : Record<string, string>
 VariableDeclaration GEMINI_MODELS
-  : { readonly PRO_2_5: string; readonly FLASH_2_5: string; readonly FLASH_2_0: "gemini-2.0-flash"; readonly PRO_1_5: "gemini-1.5-pro"; readonly FLASH_1_5: "gemini-1.5-flash"; }
+  : { readonly FLASH_1_5: "gemini-1.5-flash"; readonly FLASH_2_0: "gemini-2.0-flash"; readonly FLASH_2_5: string; readonly PRO_1_5: "gemini-1.5-pro"; readonly PRO_2_5: string; }
 ClassDeclaration GeminiAdapter
   complete(request: CompletionRequest) => Promise<Result<CompletionResponse, ModelError>>
   countTokens(text: string) => Promise<number>
@@ -3778,7 +3780,7 @@ ClassDeclaration GeminiCliAdapter
 InterfaceDeclaration GeminiCliResponse
   readonly response: string
   readonly session_id?: string | undefined
-  readonly stats?: { readonly models?: Record<string, { readonly api?: { readonly totalRequests?: number; readonly totalErrors?: number; readonly totalLatencyMs?: number; }; readonly tokens?: { readonly input?: number; readonly prompt?: number; readonly candidates?: number; readonly total?: number; readonly cached?: number; readonly thoughts?: number; readonly tool?: number; }; }>; } | undefined
+  readonly stats?: { readonly models?: Record<string, { readonly api?: { readonly totalErrors?: number; readonly totalLatencyMs?: number; readonly totalRequests?: number; }; readonly tokens?: { readonly cached?: number; readonly candidates?: number; readonly input?: number; readonly prompt?: number; readonly thoughts?: number; readonly tool?: number; readonly total?: number; }; }>; } | undefined
 InterfaceDeclaration GeminiConfig
   readonly baseDelayMs?: number | undefined
   readonly circuitBreakerConfig?: Partial<CircuitBreakerConfig> | undefined
@@ -3839,7 +3841,7 @@ InterfaceDeclaration GeneratedTest
   target: string
   type: "unit" | "integration" | "e2e"
 VariableDeclaration GeneratedTestSchema
-  : z.ZodObject<{ name: z.ZodString; type: z.ZodEnum<{ unit: "unit"; integration: "integration"; e2e: "e2e"; }>; code: z.ZodString; target: z.ZodString; scenarios: z.ZodArray<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ code: z.ZodString; name: z.ZodString; scenarios: z.ZodArray<z.ZodString>; target: z.ZodString; type: z.ZodEnum<{ e2e: "e2e"; integration: "integration"; unit: "unit"; }>; }, z.core.$strip>
 InterfaceDeclaration GenerateObjectResult
   finishReason: string
   object: unknown
@@ -3914,7 +3916,7 @@ InterfaceDeclaration GetJobResultResponse
   readonly errorMessage?: string | undefined
   readonly found: boolean
   readonly jobId: string
-  readonly record?: { v: 1; jobId: string; toolName: string; status: "pending" | "failed" | "cancelled" | "complete"; createdAt: string; completedAt?: string | undefined; result?: unknown; error?: string | undefined; } | undefined
+  readonly record?: { completedAt?: string | undefined; createdAt: string; error?: string | undefined; jobId: string; result?: unknown; status: "pending" | "failed" | "cancelled" | "complete"; toolName: string; v: 1; } | undefined
 FunctionDeclaration getKnownNexusVarNames
   : typeof getKnownNexusVarNames
 FunctionDeclaration getOutcomeStore
@@ -4044,7 +4046,7 @@ InterfaceDeclaration GitHubUserMetadata
 TypeAliasDeclaration GitHubUserRole
   = z.infer<typeof GitHubUserRoleSchema>
 VariableDeclaration GitHubUserRoleSchema
-  : z.ZodEnum<{ unknown: "unknown"; maintainer: "maintainer"; owner: "owner"; collaborator: "collaborator"; contributor: "contributor"; member: "member"; }>
+  : z.ZodEnum<{ collaborator: "collaborator"; contributor: "contributor"; maintainer: "maintainer"; member: "member"; owner: "owner"; unknown: "unknown"; }>
 ClassDeclaration GoogleGenAI
   get agents(): GeminiNextGenAgents
   get environments(): GeminiNextGenEnvironments
@@ -4063,15 +4065,15 @@ ClassDeclaration GoogleGenAI
   readonly tunings: Tunings
   readonly vertexai: boolean
 ClassDeclaration GraphBuilder
-  addConditionalEdge(from: string, router: GraphEdge & { type: "conditional"; } extends infer E ? E extends { type: "conditional"; router: infer R; } ? R : never : never, targets: readonly string[]) => this
+  addConditionalEdge(from: string, router: GraphEdge & { type: "conditional"; } extends infer E ? E extends { router: infer R; type: "conditional"; } ? R : never : never, targets: readonly string[]) => this
   addEdge(from: string, to: string, options?: { maxTraversals?: number; }) => this
-  addNode(id: string, handler: NodeHandler, opts?: { timeout?: number; retries?: number; preconditions?: readonly PreconditionConfig[]; verify?: NodeHook; }) => this
+  addNode(id: string, handler: NodeHandler, opts?: { preconditions?: readonly PreconditionConfig[]; retries?: number; timeout?: number; verify?: NodeHook; }) => this
   addState<T>(name: string, schema: StateFieldSchema<T>) => this
   compile() => CompileResult
 TypeAliasDeclaration GraphCompileError
-  = | { type: 'duplicate_node'; nodeId: string } | { type: 'missing_node'; nodeId: string; referencedBy: string } | { type: 'cycle_detected'; path: readonly string[] } | { type: 'no_entry'; message: string } | { type: 'unreachable_node'; nodeId: string } | { type: 'missing_reducer'; field: string }
+  = | { nodeId: string; type: 'duplicate_node'; } | { nodeId: string; referencedBy: string; type: 'missing_node'; } | { path: readonly string[]; type: 'cycle_detected'; } | { message: string; type: 'no_entry'; } | { nodeId: string; type: 'unreachable_node'; } | { field: string; type: 'missing_reducer'; }
 TypeAliasDeclaration GraphEdge
-  = | { readonly type: 'fixed'; readonly from: string; readonly to: string; readonly maxTraversals?: number; } | { readonly type: 'conditional'; readonly from: string; readonly router: (state: Readonly<GraphState>) => string; readonly targets: readonly string[]; readonly maxTraversals?: number; }
+  = | { readonly from: string; readonly maxTraversals?: number; readonly to: string; readonly type: 'fixed'; } | { readonly from: string; readonly router: (state: Readonly<GraphState>) => string; readonly targets: readonly string[]; readonly maxTraversals?: number;; readonly type: 'conditional'; }
 InterfaceDeclaration GraphEdgeDisplay
   readonly avgLatencyMs: number
   readonly count: number
@@ -4079,7 +4081,7 @@ InterfaceDeclaration GraphEdgeDisplay
   readonly successRate: number
   readonly to: string
 TypeAliasDeclaration GraphEvent
-  = | { readonly type: 'node_started'; readonly nodeId: string; readonly stepNumber: number; readonly timestamp: number; } | { readonly type: 'node_completed'; readonly nodeId: string; readonly stepNumber: number; readonly durationMs: number; readonly resultKeys: readonly string[]; readonly timestamp: number; } | { readonly type: 'node_error'; readonly nodeId: string; readonly stepNumber: number; readonly error: string; readonly timestamp: number; } | { readonly type: 'state_updated'; readonly stepNumber: number; readonly updatedKeys: readonly string[]; readonly timestamp: number; } | { readonly type: 'step_completed'; readonly stepNumber: number; readonly nodesExecuted: number; readonly timestamp: number; } | { readonly type: 'execution_complete'; readonly totalSteps: number; readonly totalNodes: number; readonly durationMs: number; readonly timestamp: number; } | { readonly type: 'hook_started'; readonly nodeId: string; readonly hookName: string; readonly hookPhase: 'precondition' | 'verify'; readonly stepNumber: number; readonly timestamp: number; } | { readonly type: 'hook_completed'; readonly nodeId: string; readonly hookName: string; readonly hookPhase: 'precondition' | 'verify'; readonly durationMs: number; readonly stepNumber: number; readonly timestamp: number; } | { readonly type: 'hook_failed'; readonly nodeId: string; readonly hookName: string; readonly hookPhase: 'precondition' | 'verify'; readonly error: string; readonly stepNumber: number; readonly timestamp: number; } | ContextUnavailableEvent
+  = | { readonly nodeId: string; readonly stepNumber: number; readonly timestamp: number; readonly type: 'node_started'; } | { readonly durationMs: number; readonly nodeId: string; readonly resultKeys: readonly string[]; readonly stepNumber: number; readonly timestamp: number; readonly type: 'node_completed'; } | { readonly error: string; readonly nodeId: string; readonly stepNumber: number; readonly timestamp: number; readonly type: 'node_error'; } | { readonly stepNumber: number; readonly timestamp: number; readonly type: 'state_updated'; readonly updatedKeys: readonly string[]; } | { readonly nodesExecuted: number; readonly stepNumber: number; readonly timestamp: number; readonly type: 'step_completed'; } | { readonly durationMs: number; readonly timestamp: number; readonly totalNodes: number; readonly totalSteps: number; readonly type: 'execution_complete'; } | { readonly hookName: string; readonly hookPhase: 'precondition' | 'verify'; readonly nodeId: string; readonly stepNumber: number; readonly timestamp: number; readonly type: 'hook_started'; } | { readonly durationMs: number; readonly hookName: string; readonly hookPhase: 'precondition' | 'verify'; readonly nodeId: string; readonly stepNumber: number; readonly timestamp: number; readonly type: 'hook_completed'; } | { readonly error: string; readonly hookName: string; readonly hookPhase: 'precondition' | 'verify'; readonly nodeId: string; readonly stepNumber: number; readonly timestamp: number; readonly type: 'hook_failed'; } | ContextUnavailableEvent
 InterfaceDeclaration GraphEventSummary
   readonly detail?: string | undefined
   readonly nodeId?: string | undefined
@@ -4102,7 +4104,7 @@ InterfaceDeclaration GraphExecutionAuditEvent
   readonly type: "graph_execution"
 InterfaceDeclaration GraphExecutionResult
   readonly finalState: Readonly<GraphState>
-  readonly halted?: { readonly checkpointId: string; readonly nodeId: string; readonly interruptId: string; readonly value: unknown; } | undefined
+  readonly halted?: { readonly checkpointId: string; readonly interruptId: string; readonly nodeId: string; readonly value: unknown; } | undefined
   readonly nodeResults: readonly NodeResult[]
   readonly stepsExecuted: number
   readonly totalDurationMs: number
@@ -4192,7 +4194,7 @@ InterfaceDeclaration HigherOrderVotingConfig
   readonly minObservationsForCorrelation: number
   readonly observationDecayFactor: number
 VariableDeclaration HigherOrderVotingConfigSchema
-  : z.ZodObject<{ minObservationsForCorrelation: z.ZodDefault<z.ZodNumber>; correlationThreshold: z.ZodDefault<z.ZodNumber>; correlationMaxAgeMs: z.ZodDefault<z.ZodNumber>; independenceThreshold: z.ZodDefault<z.ZodNumber>; fallbackToSimpleVoting: z.ZodDefault<z.ZodBoolean>; observationDecayFactor: z.ZodDefault<z.ZodNumber>; maxObservationsPerAgent: z.ZodDefault<z.ZodNumber>; maxProposals: z.ZodDefault<z.ZodNumber>; maxTrackedPairs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ correlationMaxAgeMs: z.ZodDefault<z.ZodNumber>; correlationThreshold: z.ZodDefault<z.ZodNumber>; fallbackToSimpleVoting: z.ZodDefault<z.ZodBoolean>; independenceThreshold: z.ZodDefault<z.ZodNumber>; maxObservationsPerAgent: z.ZodDefault<z.ZodNumber>; maxProposals: z.ZodDefault<z.ZodNumber>; maxTrackedPairs: z.ZodDefault<z.ZodNumber>; minObservationsForCorrelation: z.ZodDefault<z.ZodNumber>; observationDecayFactor: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration HigherOrderVotingResult
   readonly decision: "approve" | "reject" | "no_consensus"
   readonly downweightedAgents: readonly string[]
@@ -4205,7 +4207,7 @@ InterfaceDeclaration HigherOrderVotingResult
   readonly reasoning: string
   readonly usedCorrelationData: boolean
 VariableDeclaration HigherOrderVotingResultSchema
-  : z.ZodObject<{ decision: z.ZodEnum<{ approve: "approve"; reject: "reject"; no_consensus: "no_consensus"; }>; posteriorApproval: z.ZodNumber; posteriorRejection: z.ZodNumber; effectiveVoteCount: z.ZodNumber; usedCorrelationData: z.ZodBoolean; method: z.ZodEnum<{ simple: "simple"; ow: "ow"; isp: "isp"; }>; improvementOverBaseline: z.ZodNumber; independentSubsets: z.ZodOptional<z.ZodArray<z.ZodObject<{ id: z.ZodString; agentIds: z.ZodArray<z.ZodString>; independenceScore: z.ZodNumber; observationCount: z.ZodNumber; }, z.core.$strip>>>; downweightedAgents: z.ZodArray<z.ZodString>; reasoning: z.ZodString; }, z.core.$strip>
+  : z.ZodObject<{ decision: z.ZodEnum<{ approve: "approve"; no_consensus: "no_consensus"; reject: "reject"; }>; downweightedAgents: z.ZodArray<z.ZodString>; effectiveVoteCount: z.ZodNumber; improvementOverBaseline: z.ZodNumber; independentSubsets: z.ZodOptional<z.ZodArray<z.ZodObject<{ agentIds: z.ZodArray<z.ZodString>; id: z.ZodString; independenceScore: z.ZodNumber; observationCount: z.ZodNumber; }, z.core.$strip>>>; method: z.ZodEnum<{ isp: "isp"; ow: "ow"; simple: "simple"; }>; posteriorApproval: z.ZodNumber; posteriorRejection: z.ZodNumber; reasoning: z.ZodString; usedCorrelationData: z.ZodBoolean; }, z.core.$strip>
 ClassDeclaration HigherOrderVotingStrategy
 InterfaceDeclaration HindsightRecord
   readonly actualOutcome: string
@@ -4365,13 +4367,13 @@ InterfaceDeclaration ICTMConfig
   model: ModelSelection
   tools: ToolSet
 VariableDeclaration ICTMConfigSchema
-  : z.ZodObject<{ instructions: z.ZodString; context: z.ZodObject<{ maxTokens: z.ZodNumber; relevanceThreshold: z.ZodNumber; includeHistory: z.ZodBoolean; pruneStrategy: z.ZodEnum<{ importance: "importance"; recency: "recency"; hybrid: "hybrid"; }>; }, z.core.$strip>; tools: z.ZodObject<{ capabilities: z.ZodArray<z.ZodString>; restrictions: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>; model: z.ZodObject<{ provider: z.ZodOptional<z.ZodString>; modelId: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; reasoning: z.ZodOptional<z.ZodEnum<{ standard: "standard"; minimal: "minimal"; extended: "extended"; }>>; }, z.core.$strip>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>
+  : z.ZodObject<{ context: z.ZodObject<{ includeHistory: z.ZodBoolean; maxTokens: z.ZodNumber; pruneStrategy: z.ZodEnum<{ hybrid: "hybrid"; importance: "importance"; recency: "recency"; }>; relevanceThreshold: z.ZodNumber; }, z.core.$strip>; instructions: z.ZodString; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; model: z.ZodObject<{ maxTokens: z.ZodOptional<z.ZodNumber>; modelId: z.ZodOptional<z.ZodString>; provider: z.ZodOptional<z.ZodString>; reasoning: z.ZodOptional<z.ZodEnum<{ extended: "extended"; minimal: "minimal"; standard: "standard"; }>>; temperature: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>; tools: z.ZodObject<{ capabilities: z.ZodArray<z.ZodString>; restrictions: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>; }, z.core.$strip>
 InterfaceDeclaration ICTMInferenceResult
   confidence: number
   config: ICTMConfig
-  reasoning: { instructions: string; context: string; tools: string; model: string; }
+  reasoning: { context: string; instructions: string; model: string; tools: string; }
 VariableDeclaration ICTMInferenceResultSchema
-  : z.ZodObject<{ config: z.ZodObject<{ instructions: z.ZodString; context: z.ZodObject<{ maxTokens: z.ZodNumber; relevanceThreshold: z.ZodNumber; includeHistory: z.ZodBoolean; pruneStrategy: z.ZodEnum<{ importance: "importance"; recency: "recency"; hybrid: "hybrid"; }>; }, z.core.$strip>; tools: z.ZodObject<{ capabilities: z.ZodArray<z.ZodString>; restrictions: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>; model: z.ZodObject<{ provider: z.ZodOptional<z.ZodString>; modelId: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; reasoning: z.ZodOptional<z.ZodEnum<{ standard: "standard"; minimal: "minimal"; extended: "extended"; }>>; }, z.core.$strip>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>; reasoning: z.ZodObject<{ instructions: z.ZodString; context: z.ZodString; tools: z.ZodString; model: z.ZodString; }, z.core.$strip>; confidence: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ confidence: z.ZodNumber; config: z.ZodObject<{ context: z.ZodObject<{ includeHistory: z.ZodBoolean; maxTokens: z.ZodNumber; pruneStrategy: z.ZodEnum<{ hybrid: "hybrid"; importance: "importance"; recency: "recency"; }>; relevanceThreshold: z.ZodNumber; }, z.core.$strip>; instructions: z.ZodString; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; model: z.ZodObject<{ maxTokens: z.ZodOptional<z.ZodNumber>; modelId: z.ZodOptional<z.ZodString>; provider: z.ZodOptional<z.ZodString>; reasoning: z.ZodOptional<z.ZodEnum<{ extended: "extended"; minimal: "minimal"; standard: "standard"; }>>; temperature: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>; tools: z.ZodObject<{ capabilities: z.ZodArray<z.ZodString>; restrictions: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>; }, z.core.$strip>; reasoning: z.ZodObject<{ context: z.ZodString; instructions: z.ZodString; model: z.ZodString; tools: z.ZodString; }, z.core.$strip>; }, z.core.$strip>
 FunctionDeclaration ictmToExpertConfig
   : typeof ictmToExpertConfig
 InterfaceDeclaration IDashboard
@@ -4499,10 +4501,10 @@ TypeAliasDeclaration ImprovementReviewDeps
 TypeAliasDeclaration ImprovementReviewInput
   = z.infer<typeof ImprovementReviewInputSchema>
 VariableDeclaration ImprovementReviewInputSchema
-  : z.ZodObject<{ lookbackDays: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; fileIssues: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; minSampleSize: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; fitnessFloor: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; selfEvalReportPath: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ fileIssues: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; fitnessFloor: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; lookbackDays: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; minSampleSize: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; selfEvalReportPath: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 InterfaceDeclaration ImprovementReviewResponse
-  readonly issuesFiled: readonly { readonly signalKey: string; readonly issueUrl: string; }[]
-  readonly issuesSkipped: readonly { readonly signalKey: string; readonly reason: string; }[]
+  readonly issuesFiled: readonly { readonly issueUrl: string; readonly signalKey: string; }[]
+  readonly issuesSkipped: readonly { readonly reason: string; readonly signalKey: string; }[]
   readonly remediationTasks: readonly PipelineTask[]
   readonly signals: readonly ImprovementSignal[]
   readonly totalOutcomes: number
@@ -4510,7 +4512,7 @@ InterfaceDeclaration ImprovementReviewResponse
 InterfaceDeclaration ImprovementSignal
   readonly body: string
   readonly category: SignalCategory
-  readonly evidence: { readonly samples?: number; readonly window?: string; readonly observedValue?: number; readonly threshold?: number; }
+  readonly evidence: { readonly observedValue?: number; readonly samples?: number; readonly threshold?: number; readonly window?: string; }
   readonly severity: "info" | "warning" | "critical"
   readonly signalKey: string
   readonly title: string
@@ -4530,7 +4532,7 @@ InterfaceDeclaration IndependentSubset
   readonly independenceScore: number
   readonly observationCount: number
 VariableDeclaration IndependentSubsetSchema
-  : z.ZodObject<{ id: z.ZodString; agentIds: z.ZodArray<z.ZodString>; independenceScore: z.ZodNumber; observationCount: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ agentIds: z.ZodArray<z.ZodString>; id: z.ZodString; independenceScore: z.ZodNumber; observationCount: z.ZodNumber; }, z.core.$strip>
 FunctionDeclaration inferICTM
   : typeof inferICTM
 FunctionDeclaration initializeAgentSkills
@@ -4542,7 +4544,7 @@ FunctionDeclaration initializeEventBusBridge
 TypeAliasDeclaration InjectionFlag
   = z.infer<typeof InjectionFlagSchema>
 VariableDeclaration InjectionFlagSchema
-  : z.ZodEnum<{ authority_claim: "authority_claim"; instruction_pattern: "instruction_pattern"; system_prompt_manipulation: "system_prompt_manipulation"; hidden_content: "hidden_content"; urgency_manipulation: "urgency_manipulation"; fake_conversation: "fake_conversation"; base64_encoded: "base64_encoded"; external_link_instruction: "external_link_instruction"; }>
+  : z.ZodEnum<{ authority_claim: "authority_claim"; base64_encoded: "base64_encoded"; external_link_instruction: "external_link_instruction"; fake_conversation: "fake_conversation"; hidden_content: "hidden_content"; instruction_pattern: "instruction_pattern"; system_prompt_manipulation: "system_prompt_manipulation"; urgency_manipulation: "urgency_manipulation"; }>
 ClassDeclaration InMemoryAuditStorage
   clear() => void
   close() => Promise<void>
@@ -4581,13 +4583,13 @@ TypeAliasDeclaration InputDefinitionInput
 TypeAliasDeclaration InputDefinitionOutput
   = z.output<typeof InputDefinitionSchema>
 VariableDeclaration InputDefinitionSchema
-  : z.ZodObject<{ name: z.ZodString; type: z.ZodEnum<{ string: "string"; number: "number"; boolean: "boolean"; object: "object"; array: "array"; }>; description: z.ZodOptional<z.ZodString>; required: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; default: z.ZodOptional<z.ZodUnknown>; }, z.core.$strip>
+  : z.ZodObject<{ default: z.ZodOptional<z.ZodUnknown>; description: z.ZodOptional<z.ZodString>; name: z.ZodString; required: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; type: z.ZodEnum<{ array: "array"; boolean: "boolean"; number: "number"; object: "object"; string: "string"; }>; }, z.core.$strip>
 TypeAliasDeclaration InputModality
   = (typeof INPUT_MODALITIES)[number]
 TypeAliasDeclaration InputType
   = z.infer<typeof InputTypeSchema>
 VariableDeclaration InputTypeSchema
-  : z.ZodEnum<{ string: "string"; number: "number"; boolean: "boolean"; object: "object"; array: "array"; }>
+  : z.ZodEnum<{ array: "array"; boolean: "boolean"; number: "number"; object: "object"; string: "string"; }>
 VariableDeclaration INSTRUCTION_SAFETY_CATEGORY
   : SafetyCategory
 InterfaceDeclaration InteractionEdge
@@ -4611,7 +4613,7 @@ InterfaceDeclaration InteractionGraph
   getOutgoingEdges(agentId: AgentId) => InteractionEdge[]
   getStronglyConnectedComponents() => AgentId[][]
 VariableDeclaration InteractionObserverConfigSchema
-  : z.ZodObject<{ maxEvents: z.ZodDefault<z.ZodNumber>; metricsWindowMs: z.ZodDefault<z.ZodNumber>; logPayloads: z.ZodDefault<z.ZodBoolean>; bottleneckThreshold: z.ZodDefault<z.ZodNumber>; minClusterSize: z.ZodDefault<z.ZodNumber>; cohesionThreshold: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ bottleneckThreshold: z.ZodDefault<z.ZodNumber>; cohesionThreshold: z.ZodDefault<z.ZodNumber>; logPayloads: z.ZodDefault<z.ZodBoolean>; maxEvents: z.ZodDefault<z.ZodNumber>; metricsWindowMs: z.ZodDefault<z.ZodNumber>; minClusterSize: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 TypeAliasDeclaration InteractionOutcome
   = 'success' | 'failure' | 'timeout' | 'pending'
 InterfaceDeclaration InternalMetrics
@@ -4740,7 +4742,7 @@ InterfaceDeclaration IRoutingMemory
   getStats() => Promise<Result<RoutingMemoryStats, RoutingMemoryError>>
   getStats() => RoutingMemoryStats
   import(data: RoutingMemoryExport) => Promise<Result<void, RoutingMemoryError>>
-  recordExperience(workflow: string, models: readonly CliName[], success: boolean, metrics: { durationMs: number; tokensUsed: number; qualityScore?: number; researchMaturity?: number; }) => void
+  recordExperience(workflow: string, models: readonly CliName[], success: boolean, metrics: { durationMs: number; qualityScore?: number; researchMaturity?: number; tokensUsed: number; }) => void
   storeAction(action: ActionRecord) => Promise<Result<void, RoutingMemoryError>>
   storeExperience(experience: ExperienceRecord) => Promise<Result<void, RoutingMemoryError>>
   storePreference(decision: RoutingDecisionRecord, outcome: TaskOutcomeRecord, preference?: PreferenceSignal) => Promise<Result<void, RoutingMemoryError>>
@@ -4792,8 +4794,8 @@ InterfaceDeclaration ISharedTaskAnalyzer
   estimateTokens(task: Task | string) => number
   getCapabilities(task: Task | string) => TaskCapabilities
   getComplexity(task: Task | string) => { level: ComplexityLevel; score: number; }
-  getReasoningType(task: Task | string) => { type: ReasoningKnowledgeType; confidence: number; }
-  getTaskType(task: Task | string) => { type: TaskTypeCategory; confidence: number; }
+  getReasoningType(task: Task | string) => { confidence: number; type: ReasoningKnowledgeType; }
+  getTaskType(task: Task | string) => { confidence: number; type: TaskTypeCategory; }
 InterfaceDeclaration ISkillDependencyGraph
   addDependency(dependency: SkillDependency) => Result<void, DependencyError>
   addSkill(skillId: string, version?: number) => void
@@ -4847,15 +4849,15 @@ TypeAliasDeclaration IssueTriageDeps
 TypeAliasDeclaration IssueTriageInput
   = z.infer<typeof IssueTriageInputSchema>
 VariableDeclaration IssueTriageInputSchema
-  : z.ZodObject<{ issueUrl: z.ZodString; dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; }, z.core.$strip>
+  : z.ZodObject<{ dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; issueUrl: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration IssueTriageResponse
   readonly category: string
   readonly categoryConfidence: number
   readonly durationMs: number
   readonly issueNumber: number
-  readonly proposedActions: readonly { readonly type: string; readonly description: string; readonly policyApproved: boolean; readonly corroborated: boolean; }[]
+  readonly proposedActions: readonly { readonly corroborated: boolean; readonly description: string; readonly policyApproved: boolean; readonly type: string; }[]
   readonly repository: string
-  readonly trustAssessment: { readonly trustTier: string; readonly userRole: string; readonly reputationScore?: number | undefined; readonly isSuspicious: boolean; readonly suspiciousSignals: readonly string[]; }
+  readonly trustAssessment: { readonly isSuspicious: boolean; readonly reputationScore?: number | undefined; readonly suspiciousSignals: readonly string[]; readonly trustTier: string; readonly userRole: string; }
 InterfaceDeclaration ISwarmObserver
   attributeSuccess(taskId: TaskId) => Map<AgentId, ContributionScore>
   clear() => void
@@ -4911,7 +4913,7 @@ InterfaceDeclaration ITokenCounter
   countGemini(content: string, model: string) => Promise<Result<TokenCountResult, TokenCountError>>
   countOpenAI(text: string, model?: string) => Result<TokenCountResult, TokenCountError>
   estimate(text: string) => number
-  getCacheStats() => { size: number; maxSize: number; ttlMs: number; }
+  getCacheStats() => { maxSize: number; size: number; ttlMs: number; }
 InterfaceDeclaration ITypedMemory
   filterByRelevance(agentRole: AgentRole, limit?: number) => Promise<Result<readonly TypedMemoryEntry[], MemoryError>>
   getStats() => Promise<Result<TypedMemoryStats, MemoryError>>
@@ -5102,9 +5104,9 @@ InterfaceDeclaration LibraryStatistics
   readonly totalSkills: number
 ClassDeclaration LinUCBBandit
   getArmNames() => readonly string[]
-  getDetailedStats() => ReadonlyArray<{ name: string; pullCount: number; avgReward: number; cumulativeReward: number; learnedWeights: readonly number[]; featureImportance: readonly { feature: string; importance: number; }[]; }>
-  getExplorationStats() => { totalPulls: number; explorationRatio: number; armDistribution: ReadonlyArray<{ name: string; proportion: number; }>; }
-  getStats() => ReadonlyArray<{ name: string; pullCount: number; avgReward: number; }>
+  getDetailedStats() => ReadonlyArray<{ avgReward: number; cumulativeReward: number; featureImportance: readonly { feature: string; importance: number; }[]; learnedWeights: readonly number[]; name: string; pullCount: number; }>
+  getExplorationStats() => { armDistribution: ReadonlyArray<{ name: string; proportion: number; }>; explorationRatio: number; totalPulls: number; }
+  getStats() => ReadonlyArray<{ avgReward: number; name: string; pullCount: number; }>
   getWarmStartModelStats() => readonly WarmStartModelStat[]
   reset() => void
   seedPriors(priors: ReadonlyMap<string, number>, observationCount?: number) => void
@@ -5130,7 +5132,7 @@ TypeAliasDeclaration ListJobsDeps
 TypeAliasDeclaration ListJobsInput
   = z.infer<typeof ListJobsInputSchema>
 VariableDeclaration ListJobsInputSchema
-  : z.ZodObject<{ toolName: z.ZodOptional<z.ZodString>; status: z.ZodOptional<z.ZodEnum<{ pending: "pending"; failed: "failed"; cancelled: "cancelled"; complete: "complete"; }>>; limit: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ limit: z.ZodOptional<z.ZodNumber>; status: z.ZodOptional<z.ZodEnum<{ cancelled: "cancelled"; complete: "complete"; failed: "failed"; pending: "pending"; }>>; toolName: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 InterfaceDeclaration ListJobsResponse
   readonly count: number
   readonly jobs: readonly JobSummary[]
@@ -5157,7 +5159,7 @@ InterfaceDeclaration LoadedSkillSet
   readonly missingRequired: readonly string[]
   readonly skills: readonly Skill[]
 VariableDeclaration LoadedSkillSetSchema
-  : z.ZodObject<{ agentId: z.ZodString; agentRole: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>; skills: z.ZodReadonly<z.ZodArray<z.ZodAny>>; executionOrder: z.ZodReadonly<z.ZodArray<z.ZodString>>; missingRequired: z.ZodReadonly<z.ZodArray<z.ZodString>>; loadedAt: z.ZodDate; }, z.core.$strip>
+  : z.ZodObject<{ agentId: z.ZodString; agentRole: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; orchestrator: "orchestrator"; security_expert: "security_expert"; testing_expert: "testing_expert"; thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>; executionOrder: z.ZodReadonly<z.ZodArray<z.ZodString>>; loadedAt: z.ZodDate; missingRequired: z.ZodReadonly<z.ZodArray<z.ZodString>>; skills: z.ZodReadonly<z.ZodArray<z.ZodAny>>; }, z.core.$strip>
 FunctionDeclaration loadRules
   : typeof loadRules
 FunctionDeclaration loadTemplateFile
@@ -5172,7 +5174,7 @@ TypeAliasDeclaration LogDestination
   = 'stdout' | 'stderr' | 'file'
 InterfaceDeclaration LogEntry
   context?: LogContext | undefined
-  error?: { name: string; message: string; stack?: string; } | undefined
+  error?: { message: string; name: string; stack?: string; } | undefined
   level: LogLevel
   message: string
   timestamp: string
@@ -5183,13 +5185,13 @@ VariableDeclaration logger
 TypeAliasDeclaration LoggingConfig
   = z.infer<typeof LoggingConfigSchema>
 VariableDeclaration LoggingConfigSchema
-  : z.ZodObject<{ level: z.ZodDefault<z.ZodEnum<{ debug: "debug"; info: "info"; warn: "warn"; error: "error"; }>>; format: z.ZodDefault<z.ZodEnum<{ json: "json"; pretty: "pretty"; }>>; destination: z.ZodDefault<z.ZodEnum<{ stdout: "stdout"; stderr: "stderr"; file: "file"; }>>; filePath: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ destination: z.ZodDefault<z.ZodEnum<{ file: "file"; stderr: "stderr"; stdout: "stdout"; }>>; filePath: z.ZodOptional<z.ZodString>; format: z.ZodDefault<z.ZodEnum<{ json: "json"; pretty: "pretty"; }>>; level: z.ZodDefault<z.ZodEnum<{ debug: "debug"; error: "error"; info: "info"; warn: "warn"; }>>; }, z.core.$strip>
 TypeAliasDeclaration LogLevel
   = 'debug' | 'info' | 'warn' | 'error'
 FunctionDeclaration logPolicyAudit
   : typeof logPolicyAudit
 InterfaceDeclaration LogPolicyAuditOpts
-  actor: { type: "system" | "user" | "agent" | "external"; id: string; name?: string | undefined; ip?: string | undefined; userAgent?: string | undefined; }
+  actor: { id: string; ip?: string | undefined; name?: string | undefined; type: "system" | "user" | "agent" | "external"; userAgent?: string | undefined; }
   auditLogger: IAuditLogger
   decision: "allow" | "deny"
   policyName: string
@@ -5199,7 +5201,7 @@ InterfaceDeclaration LogPolicyAuditOpts
 FunctionDeclaration logRateLimitAudit
   : typeof logRateLimitAudit
 InterfaceDeclaration LogRateLimitAuditOpts
-  actor: { type: "system" | "user" | "agent" | "external"; id: string; name?: string | undefined; ip?: string | undefined; userAgent?: string | undefined; }
+  actor: { id: string; ip?: string | undefined; name?: string | undefined; type: "system" | "user" | "agent" | "external"; userAgent?: string | undefined; }
   auditLogger: IAuditLogger
   currentRate: number
   limitRate: number
@@ -5210,7 +5212,7 @@ FunctionDeclaration logToolError
 FunctionDeclaration logToolInvocationAudit
   : typeof logToolInvocationAudit
 InterfaceDeclaration LogToolInvocationOpts
-  actor: { type: "system" | "user" | "agent" | "external"; id: string; name?: string | undefined; ip?: string | undefined; userAgent?: string | undefined; }
+  actor: { id: string; ip?: string | undefined; name?: string | undefined; type: "system" | "user" | "agent" | "external"; userAgent?: string | undefined; }
   auditLogger: IAuditLogger
   durationMs?: number | undefined
   errorMessage?: string | undefined
@@ -5249,7 +5251,7 @@ VariableDeclaration MAX_EXECUTION_TIME_MS
 VariableDeclaration MAX_FILES_SCANNED
   : 5000
 InterfaceDeclaration McpExpertFactory
-  createBuiltIn(type: BuiltInExpertType, options?: { modelOverrides?: { modelId?: string; }; recoveryPolicy?: ExpertRecoveryPolicy; }) => { ok: true; value: Expert; } | { ok: false; error: Error; }
+  createBuiltIn(type: BuiltInExpertType, options?: { modelOverrides?: { modelId?: string; }; recoveryPolicy?: ExpertRecoveryPolicy; }) => { ok: true; value: Expert; } | { error: Error; ok: false; }
 InterfaceDeclaration McpLogContext
   durationMs?: number | undefined
   errorCode?: string | undefined
@@ -5267,32 +5269,32 @@ ClassDeclaration McpServer
   prompt{ (name: string, cb: PromptCallback): RegisteredPrompt; (name: string, description: string, cb: PromptCallback): RegisteredPrompt; <Args extends PromptArgsRawShape>(name: string, argsSchema: Args, cb: PromptCallback<Args>): RegisteredPrompt; <Args extends PromptArgsRawShape>(name: string, description: string, argsSchema: Args, cb: PromptCallback<Args>): RegisteredPrompt; }
   prompt{ (name: string, cb: PromptCallback): RegisteredPrompt; (name: string, description: string, cb: PromptCallback): RegisteredPrompt; <Args extends PromptArgsRawShape>(name: string, argsSchema: Args, cb: PromptCallback<Args>): RegisteredPrompt; <Args extends PromptArgsRawShape>(name: string, description: string, argsSchema: Args, cb: PromptCallback<Args>): RegisteredPrompt; }
   prompt{ (name: string, cb: PromptCallback): RegisteredPrompt; (name: string, description: string, cb: PromptCallback): RegisteredPrompt; <Args extends PromptArgsRawShape>(name: string, argsSchema: Args, cb: PromptCallback<Args>): RegisteredPrompt; <Args extends PromptArgsRawShape>(name: string, description: string, argsSchema: Args, cb: PromptCallback<Args>): RegisteredPrompt; }
-  readonly server: Server<{ method: string; params?: { [x: string]: unknown; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; } | undefined; }, { method: string; params?: { [x: string]: unknown; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; } | undefined; }, { [x: string]: unknown; _meta?: { [x: string]: unknown; progressToken?: string | number | undefined; "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; } | undefined; }>
-  registerPrompt<Args extends PromptArgsRawShape>(name: string, config: { title?: string; description?: string; argsSchema?: Args; }, cb: PromptCallback<Args>) => RegisteredPrompt
-  registerResource{ (name: string, uriOrTemplate: string, config: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uriOrTemplate: ResourceTemplate, config: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; }
-  registerResource{ (name: string, uriOrTemplate: string, config: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uriOrTemplate: ResourceTemplate, config: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; }
-  registerTool<OutputArgs extends ZodRawShapeCompat | AnySchema, InputArgs extends undefined | ZodRawShapeCompat | AnySchema = undefined>(name: string, config: { title?: string; description?: string; inputSchema?: InputArgs; outputSchema?: OutputArgs; annotations?: ToolAnnotations; _meta?: Record<string, unknown>; }, cb: ToolCallback<InputArgs>) => RegisteredTool
-  resource{ (name: string, uri: string, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uri: string, metadata: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, template: ResourceTemplate, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, template: ResourceTemplate, metadata: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; }
-  resource{ (name: string, uri: string, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uri: string, metadata: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, template: ResourceTemplate, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, template: ResourceTemplate, metadata: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; }
-  resource{ (name: string, uri: string, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uri: string, metadata: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, template: ResourceTemplate, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, template: ResourceTemplate, metadata: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; }
-  resource{ (name: string, uri: string, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uri: string, metadata: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, template: ResourceTemplate, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, template: ResourceTemplate, metadata: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; }
+  readonly server: Server<{ method: string; params?: { _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; } | undefined; }, { method: string; params?: { _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; } | undefined; }, { _meta?: { "io.modelcontextprotocol/related-task"?: { taskId: string; } | undefined; [x: string]: unknown; progressToken?: string | number | undefined; } | undefined; [x: string]: unknown; }>
+  registerPrompt<Args extends PromptArgsRawShape>(name: string, config: { argsSchema?: Args; description?: string; title?: string; }, cb: PromptCallback<Args>) => RegisteredPrompt
+  registerResource{ (name: string, uriOrTemplate: ResourceTemplate, config: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, uriOrTemplate: string, config: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; }
+  registerResource{ (name: string, uriOrTemplate: ResourceTemplate, config: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, uriOrTemplate: string, config: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; }
+  registerTool<OutputArgs extends ZodRawShapeCompat | AnySchema, InputArgs extends undefined | ZodRawShapeCompat | AnySchema = undefined>(name: string, config: { _meta?: Record<string, unknown>; annotations?: ToolAnnotations; description?: string; inputSchema?: InputArgs; outputSchema?: OutputArgs; title?: string; }, cb: ToolCallback<InputArgs>) => RegisteredTool
+  resource{ (name: string, template: ResourceTemplate, metadata: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, template: ResourceTemplate, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, uri: string, metadata: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uri: string, readCallback: ReadResourceCallback): RegisteredResource; }
+  resource{ (name: string, template: ResourceTemplate, metadata: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, template: ResourceTemplate, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, uri: string, metadata: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uri: string, readCallback: ReadResourceCallback): RegisteredResource; }
+  resource{ (name: string, template: ResourceTemplate, metadata: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, template: ResourceTemplate, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, uri: string, metadata: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uri: string, readCallback: ReadResourceCallback): RegisteredResource; }
+  resource{ (name: string, template: ResourceTemplate, metadata: ResourceMetadata, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, template: ResourceTemplate, readCallback: ReadResourceTemplateCallback): RegisteredResourceTemplate; (name: string, uri: string, metadata: ResourceMetadata, readCallback: ReadResourceCallback): RegisteredResource; (name: string, uri: string, readCallback: ReadResourceCallback): RegisteredResource; }
   sendLoggingMessage(params: LoggingMessageNotification["params"], sessionId?: string) => Promise<void>
   sendPromptListChanged() => void
   sendResourceListChanged() => void
   sendToolListChanged() => void
-  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
-  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
-  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
-  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
-  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
-  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
+  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
+  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
+  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
+  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
+  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
+  tool{ (name: string, cb: ToolCallback): RegisteredTool; (name: string, description: string, cb: ToolCallback): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, description: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchema: Args, annotations: ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; <Args extends ZodRawShapeCompat>(name: string, paramsSchemaOrAnnotations: Args | ToolAnnotations, cb: ToolCallback<Args>): RegisteredTool; }
 InterfaceDeclaration McpToolResult
-  content?: { type: string; text?: string; }[] | undefined
+  content?: { text?: string; type: string; }[] | undefined
   isError?: boolean | undefined
 FunctionDeclaration meanConfidenceInterval
   : typeof meanConfidenceInterval
 VariableDeclaration MEM0_TARGETS
-  : { readonly latencyReductionPercent: 91; readonly tokenSavingsPercent: 90; readonly qualityImprovementPercent: 26; }
+  : { readonly latencyReductionPercent: 91; readonly qualityImprovementPercent: 26; readonly tokenSavingsPercent: 90; }
 InterfaceDeclaration MemoryBenchmarkConfig
   readonly contentSizeBytes: number
   readonly searchPatterns: readonly string[]
@@ -5305,7 +5307,7 @@ InterfaceDeclaration MemoryEntry
   value: unknown
 ClassDeclaration MemoryError
 TypeAliasDeclaration|VariableDeclaration MemoryImportance
-  : { readonly LOW: "low"; readonly MEDIUM: "medium"; readonly HIGH: "high"; }
+  : { readonly HIGH: "high"; readonly LOW: "low"; readonly MEDIUM: "medium"; }
   = (typeof MemoryImportance)[keyof typeof MemoryImportance]
 InterfaceDeclaration MemoryMetadata
   importance: MemoryImportance
@@ -5318,14 +5320,14 @@ InterfaceDeclaration MemoryPayload
   readonly sizeBytes?: number | undefined
   readonly type: "memory"
 TypeAliasDeclaration|VariableDeclaration MemoryPersistenceMode
-  : { readonly NONE: "none"; readonly ON_TASK_COMPLETE: "on_task_complete"; readonly MANUAL: "manual"; }
+  : { readonly MANUAL: "manual"; readonly NONE: "none"; readonly ON_TASK_COMPLETE: "on_task_complete"; }
   = (typeof MemoryPersistenceMode)[keyof typeof MemoryPersistenceMode]
 TypeAliasDeclaration MemoryQueryDeps
   = BaseMcpToolDeps
 TypeAliasDeclaration MemoryQueryInput
   = z.infer<typeof MemoryQueryInputSchema>
 VariableDeclaration MemoryQueryInputSchema
-  : z.ZodObject<{ query: z.ZodString; limit: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; source: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ all: "all"; belief: "belief"; session: "session"; agentic: "agentic"; typed: "typed"; adaptive: "adaptive"; }>>>; }, z.core.$strip>
+  : z.ZodObject<{ limit: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; query: z.ZodString; source: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ adaptive: "adaptive"; agentic: "agentic"; all: "all"; belief: "belief"; session: "session"; typed: "typed"; }>>>; }, z.core.$strip>
 InterfaceDeclaration MemoryQueryResponse
   count: number
   expandedQuery?: string | undefined
@@ -5346,14 +5348,14 @@ InterfaceDeclaration MemoryStatsResponse
   session: SessionStats
   typed: Record<string, unknown> | null
 TypeAliasDeclaration|VariableDeclaration MemoryType
-  : { readonly CORE: "core"; readonly EPISODIC: "episodic"; readonly SEMANTIC: "semantic"; readonly PROCEDURAL: "procedural"; readonly RESOURCE: "resource"; readonly VAULT: "vault"; readonly BELIEF: "belief"; }
+  : { readonly BELIEF: "belief"; readonly CORE: "core"; readonly EPISODIC: "episodic"; readonly PROCEDURAL: "procedural"; readonly RESOURCE: "resource"; readonly SEMANTIC: "semantic"; readonly VAULT: "vault"; }
   = (typeof MemoryType)[keyof typeof MemoryType]
 TypeAliasDeclaration MemoryWriteDeps
   = BaseMcpToolDeps
 TypeAliasDeclaration MemoryWriteInput
   = z.infer<typeof MemoryWriteInputSchema>
 VariableDeclaration MemoryWriteInputSchema
-  : z.ZodObject<{ key: z.ZodString; content: z.ZodString; backend: z.ZodEnum<{ belief: "belief"; session: "session"; agentic: "agentic"; typed: "typed"; adaptive: "adaptive"; }>; confidence: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ high: "high"; medium: "medium"; low: "low"; }>>>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>; }, z.core.$strip>
+  : z.ZodObject<{ backend: z.ZodEnum<{ adaptive: "adaptive"; agentic: "agentic"; belief: "belief"; session: "session"; typed: "typed"; }>; confidence: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ high: "high"; low: "low"; medium: "medium"; }>>>; content: z.ZodString; key: z.ZodString; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>; }, z.core.$strip>
 InterfaceDeclaration MemoryWriteResponse
   backend: string
   deduplicated?: boolean | undefined
@@ -5382,7 +5384,7 @@ TypeAliasDeclaration MessageRole
 TypeAliasDeclaration MessageStreamEvent
   = RawMessageStreamEvent
 VariableDeclaration MIN_EXPERTS_FOR_PATTERN
-  : { readonly sequential: 1; readonly parallel: 2; readonly review: 2; readonly consensus: 3; readonly reflexion: 1; readonly aegean: 3; readonly 'self-refine': 1; readonly 'self-debug': 1; }
+  : { readonly 'self-debug': 1; readonly 'self-refine': 1; readonly aegean: 3; readonly consensus: 3; readonly parallel: 2; readonly reflexion: 1; readonly review: 2; readonly sequential: 1; }
 ClassDeclaration MobiMem
   close() => void
   getStats() => MobiMemStats
@@ -5409,9 +5411,9 @@ InterfaceDeclaration MobiMemPersistenceOptions
   readonly db: Database | null
   readonly domain: string
 InterfaceDeclaration MobiMemStats
-  readonly action: { readonly totalEntries: number; readonly totalHits: number; readonly hitRate: number; readonly timeSavedMs: number; }
-  readonly experience: { readonly totalPatterns: number; readonly uniqueTaskTypes: number; readonly avgSuccessRate: number; }
-  readonly profile: { readonly totalEntries: number; readonly uniqueEntities: number; readonly avgConfidence: number; }
+  readonly action: { readonly hitRate: number; readonly timeSavedMs: number; readonly totalEntries: number; readonly totalHits: number; }
+  readonly experience: { readonly avgSuccessRate: number; readonly totalPatterns: number; readonly uniqueTaskTypes: number; }
+  readonly profile: { readonly avgConfidence: number; readonly totalEntries: number; readonly uniqueEntities: number; }
 VariableDeclaration MODEL_CAPABILITIES
   : Record<string, CapabilityProfile>
 InterfaceDeclaration ModelCalledEvent
@@ -5425,12 +5427,12 @@ InterfaceDeclaration ModelCalledEvent
   readonly tokensOut: number
   readonly type: "model.called"
 TypeAliasDeclaration|VariableDeclaration ModelCapability
-  : { readonly COMPLETION: "completion"; readonly STREAMING: "streaming"; readonly TOOL_USE: "tool_use"; readonly VISION: "vision"; readonly EXTENDED_THINKING: "extended_thinking"; }
+  : { readonly COMPLETION: "completion"; readonly EXTENDED_THINKING: "extended_thinking"; readonly STREAMING: "streaming"; readonly TOOL_USE: "tool_use"; readonly VISION: "vision"; }
   = (typeof ModelCapability)[keyof typeof ModelCapability]
 TypeAliasDeclaration ModelConfig
   = z.infer<typeof ModelConfigSchema>
 VariableDeclaration ModelConfigSchema
-  : z.ZodObject<{ default: z.ZodString; tiers: z.ZodObject<{ fast: z.ZodArray<z.ZodString>; balanced: z.ZodArray<z.ZodString>; powerful: z.ZodArray<z.ZodString>; }, z.core.$strip>; providers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ apiKey: z.ZodOptional<z.ZodString>; baseUrl: z.ZodOptional<z.ZodURL>; timeout: z.ZodDefault<z.ZodNumber>; maxRetries: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; }, z.core.$strip>
+  : z.ZodObject<{ default: z.ZodString; providers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ apiKey: z.ZodOptional<z.ZodString>; baseUrl: z.ZodOptional<z.ZodURL>; maxRetries: z.ZodDefault<z.ZodNumber>; timeout: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; tiers: z.ZodObject<{ balanced: z.ZodArray<z.ZodString>; fast: z.ZodArray<z.ZodString>; powerful: z.ZodArray<z.ZodString>; }, z.core.$strip>; }, z.core.$strip>
 InterfaceDeclaration ModelCostBreakdown
   readonly costUsd: number
   readonly inputTokens: number
@@ -5458,7 +5460,7 @@ InterfaceDeclaration ModelEntry
   readonly pricing?: { inputPer1M: number; outputPer1M: number; } | undefined
   readonly profileId: string
   readonly promptCaching: PromptCachingMode
-  readonly qualityScores?: { reasoning: number; codeGeneration: number; speed: number; cost: number; } | undefined
+  readonly qualityScores?: { codeGeneration: number; cost: number; reasoning: number; speed: number; } | undefined
   readonly quirks: readonly string[]
   readonly resolvedFrom?: string | undefined
   readonly source: EntrySource
@@ -5530,7 +5532,7 @@ InterfaceDeclaration ModelPreference
   readonly strength: number
   temperature?: number | undefined
 VariableDeclaration ModelPreferenceSchema
-  : z.ZodObject<{ provider: z.ZodOptional<z.ZodString>; modelId: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ maxTokens: z.ZodOptional<z.ZodNumber>; modelId: z.ZodOptional<z.ZodString>; provider: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 ClassDeclaration ModelRegistry
   allEntries() => readonly ModelEntry[]
   getEntry(modelId: string, hints?: ModelHints) => ModelEntry
@@ -5548,7 +5550,7 @@ InterfaceDeclaration ModelSelection
   reasoning?: ReasoningDepth | undefined
   temperature?: number | undefined
 VariableDeclaration ModelSelectionSchema
-  : z.ZodObject<{ provider: z.ZodOptional<z.ZodString>; modelId: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; reasoning: z.ZodOptional<z.ZodEnum<{ standard: "standard"; minimal: "minimal"; extended: "extended"; }>>; }, z.core.$strip>
+  : z.ZodObject<{ maxTokens: z.ZodOptional<z.ZodNumber>; modelId: z.ZodOptional<z.ZodString>; provider: z.ZodOptional<z.ZodString>; reasoning: z.ZodOptional<z.ZodEnum<{ extended: "extended"; minimal: "minimal"; standard: "standard"; }>>; temperature: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration ModelSelectionShadowComparison
   readonly actualModel: string
   readonly agree: boolean
@@ -5572,7 +5574,7 @@ TypeAliasDeclaration|InterfaceDeclaration ModelTier
 TypeAliasDeclaration ModelTiers
   = z.infer<typeof ModelTiersSchema>
 VariableDeclaration ModelTiersSchema
-  : z.ZodObject<{ fast: z.ZodArray<z.ZodString>; balanced: z.ZodArray<z.ZodString>; powerful: z.ZodArray<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ balanced: z.ZodArray<z.ZodString>; fast: z.ZodArray<z.ZodString>; powerful: z.ZodArray<z.ZodString>; }, z.core.$strip>
 TypeAliasDeclaration ModelVendor
   = | 'anthropic' | 'openai' | 'google' | 'meta' | 'qwen' | 'nvidia' | 'mistral' | 'cohere' | 'deepseek' | 'unknown'
 InterfaceDeclaration ModelWeatherEntry
@@ -5602,7 +5604,7 @@ InterfaceDeclaration MutablePairwiseHistory
   disagreements: number
   jointObservations: number
   lastUpdated: Date
-  pairKey: `${string}:${string}`
+  pairKey: `${ string; }:${ string; }`
 ClassDeclaration NexusError
   readonly cause: Error | undefined
   readonly code: ErrorCode
@@ -5646,7 +5648,7 @@ TypeAliasDeclaration NodeReturn
 TypeAliasDeclaration NodeState
   = 'pending' | 'active' | 'completed' | 'pruned' | 'error'
 VariableDeclaration NodeStateSchema
-  : z.ZodEnum<{ pending: "pending"; completed: "completed"; error: "error"; active: "active"; pruned: "pruned"; }>
+  : z.ZodEnum<{ active: "active"; completed: "completed"; error: "error"; pending: "pending"; pruned: "pruned"; }>
 VariableDeclaration NOOP_NOTIFIER
   : IMcpNotifier
 VariableDeclaration NOOP_PROGRESS
@@ -5689,7 +5691,7 @@ ClassDeclaration Ollama
   create{ (request: CreateRequest & { stream: true; }): Promise<AbortableAsyncIterator<ProgressResponse>>; (request: CreateRequest & { stream?: false; }): Promise<ProgressResponse>; }
   encodeImage(image: Uint8Array | Buffer | string) => Promise<string>
 VariableDeclaration OLLAMA_MODELS
-  : { readonly LLAMA3_8B: "llama3:8b"; readonly LLAMA3_70B: "llama3:70b"; readonly LLAMA3_1_8B: "llama3.1:8b"; readonly LLAMA3_2_3B: "llama3.2:3b"; readonly MISTRAL: "mistral"; readonly MISTRAL_NEMO: "mistral-nemo"; readonly CODELLAMA: "codellama"; readonly CODELLAMA_34B: "codellama:34b"; readonly DEEPSEEK_CODER: "deepseek-coder"; readonly QWEN2_5_CODER: "qwen2.5-coder"; readonly PHI3: "phi3"; readonly GEMMA2: "gemma2"; }
+  : { readonly CODELLAMA_34B: "codellama:34b"; readonly CODELLAMA: "codellama"; readonly DEEPSEEK_CODER: "deepseek-coder"; readonly GEMMA2: "gemma2"; readonly LLAMA3_1_8B: "llama3.1:8b"; readonly LLAMA3_2_3B: "llama3.2:3b"; readonly LLAMA3_70B: "llama3:70b"; readonly LLAMA3_8B: "llama3:8b"; readonly MISTRAL_NEMO: "mistral-nemo"; readonly MISTRAL: "mistral"; readonly PHI3: "phi3"; readonly QWEN2_5_CODER: "qwen2.5-coder"; }
 ClassDeclaration OllamaAdapter
   complete(request: CompletionRequest) => Promise<Result<CompletionResponse, ModelError>>
   countTokens(text: string) => Promise<number>
@@ -5704,7 +5706,7 @@ InterfaceDeclaration OllamaAdapterConfig
 VariableDeclaration OPENAI_MODEL_ALIASES
   : Record<string, string>
 VariableDeclaration OPENAI_MODELS
-  : { readonly GPT_5_2: "gpt-5.2"; readonly GPT_5_2_INSTANT: "gpt-5.2-chat-latest"; readonly GPT_5_2_PRO: "gpt-5.2-pro"; readonly GPT_5_2_CODEX: string; readonly GPT_4O: "gpt-4o-2024-11-20"; readonly GPT_4O_MINI: "gpt-4o-mini-2024-07-18"; readonly GPT_4_TURBO: "gpt-4-turbo-2024-04-09"; readonly GPT_35_TURBO: "gpt-3.5-turbo-0125"; }
+  : { readonly GPT_35_TURBO: "gpt-3.5-turbo-0125"; readonly GPT_4_TURBO: "gpt-4-turbo-2024-04-09"; readonly GPT_4O_MINI: "gpt-4o-mini-2024-07-18"; readonly GPT_4O: "gpt-4o-2024-11-20"; readonly GPT_5_2_CODEX: string; readonly GPT_5_2_INSTANT: "gpt-5.2-chat-latest"; readonly GPT_5_2_PRO: "gpt-5.2-pro"; readonly GPT_5_2: "gpt-5.2"; }
 ClassDeclaration OpenAIAdapter
   complete(request: CompletionRequest) => Promise<Result<CompletionResponse, ModelError>>
   countTokens(text: string) => Promise<number>
@@ -5756,16 +5758,16 @@ InterfaceDeclaration OrchestrateInputLike
   readonly maxIterations?: number | undefined
   readonly task: string
 VariableDeclaration OrchestrateInputSchema
-  : z.ZodObject<{ task: z.ZodString; context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; maxIterations: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; timeout: z.ZodOptional<z.ZodNumber>; mode: z.ZodOptional<z.ZodEnum<{ sync: "sync"; async: "async"; }>>; idempotencyKey: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; idempotencyKey: z.ZodOptional<z.ZodString>; maxIterations: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; mode: z.ZodOptional<z.ZodEnum<{ async: "async"; sync: "sync"; }>>; task: z.ZodString; timeout: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 FunctionDeclaration orchestrateInputToTaskContract
   : typeof orchestrateInputToTaskContract
 TypeAliasDeclaration OrchestrateOutput
   = z.infer<typeof OrchestrateOutputSchema>
 VariableDeclaration OrchestrateOutputSchema
-  : z.ZodObject<{ taskId: z.ZodString; analysis: z.ZodObject<{ taskId: z.ZodString; complexity: z.ZodNumber; taskType: z.ZodString; requirements: z.ZodArray<z.ZodString>; risks: z.ZodArray<z.ZodString>; needsDecomposition: z.ZodBoolean; approach: z.ZodString; estimatedEffort: z.ZodNumber; }, z.core.$strip>; routing: z.ZodOptional<z.ZodObject<{ pattern: z.ZodString; reasoning: z.ZodString; confidence: z.ZodNumber; orchestratorType: z.ZodString; }, z.core.$strip>>; result: z.ZodUnknown; stepsCompleted: z.ZodNumber; metadata: z.ZodObject<{ durationMs: z.ZodNumber; tokensUsed: z.ZodNumber; expertsUsed: z.ZodArray<z.ZodString>; timeoutReason: z.ZodOptional<z.ZodString>; }, z.core.$strip>; workerDispatchStatus: z.ZodOptional<z.ZodEnum<{ success: "success"; partial: "partial"; failed: "failed"; }>>; }, z.core.$strip>
+  : z.ZodObject<{ analysis: z.ZodObject<{ approach: z.ZodString; complexity: z.ZodNumber; estimatedEffort: z.ZodNumber; needsDecomposition: z.ZodBoolean; requirements: z.ZodArray<z.ZodString>; risks: z.ZodArray<z.ZodString>; taskId: z.ZodString; taskType: z.ZodString; }, z.core.$strip>; metadata: z.ZodObject<{ durationMs: z.ZodNumber; expertsUsed: z.ZodArray<z.ZodString>; timeoutReason: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodNumber; }, z.core.$strip>; result: z.ZodUnknown; routing: z.ZodOptional<z.ZodObject<{ confidence: z.ZodNumber; orchestratorType: z.ZodString; pattern: z.ZodString; reasoning: z.ZodString; }, z.core.$strip>>; stepsCompleted: z.ZodNumber; taskId: z.ZodString; workerDispatchStatus: z.ZodOptional<z.ZodEnum<{ failed: "failed"; partial: "partial"; success: "success"; }>>; }, z.core.$strip>
 ClassDeclaration OrchestrationError
 TypeAliasDeclaration OrchestrationObserverEvent
-  = | { type: 'agent_state_changed'; agentId: string; state: AgentState; previousState: AgentState } | { type: 'routing_decision'; decision: RoutingDecision } | { type: 'session_started'; sessionId: string; pattern: string } | { type: 'session_completed'; sessionId: string; success: boolean; durationMs: number } | { type: 'metrics_updated'; metrics: OrchestrationStats } | { type: 'error'; source: string; error: string }
+  = | { agentId: string; previousState: AgentState; state: AgentState; type: 'agent_state_changed'; } | { decision: RoutingDecision; type: 'routing_decision'; } | { pattern: string; sessionId: string; type: 'session_started'; } | { durationMs: number; sessionId: string; success: boolean; type: 'session_completed'; } | { metrics: OrchestrationStats; type: 'metrics_updated'; } | { error: string; source: string; type: 'error'; }
 TypeAliasDeclaration OrchestrationObserverListener
   = (event: OrchestrationObserverEvent) => void
 InterfaceDeclaration OrchestrationStats
@@ -5801,7 +5803,7 @@ ClassDeclaration OrchestratorCollaborationHelper
   getProtocolSelector() => AdaptiveProtocolSelector
   shouldUseCollaboration(analysis: TaskAnalysis, resultCount: number) => boolean
 TypeAliasDeclaration OrchestratorDefinition
-  = | { type: 'task'; task: Task } | { type: 'workflow'; templatePath: string } | { type: 'policy'; policyId: string; initialState: Record<string, unknown> }
+  = | { task: Task; type: 'task'; } | { templatePath: string; type: 'workflow'; } | { initialState: Record<string, unknown>; policyId: string; type: 'policy'; }
 ClassDeclaration OrchestratorError
   readonly cause: Error | undefined
   readonly code: OrchestratorErrorCode
@@ -5835,7 +5837,7 @@ InterfaceDeclaration OrchestratorOptions
   expertWeights?: Partial<Record<AgentRole, number>> | undefined
   maxSubtasks?: number | undefined
 VariableDeclaration OrchestratorOptionsSchema
-  : z.ZodObject<{ maxSubtasks: z.ZodOptional<z.ZodNumber>; decompositionThreshold: z.ZodOptional<z.ZodNumber>; enableParallelHints: z.ZodOptional<z.ZodBoolean>; expertWeights: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; }, z.core.$strip>
+  : z.ZodObject<{ decompositionThreshold: z.ZodOptional<z.ZodNumber>; enableParallelHints: z.ZodOptional<z.ZodBoolean>; expertWeights: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; maxSubtasks: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration OrchestratorResult
   agentsUsed: string[]
   executionId: string
@@ -5868,7 +5870,7 @@ InterfaceDeclaration OutcomeDependencies
 TypeAliasDeclaration OutcomeFailureCategory
   = z.infer<typeof OutcomeFailureCategorySchema>
 VariableDeclaration OutcomeFailureCategorySchema
-  : z.ZodEnum<{ authentication: "authentication"; unknown: "unknown"; timeout: "timeout"; rate_limit: "rate_limit"; connection: "connection"; crash: "crash"; adapter_unavailable: "adapter_unavailable"; validation: "validation"; parse: "parse"; execution: "execution"; generic: "generic"; }>
+  : z.ZodEnum<{ adapter_unavailable: "adapter_unavailable"; authentication: "authentication"; connection: "connection"; crash: "crash"; execution: "execution"; generic: "generic"; parse: "parse"; rate_limit: "rate_limit"; timeout: "timeout"; unknown: "unknown"; validation: "validation"; }>
 ClassDeclaration OutcomeFeedbackCollector
   clearExpiredDecisions() => number
   computeReward(outcome: TaskOutcome) => ComputedReward
@@ -5884,7 +5886,7 @@ ClassDeclaration OutcomeFeedbackCollector
 InterfaceDeclaration OutcomeGroup
   readonly category: string
   readonly cli: "claude" | "gemini" | "codex" | "opencode"
-  readonly outcomes: readonly { id: string; cli: "claude" | "gemini" | "codex" | "opencode" | "unknown" | "api:anthropic" | "api:openai" | "api:google" | "api:custom-openai"; category: "research" | "architecture" | "documentation" | "testing" | "devops" | "planning" | "code_generation" | "code_review" | "security_review" | "exploration"; model: string; success: boolean; durationMs: number; timestamp: string; source: "delegate" | "consensus" | "manual"; qualitySignals?: string[] | undefined; failureCategory?: "authentication" | "unknown" | "timeout" | "rate_limit" | "connection" | "crash" | "adapter_unavailable" | "validation" | "parse" | "execution" | "generic" | undefined; errorMessage?: string | undefined; wasRetried?: boolean | undefined; triageAction?: string | undefined; routingStage?: string | undefined; retryCount?: number | undefined; vendor?: string | undefined; family?: string | undefined; voterRole?: string | undefined; baselineId?: string | undefined; traceId?: string | undefined; requestId?: string | undefined; }[]
+  readonly outcomes: readonly { baselineId?: string | undefined; category: "research" | "architecture" | "documentation" | "testing" | "devops" | "planning" | "code_generation" | "code_review" | "security_review" | "exploration"; cli: "claude" | "gemini" | "codex" | "opencode" | "unknown" | "api:anthropic" | "api:openai" | "api:google" | "api:custom-openai"; durationMs: number; errorMessage?: string | undefined; failureCategory?: "authentication" | "unknown" | "timeout" | "rate_limit" | "connection" | "crash" | "adapter_unavailable" | "validation" | "parse" | "execution" | "generic" | undefined; family?: string | undefined; id: string; model: string; qualitySignals?: string[] | undefined; requestId?: string | undefined; retryCount?: number | undefined; routingStage?: string | undefined; source: "delegate" | "consensus" | "manual"; success: boolean; timestamp: string; traceId?: string | undefined; triageAction?: string | undefined; vendor?: string | undefined; voterRole?: string | undefined; wasRetried?: boolean | undefined; }[]
 TypeAliasDeclaration OutcomeProcessedCallback
   = ( decision: RoutingDecision, outcome: TaskOutcome, reward: ComputedReward ) => void
 TypeAliasDeclaration OutcomeQuery
@@ -5903,7 +5905,7 @@ InterfaceDeclaration OutcomeStorageConfig
   logger?: ILogger | undefined
   maxRecords?: number | undefined
 VariableDeclaration OutcomeStorageConfigSchema
-  : z.ZodObject<{ dbPath: z.ZodString; maxRecords: z.ZodOptional<z.ZodNumber>; autoPruneInterval: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ autoPruneInterval: z.ZodOptional<z.ZodNumber>; dbPath: z.ZodString; maxRecords: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 ClassDeclaration OutcomeStorageError
 ClassDeclaration OutcomeStore
   append(outcome: TaskOutcome) => void
@@ -5911,14 +5913,14 @@ ClassDeclaration OutcomeStore
   get size(): number
   purgeSkippedWorkers() => number
   query(filter?: OutcomeQuery) => readonly TaskOutcome[]
-  queryByModelWithFamilyFallback(modelId: string, options?: { readonly threshold?: number; readonly extraFilter?: Omit<OutcomeQuery, "limit">; }) => { readonly outcomes: readonly TaskOutcome[]; readonly scope: "literal" | "family" | "empty"; readonly vendor?: string; readonly family?: string; }
+  queryByModelWithFamilyFallback(modelId: string, options?: { readonly extraFilter?: Omit<OutcomeQuery, "limit">; readonly threshold?: number; }) => { readonly family?: string; readonly outcomes: readonly TaskOutcome[]; readonly scope: "literal" | "family" | "empty"; readonly vendor?: string; }
   reclassifyAll() => number
   summarize(filter?: OutcomeQuery) => PerformanceSummary
 InterfaceDeclaration OutcomeStoreConfig
   readonly maxEntries?: number | undefined
   readonly registry?: ModelRegistry | undefined
 VariableDeclaration OutcomeTaskSchema
-  : z.ZodObject<{ id: z.ZodString; cli: z.ZodUnion<readonly [z.ZodEnum<{ claude: "claude"; gemini: "gemini"; codex: "codex"; opencode: "opencode"; }>, z.ZodEnum<{ "api:anthropic": "api:anthropic"; "api:openai": "api:openai"; "api:google": "api:google"; "api:custom-openai": "api:custom-openai"; }>, z.ZodLiteral<"unknown">]>; category: z.ZodEnum<{ research: "research"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; devops: "devops"; planning: "planning"; code_generation: "code_generation"; code_review: "code_review"; security_review: "security_review"; exploration: "exploration"; }>; model: z.ZodString; success: z.ZodBoolean; durationMs: z.ZodNumber; timestamp: z.ZodString; qualitySignals: z.ZodOptional<z.ZodArray<z.ZodString>>; failureCategory: z.ZodOptional<z.ZodEnum<{ authentication: "authentication"; unknown: "unknown"; timeout: "timeout"; rate_limit: "rate_limit"; connection: "connection"; crash: "crash"; adapter_unavailable: "adapter_unavailable"; validation: "validation"; parse: "parse"; execution: "execution"; generic: "generic"; }>>; errorMessage: z.ZodOptional<z.ZodString>; source: z.ZodEnum<{ delegate: "delegate"; consensus: "consensus"; manual: "manual"; }>; wasRetried: z.ZodOptional<z.ZodBoolean>; triageAction: z.ZodOptional<z.ZodString>; routingStage: z.ZodOptional<z.ZodString>; retryCount: z.ZodOptional<z.ZodNumber>; vendor: z.ZodOptional<z.ZodString>; family: z.ZodOptional<z.ZodString>; voterRole: z.ZodOptional<z.ZodString>; baselineId: z.ZodOptional<z.ZodString>; traceId: z.ZodOptional<z.ZodString>; requestId: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ baselineId: z.ZodOptional<z.ZodString>; category: z.ZodEnum<{ architecture: "architecture"; code_generation: "code_generation"; code_review: "code_review"; devops: "devops"; documentation: "documentation"; exploration: "exploration"; planning: "planning"; research: "research"; security_review: "security_review"; testing: "testing"; }>; cli: z.ZodUnion<readonly [z.ZodEnum<{ claude: "claude"; codex: "codex"; gemini: "gemini"; opencode: "opencode"; }>, z.ZodEnum<{ "api:anthropic": "api:anthropic"; "api:custom-openai": "api:custom-openai"; "api:google": "api:google"; "api:openai": "api:openai"; }>, z.ZodLiteral<"unknown">]>; durationMs: z.ZodNumber; errorMessage: z.ZodOptional<z.ZodString>; failureCategory: z.ZodOptional<z.ZodEnum<{ adapter_unavailable: "adapter_unavailable"; authentication: "authentication"; connection: "connection"; crash: "crash"; execution: "execution"; generic: "generic"; parse: "parse"; rate_limit: "rate_limit"; timeout: "timeout"; unknown: "unknown"; validation: "validation"; }>>; family: z.ZodOptional<z.ZodString>; id: z.ZodString; model: z.ZodString; qualitySignals: z.ZodOptional<z.ZodArray<z.ZodString>>; requestId: z.ZodOptional<z.ZodString>; retryCount: z.ZodOptional<z.ZodNumber>; routingStage: z.ZodOptional<z.ZodString>; source: z.ZodEnum<{ consensus: "consensus"; delegate: "delegate"; manual: "manual"; }>; success: z.ZodBoolean; timestamp: z.ZodString; traceId: z.ZodOptional<z.ZodString>; triageAction: z.ZodOptional<z.ZodString>; vendor: z.ZodOptional<z.ZodString>; voterRole: z.ZodOptional<z.ZodString>; wasRetried: z.ZodOptional<z.ZodBoolean>; }, z.core.$strip>
 TypeAliasDeclaration OutputModality
   = (typeof OUTPUT_MODALITIES)[number]
 FunctionDeclaration overwrite
@@ -5941,9 +5943,9 @@ InterfaceDeclaration PairwiseVotingHistory
   readonly disagreements: number
   readonly jointObservations: number
   readonly lastUpdated: Date
-  readonly pairKey: `${string}:${string}`
+  readonly pairKey: `${ string; }:${ string; }`
 VariableDeclaration PairwiseVotingHistorySchema
-  : z.ZodObject<{ pairKey: z.ZodType<AgentPairKey>; jointObservations: z.ZodNumber; agreements: z.ZodNumber; disagreements: z.ZodNumber; correlation: z.ZodNumber; lastUpdated: z.ZodDate; }, z.core.$strip>
+  : z.ZodObject<{ agreements: z.ZodNumber; correlation: z.ZodNumber; disagreements: z.ZodNumber; jointObservations: z.ZodNumber; lastUpdated: z.ZodDate; pairKey: z.ZodType<AgentPairKey>; }, z.core.$strip>
 InterfaceDeclaration ParallelOptions
   failFast?: boolean | undefined
   maxConcurrency?: number | undefined
@@ -5952,7 +5954,7 @@ ClassDeclaration ParallelProtocol
   execute(config: CollaborationConfig, agents: Map<string, IAgent>) => Promise<Result<CollaborationResult, AgentError>>
   readonly pattern: "parallel"
 InterfaceDeclaration ParallelState
-  abortCleanup?: { signal: AbortSignal; handler: () => void; } | undefined
+  abortCleanup?: { handler: () => void;; signal: AbortSignal; } | undefined
   abortController: AbortController
   completed: boolean
   firstError: WorkflowError | null
@@ -5960,7 +5962,7 @@ InterfaceDeclaration ParallelState
   results: StepResult[]
   timeoutId: NodeJS.Timeout | undefined
 TypeAliasDeclaration ParallelToolOutcome
-  = | { readonly kind: 'recorded'; readonly turn: AgentTurn; readonly toolResultBlock: Extract<ContentBlock, { type: 'tool_result' }>; } | { readonly kind: 'stop-tool-error'; readonly turn: AgentTurn }
+  = | { readonly kind: 'recorded'; readonly toolResultBlock: Extract<ContentBlock, { type: 'tool_result'; }>; readonly turn: AgentTurn; } | { readonly kind: 'stop-tool-error'; readonly turn: AgentTurn; }
 TypeAliasDeclaration ParamSeverity
   = 'behavioral' | 'cosmetic'
 FunctionDeclaration parseAgentPairKey
@@ -5974,7 +5976,7 @@ InterfaceDeclaration ParsedExpression
 TypeAliasDeclaration ParsedSpec
   = z.infer<typeof ParsedSpecSchema>
 VariableDeclaration ParsedSpecSchema
-  : z.ZodObject<{ title: z.ZodString; overview: z.ZodString; requirements: z.ZodArray<z.ZodString>; acceptanceCriteria: z.ZodArray<z.ZodString>; constraints: z.ZodArray<z.ZodString>; issueReferences: z.ZodArray<z.ZodObject<{ number: z.ZodNumber; raw: z.ZodString; }, z.core.$strip>>; fileReferences: z.ZodArray<z.ZodObject<{ path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; missingSections: z.ZodArray<z.ZodString>; rawMarkdown: z.ZodString; techStack: z.ZodOptional<z.ZodObject<{ language: z.ZodOptional<z.ZodString>; framework: z.ZodOptional<z.ZodString>; packageManager: z.ZodOptional<z.ZodString>; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ acceptanceCriteria: z.ZodArray<z.ZodString>; constraints: z.ZodArray<z.ZodString>; fileReferences: z.ZodArray<z.ZodObject<{ line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; }, z.core.$strip>>; issueReferences: z.ZodArray<z.ZodObject<{ number: z.ZodNumber; raw: z.ZodString; }, z.core.$strip>>; missingSections: z.ZodArray<z.ZodString>; overview: z.ZodString; rawMarkdown: z.ZodString; requirements: z.ZodArray<z.ZodString>; techStack: z.ZodOptional<z.ZodObject<{ framework: z.ZodOptional<z.ZodString>; language: z.ZodOptional<z.ZodString>; packageManager: z.ZodOptional<z.ZodString>; }, z.core.$strip>>; title: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration ParsedTemplate
   definition: WorkflowDefinition
   metadata: TemplateMetadata
@@ -6011,9 +6013,9 @@ InterfaceDeclaration PathScoreBreakdown
   readonly depthFactor: number
   readonly qualityScore: number
 VariableDeclaration PathScoreBreakdownSchema
-  : z.ZodObject<{ confidenceScore: z.ZodNumber; qualityScore: z.ZodNumber; coherenceScore: z.ZodNumber; depthFactor: z.ZodNumber; conclusionBonus: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ coherenceScore: z.ZodNumber; conclusionBonus: z.ZodNumber; confidenceScore: z.ZodNumber; depthFactor: z.ZodNumber; qualityScore: z.ZodNumber; }, z.core.$strip>
 VariableDeclaration PathScoreSchema
-  : z.ZodObject<{ treeId: z.ZodString; path: z.ZodArray<z.ZodString>; targetNodeId: z.ZodString; score: z.ZodNumber; breakdown: z.ZodObject<{ confidenceScore: z.ZodNumber; qualityScore: z.ZodNumber; coherenceScore: z.ZodNumber; depthFactor: z.ZodNumber; conclusionBonus: z.ZodNumber; }, z.core.$strip>; reachesConclusion: z.ZodBoolean; length: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ breakdown: z.ZodObject<{ coherenceScore: z.ZodNumber; conclusionBonus: z.ZodNumber; confidenceScore: z.ZodNumber; depthFactor: z.ZodNumber; qualityScore: z.ZodNumber; }, z.core.$strip>; length: z.ZodNumber; path: z.ZodArray<z.ZodString>; reachesConclusion: z.ZodBoolean; score: z.ZodNumber; targetNodeId: z.ZodString; treeId: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration PathScoringOptions
   readonly coherenceWeight: number
   readonly conclusionBonus: number
@@ -6062,7 +6064,7 @@ ClassDeclaration PersistentStrategyDistiller
 VariableDeclaration PIPELINE_EVENT_TYPES
   : readonly ["task.created", "task.status_changed", "task.completed", "task.failed", "pipeline.started", "pipeline.completed", "pipeline.checkpoint", "stage.started", "stage.completed", "stage.failed", "stage.retrying", "policy.evaluated", "artifact.created", "model.called", "routing.decision", "tool.invoked", "tool.completed", "wave.started", "wave.completed", "signal.fitness_declined", "signal.swarm_unhealthy", "signal.vote_rejected"]
 VariableDeclaration PIPELINE_STATE_KEYS
-  : { readonly TASK: "task"; readonly RESEARCH: "research"; readonly PLAN: "plan"; readonly VOTE_RESULT: "voteResult"; readonly VOTE_FEEDBACK: "voteFeedback"; readonly VOTE_ITERATIONS: "voteIterations"; readonly TASKS: "tasks"; readonly IMPLEMENTATIONS: "implementations"; readonly QA_ITERATIONS: "qaIterations"; readonly SECURITY_PASSED: "securityPassed"; readonly FINDINGS: "findings"; readonly PARSED_SPEC: "parsedSpec"; readonly SCAFFOLD_OUTPUT: "scaffoldOutput"; readonly COMPLETED: "completed"; }
+  : { readonly COMPLETED: "completed"; readonly FINDINGS: "findings"; readonly IMPLEMENTATIONS: "implementations"; readonly PARSED_SPEC: "parsedSpec"; readonly PLAN: "plan"; readonly QA_ITERATIONS: "qaIterations"; readonly RESEARCH: "research"; readonly SCAFFOLD_OUTPUT: "scaffoldOutput"; readonly SECURITY_PASSED: "securityPassed"; readonly TASK: "task"; readonly TASKS: "tasks"; readonly VOTE_FEEDBACK: "voteFeedback"; readonly VOTE_ITERATIONS: "voteIterations"; readonly VOTE_RESULT: "voteResult"; }
 VariableDeclaration PIPELINE_TEMPLATES
   : ReadonlyMap<string, PipelineTemplate>
 InterfaceDeclaration PipelineBridgeResult
@@ -6101,7 +6103,7 @@ InterfaceDeclaration PipelineContext
 InterfaceDeclaration PipelineDeps
   readonly pluginRegistry?: IPluginRegistry | undefined
 TypeAliasDeclaration PipelineEdge
-  = | { readonly type: 'fixed'; readonly from: string; readonly to: string } | { readonly type: 'conditional'; readonly from: string; readonly routerKey: string; readonly targets: readonly string[]; }
+  = | { readonly from: string; readonly to: string; readonly type: 'fixed'; } | { readonly from: string; readonly routerKey: string; readonly targets: readonly string[]; readonly type: 'conditional'; }
 InterfaceDeclaration PipelineError
   readonly message: string
   readonly stage: PipelineStage
@@ -6135,7 +6137,7 @@ InterfaceDeclaration PipelinePlugin
   execute(stage: StageSpec, context: StageContext) => Promise<StageResult>
   onLoad(() => Promise<void>) | undefined
   onUnload(() => Promise<void>) | undefined
-  readonly manifest: { id: string; version: string; description: string; stages: ("analyze" | "route" | "execute" | "validate" | "aggregate" | "gate")[]; requiredCapabilities: string[]; trustLevel: "external" | "core" | "standard" | "experimental"; experimental: boolean; }
+  readonly manifest: { description: string; experimental: boolean; id: string; requiredCapabilities: string[]; stages: ("analyze" | "route" | "execute" | "validate" | "aggregate" | "gate")[]; trustLevel: "external" | "core" | "standard" | "experimental"; version: string; }
   validateConfig(config: unknown) => Result<void, ValidationError>
 InterfaceDeclaration PipelinePolicyViolation
   readonly escalateTo?: string | undefined
@@ -6176,7 +6178,7 @@ ClassDeclaration PipelineRunner
 TypeAliasDeclaration PipelineStage
   = 'parse' | 'decompose' | 'compile'
 TypeAliasDeclaration PipelineStageData
-  = | { readonly type: 'research'; readonly text: string } | { readonly type: 'plan'; readonly text: string; readonly iterations: number } | { readonly type: 'vote'; readonly approved: boolean; readonly conditional: boolean; readonly conditions?: readonly string[]; readonly caveats?: readonly string[]; readonly iterations: number; } | { readonly type: 'decompose'; readonly tasks: readonly PipelineTask[] } | { readonly type: 'implement'; readonly tasks: readonly PipelineTask[] } | { readonly type: 'security'; readonly passed: boolean }
+  = | { readonly text: string; readonly type: 'research'; } | { readonly iterations: number; readonly text: string; readonly type: 'plan'; } | { readonly approved: boolean; readonly caveats?: readonly string[]; readonly conditional: boolean; readonly conditions?: readonly string[]; readonly iterations: number; readonly type: 'vote'; } | { readonly tasks: readonly PipelineTask[]; readonly type: 'decompose'; } | { readonly tasks: readonly PipelineTask[]; readonly type: 'implement'; } | { readonly passed: boolean; readonly type: 'security'; }
 InterfaceDeclaration PipelineStartedEvent
   readonly executionId: string
   readonly taskId: string
@@ -6208,7 +6210,7 @@ InterfaceDeclaration PlanCompileOptions
 TypeAliasDeclaration PlanContract
   = z.infer<typeof PlanContractSchema>
 VariableDeclaration PlanContractSchema
-  : z.ZodObject<{ taskId: z.ZodString; stages: z.ZodArray<z.ZodObject<{ id: z.ZodString; type: z.ZodEnum<{ analyze: "analyze"; route: "route"; execute: "execute"; validate: "validate"; aggregate: "aggregate"; gate: "gate"; }>; pluginId: z.ZodString; inputArtifacts: z.ZodArray<z.ZodString>; outputArtifacts: z.ZodArray<z.ZodString>; dependencies: z.ZodArray<z.ZodString>; config: z.ZodRecord<z.ZodString, z.ZodUnknown>; preferredCli: z.ZodOptional<z.ZodString>; maxRetries: z.ZodOptional<z.ZodNumber>; timeoutMs: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; policyGates: z.ZodArray<z.ZodObject<{ id: z.ZodString; afterStage: z.ZodString; beforeStage: z.ZodString; rules: z.ZodArray<z.ZodString>; }, z.core.$strip>>; estimatedCost: z.ZodObject<{ totalTokensIn: z.ZodNumber; totalTokensOut: z.ZodNumber; estimatedCostUsd: z.ZodNumber; modelCalls: z.ZodNumber; }, z.core.$strip>; approvalRequired: z.ZodBoolean; maxIterations: z.ZodNumber; timeoutMs: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ approvalRequired: z.ZodBoolean; estimatedCost: z.ZodObject<{ estimatedCostUsd: z.ZodNumber; modelCalls: z.ZodNumber; totalTokensIn: z.ZodNumber; totalTokensOut: z.ZodNumber; }, z.core.$strip>; maxIterations: z.ZodNumber; policyGates: z.ZodArray<z.ZodObject<{ afterStage: z.ZodString; beforeStage: z.ZodString; id: z.ZodString; rules: z.ZodArray<z.ZodString>; }, z.core.$strip>>; stages: z.ZodArray<z.ZodObject<{ config: z.ZodRecord<z.ZodString, z.ZodUnknown>; dependencies: z.ZodArray<z.ZodString>; id: z.ZodString; inputArtifacts: z.ZodArray<z.ZodString>; maxRetries: z.ZodOptional<z.ZodNumber>; outputArtifacts: z.ZodArray<z.ZodString>; pluginId: z.ZodString; preferredCli: z.ZodOptional<z.ZodString>; timeoutMs: z.ZodOptional<z.ZodNumber>; type: z.ZodEnum<{ aggregate: "aggregate"; analyze: "analyze"; execute: "execute"; gate: "gate"; route: "route"; validate: "validate"; }>; }, z.core.$strip>>; taskId: z.ZodString; timeoutMs: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration PlanConversionOptions
   defaultRetries?: number | undefined
   defaultStepTimeout?: number | undefined
@@ -6222,7 +6224,7 @@ VariableDeclaration PLUGIN_TRUST_LEVELS
 TypeAliasDeclaration PluginManifest
   = z.infer<typeof PluginManifestSchema>
 VariableDeclaration PluginManifestSchema
-  : z.ZodObject<{ id: z.ZodString; version: z.ZodString; description: z.ZodString; stages: z.ZodArray<z.ZodEnum<{ analyze: "analyze"; route: "route"; execute: "execute"; validate: "validate"; aggregate: "aggregate"; gate: "gate"; }>>; requiredCapabilities: z.ZodArray<z.ZodString>; trustLevel: z.ZodEnum<{ external: "external"; core: "core"; standard: "standard"; experimental: "experimental"; }>; experimental: z.ZodBoolean; }, z.core.$strip>
+  : z.ZodObject<{ description: z.ZodString; experimental: z.ZodBoolean; id: z.ZodString; requiredCapabilities: z.ZodArray<z.ZodString>; stages: z.ZodArray<z.ZodEnum<{ aggregate: "aggregate"; analyze: "analyze"; execute: "execute"; gate: "gate"; route: "route"; validate: "validate"; }>>; trustLevel: z.ZodEnum<{ core: "core"; experimental: "experimental"; external: "external"; standard: "standard"; }>; version: z.ZodString; }, z.core.$strip>
 ClassDeclaration PluginRegistry
   freeze() => void
   get frozen(): boolean
@@ -6238,7 +6240,7 @@ TypeAliasDeclaration PluginTrustLevel
 TypeAliasDeclaration PolicyConfig
   = z.infer<typeof PolicyConfigSchema>
 VariableDeclaration PolicyConfigSchema
-  : z.ZodObject<{ defaultMode: z.ZodDefault<z.ZodEnum<{ "read-only": "read-only"; "read-write": "read-write"; }>>; policyMode: z.ZodDefault<z.ZodEnum<{ warn: "warn"; enforce: "enforce"; }>>; allowedPaths: z.ZodDefault<z.ZodArray<z.ZodString>>; }, z.core.$strip>
+  : z.ZodObject<{ allowedPaths: z.ZodDefault<z.ZodArray<z.ZodString>>; defaultMode: z.ZodDefault<z.ZodEnum<{ "read-only": "read-only"; "read-write": "read-write"; }>>; policyMode: z.ZodDefault<z.ZodEnum<{ enforce: "enforce"; warn: "warn"; }>>; }, z.core.$strip>
 InterfaceDeclaration PolicyContext
   readonly allowedPaths?: readonly string[] | undefined
   readonly args: unknown
@@ -6251,13 +6253,13 @@ InterfaceDeclaration PolicyContext
   readonly toolName: string
   readonly workflowId?: string | undefined
 TypeAliasDeclaration|InterfaceDeclaration PolicyDecision
-  = | { readonly allow: true } | { readonly allow: false; readonly reason: string; readonly escalateTo?: string; }
+  = | { readonly allow: true; } | { readonly allow: false; readonly escalateTo?: string; readonly reason: string; }
   readonly allowed: boolean
   readonly reason: string
   readonly requiredArtifact?: string | undefined
   readonly ruleName?: string | undefined
 InterfaceDeclaration PolicyDecisionAuditOpts
-  actor: { type: "system" | "user" | "agent" | "external"; id: string; name?: string | undefined; ip?: string | undefined; userAgent?: string | undefined; }
+  actor: { id: string; ip?: string | undefined; name?: string | undefined; type: "system" | "user" | "agent" | "external"; userAgent?: string | undefined; }
   decision: "allow" | "deny"
   metadata?: Record<string, unknown> | undefined
   policyName: string
@@ -6316,7 +6318,7 @@ InterfaceDeclaration PolicyGateEvent
 TypeAliasDeclaration PolicyGateSpec
   = z.infer<typeof PolicyGateSpecSchema>
 VariableDeclaration PolicyGateSpecSchema
-  : z.ZodObject<{ id: z.ZodString; afterStage: z.ZodString; beforeStage: z.ZodString; rules: z.ZodArray<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ afterStage: z.ZodString; beforeStage: z.ZodString; id: z.ZodString; rules: z.ZodArray<z.ZodString>; }, z.core.$strip>
 TypeAliasDeclaration PolicyMode
   = 'enforce' | 'warn'
   = 'off' | 'warn' | 'block'
@@ -6392,7 +6394,7 @@ InterfaceDeclaration PreferenceRouterConfig
   readonly strongModel: ModelTier
   readonly weakModel: ModelTier
 VariableDeclaration PreferenceRouterConfigSchema
-  : z.ZodObject<{ strongModel: z.ZodObject<{ tier: z.ZodLiteral<"strong">; cli: z.ZodEnum<{ claude: "claude"; gemini: "gemini"; codex: "codex"; opencode: "opencode"; }>; costPerMillionTokens: z.ZodNumber; qualityBaseline: z.ZodNumber; }, z.core.$strip>; weakModel: z.ZodObject<{ tier: z.ZodLiteral<"weak">; cli: z.ZodEnum<{ claude: "claude"; gemini: "gemini"; codex: "codex"; opencode: "opencode"; }>; costPerMillionTokens: z.ZodNumber; qualityBaseline: z.ZodNumber; }, z.core.$strip>; routingThreshold: z.ZodDefault<z.ZodNumber>; minDataPoints: z.ZodDefault<z.ZodNumber>; maxDataPoints: z.ZodDefault<z.ZodNumber>; enableOnlineLearning: z.ZodDefault<z.ZodBoolean>; domainThresholds: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; }, z.core.$strip>
+  : z.ZodObject<{ domainThresholds: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; enableOnlineLearning: z.ZodDefault<z.ZodBoolean>; maxDataPoints: z.ZodDefault<z.ZodNumber>; minDataPoints: z.ZodDefault<z.ZodNumber>; routingThreshold: z.ZodDefault<z.ZodNumber>; strongModel: z.ZodObject<{ cli: z.ZodEnum<{ claude: "claude"; codex: "codex"; gemini: "gemini"; opencode: "opencode"; }>; costPerMillionTokens: z.ZodNumber; qualityBaseline: z.ZodNumber; tier: z.ZodLiteral<"strong">; }, z.core.$strip>; weakModel: z.ZodObject<{ cli: z.ZodEnum<{ claude: "claude"; codex: "codex"; gemini: "gemini"; opencode: "opencode"; }>; costPerMillionTokens: z.ZodNumber; qualityBaseline: z.ZodNumber; tier: z.ZodLiteral<"weak">; }, z.core.$strip>; }, z.core.$strip>
 InterfaceDeclaration PreferenceRoutingDecision
   readonly estimatedCostSavings: number
   readonly prediction: PreferencePrediction
@@ -6469,7 +6471,7 @@ InterfaceDeclaration PromptDefinition
   readonly description: string
   readonly name: string
 InterfaceDeclaration PromptMessage
-  readonly content: { readonly type: "text"; readonly text: string; }
+  readonly content: { readonly text: string; readonly type: "text"; }
   readonly role: "user" | "assistant"
 InterfaceDeclaration PromptRegistrationResult
   readonly prompts: readonly string[]
@@ -6491,20 +6493,20 @@ InterfaceDeclaration ProposalCacheEntry
 TypeAliasDeclaration ProposalId
   = string
 VariableDeclaration ProposalSchema
-  : z.ZodObject<{ id: z.ZodOptional<z.ZodString>; title: z.ZodString; description: z.ZodString; algorithm: z.ZodEnum<{ simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; proof_of_learning: "proof_of_learning"; higher_order: "higher_order"; opinion_wise: "opinion_wise"; }>; timeout: z.ZodOptional<z.ZodNumber>; requiredVoters: z.ZodOptional<z.ZodArray<z.ZodString>>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; createdAt: z.ZodOptional<z.ZodISODateTime>; }, z.core.$strip>
+  : z.ZodObject<{ algorithm: z.ZodEnum<{ higher_order: "higher_order"; opinion_wise: "opinion_wise"; proof_of_learning: "proof_of_learning"; simple_majority: "simple_majority"; supermajority: "supermajority"; unanimous: "unanimous"; }>; createdAt: z.ZodOptional<z.ZodISODateTime>; description: z.ZodString; id: z.ZodOptional<z.ZodString>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; requiredVoters: z.ZodOptional<z.ZodArray<z.ZodString>>; timeout: z.ZodOptional<z.ZodNumber>; title: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration ProposalState
   expansionInFlight?: boolean | undefined
   expansionRounds?: number | undefined
-  proposal: { title: string; description: string; algorithm: "simple_majority" | "supermajority" | "unanimous" | "proof_of_learning" | "higher_order" | "opinion_wise"; id?: string | undefined; timeout?: number | undefined; requiredVoters?: string[] | undefined; metadata?: Record<string, unknown> | undefined; createdAt?: string | undefined; }
+  proposal: { algorithm: "simple_majority" | "supermajority" | "unanimous" | "proof_of_learning" | "higher_order" | "opinion_wise"; createdAt?: string | undefined; description: string; id?: string | undefined; metadata?: Record<string, unknown> | undefined; requiredVoters?: string[] | undefined; timeout?: number | undefined; title: string; }
   startedAt: Date
   status: "pending" | "approved" | "closed" | "rejected" | "timeout" | "voting"
   timeoutId?: NodeJS.Timeout | undefined
   voteWeights: Map<string, number>
-  votes: Map<string, { decision: "approve" | "reject" | "abstain"; reasoning: string; confidence: number; conditions?: string[] | undefined; rejectionCategories?: ("YAGNI" | "DRY_VIOLATION" | "OVER_ENGINEERING" | "SCOPE_CREEP" | "SECURITY_RISK" | "MISALIGNED" | "INSUFFICIENT_EVIDENCE")[] | undefined; findings?: { summary: string; location: string; severity: "critical" | "high" | "medium" | "low"; gate: { reread_cited_line: "failed" | "skipped" | "passed"; traced_call_path: "failed" | "skipped" | "passed"; named_assertion: string; ruled_out_language_non_issue: "failed" | "skipped" | "passed"; }; claim: string; }[] | undefined; selectedOption?: string | undefined; timestamp?: string | undefined; }>
+  votes: Map<string, { conditions?: string[] | undefined; confidence: number; decision: "approve" | "reject" | "abstain"; findings?: { claim: string; gate: { named_assertion: string; reread_cited_line: "failed" | "skipped" | "passed"; ruled_out_language_non_issue: "failed" | "skipped" | "passed"; traced_call_path: "failed" | "skipped" | "passed"; }; location: string; severity: "critical" | "high" | "medium" | "low"; summary: string; }[] | undefined; reasoning: string; rejectionCategories?: ("YAGNI" | "DRY_VIOLATION" | "OVER_ENGINEERING" | "SCOPE_CREEP" | "SECURITY_RISK" | "MISALIGNED" | "INSUFFICIENT_EVIDENCE")[] | undefined; selectedOption?: string | undefined; timestamp?: string | undefined; }>
 TypeAliasDeclaration ProposalStatus
   = z.infer<typeof ProposalStatusSchema>
 VariableDeclaration ProposalStatusSchema
-  : z.ZodEnum<{ pending: "pending"; approved: "approved"; closed: "closed"; rejected: "rejected"; timeout: "timeout"; voting: "voting"; }>
+  : z.ZodEnum<{ approved: "approved"; closed: "closed"; pending: "pending"; rejected: "rejected"; timeout: "timeout"; voting: "voting"; }>
 ClassDeclaration ProtocolFactory
   create(pattern: CollaborationConfig["pattern"]) => ICollaborationProtocol
   execute(config: CollaborationConfig, agents: Map<string, IAgent>) => Promise<Result<CollaborationResult, AgentError>>
@@ -6521,7 +6523,7 @@ InterfaceDeclaration ProvenanceEntry
 TypeAliasDeclaration ProviderConfig
   = z.infer<typeof ProviderConfigSchema>
 VariableDeclaration ProviderConfigSchema
-  : z.ZodObject<{ apiKey: z.ZodOptional<z.ZodString>; baseUrl: z.ZodOptional<z.ZodURL>; timeout: z.ZodDefault<z.ZodNumber>; maxRetries: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ apiKey: z.ZodOptional<z.ZodString>; baseUrl: z.ZodOptional<z.ZodURL>; maxRetries: z.ZodDefault<z.ZodNumber>; timeout: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration PrReviewAggregate
   readonly decision: PrReviewDecision
   readonly reason?: string | undefined
@@ -6539,9 +6541,9 @@ InterfaceDeclaration PrReviewDeps
 TypeAliasDeclaration PrReviewInput
   = z.infer<typeof PrReviewInputSchema>
 VariableDeclaration PrReviewInputSchema
-  : z.ZodObject<{ prTitle: z.ZodString; prDescription: z.ZodOptional<z.ZodString>; prDiff: z.ZodString; repoContext: z.ZodOptional<z.ZodString>; baseRef: z.ZodOptional<z.ZodString>; headRef: z.ZodOptional<z.ZodString>; prNumber: z.ZodOptional<z.ZodNumber>; baseSha: z.ZodOptional<z.ZodString>; repoPath: z.ZodOptional<z.ZodString>; simulate: z.ZodDefault<z.ZodBoolean>; errorPolicy: z.ZodDefault<z.ZodEnum<{ absolute_quorum: "absolute_quorum"; standard: "standard"; }>>; dispatch: z.ZodDefault<z.ZodEnum<{ sync: "sync"; async: "async"; }>>; }, z.core.$strip>
+  : z.ZodObject<{ baseRef: z.ZodOptional<z.ZodString>; baseSha: z.ZodOptional<z.ZodString>; dispatch: z.ZodDefault<z.ZodEnum<{ async: "async"; sync: "sync"; }>>; errorPolicy: z.ZodDefault<z.ZodEnum<{ absolute_quorum: "absolute_quorum"; standard: "standard"; }>>; headRef: z.ZodOptional<z.ZodString>; prDescription: z.ZodOptional<z.ZodString>; prDiff: z.ZodString; prNumber: z.ZodOptional<z.ZodNumber>; prTitle: z.ZodString; repoContext: z.ZodOptional<z.ZodString>; repoPath: z.ZodOptional<z.ZodString>; simulate: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>
 TypeAliasDeclaration PrReviewRecordOutcome
-  = | { readonly persisted: true; readonly prNumber: number; readonly baseSha: string; readonly reviewedDiffHash: string; readonly sequence: number; } | { readonly persisted: false; readonly reason: | 'binding-inputs-absent' | 'simulated' | 'no-live-votes' | 'diff-not-unified' | 'write-failed'; readonly detail: string; }
+  = | { readonly baseSha: string; readonly persisted: true; readonly prNumber: number; readonly reviewedDiffHash: string; readonly sequence: number; } | { readonly detail: string; readonly persisted: false; readonly reason: | 'binding-inputs-absent' | 'simulated' | 'no-live-votes' | 'diff-not-unified' | 'write-failed'; }
 InterfaceDeclaration PrReviewResponse
   readonly abstainCount: number
   readonly approveCount: number
@@ -6583,7 +6585,7 @@ InterfaceDeclaration PruneResult
   targetReached: boolean
   tokensFreed: number
 VariableDeclaration|TypeAliasDeclaration PruningStrategy
-  : { readonly OLDEST_FIRST: "oldest_first"; readonly LOWEST_PRIORITY: "lowest_priority"; readonly PRIORITY_WEIGHTED_AGE: "priority_weighted_age"; readonly SUMMARIZE: "summarize"; readonly SLIDING_WINDOW: "sliding_window"; readonly HIERARCHICAL: "hierarchical"; readonly SEMANTIC: "semantic"; }
+  : { readonly HIERARCHICAL: "hierarchical"; readonly LOWEST_PRIORITY: "lowest_priority"; readonly OLDEST_FIRST: "oldest_first"; readonly PRIORITY_WEIGHTED_AGE: "priority_weighted_age"; readonly SEMANTIC: "semantic"; readonly SLIDING_WINDOW: "sliding_window"; readonly SUMMARIZE: "summarize"; }
   = (typeof PruningStrategy)[keyof typeof PruningStrategy]
 InterfaceDeclaration QaReviewResult
   readonly feedback: string
@@ -6627,7 +6629,7 @@ InterfaceDeclaration QualitySignals
   readonly userApproved?: boolean | undefined
   readonly validStructure?: boolean | undefined
 VariableDeclaration QualitySignalsSchema
-  : z.ZodObject<{ testsPass: z.ZodOptional<z.ZodBoolean>; lintErrors: z.ZodOptional<z.ZodNumber>; userApproved: z.ZodOptional<z.ZodBoolean>; retryCount: z.ZodDefault<z.ZodNumber>; completionRatio: z.ZodDefault<z.ZodNumber>; validStructure: z.ZodOptional<z.ZodBoolean>; coherenceScore: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ coherenceScore: z.ZodOptional<z.ZodNumber>; completionRatio: z.ZodDefault<z.ZodNumber>; lintErrors: z.ZodOptional<z.ZodNumber>; retryCount: z.ZodDefault<z.ZodNumber>; testsPass: z.ZodOptional<z.ZodBoolean>; userApproved: z.ZodOptional<z.ZodBoolean>; validStructure: z.ZodOptional<z.ZodBoolean>; }, z.core.$strip>
 ClassDeclaration QueryFeatureExtractor
   extract(query: string) => QueryFeatures
 InterfaceDeclaration QueryFeatures
@@ -6649,7 +6651,7 @@ TypeAliasDeclaration QueryTraceDeps
 TypeAliasDeclaration QueryTraceInput
   = z.infer<typeof QueryTraceInputSchema>
 VariableDeclaration QueryTraceInputSchema
-  : z.ZodObject<{ runId: z.ZodString; eventType: z.ZodOptional<z.ZodString>; limit: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ eventType: z.ZodOptional<z.ZodString>; limit: z.ZodOptional<z.ZodNumber>; runId: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration QueuedTask
   reject: (error: Error) => void
   resolve: (value: T) => void
@@ -6658,7 +6660,7 @@ FunctionDeclaration quickSelect
   : typeof quickSelect
 TypeParameter R
 InterfaceDeclaration RateLimitAuditOpts
-  actor: { type: "system" | "user" | "agent" | "external"; id: string; name?: string | undefined; ip?: string | undefined; userAgent?: string | undefined; }
+  actor: { id: string; ip?: string | undefined; name?: string | undefined; type: "system" | "user" | "agent" | "external"; userAgent?: string | undefined; }
   currentRate: number
   limitRate: number
   requestId?: string | undefined
@@ -6707,7 +6709,7 @@ InterfaceDeclaration RateLimitReport
 TypeAliasDeclaration ReasoningDepth
   = 'minimal' | 'standard' | 'extended'
 VariableDeclaration ReasoningDepthSchema
-  : z.ZodEnum<{ standard: "standard"; minimal: "minimal"; extended: "extended"; }>
+  : z.ZodEnum<{ extended: "extended"; minimal: "minimal"; standard: "standard"; }>
 TypeAliasDeclaration ReasoningKnowledgeType
   = 'reasoning' | 'knowledge' | 'unknown'
 InterfaceDeclaration ReasoningNode
@@ -6734,13 +6736,13 @@ InterfaceDeclaration ReasoningNodeMetadata
   readonly source?: string | undefined
   readonly tokensUsed?: number | undefined
 VariableDeclaration ReasoningNodeMetadataSchema
-  : z.ZodObject<{ source: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodOptional<z.ZodNumber>; generationTimeMs: z.ZodOptional<z.ZodNumber>; crossReferences: z.ZodOptional<z.ZodArray<z.ZodString>>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>
+  : z.ZodObject<{ crossReferences: z.ZodOptional<z.ZodArray<z.ZodString>>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; generationTimeMs: z.ZodOptional<z.ZodNumber>; source: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 VariableDeclaration ReasoningNodeSchema
-  : z.ZodObject<{ id: z.ZodString; treeId: z.ZodString; parentId: z.ZodNullable<z.ZodString>; children: z.ZodArray<z.ZodString>; depth: z.ZodNumber; stepType: z.ZodEnum<{ inference: "inference"; hypothesis: "hypothesis"; decomposition: "decomposition"; synthesis: "synthesis"; verification: "verification"; conclusion: "conclusion"; }>; content: z.ZodString; metadata: z.ZodObject<{ source: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodOptional<z.ZodNumber>; generationTimeMs: z.ZodOptional<z.ZodNumber>; crossReferences: z.ZodOptional<z.ZodArray<z.ZodString>>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>; state: z.ZodEnum<{ pending: "pending"; completed: "completed"; error: "error"; active: "active"; pruned: "pruned"; }>; isActive: z.ZodBoolean; activationScore: z.ZodNumber; confidence: z.ZodNumber; qualityScore: z.ZodNumber; estimatedValue: z.ZodNumber; createdAt: z.ZodNumber; updatedAt: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ activationScore: z.ZodNumber; children: z.ZodArray<z.ZodString>; confidence: z.ZodNumber; content: z.ZodString; createdAt: z.ZodNumber; depth: z.ZodNumber; estimatedValue: z.ZodNumber; id: z.ZodString; isActive: z.ZodBoolean; metadata: z.ZodObject<{ crossReferences: z.ZodOptional<z.ZodArray<z.ZodString>>; custom: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; generationTimeMs: z.ZodOptional<z.ZodNumber>; source: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>; parentId: z.ZodNullable<z.ZodString>; qualityScore: z.ZodNumber; state: z.ZodEnum<{ active: "active"; completed: "completed"; error: "error"; pending: "pending"; pruned: "pruned"; }>; stepType: z.ZodEnum<{ conclusion: "conclusion"; decomposition: "decomposition"; hypothesis: "hypothesis"; inference: "inference"; synthesis: "synthesis"; verification: "verification"; }>; treeId: z.ZodString; updatedAt: z.ZodNumber; }, z.core.$strip>
 TypeAliasDeclaration ReasoningStepType
   = | 'hypothesis' | 'inference' | 'decomposition' | 'synthesis' | 'verification' | 'conclusion'
 VariableDeclaration ReasoningStepTypeSchema
-  : z.ZodEnum<{ inference: "inference"; hypothesis: "hypothesis"; decomposition: "decomposition"; synthesis: "synthesis"; verification: "verification"; conclusion: "conclusion"; }>
+  : z.ZodEnum<{ conclusion: "conclusion"; decomposition: "decomposition"; hypothesis: "hypothesis"; inference: "inference"; synthesis: "synthesis"; verification: "verification"; }>
 InterfaceDeclaration ReasoningTree
   readonly bestPaths: readonly PathScore[]
   readonly createdAt: number
@@ -6755,7 +6757,7 @@ InterfaceDeclaration ReasoningTree
   readonly statistics: TreeStatistics
   readonly updatedAt: number
 VariableDeclaration ReasoningTreeSchema
-  : z.ZodObject<{ id: z.ZodString; forestId: z.ZodString; rootId: z.ZodString; state: z.ZodEnum<{ completed: "completed"; paused: "paused"; growing: "growing"; abandoned: "abandoned"; }>; overallScore: z.ZodNumber; explorationPriority: z.ZodNumber; hypothesis: z.ZodString; statistics: z.ZodObject<{ totalNodes: z.ZodNumber; activeNodes: z.ZodNumber; maxDepth: z.ZodNumber; avgQualityScore: z.ZodNumber; avgConfidence: z.ZodNumber; conclusionCount: z.ZodNumber; totalTokensUsed: z.ZodNumber; avgBranchingFactor: z.ZodNumber; }, z.core.$strip>; createdAt: z.ZodNumber; updatedAt: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ createdAt: z.ZodNumber; explorationPriority: z.ZodNumber; forestId: z.ZodString; hypothesis: z.ZodString; id: z.ZodString; overallScore: z.ZodNumber; rootId: z.ZodString; state: z.ZodEnum<{ abandoned: "abandoned"; completed: "completed"; growing: "growing"; paused: "paused"; }>; statistics: z.ZodObject<{ activeNodes: z.ZodNumber; avgBranchingFactor: z.ZodNumber; avgConfidence: z.ZodNumber; avgQualityScore: z.ZodNumber; conclusionCount: z.ZodNumber; maxDepth: z.ZodNumber; totalNodes: z.ZodNumber; totalTokensUsed: z.ZodNumber; }, z.core.$strip>; updatedAt: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration RecContext
   readonly categoryFilter: ReadonlySet<string> | null
   readonly ciProvider: string | null
@@ -6914,7 +6916,7 @@ FunctionDeclaration registerTools
 FunctionDeclaration registerWeatherReportTool
   : typeof registerWeatherReportTool
 TypeAliasDeclaration RegistrationError
-  = | { readonly type: 'duplicate_id'; readonly pluginId: string } | { readonly type: 'invalid_manifest'; readonly message: string } | { readonly type: 'missing_capability'; readonly capability: string; } | { readonly type: 'validation_failed'; readonly message: string } | { readonly type: 'registry_frozen' }
+  = | { readonly pluginId: string; readonly type: 'duplicate_id'; } | { readonly message: string; readonly type: 'invalid_manifest'; } | { readonly capability: string; readonly type: 'missing_capability'; } | { readonly message: string; readonly type: 'validation_failed'; } | { readonly type: 'registry_frozen'; }
 InterfaceDeclaration RegistryDomainStats
   count: number | null
   domain: string
@@ -6925,7 +6927,7 @@ TypeAliasDeclaration RegistryImportDeps
 TypeAliasDeclaration RegistryImportInput
   = z.infer<typeof RegistryImportInputSchema>
 VariableDeclaration RegistryImportInputSchema
-  : z.ZodObject<{ provider: z.ZodEnum<{ anthropic: "anthropic"; openai: "openai"; google: "google"; }>; modelId: z.ZodString; dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; }, z.core.$strip>
+  : z.ZodObject<{ dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; modelId: z.ZodString; provider: z.ZodEnum<{ anthropic: "anthropic"; google: "google"; openai: "openai"; }>; }, z.core.$strip>
 InterfaceDeclaration RegistryRelationship
   readonly target: string
   readonly type: "uses" | "supersedes" | "bundles" | "competes-with"
@@ -6956,7 +6958,7 @@ VariableDeclaration REJECTION_CATEGORIES
 TypeAliasDeclaration RejectionCategory
   = z.infer<typeof RejectionCategorySchema>
 VariableDeclaration RejectionCategorySchema
-  : z.ZodEnum<{ YAGNI: "YAGNI"; DRY_VIOLATION: "DRY_VIOLATION"; OVER_ENGINEERING: "OVER_ENGINEERING"; SCOPE_CREEP: "SCOPE_CREEP"; SECURITY_RISK: "SECURITY_RISK"; MISALIGNED: "MISALIGNED"; INSUFFICIENT_EVIDENCE: "INSUFFICIENT_EVIDENCE"; }>
+  : z.ZodEnum<{ DRY_VIOLATION: "DRY_VIOLATION"; INSUFFICIENT_EVIDENCE: "INSUFFICIENT_EVIDENCE"; MISALIGNED: "MISALIGNED"; OVER_ENGINEERING: "OVER_ENGINEERING"; SCOPE_CREEP: "SCOPE_CREEP"; SECURITY_RISK: "SECURITY_RISK"; YAGNI: "YAGNI"; }>
 InterfaceDeclaration RelevanceFilterConfig
   readonly maxEntriesPerType: number
   readonly minRelevanceScore: number
@@ -6983,7 +6985,7 @@ TypeAliasDeclaration RepoAnalyzeDeps
 TypeAliasDeclaration RepoAnalyzeInput
   = z.infer<typeof RepoAnalyzeInputSchema>
 VariableDeclaration RepoAnalyzeInputSchema
-  : z.ZodObject<{ repo: z.ZodString; depth: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ shallow: "shallow"; deep: "deep"; }>>>; }, z.core.$strip>
+  : z.ZodObject<{ depth: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ deep: "deep"; shallow: "shallow"; }>>>; repo: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration ReportOptions
   readonly comparison?: BenchmarkComparison | undefined
   readonly consolidation?: ConsolidationBenchmarkResult | undefined
@@ -7004,7 +7006,7 @@ TypeAliasDeclaration RepoSecurityPlanDeps
 TypeAliasDeclaration RepoSecurityPlanInput
   = z.infer<typeof RepoSecurityPlanInputSchema>
 VariableDeclaration RepoSecurityPlanInputSchema
-  : z.ZodObject<{ repo: z.ZodString; categories: z.ZodOptional<z.ZodArray<z.ZodString>>; maxScanners: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; }, z.core.$strip>
+  : z.ZodObject<{ categories: z.ZodOptional<z.ZodArray<z.ZodString>>; maxScanners: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; repo: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration ReputationAssessment
   readonly assessedAt: string
   readonly effectiveTrustTier: "1" | "2" | "3" | "4"
@@ -7048,7 +7050,7 @@ TypeAliasDeclaration ResearchAddDeps
 TypeAliasDeclaration ResearchAddInput
   = z.infer<typeof ResearchAddInputSchema>
 VariableDeclaration ResearchAddInputSchema
-  : z.ZodObject<{ arxivId: z.ZodString; topic: z.ZodOptional<z.ZodString>; priority: z.ZodOptional<z.ZodEnum<{ P1: "P1"; P2: "P2"; P3: "P3"; P4: "P4"; }>>; dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; }, z.core.$strip>
+  : z.ZodObject<{ arxivId: z.ZodString; dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; priority: z.ZodOptional<z.ZodEnum<{ P1: "P1"; P2: "P2"; P3: "P3"; P4: "P4"; }>>; topic: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 InterfaceDeclaration ResearchAddResponse
   dryRun: boolean
   errorCategory?: "validation" | "transient" | "permission" | "business" | "internal" | undefined
@@ -7061,7 +7063,7 @@ TypeAliasDeclaration ResearchAddSourceDeps
 TypeAliasDeclaration ResearchAddSourceInput
   = z.infer<typeof ResearchAddSourceInputSchema>
 VariableDeclaration ResearchAddSourceInputSchema
-  : z.ZodObject<{ url: z.ZodString; name: z.ZodString; type: z.ZodEnum<{ product_docs: "product_docs"; specification: "specification"; research_blog: "research_blog"; code_analysis: "code_analysis"; open_source_repo: "open_source_repo"; }>; vendor: z.ZodOptional<z.ZodString>; topics: z.ZodOptional<z.ZodArray<z.ZodString>>; tags: z.ZodOptional<z.ZodArray<z.ZodString>>; quality_signals: z.ZodOptional<z.ZodObject<{ stars_at_review: z.ZodOptional<z.ZodNumber>; language: z.ZodOptional<z.ZodString>; has_tests: z.ZodOptional<z.ZodBoolean>; has_docs: z.ZodOptional<z.ZodBoolean>; has_paper: z.ZodOptional<z.ZodBoolean>; }, z.core.$strip>>; techniques_extracted: z.ZodOptional<z.ZodArray<z.ZodString>>; verdict: z.ZodOptional<z.ZodEnum<{ rejected: "rejected"; adopted: "adopted"; partially_adopted: "partially_adopted"; monitoring: "monitoring"; planned: "planned"; }>>; verdict_notes: z.ZodOptional<z.ZodString>; dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; }, z.core.$strip>
+  : z.ZodObject<{ dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; name: z.ZodString; quality_signals: z.ZodOptional<z.ZodObject<{ has_docs: z.ZodOptional<z.ZodBoolean>; has_paper: z.ZodOptional<z.ZodBoolean>; has_tests: z.ZodOptional<z.ZodBoolean>; language: z.ZodOptional<z.ZodString>; stars_at_review: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; tags: z.ZodOptional<z.ZodArray<z.ZodString>>; techniques_extracted: z.ZodOptional<z.ZodArray<z.ZodString>>; topics: z.ZodOptional<z.ZodArray<z.ZodString>>; type: z.ZodEnum<{ code_analysis: "code_analysis"; open_source_repo: "open_source_repo"; product_docs: "product_docs"; research_blog: "research_blog"; specification: "specification"; }>; url: z.ZodString; vendor: z.ZodOptional<z.ZodString>; verdict_notes: z.ZodOptional<z.ZodString>; verdict: z.ZodOptional<z.ZodEnum<{ adopted: "adopted"; monitoring: "monitoring"; partially_adopted: "partially_adopted"; planned: "planned"; rejected: "rejected"; }>>; }, z.core.$strip>
 InterfaceDeclaration ResearchAddSourceResponse
   dryRun: boolean
   errorCategory?: "validation" | "transient" | "permission" | "business" | "internal" | undefined
@@ -7076,7 +7078,7 @@ TypeAliasDeclaration ResearchAnalyzeDeps
 TypeAliasDeclaration ResearchAnalyzeInput
   = z.infer<typeof ResearchAnalyzeInputSchema>
 VariableDeclaration ResearchAnalyzeInputSchema
-  : z.ZodObject<{ focus: z.ZodEnum<{ gaps: "gaps"; trends: "trends"; priorities: "priorities"; stale: "stale"; coverage: "coverage"; }>; topic: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ focus: z.ZodEnum<{ coverage: "coverage"; gaps: "gaps"; priorities: "priorities"; stale: "stale"; trends: "trends"; }>; topic: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 InterfaceDeclaration ResearchAnalyzeResponse
   analysis: unknown
   focus: string
@@ -7085,7 +7087,7 @@ InterfaceDeclaration ResearchAnalyzeResponse
 TypeAliasDeclaration ResearchCatalogReviewDeps
   = BaseMcpToolDeps
 VariableDeclaration ResearchCatalogReviewInputSchema
-  : z.ZodObject<{ action: z.ZodEnum<{ approve: "approve"; list: "list"; dismiss: "dismiss"; flush: "flush"; }>; identifier: z.ZodOptional<z.ZodString>; topic: z.ZodOptional<z.ZodString>; createIssue: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; }, z.core.$strip>
+  : z.ZodObject<{ action: z.ZodEnum<{ approve: "approve"; dismiss: "dismiss"; flush: "flush"; list: "list"; }>; createIssue: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; identifier: z.ZodOptional<z.ZodString>; topic: z.ZodOptional<z.ZodString>; }, z.core.$strip>
 InterfaceDeclaration ResearchContext
   readonly metadata: ResearchContextMetadata
   readonly text: string
@@ -7103,7 +7105,7 @@ InterfaceDeclaration ResearchDiscoveredItem
 TypeAliasDeclaration ResearchDiscoverInput
   = z.infer<typeof ResearchDiscoverInputSchema>
 VariableDeclaration ResearchDiscoverInputSchema
-  : z.ZodObject<{ topic: z.ZodString; source: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ github: "github"; all: "all"; arxiv: "arxiv"; google_ai: "google_ai"; meta_fair: "meta_fair"; microsoft: "microsoft"; deepmind: "deepmind"; semantic_scholar: "semantic_scholar"; papers_with_code: "papers_with_code"; openalex: "openalex"; }>>>; maxResults: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; sinceDate: z.ZodOptional<z.ZodString>; relevanceThreshold: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; }, z.core.$strip>
+  : z.ZodObject<{ maxResults: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; relevanceThreshold: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; sinceDate: z.ZodOptional<z.ZodString>; source: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ all: "all"; arxiv: "arxiv"; deepmind: "deepmind"; github: "github"; google_ai: "google_ai"; meta_fair: "meta_fair"; microsoft: "microsoft"; openalex: "openalex"; papers_with_code: "papers_with_code"; semantic_scholar: "semantic_scholar"; }>>>; topic: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration ResearchDiscoverResponse
   alreadyInRegistry: number
   failedSources: string[]
@@ -7132,7 +7134,7 @@ TypeAliasDeclaration ResearchQueryDeps
 TypeAliasDeclaration ResearchQueryInput
   = z.infer<typeof ResearchQueryInputSchema>
 VariableDeclaration ResearchQueryInputSchema
-  : z.ZodObject<{ action: z.ZodEnum<{ status: "status"; overlap: "overlap"; stats: "stats"; search: "search"; }>; techniqueId: z.ZodOptional<z.ZodString>; query: z.ZodOptional<z.ZodString>; status: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ all: "all"; rejected: "rejected"; planned: "planned"; implemented: "implemented"; "not-started": "not-started"; }>>>; threshold: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; }, z.core.$strip>
+  : z.ZodObject<{ action: z.ZodEnum<{ overlap: "overlap"; search: "search"; stats: "stats"; status: "status"; }>; query: z.ZodOptional<z.ZodString>; status: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ "not-started": "not-started"; all: "all"; implemented: "implemented"; planned: "planned"; rejected: "rejected"; }>>>; techniqueId: z.ZodOptional<z.ZodString>; threshold: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; }, z.core.$strip>
 InterfaceDeclaration ResearchQueryResponse
   action: string
   data: unknown
@@ -7257,9 +7259,9 @@ InterfaceDeclaration ResourceUsage
   readonly processCount: number
   readonly wallTimeMs: number
 TypeAliasDeclaration ResponseFormat
-  = | { type: 'text' } | { type: 'json_object' } | { type: 'json_schema'; schema: Record<string, unknown> }
+  = | { type: 'text'; } | { type: 'json_object'; } | { schema: Record<string, unknown>; type: 'json_schema'; }
 TypeAliasDeclaration Result
-  = | { readonly ok: true; readonly value: T } | { readonly ok: false; readonly error: E }
+  = | { readonly ok: true; readonly value: T; } | { readonly error: E; readonly ok: false; }
 ClassDeclaration ResultAggregator
   aggregate(input: AggregatorInput) => Result<AggregatedResult, AgentError>
 InterfaceDeclaration ResultBuildOpts
@@ -7336,13 +7338,13 @@ InterfaceDeclaration ReviewResponseMessage
   suggestions?: string[] | undefined
   type: "review_response"
 VariableDeclaration ReviewResponseMessageSchema
-  : z.ZodObject<{ type: z.ZodLiteral<"review_response">; reviewerId: z.ZodString; requesterId: z.ZodString; approved: z.ZodBoolean; feedback: z.ZodString; suggestions: z.ZodOptional<z.ZodArray<z.ZodString>>; severity: z.ZodOptional<z.ZodEnum<{ critical: "critical"; none: "none"; major: "major"; minor: "minor"; }>>; }, z.core.$strip>
+  : z.ZodObject<{ approved: z.ZodBoolean; feedback: z.ZodString; requesterId: z.ZodString; reviewerId: z.ZodString; severity: z.ZodOptional<z.ZodEnum<{ critical: "critical"; major: "major"; minor: "minor"; none: "none"; }>>; suggestions: z.ZodOptional<z.ZodArray<z.ZodString>>; type: z.ZodLiteral<"review_response">; }, z.core.$strip>
 VariableDeclaration RISK_AWARENESS_CATEGORY
   : SafetyCategory
 VariableDeclaration RiskLevel
-  : { readonly LOW: "low"; readonly MEDIUM: "medium"; readonly HIGH: "high"; readonly CRITICAL: "critical"; }
+  : { readonly CRITICAL: "critical"; readonly HIGH: "high"; readonly LOW: "low"; readonly MEDIUM: "medium"; }
 VariableDeclaration RiskLevelSchema
-  : z.ZodEnum<{ critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>
+  : z.ZodEnum<{ critical: "critical"; high: "high"; low: "low"; medium: "medium"; }>
 TypeAliasDeclaration RiskLevelType
   = (typeof RiskLevel)[keyof typeof RiskLevel]
 VariableDeclaration ROBUSTNESS_CATEGORY
@@ -7441,7 +7443,7 @@ ClassDeclaration RoutingMemory
   getRecommendation(taskType: string) => CliName | undefined
   getResearchMaturityReport() => ResearchMaturityReport
   getStats() => RoutingMemoryStats
-  recordExperience(workflow: string, models: readonly CliName[], success: boolean, metrics: { durationMs: number; tokensUsed: number; qualityScore?: number; researchMaturity?: number; }) => void
+  recordExperience(workflow: string, models: readonly CliName[], success: boolean, metrics: { durationMs: number; qualityScore?: number; researchMaturity?: number; tokensUsed: number; }) => void
   storePreference(model: CliName, taskType: string, performance: ModelPerformance) => void
 InterfaceDeclaration RoutingMemoryConfig
   readonly actionCacheMaxAgeMs: number
@@ -7510,7 +7512,7 @@ InterfaceDeclaration RoutingRecord
 TypeAliasDeclaration RulesSnapshot
   = z.infer<typeof RulesSnapshotSchema>
 VariableDeclaration RulesSnapshotSchema
-  : z.ZodObject<{ version: z.ZodLiteral<1>; savedAt: z.ZodString; rules: z.ZodArray<z.ZodObject<{ id: z.ZodString; patternType: z.ZodEnum<{ "failure-rate": "failure-rate"; "success-rate": "success-rate"; "latency-spike": "latency-spike"; }>; cli: z.ZodEnum<{ claude: "claude"; gemini: "gemini"; codex: "codex"; opencode: "opencode"; }>; category: z.ZodString; action: z.ZodEnum<{ penalize: "penalize"; boost: "boost"; avoid: "avoid"; }>; confidence: z.ZodNumber; observationCount: z.ZodNumber; metric: z.ZodNumber; status: z.ZodEnum<{ active: "active"; draft: "draft"; promoted: "promoted"; expired: "expired"; }>; createdAt: z.ZodNumber; updatedAt: z.ZodNumber; tainted: z.ZodBoolean; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ rules: z.ZodArray<z.ZodObject<{ action: z.ZodEnum<{ avoid: "avoid"; boost: "boost"; penalize: "penalize"; }>; category: z.ZodString; cli: z.ZodEnum<{ claude: "claude"; codex: "codex"; gemini: "gemini"; opencode: "opencode"; }>; confidence: z.ZodNumber; createdAt: z.ZodNumber; id: z.ZodString; metric: z.ZodNumber; observationCount: z.ZodNumber; patternType: z.ZodEnum<{ "failure-rate": "failure-rate"; "latency-spike": "latency-spike"; "success-rate": "success-rate"; }>; status: z.ZodEnum<{ active: "active"; draft: "draft"; expired: "expired"; promoted: "promoted"; }>; tainted: z.ZodBoolean; updatedAt: z.ZodNumber; }, z.core.$strip>>; savedAt: z.ZodString; version: z.ZodLiteral<1>; }, z.core.$strip>
 TypeAliasDeclaration RuleStatus
   = 'draft' | 'active' | 'promoted' | 'expired'
 FunctionDeclaration runAdapterLatencyBenchmark
@@ -7556,7 +7558,7 @@ InterfaceDeclaration RunGraphWorkflowDeps
 TypeAliasDeclaration RunGraphWorkflowInput
   = z.infer<typeof RunGraphWorkflowInputSchema>
 VariableDeclaration RunGraphWorkflowInputSchema
-  : z.ZodObject<{ workflow: z.ZodString; inputs: z.ZodDefault<z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>>; enableCheckpointing: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; enableAuditTrail: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; dispatch: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ sync: "sync"; async: "async"; }>>>; }, z.core.$strip>
+  : z.ZodObject<{ dispatch: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ async: "async"; sync: "sync"; }>>>; enableAuditTrail: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; enableCheckpointing: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; inputs: z.ZodDefault<z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>>; workflow: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration RunGraphWorkflowResponse
   readonly checkpointCount: number
   readonly durationMs: number
@@ -7589,7 +7591,7 @@ InterfaceDeclaration RunWorkflowDeps
 TypeAliasDeclaration RunWorkflowInput
   = z.infer<typeof RunWorkflowInputSchema>
 VariableDeclaration RunWorkflowInputSchema
-  : z.ZodObject<{ template: z.ZodString; inputs: z.ZodRecord<z.ZodString, z.ZodUnknown>; dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; timeoutMs: z.ZodOptional<z.ZodNumber>; mode: z.ZodOptional<z.ZodEnum<{ sync: "sync"; async: "async"; }>>; idempotencyKey: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ dryRun: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; idempotencyKey: z.ZodOptional<z.ZodString>; inputs: z.ZodRecord<z.ZodString, z.ZodUnknown>; mode: z.ZodOptional<z.ZodEnum<{ async: "async"; sync: "sync"; }>>; template: z.ZodString; timeoutMs: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 VariableDeclaration safePathsRule
   : PolicyRule
 VariableDeclaration SAFETY_CATEGORIES
@@ -7607,13 +7609,13 @@ InterfaceDeclaration SafetyCategory
   readonly name: string
   readonly parentId?: SafetyCategoryIdType | undefined
 VariableDeclaration SafetyCategoryId
-  : { readonly HARM_PHYSICAL: "harm_physical"; readonly HARM_EMOTIONAL: "harm_emotional"; readonly HARM_FINANCIAL: "harm_financial"; readonly DECEPTION: "deception"; readonly BIAS: "bias"; readonly PRIVACY: "privacy"; readonly MANIPULATION: "manipulation"; readonly INSTRUCTION_SAFETY: "instruction_safety"; readonly ROBUSTNESS: "robustness"; readonly RISK_AWARENESS: "risk_awareness"; }
+  : { readonly BIAS: "bias"; readonly DECEPTION: "deception"; readonly HARM_EMOTIONAL: "harm_emotional"; readonly HARM_FINANCIAL: "harm_financial"; readonly HARM_PHYSICAL: "harm_physical"; readonly INSTRUCTION_SAFETY: "instruction_safety"; readonly MANIPULATION: "manipulation"; readonly PRIVACY: "privacy"; readonly RISK_AWARENESS: "risk_awareness"; readonly ROBUSTNESS: "robustness"; }
 VariableDeclaration SafetyCategoryIdSchema
-  : z.ZodEnum<{ harm_physical: "harm_physical"; harm_emotional: "harm_emotional"; harm_financial: "harm_financial"; deception: "deception"; bias: "bias"; privacy: "privacy"; manipulation: "manipulation"; instruction_safety: "instruction_safety"; robustness: "robustness"; risk_awareness: "risk_awareness"; }>
+  : z.ZodEnum<{ bias: "bias"; deception: "deception"; harm_emotional: "harm_emotional"; harm_financial: "harm_financial"; harm_physical: "harm_physical"; instruction_safety: "instruction_safety"; manipulation: "manipulation"; privacy: "privacy"; risk_awareness: "risk_awareness"; robustness: "robustness"; }>
 TypeAliasDeclaration SafetyCategoryIdType
   = (typeof SafetyCategoryId)[keyof typeof SafetyCategoryId]
 VariableDeclaration SafetyCategorySchema
-  : z.ZodObject<{ id: z.ZodEnum<{ harm_physical: "harm_physical"; harm_emotional: "harm_emotional"; harm_financial: "harm_financial"; deception: "deception"; bias: "bias"; privacy: "privacy"; manipulation: "manipulation"; instruction_safety: "instruction_safety"; robustness: "robustness"; risk_awareness: "risk_awareness"; }>; name: z.ZodString; description: z.ZodString; defaultRiskLevel: z.ZodEnum<{ critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>; parentId: z.ZodOptional<z.ZodEnum<{ harm_physical: "harm_physical"; harm_emotional: "harm_emotional"; harm_financial: "harm_financial"; deception: "deception"; bias: "bias"; privacy: "privacy"; manipulation: "manipulation"; instruction_safety: "instruction_safety"; robustness: "robustness"; risk_awareness: "risk_awareness"; }>>; criteria: z.ZodReadonly<z.ZodArray<z.ZodObject<{ id: z.ZodString; name: z.ZodString; description: z.ZodString; type: z.ZodEnum<{ binary: "binary"; scaled: "scaled"; threshold: "threshold"; categorical: "categorical"; }>; weight: z.ZodNumber; passThreshold: z.ZodOptional<z.ZodNumber>; categories: z.ZodOptional<z.ZodReadonly<z.ZodArray<z.ZodString>>>; }, z.core.$strip>>>; exampleTestCases: z.ZodReadonly<z.ZodArray<z.ZodObject<{ id: z.ZodString; name: z.ZodString; description: z.ZodString; input: z.ZodString; expectedOutcome: z.ZodEnum<{ refuse: "refuse"; caution: "caution"; clarify: "clarify"; escalate: "escalate"; proceed: "proceed"; detect: "detect"; }>; riskLevel: z.ZodEnum<{ critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>; tags: z.ZodReadonly<z.ZodArray<z.ZodString>>; context: z.ZodOptional<z.ZodString>; }, z.core.$strip>>>; failureModes: z.ZodReadonly<z.ZodArray<z.ZodString>>; mitigationStrategies: z.ZodReadonly<z.ZodArray<z.ZodString>>; }, z.core.$strip>
+  : z.ZodObject<{ criteria: z.ZodReadonly<z.ZodArray<z.ZodObject<{ categories: z.ZodOptional<z.ZodReadonly<z.ZodArray<z.ZodString>>>; description: z.ZodString; id: z.ZodString; name: z.ZodString; passThreshold: z.ZodOptional<z.ZodNumber>; type: z.ZodEnum<{ binary: "binary"; categorical: "categorical"; scaled: "scaled"; threshold: "threshold"; }>; weight: z.ZodNumber; }, z.core.$strip>>>; defaultRiskLevel: z.ZodEnum<{ critical: "critical"; high: "high"; low: "low"; medium: "medium"; }>; description: z.ZodString; exampleTestCases: z.ZodReadonly<z.ZodArray<z.ZodObject<{ context: z.ZodOptional<z.ZodString>; description: z.ZodString; expectedOutcome: z.ZodEnum<{ caution: "caution"; clarify: "clarify"; detect: "detect"; escalate: "escalate"; proceed: "proceed"; refuse: "refuse"; }>; id: z.ZodString; input: z.ZodString; name: z.ZodString; riskLevel: z.ZodEnum<{ critical: "critical"; high: "high"; low: "low"; medium: "medium"; }>; tags: z.ZodReadonly<z.ZodArray<z.ZodString>>; }, z.core.$strip>>>; failureModes: z.ZodReadonly<z.ZodArray<z.ZodString>>; id: z.ZodEnum<{ bias: "bias"; deception: "deception"; harm_emotional: "harm_emotional"; harm_financial: "harm_financial"; harm_physical: "harm_physical"; instruction_safety: "instruction_safety"; manipulation: "manipulation"; privacy: "privacy"; risk_awareness: "risk_awareness"; robustness: "robustness"; }>; mitigationStrategies: z.ZodReadonly<z.ZodArray<z.ZodString>>; name: z.ZodString; parentId: z.ZodOptional<z.ZodEnum<{ bias: "bias"; deception: "deception"; harm_emotional: "harm_emotional"; harm_financial: "harm_financial"; harm_physical: "harm_physical"; instruction_safety: "instruction_safety"; manipulation: "manipulation"; privacy: "privacy"; risk_awareness: "risk_awareness"; robustness: "robustness"; }>>; }, z.core.$strip>
 InterfaceDeclaration SafetyTaxonomySummary
   readonly categoriesByRiskLevel: Readonly<Record<RiskLevelType, number>>
   readonly testCasesByOutcome: Readonly<Record<ExpectedOutcomeType, number>>
@@ -7630,7 +7632,7 @@ InterfaceDeclaration SafetyTestCase
   readonly riskLevel: RiskLevelType
   readonly tags: readonly string[]
 VariableDeclaration SafetyTestCaseSchema
-  : z.ZodObject<{ id: z.ZodString; name: z.ZodString; description: z.ZodString; input: z.ZodString; expectedOutcome: z.ZodEnum<{ refuse: "refuse"; caution: "caution"; clarify: "clarify"; escalate: "escalate"; proceed: "proceed"; detect: "detect"; }>; riskLevel: z.ZodEnum<{ critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>; tags: z.ZodReadonly<z.ZodArray<z.ZodString>>; context: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ context: z.ZodOptional<z.ZodString>; description: z.ZodString; expectedOutcome: z.ZodEnum<{ caution: "caution"; clarify: "clarify"; detect: "detect"; escalate: "escalate"; proceed: "proceed"; refuse: "refuse"; }>; id: z.ZodString; input: z.ZodString; name: z.ZodString; riskLevel: z.ZodEnum<{ critical: "critical"; high: "high"; low: "low"; medium: "medium"; }>; tags: z.ZodReadonly<z.ZodArray<z.ZodString>>; }, z.core.$strip>
 FunctionDeclaration safeValidateExpertConfig
   : typeof safeValidateExpertConfig
 InterfaceDeclaration SandboxConfig
@@ -7673,7 +7675,7 @@ FunctionDeclaration sanitize
 TypeAliasDeclaration SanitizedInput
   = z.infer<typeof SanitizedInputSchema>
 VariableDeclaration SanitizedInputSchema
-  : z.ZodObject<{ content: z.ZodString; originalLength: z.ZodNumber; trustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; userRole: z.ZodEnum<{ unknown: "unknown"; maintainer: "maintainer"; owner: "owner"; collaborator: "collaborator"; contributor: "contributor"; member: "member"; }>; injectionFlags: z.ZodArray<z.ZodEnum<{ authority_claim: "authority_claim"; instruction_pattern: "instruction_pattern"; system_prompt_manipulation: "system_prompt_manipulation"; hidden_content: "hidden_content"; urgency_manipulation: "urgency_manipulation"; fake_conversation: "fake_conversation"; base64_encoded: "base64_encoded"; external_link_instruction: "external_link_instruction"; }>>; strippedElements: z.ZodArray<z.ZodObject<{ tag: z.ZodString; reason: z.ZodString; startIndex: z.ZodNumber; length: z.ZodNumber; }, z.core.$strip>>; wasModified: z.ZodBoolean; sanitizedAt: z.ZodISODateTime; }, z.core.$strip>
+  : z.ZodObject<{ content: z.ZodString; injectionFlags: z.ZodArray<z.ZodEnum<{ authority_claim: "authority_claim"; base64_encoded: "base64_encoded"; external_link_instruction: "external_link_instruction"; fake_conversation: "fake_conversation"; hidden_content: "hidden_content"; instruction_pattern: "instruction_pattern"; system_prompt_manipulation: "system_prompt_manipulation"; urgency_manipulation: "urgency_manipulation"; }>>; originalLength: z.ZodNumber; sanitizedAt: z.ZodISODateTime; strippedElements: z.ZodArray<z.ZodObject<{ length: z.ZodNumber; reason: z.ZodString; startIndex: z.ZodNumber; tag: z.ZodString; }, z.core.$strip>>; trustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; userRole: z.ZodEnum<{ collaborator: "collaborator"; contributor: "contributor"; maintainer: "maintainer"; member: "member"; owner: "owner"; unknown: "unknown"; }>; wasModified: z.ZodBoolean; }, z.core.$strip>
 FunctionDeclaration sanitizeInput
   : typeof sanitizeInput
 TypeAliasDeclaration SanitizerConfig
@@ -7712,7 +7714,7 @@ InterfaceDeclaration ScenarioError
 TypeAliasDeclaration ScenarioResult
   = z.infer<typeof ScenarioResultSchema>
 VariableDeclaration ScenarioResultSchema
-  : z.ZodObject<{ satisfaction: z.ZodNumber; totalCriteria: z.ZodNumber; metCount: z.ZodNumber; criteria: z.ZodArray<z.ZodObject<{ criterion: z.ZodString; met: z.ZodBoolean; matchedResults: z.ZodArray<z.ZodString>; }, z.core.$strip>>; allMet: z.ZodBoolean; }, z.core.$strip>
+  : z.ZodObject<{ allMet: z.ZodBoolean; criteria: z.ZodArray<z.ZodObject<{ criterion: z.ZodString; matchedResults: z.ZodArray<z.ZodString>; met: z.ZodBoolean; }, z.core.$strip>>; metCount: z.ZodNumber; satisfaction: z.ZodNumber; totalCriteria: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration ScmComment
   readonly author: string
   readonly body: string
@@ -7777,7 +7779,7 @@ InterfaceDeclaration ScoreBreakdown
   finalScore: number
   weightScore: number
 VariableDeclaration ScoreBreakdownSchema
-  : z.ZodObject<{ capabilityScore: z.ZodNumber; domainScore: z.ZodNumber; weightScore: z.ZodNumber; finalScore: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ capabilityScore: z.ZodNumber; domainScore: z.ZodNumber; finalScore: z.ZodNumber; weightScore: z.ZodNumber; }, z.core.$strip>
 FunctionDeclaration scoreByHybrid
   : typeof scoreByHybrid
 FunctionDeclaration scoreByImportance
@@ -7801,11 +7803,11 @@ TypeAliasDeclaration SdkProviderId
 TypeAliasDeclaration SearchCodebaseDeps
   = BaseMcpToolDeps
 VariableDeclaration SearchCodebaseInputSchema
-  : z.ZodObject<{ query: z.ZodString; directory: z.ZodOptional<z.ZodString>; limit: z.ZodOptional<z.ZodNumber>; mode: z.ZodOptional<z.ZodEnum<{ summary: "summary"; list: "list"; search: "search"; }>>; maxDepth: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ directory: z.ZodOptional<z.ZodString>; limit: z.ZodOptional<z.ZodNumber>; maxDepth: z.ZodOptional<z.ZodNumber>; mode: z.ZodOptional<z.ZodEnum<{ list: "list"; search: "search"; summary: "summary"; }>>; query: z.ZodString; }, z.core.$strip>
 TypeAliasDeclaration SearchUsagesDeps
   = BaseMcpToolDeps
 VariableDeclaration SearchUsagesInputSchema
-  : z.ZodObject<{ symbol: z.ZodString; path: z.ZodOptional<z.ZodString>; dir: z.ZodOptional<z.ZodString>; lang: z.ZodOptional<z.ZodEnum<{ typescript: "typescript"; tsx: "tsx"; javascript: "javascript"; }>>; limit: z.ZodOptional<z.ZodNumber>; maxDepth: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ dir: z.ZodOptional<z.ZodString>; lang: z.ZodOptional<z.ZodEnum<{ javascript: "javascript"; tsx: "tsx"; typescript: "typescript"; }>>; limit: z.ZodOptional<z.ZodNumber>; maxDepth: z.ZodOptional<z.ZodNumber>; path: z.ZodOptional<z.ZodString>; symbol: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration SecurityAnalysisResult
   compliance?: ComplianceStatus | undefined
   securityScore: number
@@ -7815,14 +7817,14 @@ TypeAliasDeclaration SecurityCapability
 TypeAliasDeclaration SecurityConfig
   = z.infer<typeof SecurityConfigSchema>
 VariableDeclaration SecurityConfigSchema
-  : z.ZodObject<{ allowedPaths: z.ZodDefault<z.ZodArray<z.ZodString>>; blockedPatterns: z.ZodDefault<z.ZodArray<z.ZodString>>; rateLimit: z.ZodDefault<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; requestsPerMinute: z.ZodDefault<z.ZodNumber>; perTool: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ capacity: z.ZodDefault<z.ZodNumber>; refillRate: z.ZodDefault<z.ZodNumber>; refillIntervalMs: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; }, z.core.$strip>>; secretsFile: z.ZodOptional<z.ZodString>; policy: z.ZodOptional<z.ZodObject<{ defaultMode: z.ZodDefault<z.ZodEnum<{ "read-only": "read-only"; "read-write": "read-write"; }>>; policyMode: z.ZodDefault<z.ZodEnum<{ warn: "warn"; enforce: "enforce"; }>>; }, z.core.$strip>>; sandbox: z.ZodOptional<z.ZodObject<{ mode: z.ZodDefault<z.ZodEnum<{ none: "none"; policy: "policy"; container: "container"; }>>; fallbackToPolicy: z.ZodDefault<z.ZodBoolean>; dockerImage: z.ZodOptional<z.ZodString>; networkEnabled: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; timeout: z.ZodOptional<z.ZodObject<{ defaultTimeoutMs: z.ZodDefault<z.ZodNumber>; maxTimeoutMs: z.ZodDefault<z.ZodNumber>; enableLogging: z.ZodDefault<z.ZodBoolean>; uriValidation: z.ZodDefault<z.ZodBoolean>; perToolTimeout: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; }, z.core.$strip>>; toolAllowlist: z.ZodOptional<z.ZodArray<z.ZodString>>; audit: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; logDir: z.ZodOptional<z.ZodString>; minSeverity: z.ZodDefault<z.ZodEnum<{ info: "info"; warning: "warning"; critical: "critical"; }>>; enableHashChain: z.ZodDefault<z.ZodBoolean>; maxFileSizeBytes: z.ZodDefault<z.ZodNumber>; maxFiles: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; auth: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; method: z.ZodDefault<z.ZodEnum<{ token: "token"; oauth2: "oauth2"; }>>; tokenHeader: z.ZodDefault<z.ZodString>; tokenFile: z.ZodOptional<z.ZodString>; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ allowedPaths: z.ZodDefault<z.ZodArray<z.ZodString>>; audit: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; enableHashChain: z.ZodDefault<z.ZodBoolean>; logDir: z.ZodOptional<z.ZodString>; maxFiles: z.ZodDefault<z.ZodNumber>; maxFileSizeBytes: z.ZodDefault<z.ZodNumber>; minSeverity: z.ZodDefault<z.ZodEnum<{ critical: "critical"; info: "info"; warning: "warning"; }>>; }, z.core.$strip>>; auth: z.ZodOptional<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; method: z.ZodDefault<z.ZodEnum<{ oauth2: "oauth2"; token: "token"; }>>; tokenFile: z.ZodOptional<z.ZodString>; tokenHeader: z.ZodDefault<z.ZodString>; }, z.core.$strip>>; blockedPatterns: z.ZodDefault<z.ZodArray<z.ZodString>>; policy: z.ZodOptional<z.ZodObject<{ defaultMode: z.ZodDefault<z.ZodEnum<{ "read-only": "read-only"; "read-write": "read-write"; }>>; policyMode: z.ZodDefault<z.ZodEnum<{ enforce: "enforce"; warn: "warn"; }>>; }, z.core.$strip>>; rateLimit: z.ZodDefault<z.ZodObject<{ enabled: z.ZodDefault<z.ZodBoolean>; perTool: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{ capacity: z.ZodDefault<z.ZodNumber>; refillIntervalMs: z.ZodDefault<z.ZodNumber>; refillRate: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>>; requestsPerMinute: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>>; sandbox: z.ZodOptional<z.ZodObject<{ dockerImage: z.ZodOptional<z.ZodString>; fallbackToPolicy: z.ZodDefault<z.ZodBoolean>; mode: z.ZodDefault<z.ZodEnum<{ container: "container"; none: "none"; policy: "policy"; }>>; networkEnabled: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; secretsFile: z.ZodOptional<z.ZodString>; timeout: z.ZodOptional<z.ZodObject<{ defaultTimeoutMs: z.ZodDefault<z.ZodNumber>; enableLogging: z.ZodDefault<z.ZodBoolean>; maxTimeoutMs: z.ZodDefault<z.ZodNumber>; perToolTimeout: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; uriValidation: z.ZodDefault<z.ZodBoolean>; }, z.core.$strip>>; toolAllowlist: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>
 ClassDeclaration SecurityError
 TypeAliasDeclaration SecurityErrorCode
   = | 'PERMISSION_DENIED' | 'ROLE_NOT_ALLOWED' | 'ATTESTATION_REQUIRED' | 'INVALID_PROVENANCE' | 'SIGNATURE_MISMATCH' | 'EXECUTION_TIMEOUT' | 'SANDBOX_VIOLATION'
 VariableDeclaration SecurityErrorCodeSchema
-  : z.ZodEnum<{ PERMISSION_DENIED: "PERMISSION_DENIED"; ROLE_NOT_ALLOWED: "ROLE_NOT_ALLOWED"; ATTESTATION_REQUIRED: "ATTESTATION_REQUIRED"; INVALID_PROVENANCE: "INVALID_PROVENANCE"; SIGNATURE_MISMATCH: "SIGNATURE_MISMATCH"; EXECUTION_TIMEOUT: "EXECUTION_TIMEOUT"; SANDBOX_VIOLATION: "SANDBOX_VIOLATION"; }>
+  : z.ZodEnum<{ ATTESTATION_REQUIRED: "ATTESTATION_REQUIRED"; EXECUTION_TIMEOUT: "EXECUTION_TIMEOUT"; INVALID_PROVENANCE: "INVALID_PROVENANCE"; PERMISSION_DENIED: "PERMISSION_DENIED"; ROLE_NOT_ALLOWED: "ROLE_NOT_ALLOWED"; SANDBOX_VIOLATION: "SANDBOX_VIOLATION"; SIGNATURE_MISMATCH: "SIGNATURE_MISMATCH"; }>
 InterfaceDeclaration SecurityEventAuditOpts
-  actor: { type: "system" | "user" | "agent" | "external"; id: string; name?: string | undefined; ip?: string | undefined; userAgent?: string | undefined; }
+  actor: { id: string; ip?: string | undefined; name?: string | undefined; type: "system" | "user" | "agent" | "external"; userAgent?: string | undefined; }
   description: string
   eventType: string
   metadata?: Record<string, unknown> | undefined
@@ -7841,7 +7843,7 @@ InterfaceDeclaration SecurityPolicyDecision
   readonly allowed: boolean
   readonly evaluatedAt: string
   readonly requiresApproval: boolean
-  readonly violations: readonly { rule: string; message: string; severity: "warn" | "block"; }[]
+  readonly violations: readonly { message: string; rule: string; severity: "warn" | "block"; }[]
 FunctionDeclaration selectExperts
   : typeof selectExperts
 ClassDeclaration SelectionError
@@ -7859,9 +7861,9 @@ InterfaceDeclaration SelectionOptions
   minScore?: number | undefined
   preferredDomains?: ExpertTaskDomain[] | undefined
 VariableDeclaration SelectionOptionsSchema
-  : z.ZodObject<{ minScore: z.ZodOptional<z.ZodNumber>; maxAlternatives: z.ZodOptional<z.ZodNumber>; capabilityWeights: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; preferredDomains: z.ZodOptional<z.ZodArray<z.ZodEnum<{ general: "general"; security: "security"; code: "code"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; }>>>; excludeExperts: z.ZodOptional<z.ZodArray<z.ZodString>>; forceCollaboration: z.ZodOptional<z.ZodBoolean>; }, z.core.$strip>
+  : z.ZodObject<{ capabilityWeights: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodNumber>>; excludeExperts: z.ZodOptional<z.ZodArray<z.ZodString>>; forceCollaboration: z.ZodOptional<z.ZodBoolean>; maxAlternatives: z.ZodOptional<z.ZodNumber>; minScore: z.ZodOptional<z.ZodNumber>; preferredDomains: z.ZodOptional<z.ZodArray<z.ZodEnum<{ architecture: "architecture"; code: "code"; documentation: "documentation"; general: "general"; security: "security"; testing: "testing"; }>>>; }, z.core.$strip>
 TypeAliasDeclaration|InterfaceDeclaration SelectionResult
-  = { model: string; reasoning: string; alternatives: Array<{ model: string; score: number; tradeoff: string }>; }
+  = { alternatives: Array<{ model: string; score: number; tradeoff: string; }>; model: string; reasoning: string; }
   alternatives: ExpertMatch[]
   confidence: number
   primary: ExpertMatch
@@ -7871,7 +7873,7 @@ TypeAliasDeclaration|InterfaceDeclaration SelectionResult
   requiresCollaboration: boolean
   suggestedPattern?: ExpertCollaborationPatternType | undefined
 VariableDeclaration SelectionResultSchema
-  : z.ZodObject<{ primary: z.ZodObject<{ expertId: z.ZodString; score: z.ZodNumber; matchedCapabilities: z.ZodArray<z.ZodString>; reasoning: z.ZodString; scoreBreakdown: z.ZodObject<{ capabilityScore: z.ZodNumber; domainScore: z.ZodNumber; weightScore: z.ZodNumber; finalScore: z.ZodNumber; }, z.core.$strip>; }, z.core.$strip>; alternatives: z.ZodArray<z.ZodObject<{ expertId: z.ZodString; score: z.ZodNumber; matchedCapabilities: z.ZodArray<z.ZodString>; reasoning: z.ZodString; scoreBreakdown: z.ZodObject<{ capabilityScore: z.ZodNumber; domainScore: z.ZodNumber; weightScore: z.ZodNumber; finalScore: z.ZodNumber; }, z.core.$strip>; }, z.core.$strip>>; requiresCollaboration: z.ZodBoolean; suggestedPattern: z.ZodOptional<z.ZodEnum<{ sequential: "sequential"; parallel: "parallel"; review_chain: "review_chain"; pair: "pair"; }>>; confidence: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ alternatives: z.ZodArray<z.ZodObject<{ expertId: z.ZodString; matchedCapabilities: z.ZodArray<z.ZodString>; reasoning: z.ZodString; score: z.ZodNumber; scoreBreakdown: z.ZodObject<{ capabilityScore: z.ZodNumber; domainScore: z.ZodNumber; finalScore: z.ZodNumber; weightScore: z.ZodNumber; }, z.core.$strip>; }, z.core.$strip>>; confidence: z.ZodNumber; primary: z.ZodObject<{ expertId: z.ZodString; matchedCapabilities: z.ZodArray<z.ZodString>; reasoning: z.ZodString; score: z.ZodNumber; scoreBreakdown: z.ZodObject<{ capabilityScore: z.ZodNumber; domainScore: z.ZodNumber; finalScore: z.ZodNumber; weightScore: z.ZodNumber; }, z.core.$strip>; }, z.core.$strip>; requiresCollaboration: z.ZodBoolean; suggestedPattern: z.ZodOptional<z.ZodEnum<{ pair: "pair"; parallel: "parallel"; review_chain: "review_chain"; sequential: "sequential"; }>>; }, z.core.$strip>
 FunctionDeclaration selectModel
   : typeof selectModel
 InterfaceDeclaration SelectModelOptions
@@ -7926,12 +7928,12 @@ InterfaceDeclaration SessionBudget
   readonly tokensUsed: number
   readonly utilizationPercent: number
 InterfaceDeclaration SessionCreatedEvent
-  readonly payload: { readonly sessionId: string; readonly pattern: string; readonly experts: readonly string[]; }
+  readonly payload: { readonly experts: readonly string[]; readonly pattern: string; readonly sessionId: string; }
   readonly topic: "session.created"
 TypeAliasDeclaration SessionEvent
-  = | { type: 'status_change'; status: SessionStatus } | { type: 'expert_joined'; expertId: string } | { type: 'result_submitted'; expertId: string; result: TaskResult } | { type: 'review_completed'; reviewerId: string; approved: boolean } | { type: 'vote_received'; expertId: string; decision: string } | { type: 'timeout'; expertId?: string } | { type: 'error'; error: Error }
+  = | { status: SessionStatus; type: 'status_change'; } | { expertId: string; type: 'expert_joined'; } | { expertId: string; result: TaskResult; type: 'result_submitted'; } | { approved: boolean; reviewerId: string; type: 'review_completed'; } | { decision: string; expertId: string; type: 'vote_received'; } | { expertId?: string; type: 'timeout'; } | { error: Error; type: 'error'; }
 InterfaceDeclaration SessionFinalizedEvent
-  readonly payload: { readonly success: boolean; readonly resultCount: number; readonly durationMs: number; }
+  readonly payload: { readonly durationMs: number; readonly resultCount: number; readonly success: boolean; }
   readonly topic: "session.finalized"
 InterfaceDeclaration SessionParticipantJoinedEvent
   readonly payload: { readonly expertId: string; readonly role: AgentRole; }
@@ -7957,10 +7959,10 @@ InterfaceDeclaration SessionStats
 TypeAliasDeclaration SessionStatus
   = | 'pending' | 'in_progress' | 'awaiting_review' | 'voting' | 'finalizing' | 'completed' | 'failed' | 'timed_out'
 InterfaceDeclaration SessionStatusChangedEvent
-  readonly payload: { readonly previousStatus: SessionStatus; readonly newStatus: SessionStatus; }
+  readonly payload: { readonly newStatus: SessionStatus; readonly previousStatus: SessionStatus; }
   readonly topic: "session.status_changed"
 VariableDeclaration SessionStatusSchema
-  : z.ZodEnum<{ pending: "pending"; in_progress: "in_progress"; completed: "completed"; failed: "failed"; voting: "voting"; awaiting_review: "awaiting_review"; finalizing: "finalizing"; timed_out: "timed_out"; }>
+  : z.ZodEnum<{ awaiting_review: "awaiting_review"; completed: "completed"; failed: "failed"; finalizing: "finalizing"; in_progress: "in_progress"; pending: "pending"; timed_out: "timed_out"; voting: "voting"; }>
 FunctionDeclaration setDefaultAvailableModelsCache
   : typeof setDefaultAvailableModelsCache
 FunctionDeclaration setDefaultRegistry
@@ -7976,14 +7978,14 @@ InterfaceDeclaration SharedConclusion
   readonly sourceNodeId: string
   readonly sourceTreeId: string
 VariableDeclaration SharedConclusionSchema
-  : z.ZodObject<{ sourceTreeId: z.ZodString; sourceNodeId: z.ZodString; content: z.ZodString; confidence: z.ZodNumber; qualityScore: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ confidence: z.ZodNumber; content: z.ZodString; qualityScore: z.ZodNumber; sourceNodeId: z.ZodString; sourceTreeId: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration SharedInsight
   readonly content: string
   readonly relevance: number
   readonly sourceNodeId: string
   readonly sourceTreeId: string
 VariableDeclaration SharedInsightSchema
-  : z.ZodObject<{ sourceTreeId: z.ZodString; sourceNodeId: z.ZodString; content: z.ZodString; relevance: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ content: z.ZodString; relevance: z.ZodNumber; sourceNodeId: z.ZodString; sourceTreeId: z.ZodString; }, z.core.$strip>
 FunctionDeclaration sigmoidConfidence
   : typeof sigmoidConfidence
 TypeAliasDeclaration SignalCategory
@@ -8015,7 +8017,7 @@ VariableDeclaration SKILL_DEFAULT_CAPABILITIES
 VariableDeclaration SKILL_PERMISSIONS
   : readonly SkillPermission[]
 VariableDeclaration SkillAgentRoleSchema
-  : z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; infrastructure_expert: "infrastructure_expert"; thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>
+  : z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; security_expert: "security_expert"; testing_expert: "testing_expert"; thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>
 InterfaceDeclaration SkillAttestation
   readonly authorizationMethod: AuthorizationMethod
   readonly authorized: boolean
@@ -8024,13 +8026,13 @@ InterfaceDeclaration SkillAttestation
   readonly skillId: string
   readonly timestamp: Date
 VariableDeclaration SkillAttestationSchema
-  : z.ZodObject<{ skillId: z.ZodString; executorId: z.ZodString; timestamp: z.ZodDate; inputHash: z.ZodString; authorized: z.ZodBoolean; authorizationMethod: z.ZodEnum<{ explicit: "explicit"; role: "role"; inherited: "inherited"; }>; }, z.core.$strip>
+  : z.ZodObject<{ authorizationMethod: z.ZodEnum<{ explicit: "explicit"; inherited: "inherited"; role: "role"; }>; authorized: z.ZodBoolean; executorId: z.ZodString; inputHash: z.ZodString; skillId: z.ZodString; timestamp: z.ZodDate; }, z.core.$strip>
 InterfaceDeclaration SkillCapabilities
   readonly maxExecutionTime: number
   readonly permissions: readonly SkillPermission[]
   readonly sandboxed: boolean
 VariableDeclaration SkillCapabilitiesSchema
-  : z.ZodObject<{ permissions: z.ZodReadonly<z.ZodArray<z.ZodEnum<{ execute: "execute"; read: "read"; write: "write"; network: "network"; filesystem: "filesystem"; spawn: "spawn"; }>>>; maxExecutionTime: z.ZodNumber; sandboxed: z.ZodBoolean; }, z.core.$strip>
+  : z.ZodObject<{ maxExecutionTime: z.ZodNumber; permissions: z.ZodReadonly<z.ZodArray<z.ZodEnum<{ execute: "execute"; filesystem: "filesystem"; network: "network"; read: "read"; spawn: "spawn"; write: "write"; }>>>; sandboxed: z.ZodBoolean; }, z.core.$strip>
 TypeAliasDeclaration SkillCategory
   = | 'file-operations' | 'code-generation' | 'code-analysis' | 'testing' | 'documentation' | 'refactoring' | 'debugging' | 'deployment' | 'general' | 'coding-standards' | 'security' | 'database' | 'cloud-native' | 'devops' | 'api' | 'frontend' | 'observability' | 'compliance'
 TypeAliasDeclaration SkillComplexity
@@ -8072,7 +8074,7 @@ ClassDeclaration SkillDependencyGraph
   removeDependency(skillId: string, dependsOn: string) => boolean
   validateGraph() => Result<void, DependencyError>
 VariableDeclaration SkillDependencySchema
-  : z.ZodObject<{ skillId: z.ZodString; dependsOn: z.ZodString; type: z.ZodEnum<{ optional: "optional"; recommended: "recommended"; required: "required"; }>; minVersion: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ dependsOn: z.ZodString; minVersion: z.ZodOptional<z.ZodNumber>; skillId: z.ZodString; type: z.ZodEnum<{ optional: "optional"; recommended: "recommended"; required: "required"; }>; }, z.core.$strip>
 TypeAliasDeclaration SkillDependencyType
   = 'required' | 'optional' | 'recommended'
 VariableDeclaration SkillDependencyTypeSchema
@@ -8128,7 +8130,7 @@ InterfaceDeclaration SkillLoaderConfig
   readonly fallbackBehavior: FallbackBehavior
   readonly mappings: readonly RoleSkillMapping[]
 VariableDeclaration SkillLoaderConfigSchema
-  : z.ZodObject<{ mappings: z.ZodReadonly<z.ZodArray<z.ZodObject<{ role: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>; requiredCategories: z.ZodReadonly<z.ZodArray<z.ZodEnum<{ general: "general"; security: "security"; documentation: "documentation"; testing: "testing"; devops: "devops"; api: "api"; database: "database"; refactoring: "refactoring"; "file-operations": "file-operations"; "code-generation": "code-generation"; "code-analysis": "code-analysis"; debugging: "debugging"; deployment: "deployment"; "coding-standards": "coding-standards"; "cloud-native": "cloud-native"; frontend: "frontend"; observability: "observability"; compliance: "compliance"; }>>>; optionalCategories: z.ZodOptional<z.ZodReadonly<z.ZodArray<z.ZodEnum<{ general: "general"; security: "security"; documentation: "documentation"; testing: "testing"; devops: "devops"; api: "api"; database: "database"; refactoring: "refactoring"; "file-operations": "file-operations"; "code-generation": "code-generation"; "code-analysis": "code-analysis"; debugging: "debugging"; deployment: "deployment"; "coding-standards": "coding-standards"; "cloud-native": "cloud-native"; frontend: "frontend"; observability: "observability"; compliance: "compliance"; }>>>>; maxSkills: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>>; defaultMaxSkills: z.ZodDefault<z.ZodNumber>; enforceRBAC: z.ZodDefault<z.ZodBoolean>; enforceDependencies: z.ZodDefault<z.ZodBoolean>; fallbackBehavior: z.ZodDefault<z.ZodEnum<{ error: "error"; partial: "partial"; empty: "empty"; }>>; }, z.core.$strip>
+  : z.ZodObject<{ defaultMaxSkills: z.ZodDefault<z.ZodNumber>; enforceDependencies: z.ZodDefault<z.ZodBoolean>; enforceRBAC: z.ZodDefault<z.ZodBoolean>; fallbackBehavior: z.ZodDefault<z.ZodEnum<{ empty: "empty"; error: "error"; partial: "partial"; }>>; mappings: z.ZodReadonly<z.ZodArray<z.ZodObject<{ maxSkills: z.ZodOptional<z.ZodNumber>; optionalCategories: z.ZodOptional<z.ZodReadonly<z.ZodArray<z.ZodEnum<{ "cloud-native": "cloud-native"; "code-analysis": "code-analysis"; "code-generation": "code-generation"; "coding-standards": "coding-standards"; "file-operations": "file-operations"; api: "api"; compliance: "compliance"; database: "database"; debugging: "debugging"; deployment: "deployment"; devops: "devops"; documentation: "documentation"; frontend: "frontend"; general: "general"; observability: "observability"; refactoring: "refactoring"; security: "security"; testing: "testing"; }>>>>; requiredCategories: z.ZodReadonly<z.ZodArray<z.ZodEnum<{ "cloud-native": "cloud-native"; "code-analysis": "code-analysis"; "code-generation": "code-generation"; "coding-standards": "coding-standards"; "file-operations": "file-operations"; api: "api"; compliance: "compliance"; database: "database"; debugging: "debugging"; deployment: "deployment"; devops: "devops"; documentation: "documentation"; frontend: "frontend"; general: "general"; observability: "observability"; refactoring: "refactoring"; security: "security"; testing: "testing"; }>>>; role: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; orchestrator: "orchestrator"; security_expert: "security_expert"; testing_expert: "testing_expert"; thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>; }, z.core.$strip>>>; }, z.core.$strip>
 InterfaceDeclaration SkillLoaderError
   readonly code: SkillLoaderErrorCode
   readonly context?: Record<string, unknown> | undefined
@@ -8136,7 +8138,7 @@ InterfaceDeclaration SkillLoaderError
 TypeAliasDeclaration SkillLoaderErrorCode
   = | 'ROLE_NOT_MAPPED' | 'REQUIRED_CATEGORY_MISSING' | 'RBAC_DENIED' | 'DEPENDENCY_ERROR' | 'VALIDATION_ERROR' | 'EMPTY_RESULT'
 VariableDeclaration SkillLoaderErrorSchema
-  : z.ZodObject<{ code: z.ZodEnum<{ VALIDATION_ERROR: "VALIDATION_ERROR"; ROLE_NOT_MAPPED: "ROLE_NOT_MAPPED"; REQUIRED_CATEGORY_MISSING: "REQUIRED_CATEGORY_MISSING"; RBAC_DENIED: "RBAC_DENIED"; DEPENDENCY_ERROR: "DEPENDENCY_ERROR"; EMPTY_RESULT: "EMPTY_RESULT"; }>; message: z.ZodString; context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>
+  : z.ZodObject<{ code: z.ZodEnum<{ DEPENDENCY_ERROR: "DEPENDENCY_ERROR"; EMPTY_RESULT: "EMPTY_RESULT"; RBAC_DENIED: "RBAC_DENIED"; REQUIRED_CATEGORY_MISSING: "REQUIRED_CATEGORY_MISSING"; ROLE_NOT_MAPPED: "ROLE_NOT_MAPPED"; VALIDATION_ERROR: "VALIDATION_ERROR"; }>; context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; message: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration SkillMetrics
   readonly avgExecutionTimeMs: number
   readonly executionCount: number
@@ -8157,7 +8159,7 @@ InterfaceDeclaration SkillParameter
 TypeAliasDeclaration SkillPermission
   = | 'read' // Read files, data, state | 'write' // Write files, modify state | 'execute' // Execute code, commands | 'network' // Make network requests | 'filesystem' // Access filesystem beyond working directory | 'spawn'
 VariableDeclaration SkillPermissionSchema
-  : z.ZodEnum<{ execute: "execute"; read: "read"; write: "write"; network: "network"; filesystem: "filesystem"; spawn: "spawn"; }>
+  : z.ZodEnum<{ execute: "execute"; filesystem: "filesystem"; network: "network"; read: "read"; spawn: "spawn"; write: "write"; }>
 TypeAliasDeclaration SkillPromoter
   = (event: SkillPromotionEvent) => void | Promise<void>
 InterfaceDeclaration SkillPromotionEvent
@@ -8174,7 +8176,7 @@ InterfaceDeclaration SkillProvenance
   readonly signature?: string | undefined
   readonly version: number
 VariableDeclaration SkillProvenanceSchema
-  : z.ZodObject<{ createdBy: z.ZodString; createdAt: z.ZodDate; modifiedBy: z.ZodOptional<z.ZodString>; modifiedAt: z.ZodOptional<z.ZodDate>; version: z.ZodNumber; signature: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ createdAt: z.ZodDate; createdBy: z.ZodString; modifiedAt: z.ZodOptional<z.ZodDate>; modifiedBy: z.ZodOptional<z.ZodString>; signature: z.ZodOptional<z.ZodString>; version: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration SkillQuery
   readonly category?: SkillCategory | undefined
   readonly complexity?: SkillComplexity | undefined
@@ -8189,7 +8191,7 @@ InterfaceDeclaration SkillRBAC
   readonly deniedRoles?: readonly AgentRole[] | undefined
   readonly requiresAttestation: boolean
 VariableDeclaration SkillRBACSchema
-  : z.ZodObject<{ allowedRoles: z.ZodReadonly<z.ZodArray<z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; infrastructure_expert: "infrastructure_expert"; thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>>>; deniedRoles: z.ZodOptional<z.ZodReadonly<z.ZodArray<z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; infrastructure_expert: "infrastructure_expert"; thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>>>>; requiresAttestation: z.ZodBoolean; }, z.core.$strip>
+  : z.ZodObject<{ allowedRoles: z.ZodReadonly<z.ZodArray<z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; security_expert: "security_expert"; testing_expert: "testing_expert"; thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>>>; deniedRoles: z.ZodOptional<z.ZodReadonly<z.ZodArray<z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; security_expert: "security_expert"; testing_expert: "testing_expert"; thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>>>>; requiresAttestation: z.ZodBoolean; }, z.core.$strip>
 InterfaceDeclaration SkillSearchResult
   readonly query: SkillQuery
   readonly skills: readonly SkillWithMetrics[]
@@ -8199,7 +8201,7 @@ InterfaceDeclaration SkillSecurityError
   readonly context?: Record<string, unknown> | undefined
   readonly message: string
 VariableDeclaration SkillSecurityErrorSchema
-  : z.ZodObject<{ code: z.ZodEnum<{ PERMISSION_DENIED: "PERMISSION_DENIED"; ROLE_NOT_ALLOWED: "ROLE_NOT_ALLOWED"; ATTESTATION_REQUIRED: "ATTESTATION_REQUIRED"; INVALID_PROVENANCE: "INVALID_PROVENANCE"; SIGNATURE_MISMATCH: "SIGNATURE_MISMATCH"; EXECUTION_TIMEOUT: "EXECUTION_TIMEOUT"; SANDBOX_VIOLATION: "SANDBOX_VIOLATION"; }>; message: z.ZodString; context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>
+  : z.ZodObject<{ code: z.ZodEnum<{ ATTESTATION_REQUIRED: "ATTESTATION_REQUIRED"; EXECUTION_TIMEOUT: "EXECUTION_TIMEOUT"; INVALID_PROVENANCE: "INVALID_PROVENANCE"; PERMISSION_DENIED: "PERMISSION_DENIED"; ROLE_NOT_ALLOWED: "ROLE_NOT_ALLOWED"; SANDBOX_VIOLATION: "SANDBOX_VIOLATION"; SIGNATURE_MISMATCH: "SIGNATURE_MISMATCH"; }>; context: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; message: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration SkillStore
   executions: Map<string, SkillExecution[]>
   metrics: Map<string, SkillMetrics>
@@ -8218,7 +8220,7 @@ FunctionDeclaration snapshotContext
 TypeAliasDeclaration SourceCitation
   = z.infer<typeof SourceCitationSchema>
 VariableDeclaration SourceCitationSchema
-  : z.ZodDiscriminatedUnion<[z.ZodObject<{ type: z.ZodLiteral<"issueBody">; issueNumber: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"repoFile">; path: z.ZodString; line: z.ZodOptional<z.ZodNumber>; commit: z.ZodOptional<z.ZodString>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"issueComment">; issueNumber: z.ZodNumber; commentId: z.ZodNumber; author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"ciResult">; runId: z.ZodNumber; status: z.ZodEnum<{ pass: "pass"; fail: "fail"; }>; job: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"policyDoc">; path: z.ZodString; section: z.ZodString; }, z.core.$strip>, z.ZodObject<{ type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; commentId: z.ZodNumber; }, z.core.$strip>], "type">
+  : z.ZodDiscriminatedUnion<[z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueBody">; }, z.core.$strip>, z.ZodObject<{ commit: z.ZodOptional<z.ZodString>; line: z.ZodOptional<z.ZodNumber>; path: z.ZodString; type: z.ZodLiteral<"repoFile">; }, z.core.$strip>, z.ZodObject<{ author: z.ZodString; authorTrustTier: z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>; commentId: z.ZodNumber; issueNumber: z.ZodNumber; type: z.ZodLiteral<"issueComment">; }, z.core.$strip>, z.ZodObject<{ job: z.ZodString; runId: z.ZodNumber; status: z.ZodEnum<{ fail: "fail"; pass: "pass"; }>; type: z.ZodLiteral<"ciResult">; }, z.core.$strip>, z.ZodObject<{ path: z.ZodString; section: z.ZodString; type: z.ZodLiteral<"policyDoc">; }, z.core.$strip>, z.ZodObject<{ commentId: z.ZodNumber; type: z.ZodLiteral<"maintainerCommand">; username: z.ZodString; }, z.core.$strip>], "type">
 InterfaceDeclaration SourceMetadata
   readonly authorAssociation: string
   readonly content: string
@@ -8236,10 +8238,10 @@ InterfaceDeclaration SpecExecutionError
 TypeAliasDeclaration SpecExecutionOptions
   = CompileOptions
 InterfaceDeclaration SpecExecutionResult
-  readonly dag: { nodes: { id: string; description: string; type: "config" | "code" | "test" | "docs" | "refactor"; complexity: "simple" | "moderate" | "complex" | "expert"; capabilities: string[]; dependsOn: string[]; sourceRequirement?: string | undefined; }[]; edges: { from: string; to: string; }[]; roots: string[]; totalComplexity: "simple" | "moderate" | "complex" | "expert"; specTitle: string; }
+  readonly dag: { edges: { from: string; to: string; }[]; nodes: { capabilities: string[]; complexity: "simple" | "moderate" | "complex" | "expert"; dependsOn: string[]; description: string; id: string; sourceRequirement?: string | undefined; type: "config" | "code" | "test" | "docs" | "refactor"; }[]; roots: string[]; specTitle: string; totalComplexity: "simple" | "moderate" | "complex" | "expert"; }
   readonly durationMs: number
   readonly outputs: readonly string[]
-  readonly validation: { satisfaction: number; totalCriteria: number; metCount: number; criteria: { criterion: string; met: boolean; matchedResults: string[]; }[]; allMet: boolean; }
+  readonly validation: { allMet: boolean; criteria: { criterion: string; matchedResults: string[]; met: boolean; }[]; metCount: number; satisfaction: number; totalCriteria: number; }
 TypeAliasDeclaration SpecialFeature
   = (typeof SPECIAL_FEATURES)[number]
 InterfaceDeclaration SpecParseError
@@ -8276,7 +8278,7 @@ InterfaceDeclaration StageCompletedOptions
 InterfaceDeclaration StageContext
   readonly config: Record<string, unknown>
   readonly signal: AbortSignal
-  readonly task: Readonly<{ id: string; description: string; status: "approved" | "done" | "intake" | "clarifying" | "planning" | "executing" | "validating" | "failed"; analysis: { complexity: string; taskType: string; ambiguityScore: number; }; constraints: { scope: string[]; time?: string | undefined; quality?: string | undefined; }; requiredCapabilities: { tools: string[]; experts: string[]; }; capabilityGaps: { available: { tools: string[]; experts: string[]; }; gaps: unknown[]; allSatisfied: boolean; }; artifacts: { id: string; type: "review" | "plan" | "vote" | "code" | "test" | "report" | "spec" | "analysis"; }[]; metadata: Record<string, unknown>; createdAt: number; updatedAt: number; parentId?: string | undefined; completedAt?: number | undefined; error?: string | undefined; }>
+  readonly task: Readonly<{ analysis: { ambiguityScore: number; complexity: string; taskType: string; }; artifacts: { id: string; type: "review" | "plan" | "vote" | "code" | "test" | "report" | "spec" | "analysis"; }[]; capabilityGaps: { allSatisfied: boolean; available: { experts: string[]; tools: string[]; }; gaps: unknown[]; }; completedAt?: number | undefined; constraints: { quality?: string | undefined; scope: string[]; time?: string | undefined; }; createdAt: number; description: string; error?: string | undefined; id: string; metadata: Record<string, unknown>; parentId?: string | undefined; requiredCapabilities: { experts: string[]; tools: string[]; }; status: "approved" | "done" | "intake" | "clarifying" | "planning" | "executing" | "validating" | "failed"; updatedAt: number; }>
 InterfaceDeclaration StageDependencies
   budgetRouter: BudgetRouter | undefined
   capabilityMatchStage: CapabilityMatchStage | undefined
@@ -8327,7 +8329,7 @@ TypeAliasDeclaration|InterfaceDeclaration StageResult
   readonly continuesPipeline: boolean
   readonly decision?: RoutingDecision | undefined
 VariableDeclaration StageResultSchema
-  : z.ZodObject<{ success: z.ZodBoolean; outputArtifacts: z.ZodArray<z.ZodObject<{ id: z.ZodString; type: z.ZodEnum<{ review: "review"; plan: "plan"; vote: "vote"; code: "code"; test: "test"; report: "report"; spec: "spec"; analysis: "analysis"; }>; }, z.core.$strip>>; metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>; error: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ error: z.ZodOptional<z.ZodString>; metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>; outputArtifacts: z.ZodArray<z.ZodObject<{ id: z.ZodString; type: z.ZodEnum<{ analysis: "analysis"; code: "code"; plan: "plan"; report: "report"; review: "review"; spec: "spec"; test: "test"; vote: "vote"; }>; }, z.core.$strip>>; success: z.ZodBoolean; }, z.core.$strip>
 InterfaceDeclaration StageRetryingEvent
   readonly attempt: number
   readonly executionId: string
@@ -8336,7 +8338,7 @@ InterfaceDeclaration StageRetryingEvent
 TypeAliasDeclaration StageSpec
   = z.infer<typeof StageSpecSchema>
 VariableDeclaration StageSpecSchema
-  : z.ZodObject<{ id: z.ZodString; type: z.ZodEnum<{ analyze: "analyze"; route: "route"; execute: "execute"; validate: "validate"; aggregate: "aggregate"; gate: "gate"; }>; pluginId: z.ZodString; inputArtifacts: z.ZodArray<z.ZodString>; outputArtifacts: z.ZodArray<z.ZodString>; dependencies: z.ZodArray<z.ZodString>; config: z.ZodRecord<z.ZodString, z.ZodUnknown>; preferredCli: z.ZodOptional<z.ZodString>; maxRetries: z.ZodOptional<z.ZodNumber>; timeoutMs: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ config: z.ZodRecord<z.ZodString, z.ZodUnknown>; dependencies: z.ZodArray<z.ZodString>; id: z.ZodString; inputArtifacts: z.ZodArray<z.ZodString>; maxRetries: z.ZodOptional<z.ZodNumber>; outputArtifacts: z.ZodArray<z.ZodString>; pluginId: z.ZodString; preferredCli: z.ZodOptional<z.ZodString>; timeoutMs: z.ZodOptional<z.ZodNumber>; type: z.ZodEnum<{ aggregate: "aggregate"; analyze: "analyze"; execute: "execute"; gate: "gate"; route: "route"; validate: "validate"; }>; }, z.core.$strip>
 InterfaceDeclaration StageStartedEvent
   readonly executionId: string
   readonly pluginId: string
@@ -8376,7 +8378,7 @@ InterfaceDeclaration StateMachineOptions
 TypeAliasDeclaration Statement
   = ReturnType<DatabaseType['prepare']>
 TypeAliasDeclaration StateReducer
-  = | { type: 'overwrite' } | { type: 'append' } | { type: 'custom'; merge: (existing: T, incoming: T) => T }
+  = | { type: 'overwrite'; } | { type: 'append'; } | { merge: (existing: T, incoming: T) => T; type: 'custom'; }
 TypeAliasDeclaration StateSchema
   = Record<string, StateFieldSchema>
 InterfaceDeclaration StateTransition
@@ -8419,7 +8421,7 @@ ClassDeclaration|TypeAliasDeclaration StepExecutor
   execute(step: WorkflowStep, context: WorkflowExecutionContext, options?: StepExecutionOptions) => Promise<Result<StepResult, WorkflowError>>
 InterfaceDeclaration StepExecutorDeps
   expertFactory: IExpertFactory
-  logger?: { debug: (message: string, data?: Record<string, unknown>) => void; info: (message: string, data?: Record<string, unknown>) => void; warn: (message: string, data?: Record<string, unknown>) => void; error: (message: string, data?: Record<string, unknown>) => void; } | undefined
+  logger?: { debug: (message: string, data?: Record<string, unknown>) => void; info: (message: string, data?: Record<string, unknown>) => void; warn: (message: string, data?: Record<string, unknown>) => void; error: (message: string, data?: Record<string, unknown>) => void;; } | undefined
 InterfaceDeclaration StepOutcome
   readonly durationMs: number
   readonly error?: string | undefined
@@ -8492,7 +8494,7 @@ ClassDeclaration StrategyDistiller
   promote(routingMemory: IRoutingMemory) => number
 ClassDeclaration StreamCancelledError
 TypeAliasDeclaration StreamChunk
-  = | { type: 'content_block_start'; index: number; contentBlock: ContentBlock } | { type: 'content_block_delta'; index: number; delta: { type: 'text_delta'; text: string } } | { type: 'content_block_stop'; index: number } | { type: 'message_start'; message: { model: string } } | { type: 'message_delta'; delta: { stop_reason: StopReason }; usage?: TokenUsage } | { type: 'message_stop' }
+  = | { contentBlock: ContentBlock; index: number; type: 'content_block_start'; } | { delta: { text: string; type: 'text_delta'; }; index: number; type: 'content_block_delta'; } | { index: number; type: 'content_block_stop'; } | { message: { model: string; }; type: 'message_start'; } | { delta: { stop_reason: StopReason; }; type: 'message_delta'; usage?: TokenUsage; } | { type: 'message_stop'; }
 ClassDeclaration StreamController
   cancel(reason?: string) => void
   complete() => void
@@ -8508,17 +8510,17 @@ TypeAliasDeclaration StreamState
 InterfaceDeclaration StreamTextResult
   textStream: AsyncIterable<string>
 VariableDeclaration StrictAgentRoleSchema
-  : z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; infrastructure_expert: "infrastructure_expert"; }>
+  : z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; security_expert: "security_expert"; testing_expert: "testing_expert"; }>
 VariableDeclaration StrictInputDefinitionSchema
-  : z.ZodObject<{ name: z.ZodString; type: z.ZodEnum<{ string: "string"; number: "number"; boolean: "boolean"; object: "object"; array: "array"; }>; description: z.ZodOptional<z.ZodString>; required: z.ZodDefault<z.ZodBoolean>; default: z.ZodOptional<z.ZodUnknown>; }, z.core.$strict>
+  : z.ZodObject<{ default: z.ZodOptional<z.ZodUnknown>; description: z.ZodOptional<z.ZodString>; name: z.ZodString; required: z.ZodDefault<z.ZodBoolean>; type: z.ZodEnum<{ array: "array"; boolean: "boolean"; number: "number"; object: "object"; string: "string"; }>; }, z.core.$strict>
 VariableDeclaration StrictWorkflowDefinitionSchema
-  : z.ZodObject<{ name: z.ZodString; version: z.ZodString; description: z.ZodOptional<z.ZodString>; inputs: z.ZodDefault<z.ZodArray<z.ZodObject<{ name: z.ZodString; type: z.ZodEnum<{ string: "string"; number: "number"; boolean: "boolean"; object: "object"; array: "array"; }>; description: z.ZodOptional<z.ZodString>; required: z.ZodDefault<z.ZodBoolean>; default: z.ZodOptional<z.ZodUnknown>; }, z.core.$strict>>>; steps: z.ZodArray<z.ZodObject<{ id: z.ZodString; agent: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; infrastructure_expert: "infrastructure_expert"; }>; action: z.ZodString; inputs: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodUnknown>>; dependsOn: z.ZodOptional<z.ZodArray<z.ZodString>>; parallel: z.ZodOptional<z.ZodBoolean>; retries: z.ZodOptional<z.ZodNumber>; timeout: z.ZodOptional<z.ZodNumber>; condition: z.ZodOptional<z.ZodString>; contextBudget: z.ZodOptional<z.ZodObject<{ system: z.ZodOptional<z.ZodNumber>; task: z.ZodOptional<z.ZodNumber>; active: z.ZodOptional<z.ZodNumber>; reserved: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; }, z.core.$strict>>; timeout: z.ZodOptional<z.ZodNumber>; defaultBudget: z.ZodOptional<z.ZodObject<{ system: z.ZodNumber; task: z.ZodNumber; active: z.ZodNumber; reserved: z.ZodNumber; }, z.core.$strip>>; }, z.core.$strict>
+  : z.ZodObject<{ defaultBudget: z.ZodOptional<z.ZodObject<{ active: z.ZodNumber; reserved: z.ZodNumber; system: z.ZodNumber; task: z.ZodNumber; }, z.core.$strip>>; description: z.ZodOptional<z.ZodString>; inputs: z.ZodDefault<z.ZodArray<z.ZodObject<{ default: z.ZodOptional<z.ZodUnknown>; description: z.ZodOptional<z.ZodString>; name: z.ZodString; required: z.ZodDefault<z.ZodBoolean>; type: z.ZodEnum<{ array: "array"; boolean: "boolean"; number: "number"; object: "object"; string: "string"; }>; }, z.core.$strict>>>; name: z.ZodString; steps: z.ZodArray<z.ZodObject<{ action: z.ZodString; agent: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; security_expert: "security_expert"; testing_expert: "testing_expert"; }>; condition: z.ZodOptional<z.ZodString>; contextBudget: z.ZodOptional<z.ZodObject<{ active: z.ZodOptional<z.ZodNumber>; reserved: z.ZodOptional<z.ZodNumber>; system: z.ZodOptional<z.ZodNumber>; task: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; dependsOn: z.ZodOptional<z.ZodArray<z.ZodString>>; id: z.ZodString; inputs: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodUnknown>>; parallel: z.ZodOptional<z.ZodBoolean>; retries: z.ZodOptional<z.ZodNumber>; timeout: z.ZodOptional<z.ZodNumber>; }, z.core.$strict>>; timeout: z.ZodOptional<z.ZodNumber>; version: z.ZodString; }, z.core.$strict>
 VariableDeclaration StrictWorkflowStepSchema
-  : z.ZodObject<{ id: z.ZodString; agent: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; infrastructure_expert: "infrastructure_expert"; }>; action: z.ZodString; inputs: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodUnknown>>; dependsOn: z.ZodOptional<z.ZodArray<z.ZodString>>; parallel: z.ZodOptional<z.ZodBoolean>; retries: z.ZodOptional<z.ZodNumber>; timeout: z.ZodOptional<z.ZodNumber>; condition: z.ZodOptional<z.ZodString>; contextBudget: z.ZodOptional<z.ZodObject<{ system: z.ZodOptional<z.ZodNumber>; task: z.ZodOptional<z.ZodNumber>; active: z.ZodOptional<z.ZodNumber>; reserved: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; }, z.core.$strict>
+  : z.ZodObject<{ action: z.ZodString; agent: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; security_expert: "security_expert"; testing_expert: "testing_expert"; }>; condition: z.ZodOptional<z.ZodString>; contextBudget: z.ZodOptional<z.ZodObject<{ active: z.ZodOptional<z.ZodNumber>; reserved: z.ZodOptional<z.ZodNumber>; system: z.ZodOptional<z.ZodNumber>; task: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; dependsOn: z.ZodOptional<z.ZodArray<z.ZodString>>; id: z.ZodString; inputs: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodUnknown>>; parallel: z.ZodOptional<z.ZodBoolean>; retries: z.ZodOptional<z.ZodNumber>; timeout: z.ZodOptional<z.ZodNumber>; }, z.core.$strict>
 TypeAliasDeclaration StrippedElement
   = z.infer<typeof StrippedElementSchema>
 VariableDeclaration StrippedElementSchema
-  : z.ZodObject<{ tag: z.ZodString; reason: z.ZodString; startIndex: z.ZodNumber; length: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ length: z.ZodNumber; reason: z.ZodString; startIndex: z.ZodNumber; tag: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration StrippedElementSummary
   readonly reason: string
   readonly tag: string
@@ -8549,28 +8551,28 @@ InterfaceDeclaration SubTask
 TypeAliasDeclaration SubtaskNode
   = z.infer<typeof SubtaskNodeSchema>
 VariableDeclaration SubtaskNodeSchema
-  : z.ZodObject<{ id: z.ZodString; description: z.ZodString; type: z.ZodEnum<{ config: "config"; code: "code"; test: "test"; docs: "docs"; refactor: "refactor"; }>; complexity: z.ZodEnum<{ simple: "simple"; moderate: "moderate"; complex: "complex"; expert: "expert"; }>; capabilities: z.ZodArray<z.ZodString>; dependsOn: z.ZodArray<z.ZodString>; sourceRequirement: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ capabilities: z.ZodArray<z.ZodString>; complexity: z.ZodEnum<{ complex: "complex"; expert: "expert"; moderate: "moderate"; simple: "simple"; }>; dependsOn: z.ZodArray<z.ZodString>; description: z.ZodString; id: z.ZodString; sourceRequirement: z.ZodOptional<z.ZodString>; type: z.ZodEnum<{ code: "code"; config: "config"; docs: "docs"; refactor: "refactor"; test: "test"; }>; }, z.core.$strip>
 TypeAliasDeclaration SubtaskPriority
   = 'critical' | 'high' | 'medium' | 'low'
 VariableDeclaration SubtaskPrioritySchema
-  : z.ZodEnum<{ critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>
+  : z.ZodEnum<{ critical: "critical"; high: "high"; low: "low"; medium: "medium"; }>
 VariableDeclaration SubTaskSchema
-  : z.ZodObject<{ id: z.ZodString; parentTaskId: z.ZodString; description: z.ZodString; expectedOutput: z.ZodString; dependencies: z.ZodArray<z.ZodString>; priority: z.ZodEnum<{ critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>; status: z.ZodEnum<{ pending: "pending"; in_progress: "in_progress"; completed: "completed"; failed: "failed"; assigned: "assigned"; }>; assignedRole: z.ZodOptional<z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; research_expert: "research_expert"; pm_expert: "pm_expert"; ux_expert: "ux_expert"; infrastructure_expert: "infrastructure_expert"; }>>; complexity: z.ZodNumber; requiredCapabilities: z.ZodArray<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ assignedRole: z.ZodOptional<z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; pm_expert: "pm_expert"; research_expert: "research_expert"; security_expert: "security_expert"; testing_expert: "testing_expert"; ux_expert: "ux_expert"; }>>; complexity: z.ZodNumber; dependencies: z.ZodArray<z.ZodString>; description: z.ZodString; expectedOutput: z.ZodString; id: z.ZodString; parentTaskId: z.ZodString; priority: z.ZodEnum<{ critical: "critical"; high: "high"; low: "low"; medium: "medium"; }>; requiredCapabilities: z.ZodArray<z.ZodString>; status: z.ZodEnum<{ assigned: "assigned"; completed: "completed"; failed: "failed"; in_progress: "in_progress"; pending: "pending"; }>; }, z.core.$strip>
 TypeAliasDeclaration SubtaskStatus
   = 'pending' | 'assigned' | 'in_progress' | 'completed' | 'failed'
 VariableDeclaration SubtaskStatusSchema
-  : z.ZodEnum<{ pending: "pending"; in_progress: "in_progress"; completed: "completed"; failed: "failed"; assigned: "assigned"; }>
+  : z.ZodEnum<{ assigned: "assigned"; completed: "completed"; failed: "failed"; in_progress: "in_progress"; pending: "pending"; }>
 TypeAliasDeclaration SubtaskType
   = z.infer<typeof SubtaskTypeSchema>
 VariableDeclaration SubtaskTypeSchema
-  : z.ZodEnum<{ config: "config"; code: "code"; test: "test"; docs: "docs"; refactor: "refactor"; }>
+  : z.ZodEnum<{ code: "code"; config: "config"; docs: "docs"; refactor: "refactor"; test: "test"; }>
 ClassDeclaration SupermajorityStrategy
   calculateOutcome(votes: Map<string, Vote>) => VotingOutcome
   readonly algorithm: "simple_majority" | "supermajority" | "unanimous" | "proof_of_learning" | "higher_order" | "opinion_wise"
 TypeAliasDeclaration SuspiciousSignal
   = z.infer<typeof SuspiciousSignalSchema>
 VariableDeclaration SuspiciousSignalSchema
-  : z.ZodEnum<{ new_account: "new_account"; no_prior_contributions: "no_prior_contributions"; injection_patterns_detected: "injection_patterns_detected"; rapid_comments: "rapid_comments"; mismatched_authority_claim: "mismatched_authority_claim"; }>
+  : z.ZodEnum<{ injection_patterns_detected: "injection_patterns_detected"; mismatched_authority_claim: "mismatched_authority_claim"; new_account: "new_account"; no_prior_contributions: "no_prior_contributions"; rapid_comments: "rapid_comments"; }>
 InterfaceDeclaration SwarmHealthMetrics
   readonly activeAgents: number
   readonly adaptationSpeed: number
@@ -8633,7 +8635,7 @@ InterfaceDeclaration SynthesizedResult
   resultSummaries: ResultSummary[]
   summary: string
 VariableDeclaration SynthesizedResultSchema
-  : z.ZodObject<{ combinedOutput: z.ZodString; summary: z.ZodString; resultSummaries: z.ZodArray<z.ZodObject<{ subtaskId: z.ZodString; summary: z.ZodString; quality: z.ZodNumber; contributions: z.ZodArray<z.ZodString>; }, z.core.$strip>>; conflicts: z.ZodArray<z.ZodObject<{ subtaskId1: z.ZodString; subtaskId2: z.ZodString; description: z.ZodString; resolution: z.ZodString; }, z.core.$strip>>; qualityScore: z.ZodNumber; recommendations: z.ZodArray<z.ZodString>; collaborationMetadata: z.ZodOptional<z.ZodObject<{ sessionId: z.ZodString; pattern: z.ZodString; participantCount: z.ZodNumber; agreementLevel: z.ZodNumber; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ collaborationMetadata: z.ZodOptional<z.ZodObject<{ agreementLevel: z.ZodNumber; participantCount: z.ZodNumber; pattern: z.ZodString; sessionId: z.ZodString; }, z.core.$strip>>; combinedOutput: z.ZodString; conflicts: z.ZodArray<z.ZodObject<{ description: z.ZodString; resolution: z.ZodString; subtaskId1: z.ZodString; subtaskId2: z.ZodString; }, z.core.$strip>>; qualityScore: z.ZodNumber; recommendations: z.ZodArray<z.ZodString>; resultSummaries: z.ZodArray<z.ZodObject<{ contributions: z.ZodArray<z.ZodString>; quality: z.ZodNumber; subtaskId: z.ZodString; summary: z.ZodString; }, z.core.$strip>>; summary: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration SystemComponent
   dependencies: string[]
   name: string
@@ -8684,7 +8686,7 @@ InterfaceDeclaration TaskAnalysisResult
   readonly taskType: TaskTypeCategory
   readonly taskTypeConfidence: number
 VariableDeclaration TaskAnalysisSchema
-  : z.ZodObject<{ taskId: z.ZodString; complexity: z.ZodPipe<z.ZodUnion<readonly [z.ZodNumber, z.ZodString]>, z.ZodTransform<number, string | number>>; taskType: z.ZodString; requirements: z.ZodArray<z.ZodString>; risks: z.ZodArray<z.ZodString>; needsDecomposition: z.ZodPipe<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>, z.ZodTransform<boolean, string | boolean>>; approach: z.ZodString; estimatedEffort: z.ZodPipe<z.ZodUnion<readonly [z.ZodNumber, z.ZodString]>, z.ZodTransform<number, string | number>>; commitment: z.ZodOptional<z.ZodObject<{ purpose: z.ZodString; approach: z.ZodString; differentiation: z.ZodString; constraints: z.ZodArray<z.ZodString>; }, z.core.$strip>>; }, z.core.$strip>
+  : z.ZodObject<{ approach: z.ZodString; commitment: z.ZodOptional<z.ZodObject<{ approach: z.ZodString; constraints: z.ZodArray<z.ZodString>; differentiation: z.ZodString; purpose: z.ZodString; }, z.core.$strip>>; complexity: z.ZodPipe<z.ZodUnion<readonly [z.ZodNumber, z.ZodString]>, z.ZodTransform<number, string | number>>; estimatedEffort: z.ZodPipe<z.ZodUnion<readonly [z.ZodNumber, z.ZodString]>, z.ZodTransform<number, string | number>>; needsDecomposition: z.ZodPipe<z.ZodUnion<readonly [z.ZodBoolean, z.ZodString]>, z.ZodTransform<boolean, string | boolean>>; requirements: z.ZodArray<z.ZodString>; risks: z.ZodArray<z.ZodString>; taskId: z.ZodString; taskType: z.ZodString; }, z.core.$strip>
 InterfaceDeclaration TaskAssignmentMessage
   deadline?: string | undefined
   expertId: string
@@ -8730,14 +8732,14 @@ InterfaceDeclaration TaskContext
 TypeAliasDeclaration TaskContract
   = z.infer<typeof TaskContractSchema>
 VariableDeclaration TaskContractSchema
-  : z.ZodObject<{ id: z.ZodString; description: z.ZodString; status: z.ZodEnum<{ approved: "approved"; done: "done"; intake: "intake"; clarifying: "clarifying"; planning: "planning"; executing: "executing"; validating: "validating"; failed: "failed"; }>; analysis: z.ZodObject<{ complexity: z.ZodString; taskType: z.ZodString; ambiguityScore: z.ZodNumber; }, z.core.$strip>; constraints: z.ZodObject<{ time: z.ZodOptional<z.ZodString>; quality: z.ZodOptional<z.ZodString>; scope: z.ZodArray<z.ZodString>; }, z.core.$strip>; requiredCapabilities: z.ZodObject<{ tools: z.ZodArray<z.ZodString>; experts: z.ZodArray<z.ZodString>; }, z.core.$strip>; capabilityGaps: z.ZodObject<{ available: z.ZodObject<{ tools: z.ZodArray<z.ZodString>; experts: z.ZodArray<z.ZodString>; }, z.core.$strip>; gaps: z.ZodArray<z.ZodUnknown>; allSatisfied: z.ZodBoolean; }, z.core.$strip>; parentId: z.ZodOptional<z.ZodString>; artifacts: z.ZodArray<z.ZodObject<{ id: z.ZodString; type: z.ZodEnum<{ review: "review"; plan: "plan"; vote: "vote"; code: "code"; test: "test"; report: "report"; spec: "spec"; analysis: "analysis"; }>; }, z.core.$strip>>; metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>; createdAt: z.ZodNumber; updatedAt: z.ZodNumber; completedAt: z.ZodOptional<z.ZodNumber>; error: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ analysis: z.ZodObject<{ ambiguityScore: z.ZodNumber; complexity: z.ZodString; taskType: z.ZodString; }, z.core.$strip>; artifacts: z.ZodArray<z.ZodObject<{ id: z.ZodString; type: z.ZodEnum<{ analysis: "analysis"; code: "code"; plan: "plan"; report: "report"; review: "review"; spec: "spec"; test: "test"; vote: "vote"; }>; }, z.core.$strip>>; capabilityGaps: z.ZodObject<{ allSatisfied: z.ZodBoolean; available: z.ZodObject<{ experts: z.ZodArray<z.ZodString>; tools: z.ZodArray<z.ZodString>; }, z.core.$strip>; gaps: z.ZodArray<z.ZodUnknown>; }, z.core.$strip>; completedAt: z.ZodOptional<z.ZodNumber>; constraints: z.ZodObject<{ quality: z.ZodOptional<z.ZodString>; scope: z.ZodArray<z.ZodString>; time: z.ZodOptional<z.ZodString>; }, z.core.$strip>; createdAt: z.ZodNumber; description: z.ZodString; error: z.ZodOptional<z.ZodString>; id: z.ZodString; metadata: z.ZodRecord<z.ZodString, z.ZodUnknown>; parentId: z.ZodOptional<z.ZodString>; requiredCapabilities: z.ZodObject<{ experts: z.ZodArray<z.ZodString>; tools: z.ZodArray<z.ZodString>; }, z.core.$strip>; status: z.ZodEnum<{ approved: "approved"; clarifying: "clarifying"; done: "done"; executing: "executing"; failed: "failed"; intake: "intake"; planning: "planning"; validating: "validating"; }>; updatedAt: z.ZodNumber; }, z.core.$strip>
 InterfaceDeclaration TaskCreatedEvent
   readonly taskId: string
   readonly type: "task.created"
 TypeAliasDeclaration TaskDag
   = z.infer<typeof TaskDagSchema>
 VariableDeclaration TaskDagSchema
-  : z.ZodObject<{ nodes: z.ZodArray<z.ZodObject<{ id: z.ZodString; description: z.ZodString; type: z.ZodEnum<{ config: "config"; code: "code"; test: "test"; docs: "docs"; refactor: "refactor"; }>; complexity: z.ZodEnum<{ simple: "simple"; moderate: "moderate"; complex: "complex"; expert: "expert"; }>; capabilities: z.ZodArray<z.ZodString>; dependsOn: z.ZodArray<z.ZodString>; sourceRequirement: z.ZodOptional<z.ZodString>; }, z.core.$strip>>; edges: z.ZodArray<z.ZodObject<{ from: z.ZodString; to: z.ZodString; }, z.core.$strip>>; roots: z.ZodArray<z.ZodString>; totalComplexity: z.ZodEnum<{ simple: "simple"; moderate: "moderate"; complex: "complex"; expert: "expert"; }>; specTitle: z.ZodString; }, z.core.$strip>
+  : z.ZodObject<{ edges: z.ZodArray<z.ZodObject<{ from: z.ZodString; to: z.ZodString; }, z.core.$strip>>; nodes: z.ZodArray<z.ZodObject<{ capabilities: z.ZodArray<z.ZodString>; complexity: z.ZodEnum<{ complex: "complex"; expert: "expert"; moderate: "moderate"; simple: "simple"; }>; dependsOn: z.ZodArray<z.ZodString>; description: z.ZodString; id: z.ZodString; sourceRequirement: z.ZodOptional<z.ZodString>; type: z.ZodEnum<{ code: "code"; config: "config"; docs: "docs"; refactor: "refactor"; test: "test"; }>; }, z.core.$strip>>; roots: z.ZodArray<z.ZodString>; specTitle: z.ZodString; totalComplexity: z.ZodEnum<{ complex: "complex"; expert: "expert"; moderate: "moderate"; simple: "simple"; }>; }, z.core.$strip>
 TypeAliasDeclaration TaskDomain
   = ExpertTaskDomain
   = ExpertTaskDomain
@@ -8788,7 +8790,7 @@ InterfaceDeclaration TaskOutcomeRow
   timestamp: number
   token_usage: number
 VariableDeclaration TaskOutcomeSchema
-  : z.ZodObject<{ routingDecisionId: z.ZodUUID; timestamp: z.ZodISODateTime; outcomeClass: z.ZodEnum<{ success: "success"; failure: "failure"; error: "error"; partial: "partial"; timeout: "timeout"; }>; success: z.ZodBoolean; qualityScore: z.ZodNumber; durationMs: z.ZodNumber; tokenUsage: z.ZodNumber; errorMessage: z.ZodOptional<z.ZodString>; qualitySignals: z.ZodObject<{ testsPass: z.ZodOptional<z.ZodBoolean>; lintErrors: z.ZodOptional<z.ZodNumber>; userApproved: z.ZodOptional<z.ZodBoolean>; retryCount: z.ZodDefault<z.ZodNumber>; completionRatio: z.ZodDefault<z.ZodNumber>; validStructure: z.ZodOptional<z.ZodBoolean>; coherenceScore: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>; traceId: z.ZodString; }, z.core.$strip>
+  : z.ZodObject<{ durationMs: z.ZodNumber; errorMessage: z.ZodOptional<z.ZodString>; outcomeClass: z.ZodEnum<{ error: "error"; failure: "failure"; partial: "partial"; success: "success"; timeout: "timeout"; }>; qualityScore: z.ZodNumber; qualitySignals: z.ZodObject<{ coherenceScore: z.ZodOptional<z.ZodNumber>; completionRatio: z.ZodDefault<z.ZodNumber>; lintErrors: z.ZodOptional<z.ZodNumber>; retryCount: z.ZodDefault<z.ZodNumber>; testsPass: z.ZodOptional<z.ZodBoolean>; userApproved: z.ZodOptional<z.ZodBoolean>; validStructure: z.ZodOptional<z.ZodBoolean>; }, z.core.$strip>; routingDecisionId: z.ZodUUID; success: z.ZodBoolean; timestamp: z.ZodISODateTime; tokenUsage: z.ZodNumber; traceId: z.ZodString; }, z.core.$strip>
 TypeAliasDeclaration TaskOutcomeStatus
   = z.infer<typeof TaskOutcomeStatusSchema>
 InterfaceDeclaration TaskPayload
@@ -8839,7 +8841,7 @@ InterfaceDeclaration TaskRoutingEntry
   readonly primaryModel: string
   readonly secondaryCli: "claude" | "gemini" | "codex" | "opencode"
 VariableDeclaration TaskSchema
-  : z.ZodObject<{ id: z.ZodString; description: z.ZodString; context: z.ZodObject<{ workingDirectory: z.ZodOptional<z.ZodString>; files: z.ZodOptional<z.ZodArray<z.ZodString>>; history: z.ZodOptional<z.ZodArray<z.ZodObject<{ role: z.ZodEnum<{ system: "system"; user: "user"; assistant: "assistant"; }>; content: z.ZodString; timestamp: z.ZodString; }, z.core.$strip>>>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; }, z.core.$strip>; constraints: z.ZodOptional<z.ZodObject<{ maxDuration: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; priority: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ constraints: z.ZodOptional<z.ZodObject<{ maxDuration: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; context: z.ZodObject<{ files: z.ZodOptional<z.ZodArray<z.ZodString>>; history: z.ZodOptional<z.ZodArray<z.ZodObject<{ content: z.ZodString; role: z.ZodEnum<{ assistant: "assistant"; system: "system"; user: "user"; }>; timestamp: z.ZodString; }, z.core.$strip>>>; metadata: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnknown>>; workingDirectory: z.ZodOptional<z.ZodString>; }, z.core.$strip>; description: z.ZodString; id: z.ZodString; priority: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration TaskSignals
   readonly dependencyStructure?: DependencyStructure | undefined
   readonly description: string
@@ -8874,7 +8876,7 @@ VariableDeclaration TEMPLATE_KEYWORDS
 TypeAliasDeclaration TemplateCategory
   = 'development' | 'review' | 'documentation' | 'testing' | 'custom'
 VariableDeclaration TemplateCategorySchema
-  : z.ZodEnum<{ review: "review"; documentation: "documentation"; testing: "testing"; custom: "custom"; development: "development"; }>
+  : z.ZodEnum<{ custom: "custom"; development: "development"; documentation: "documentation"; review: "review"; testing: "testing"; }>
 InterfaceDeclaration TemplateMetadata
   author?: string | undefined
   builtIn: boolean
@@ -8883,7 +8885,7 @@ InterfaceDeclaration TemplateMetadata
   readonly id: string
   updatedAt?: string | undefined
 VariableDeclaration TemplateMetadataSchema
-  : z.ZodObject<{ name: z.ZodString; version: z.ZodString; description: z.ZodOptional<z.ZodString>; path: z.ZodString; category: z.ZodEnum<{ review: "review"; documentation: "documentation"; testing: "testing"; custom: "custom"; development: "development"; }>; keywords: z.ZodDefault<z.ZodArray<z.ZodString>>; builtIn: z.ZodDefault<z.ZodBoolean>; author: z.ZodOptional<z.ZodString>; updatedAt: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ author: z.ZodOptional<z.ZodString>; builtIn: z.ZodDefault<z.ZodBoolean>; category: z.ZodEnum<{ custom: "custom"; development: "development"; documentation: "documentation"; review: "review"; testing: "testing"; }>; description: z.ZodOptional<z.ZodString>; keywords: z.ZodDefault<z.ZodArray<z.ZodString>>; name: z.ZodString; path: z.ZodString; updatedAt: z.ZodOptional<z.ZodString>; version: z.ZodString; }, z.core.$strip>
 ClassDeclaration TemplateRegistry
   clear() => void
   clearCustom() => void
@@ -8907,7 +8909,7 @@ ClassDeclaration TemplateRegistryError
 TypeAliasDeclaration TerminationReason
   = | 'solution_found' | 'convergence' | 'max_time' | 'max_tokens' | 'max_depth' | 'no_progress' | 'error'
 VariableDeclaration TerminationReasonSchema
-  : z.ZodEnum<{ error: "error"; max_tokens: "max_tokens"; solution_found: "solution_found"; convergence: "convergence"; max_time: "max_time"; max_depth: "max_depth"; no_progress: "no_progress"; }>
+  : z.ZodEnum<{ convergence: "convergence"; error: "error"; max_depth: "max_depth"; max_time: "max_time"; max_tokens: "max_tokens"; no_progress: "no_progress"; solution_found: "solution_found"; }>
 InterfaceDeclaration TestingAnalysisResult
   coverage?: CoverageMetrics | undefined
   operationType: "generation" | "coverage_analysis" | "quality_assessment"
@@ -8956,7 +8958,7 @@ InterfaceDeclaration TierRecommendationEntry
   readonly sampleCount: number
   readonly successRate: number
 InterfaceDeclaration TierTransitionAuditOpts
-  actor?: { type: "system" | "user" | "agent" | "external"; id: string; name?: string | undefined; ip?: string | undefined; userAgent?: string | undefined; } | undefined
+  actor?: { id: string; ip?: string | undefined; name?: string | undefined; type: "system" | "user" | "agent" | "external"; userAgent?: string | undefined; } | undefined
   evidenceRef: string
   fromTier: "advisory" | "observe" | "suggest" | "enforce"
   kind: "promotion" | "demotion"
@@ -9013,7 +9015,7 @@ ClassDeclaration TokenCounter
   dispose() => void
   estimate(text: string) => number
   estimateForProvider(text: string, provider: TokenCounterProvider) => number
-  getCacheStats() => { size: number; maxSize: number; ttlMs: number; }
+  getCacheStats() => { maxSize: number; size: number; ttlMs: number; }
 InterfaceDeclaration TokenCounterConfig
   anthropicApiKey?: string | undefined
   cacheTtlMs?: number | undefined
@@ -9080,7 +9082,7 @@ TypeAliasDeclaration ToolDefinitionFormat
 FunctionDeclaration toolError
   : typeof toolError
 InterfaceDeclaration ToolInvocationAuditOpts
-  actor: { type: "system" | "user" | "agent" | "external"; id: string; name?: string | undefined; ip?: string | undefined; userAgent?: string | undefined; }
+  actor: { id: string; ip?: string | undefined; name?: string | undefined; type: "system" | "user" | "agent" | "external"; userAgent?: string | undefined; }
   durationMs?: number | undefined
   errorMessage?: string | undefined
   metadata?: Record<string, unknown> | undefined
@@ -9092,7 +9094,7 @@ InterfaceDeclaration ToolInvokedEvent
   readonly toolName: string
   readonly type: "tool.invoked"
 TypeAliasDeclaration ToolOutcome
-  = | { readonly kind: 'recorded'; readonly toolResultBlock: Extract<ContentBlock, { type: 'tool_result' }>; } | { readonly kind: 'stop'; readonly reason: AgentRunResult['stopReason'] }
+  = | { readonly kind: 'recorded'; readonly toolResultBlock: Extract<ContentBlock, { type: 'tool_result'; }>; } | { readonly kind: 'stop'; readonly reason: AgentRunResult['stopReason']; }
 InterfaceDeclaration ToolPayload
   readonly errorMessage?: string | undefined
   readonly phase: "completed" | "invoked"
@@ -9200,7 +9202,7 @@ TypeAliasDeclaration TreeId
 TypeAliasDeclaration TreeState
   = 'growing' | 'paused' | 'completed' | 'abandoned'
 VariableDeclaration TreeStateSchema
-  : z.ZodEnum<{ completed: "completed"; paused: "paused"; growing: "growing"; abandoned: "abandoned"; }>
+  : z.ZodEnum<{ abandoned: "abandoned"; completed: "completed"; growing: "growing"; paused: "paused"; }>
 InterfaceDeclaration TreeStatistics
   readonly activeNodes: number
   readonly avgBranchingFactor: number
@@ -9211,7 +9213,7 @@ InterfaceDeclaration TreeStatistics
   readonly totalNodes: number
   readonly totalTokensUsed: number
 VariableDeclaration TreeStatisticsSchema
-  : z.ZodObject<{ totalNodes: z.ZodNumber; activeNodes: z.ZodNumber; maxDepth: z.ZodNumber; avgQualityScore: z.ZodNumber; avgConfidence: z.ZodNumber; conclusionCount: z.ZodNumber; totalTokensUsed: z.ZodNumber; avgBranchingFactor: z.ZodNumber; }, z.core.$strip>
+  : z.ZodObject<{ activeNodes: z.ZodNumber; avgBranchingFactor: z.ZodNumber; avgConfidence: z.ZodNumber; avgQualityScore: z.ZodNumber; conclusionCount: z.ZodNumber; maxDepth: z.ZodNumber; totalNodes: z.ZodNumber; totalTokensUsed: z.ZodNumber; }, z.core.$strip>
 TypeAliasDeclaration Trend
   = 'improving' | 'declining' | 'stable'
 TypeParameter TResult
@@ -9232,7 +9234,7 @@ InterfaceDeclaration TrinityConfig
   readonly roleConfigs?: Partial<Record<TrinityRole, Partial<TrinityRoleConfig>>> | undefined
   readonly timeoutMs?: number | undefined
 VariableDeclaration TrinityConfigSchema
-  : z.ZodObject<{ maxIterations: z.ZodOptional<z.ZodNumber>; timeoutMs: z.ZodOptional<z.ZodNumber>; includeHistory: z.ZodOptional<z.ZodBoolean>; roleConfigs: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>, z.ZodObject<{ systemPrompt: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; maxTokens: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>>; }, z.core.$strip>
+  : z.ZodObject<{ includeHistory: z.ZodOptional<z.ZodBoolean>; maxIterations: z.ZodOptional<z.ZodNumber>; roleConfigs: z.ZodOptional<z.ZodRecord<z.ZodEnum<{ thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>, z.ZodObject<{ maxTokens: z.ZodOptional<z.ZodNumber>; systemPrompt: z.ZodOptional<z.ZodString>; temperature: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>>; timeoutMs: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 ClassDeclaration TrinityCoordinator
   cancel(reason: string) => void
   execute(options: TrinityExecuteOptions) => Promise<Result<TrinityResult, AgentError>>
@@ -9252,7 +9254,7 @@ InterfaceDeclaration TrinityPhaseResult
   readonly tokensMeasured?: boolean | undefined
   readonly tokensUsed: number
 VariableDeclaration TrinityPhaseSchema
-  : z.ZodEnum<{ thinking: "thinking"; working: "working"; complete: "complete"; verifying: "verifying"; }>
+  : z.ZodEnum<{ complete: "complete"; thinking: "thinking"; verifying: "verifying"; working: "working"; }>
 InterfaceDeclaration TrinityResult
   readonly finalOutput: string
   readonly history: TrinityPhaseResult[]
@@ -9271,9 +9273,9 @@ InterfaceDeclaration TrinityRoleConfig
   readonly systemPrompt: string
   readonly temperature: number
 VariableDeclaration TrinityRoleSchema
-  : z.ZodEnum<{ thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>
+  : z.ZodEnum<{ thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>
 VariableDeclaration TrinityStopReasonSchema
-  : z.ZodEnum<{ error: "error"; timeout: "timeout"; verified: "verified"; max_iterations: "max_iterations"; }>
+  : z.ZodEnum<{ error: "error"; max_iterations: "max_iterations"; timeout: "timeout"; verified: "verified"; }>
 VariableDeclaration TRUST_TIER_NUMERIC
   : Record<"1" | "2" | "3" | "4", number>
 InterfaceDeclaration TrustClassificationEvent
@@ -9289,7 +9291,7 @@ TypeAliasDeclaration TrustTier
 VariableDeclaration TrustTierSchema
   : z.ZodEnum<{ 1: "1"; 2: "2"; 3: "3"; 4: "4"; }>
 TypeAliasDeclaration TurnOutcome
-  = | { readonly kind: 'continue' } | { readonly kind: 'stop'; readonly reason: AgentRunResult['stopReason'] } | { readonly kind: 'error'; readonly error: AgentError }
+  = | { readonly kind: 'continue'; } | { readonly kind: 'stop'; readonly reason: AgentRunResult['stopReason']; } | { readonly error: AgentError; readonly kind: 'error'; }
 TypeParameter TValue
 InterfaceDeclaration TypedMemoryEntry
   readonly accessedAt: Date
@@ -9454,7 +9456,7 @@ InterfaceDeclaration VerifierOutput
   readonly recommendations: string[]
   readonly verdict: "pass" | "fail"
 VariableDeclaration VerifierVerdictSchema
-  : z.ZodEnum<{ pass: "pass"; fail: "fail"; }>
+  : z.ZodEnum<{ fail: "fail"; pass: "pass"; }>
 VariableDeclaration VERSION
   : string
 InterfaceDeclaration VersionRequirements
@@ -9466,7 +9468,7 @@ TypeAliasDeclaration VersionStatus
 TypeAliasDeclaration Violation
   = z.infer<typeof ViolationSchema>
 VariableDeclaration ViolationSchema
-  : z.ZodObject<{ rule: z.ZodString; message: z.ZodString; severity: z.ZodEnum<{ warn: "warn"; block: "block"; }>; }, z.core.$strip>
+  : z.ZodObject<{ message: z.ZodString; rule: z.ZodString; severity: z.ZodEnum<{ block: "block"; warn: "warn"; }>; }, z.core.$strip>
 TypeAliasDeclaration Vote
   = z.infer<typeof VoteSchema>
 InterfaceDeclaration VoteCounts
@@ -9478,7 +9480,7 @@ TypeAliasDeclaration VoteDecision
   = 'approve' | 'reject' | 'abstain'
   = z.infer<typeof VoteDecisionSchema>
 VariableDeclaration VoteDecisionSchema
-  : z.ZodEnum<{ approve: "approve"; reject: "reject"; abstain: "abstain"; }>
+  : z.ZodEnum<{ abstain: "abstain"; approve: "approve"; reject: "reject"; }>
 TypeAliasDeclaration VoteDecisionStatus
   = z.infer<typeof VoteDecisionStatusSchema>
 InterfaceDeclaration VoteMessage
@@ -9488,7 +9490,7 @@ InterfaceDeclaration VoteMessage
   reasoning: string
   type: "vote"
 VariableDeclaration VoteMessageSchema
-  : z.ZodObject<{ type: z.ZodLiteral<"vote">; expertId: z.ZodString; decision: z.ZodEnum<{ approve: "approve"; reject: "reject"; abstain: "abstain"; }>; reasoning: z.ZodString; conditions: z.ZodOptional<z.ZodArray<z.ZodString>>; }, z.core.$strip>
+  : z.ZodObject<{ conditions: z.ZodOptional<z.ZodArray<z.ZodString>>; decision: z.ZodEnum<{ abstain: "abstain"; approve: "approve"; reject: "reject"; }>; expertId: z.ZodString; reasoning: z.ZodString; type: z.ZodLiteral<"vote">; }, z.core.$strip>
 InterfaceDeclaration VoterCostBreakdown
   readonly cacheCreationInputTokens?: number | undefined
   readonly cachedInputTokens?: number | undefined
@@ -9506,13 +9508,13 @@ InterfaceDeclaration VoteRejectedSignalEvent
   readonly rejectionRules?: readonly string[] | undefined
   readonly type: "signal.vote_rejected"
 TypeAliasDeclaration VoteResult
-  = | { readonly kind: 'approved'; readonly approvalPercentage: number } | { readonly kind: 'rejected'; readonly feedback: string; readonly approvalPercentage: number } | { readonly kind: 'conditional_go'; readonly conditions: readonly string[]; readonly caveats: readonly string[]; readonly approvalPercentage: number; } // #4135: the vote could not reach a valid quorum — a recoverable "re-run the // missing voice" state, DISTINCT from a rejection. Only produced when a caller // opts into the `absolute_quorum` error policy (or an error-policy short-circuit // voids the vote); inert under every default policy. Consumers must NOT feed this // into plan-revision (it carries no reviewer feedback — the plan is fine, a voice // was missing); it terminates/escalates instead. `isApproved` and // `getVoteFeedback` already treat it as not-approved / no-feedback. | { readonly kind: 'no_quorum'; readonly reason: string; readonly approvalPercentage: number }
+  = | { readonly approvalPercentage: number; readonly kind: 'approved'; } | { readonly approvalPercentage: number; readonly feedback: string; readonly kind: 'rejected'; } | { readonly approvalPercentage: number; readonly caveats: readonly string[]; readonly conditions: readonly string[]; readonly kind: 'conditional_go'; } // #4135: the vote could not reach a valid quorum — a recoverable "re-run the // missing voice" state, DISTINCT from a rejection. Only produced when a caller // opts into the `absolute_quorum` error policy (or an error-policy short-circuit // voids the vote); inert under every default policy. Consumers must NOT feed this // into plan-revision (it carries no reviewer feedback — the plan is fine, a voice // was missing); it terminates/escalates instead. `isApproved` and // `getVoteFeedback` already treat it as not-approved / no-feedback. | { readonly approvalPercentage: number; readonly kind: 'no_quorum'; readonly reason: string; }
 TypeAliasDeclaration VoterExpansionCallback
   = ( proposalId: ProposalId, currentVoterCount: number, requestedCount: number ) => Promise<readonly string[]>
 TypeAliasDeclaration VoterRole
   = 'architect' | 'security' | 'devex' | 'ai_ml' | 'pm' | 'catfish' | 'scope_steward'
 VariableDeclaration VoteSchema
-  : z.ZodObject<{ decision: z.ZodEnum<{ approve: "approve"; reject: "reject"; abstain: "abstain"; }>; reasoning: z.ZodString; confidence: z.ZodNumber; conditions: z.ZodOptional<z.ZodArray<z.ZodString>>; rejectionCategories: z.ZodOptional<z.ZodArray<z.ZodEnum<{ YAGNI: "YAGNI"; DRY_VIOLATION: "DRY_VIOLATION"; OVER_ENGINEERING: "OVER_ENGINEERING"; SCOPE_CREEP: "SCOPE_CREEP"; SECURITY_RISK: "SECURITY_RISK"; MISALIGNED: "MISALIGNED"; INSUFFICIENT_EVIDENCE: "INSUFFICIENT_EVIDENCE"; }>>>; findings: z.ZodOptional<z.ZodArray<z.ZodObject<{ summary: z.ZodString; location: z.ZodString; severity: z.ZodDefault<z.ZodEnum<{ critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>>; gate: z.ZodObject<{ reread_cited_line: z.ZodDefault<z.ZodEnum<{ failed: "failed"; skipped: "skipped"; passed: "passed"; }>>; traced_call_path: z.ZodDefault<z.ZodEnum<{ failed: "failed"; skipped: "skipped"; passed: "passed"; }>>; named_assertion: z.ZodDefault<z.ZodString>; ruled_out_language_non_issue: z.ZodDefault<z.ZodEnum<{ failed: "failed"; skipped: "skipped"; passed: "passed"; }>>; }, z.core.$strip>; claim: z.ZodString; }, z.core.$strip>>>; selectedOption: z.ZodOptional<z.ZodString>; timestamp: z.ZodOptional<z.ZodISODateTime>; }, z.core.$strip>
+  : z.ZodObject<{ conditions: z.ZodOptional<z.ZodArray<z.ZodString>>; confidence: z.ZodNumber; decision: z.ZodEnum<{ abstain: "abstain"; approve: "approve"; reject: "reject"; }>; findings: z.ZodOptional<z.ZodArray<z.ZodObject<{ claim: z.ZodString; gate: z.ZodObject<{ named_assertion: z.ZodDefault<z.ZodString>; reread_cited_line: z.ZodDefault<z.ZodEnum<{ failed: "failed"; passed: "passed"; skipped: "skipped"; }>>; ruled_out_language_non_issue: z.ZodDefault<z.ZodEnum<{ failed: "failed"; passed: "passed"; skipped: "skipped"; }>>; traced_call_path: z.ZodDefault<z.ZodEnum<{ failed: "failed"; passed: "passed"; skipped: "skipped"; }>>; }, z.core.$strip>; location: z.ZodString; severity: z.ZodDefault<z.ZodEnum<{ critical: "critical"; high: "high"; low: "low"; medium: "medium"; }>>; summary: z.ZodString; }, z.core.$strip>>>; reasoning: z.ZodString; rejectionCategories: z.ZodOptional<z.ZodArray<z.ZodEnum<{ DRY_VIOLATION: "DRY_VIOLATION"; INSUFFICIENT_EVIDENCE: "INSUFFICIENT_EVIDENCE"; MISALIGNED: "MISALIGNED"; OVER_ENGINEERING: "OVER_ENGINEERING"; SCOPE_CREEP: "SCOPE_CREEP"; SECURITY_RISK: "SECURITY_RISK"; YAGNI: "YAGNI"; }>>>; selectedOption: z.ZodOptional<z.ZodString>; timestamp: z.ZodOptional<z.ZodISODateTime>; }, z.core.$strip>
 TypeAliasDeclaration VoteThreshold
   = z.infer<typeof VoteThresholdSchema>
 VariableDeclaration VOTING_THRESHOLDS
@@ -9525,7 +9527,7 @@ InterfaceDeclaration VotingObservation
   readonly proposalId: string
   readonly timestamp: Date
 VariableDeclaration VotingObservationSchema
-  : z.ZodObject<{ proposalId: z.ZodString; agentId: z.ZodString; decision: z.ZodEnum<{ approve: "approve"; reject: "reject"; abstain: "abstain"; }>; confidence: z.ZodNumber; alignedWithOutcome: z.ZodBoolean; timestamp: z.ZodDate; }, z.core.$strip>
+  : z.ZodObject<{ agentId: z.ZodString; alignedWithOutcome: z.ZodBoolean; confidence: z.ZodNumber; decision: z.ZodEnum<{ abstain: "abstain"; approve: "approve"; reject: "reject"; }>; proposalId: z.ZodString; timestamp: z.ZodDate; }, z.core.$strip>
 InterfaceDeclaration VotingOutcome
   approvalPercentage: number
   approved: boolean
@@ -9551,7 +9553,7 @@ InterfaceDeclaration VotingProtocolConfig
   roundTimeoutMs: number
   sycophancyThreshold: number
 VariableDeclaration VotingProtocolConfigSchema
-  : z.ZodObject<{ committeeSize: z.ZodDefault<z.ZodNumber>; maxRounds: z.ZodDefault<z.ZodNumber>; roundTimeoutMs: z.ZodDefault<z.ZodNumber>; agreementThreshold: z.ZodDefault<z.ZodNumber>; enableAntiSycophancy: z.ZodDefault<z.ZodBoolean>; sycophancyThreshold: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ agreementThreshold: z.ZodDefault<z.ZodNumber>; committeeSize: z.ZodDefault<z.ZodNumber>; enableAntiSycophancy: z.ZodDefault<z.ZodBoolean>; maxRounds: z.ZodDefault<z.ZodNumber>; roundTimeoutMs: z.ZodDefault<z.ZodNumber>; sycophancyThreshold: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration VotingProtocolResult
   agreementScore: number
   consolidatedFindings: ConsolidatedFinding[]
@@ -9564,9 +9566,9 @@ InterfaceDeclaration VotingProtocolResult
   totalDurationMs: number
 InterfaceDeclaration VotingRound
   completedAt?: string | undefined
-  finalVotes: Map<string, { decision: "approve" | "reject" | "abstain"; reasoning: string; confidence: number; conditions?: string[] | undefined; rejectionCategories?: ("YAGNI" | "DRY_VIOLATION" | "OVER_ENGINEERING" | "SCOPE_CREEP" | "SECURITY_RISK" | "MISALIGNED" | "INSUFFICIENT_EVIDENCE")[] | undefined; findings?: { summary: string; location: string; severity: "critical" | "high" | "medium" | "low"; gate: { reread_cited_line: "failed" | "skipped" | "passed"; traced_call_path: "failed" | "skipped" | "passed"; named_assertion: string; ruled_out_language_non_issue: "failed" | "skipped" | "passed"; }; claim: string; }[] | undefined; selectedOption?: string | undefined; timestamp?: string | undefined; }>
-  findingVotes: Map<string, { agentId: string; findingId: string; agree: boolean; reasoning?: string | undefined; amendedSeverity?: "critical" | "major" | "minor" | "suggestion" | undefined; }[]>
-  findings: Map<string, { agentId: string; category: "security" | "documentation" | "bug" | "performance" | "style" | "design" | "other"; severity: "critical" | "major" | "minor" | "suggestion"; description: string; confidence: number; location?: string | undefined; suggestion?: string | undefined; timestamp?: string | undefined; }>
+  finalVotes: Map<string, { conditions?: string[] | undefined; confidence: number; decision: "approve" | "reject" | "abstain"; findings?: { claim: string; gate: { named_assertion: string; reread_cited_line: "failed" | "skipped" | "passed"; ruled_out_language_non_issue: "failed" | "skipped" | "passed"; traced_call_path: "failed" | "skipped" | "passed"; }; location: string; severity: "critical" | "high" | "medium" | "low"; summary: string; }[] | undefined; reasoning: string; rejectionCategories?: ("YAGNI" | "DRY_VIOLATION" | "OVER_ENGINEERING" | "SCOPE_CREEP" | "SECURITY_RISK" | "MISALIGNED" | "INSUFFICIENT_EVIDENCE")[] | undefined; selectedOption?: string | undefined; timestamp?: string | undefined; }>
+  findingVotes: Map<string, { agentId: string; agree: boolean; amendedSeverity?: "critical" | "major" | "minor" | "suggestion" | undefined; findingId: string; reasoning?: string | undefined; }[]>
+  findings: Map<string, { agentId: string; category: "security" | "documentation" | "bug" | "performance" | "style" | "design" | "other"; confidence: number; description: string; location?: string | undefined; severity: "critical" | "major" | "minor" | "suggestion"; suggestion?: string | undefined; timestamp?: string | undefined; }>
   id: string
   phase: "analysis" | "consensus" | "deliberation"
   roundNumber: number
@@ -9579,7 +9581,7 @@ VariableDeclaration VotingRoundPhaseSchema
 TypeAliasDeclaration VotingRoundStatus
   = z.infer<typeof VotingRoundStatusSchema>
 VariableDeclaration VotingRoundStatusSchema
-  : z.ZodEnum<{ pending: "pending"; in_progress: "in_progress"; completed: "completed"; aborted: "aborted"; awaiting_votes: "awaiting_votes"; }>
+  : z.ZodEnum<{ aborted: "aborted"; awaiting_votes: "awaiting_votes"; completed: "completed"; in_progress: "in_progress"; pending: "pending"; }>
 InterfaceDeclaration VotingSession
   committee: string[]
   completedAt?: string | undefined
@@ -9606,9 +9608,9 @@ InterfaceDeclaration Vulnerability
   severity: "info" | "critical" | "high" | "medium" | "low"
   type: string
 VariableDeclaration VulnerabilitySchema
-  : z.ZodObject<{ id: z.ZodString; severity: z.ZodEnum<{ info: "info"; critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>; type: z.ZodString; description: z.ZodString; location: z.ZodOptional<z.ZodString>; remediation: z.ZodString; cweId: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ cweId: z.ZodOptional<z.ZodString>; description: z.ZodString; id: z.ZodString; location: z.ZodOptional<z.ZodString>; remediation: z.ZodString; severity: z.ZodEnum<{ critical: "critical"; high: "high"; info: "info"; low: "low"; medium: "medium"; }>; type: z.ZodString; }, z.core.$strip>
 VariableDeclaration VulnerabilitySeveritySchema
-  : z.ZodEnum<{ info: "info"; critical: "critical"; high: "high"; medium: "medium"; low: "low"; }>
+  : z.ZodEnum<{ critical: "critical"; high: "high"; info: "info"; low: "low"; medium: "medium"; }>
 InterfaceDeclaration WarmStartModelStat
   readonly arm: string
   readonly model: string
@@ -9672,9 +9674,9 @@ TypeAliasDeclaration WeatherReportConfig
   = z.infer<typeof WeatherReportConfigSchema>
 TypeAliasDeclaration|InterfaceDeclaration WeatherReportDeps
   = BaseMcpToolDeps
-  readonly decisionCostRecords?: readonly { decisionId: string; gate: "consensus_vote" | "pr_review"; timestamp: string; summary: { billingMode: "plan" | "api"; voterCount: number; measuredVoters: number; unmeasuredVoters: number; totalInputTokens: number; totalOutputTokens: number; totalTokens: number; totalCostUsd: number; perVoter: readonly { role: string; model: string; inputTokens: number; outputTokens: number; totalTokens: number; costUsd: number; unmeasured: boolean; cachedInputTokens?: number | undefined; cacheCreationInputTokens?: number | undefined; priceBasis?: "unknown" | "list" | undefined; }[]; perModel: readonly { model: string; voterCount: number; inputTokens: number; outputTokens: number; totalTokens: number; costUsd: number; }[]; priceBasis?: "unknown" | "list" | undefined; }; }[] | undefined
+  readonly decisionCostRecords?: readonly { decisionId: string; gate: "consensus_vote" | "pr_review"; summary: { billingMode: "plan" | "api"; measuredVoters: number; perModel: readonly { costUsd: number; inputTokens: number; model: string; outputTokens: number; totalTokens: number; voterCount: number; }[]; perVoter: readonly { cacheCreationInputTokens?: number | undefined; cachedInputTokens?: number | undefined; costUsd: number; inputTokens: number; model: string; outputTokens: number; priceBasis?: "unknown" | "list" | undefined; role: string; totalTokens: number; unmeasured: boolean; }[]; priceBasis?: "unknown" | "list" | undefined; totalCostUsd: number; totalInputTokens: number; totalOutputTokens: number; totalTokens: number; unmeasuredVoters: number; voterCount: number; }; timestamp: string; }[] | undefined
 VariableDeclaration WeatherReportInputSchema
-  : z.ZodObject<{ cli: z.ZodOptional<z.ZodEnum<{ claude: "claude"; gemini: "gemini"; codex: "codex"; opencode: "opencode"; }>>; category: z.ZodOptional<z.ZodEnum<{ research: "research"; architecture: "architecture"; documentation: "documentation"; testing: "testing"; devops: "devops"; planning: "planning"; code_generation: "code_generation"; code_review: "code_review"; security_review: "security_review"; exploration: "exploration"; }>>; includeAdaptive: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; }, z.core.$strip>
+  : z.ZodObject<{ category: z.ZodOptional<z.ZodEnum<{ architecture: "architecture"; code_generation: "code_generation"; code_review: "code_review"; devops: "devops"; documentation: "documentation"; exploration: "exploration"; planning: "planning"; research: "research"; security_review: "security_review"; testing: "testing"; }>>; cli: z.ZodOptional<z.ZodEnum<{ claude: "claude"; codex: "codex"; gemini: "gemini"; opencode: "opencode"; }>>; includeAdaptive: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; }, z.core.$strip>
 InterfaceDeclaration WeatherReportOptions
   readonly category?: string | undefined
   readonly cli?: "claude" | "gemini" | "codex" | "opencode" | undefined
@@ -9692,9 +9694,9 @@ InterfaceDeclaration WeatherReportResponse
   readonly failureBreakdown?: readonly FailureBreakdownEntry[] | undefined
   readonly learningInsights?: readonly LearningInsight[] | undefined
   readonly modelWeather?: readonly ModelWeatherEntry[] | undefined
-  readonly overall: AdapterAttemptStats & { readonly totalTasks: number; readonly successRate: number; readonly avgDurationMs: number; }
+  readonly overall: AdapterAttemptStats & { readonly avgDurationMs: number; readonly successRate: number; readonly totalTasks: number; }
   readonly rateLimits?: readonly RateLimitReport[] | undefined
-  readonly recentWindow?: { readonly windowMs: number; readonly totalTasks: number; readonly successRate: number; readonly avgDurationMs: number; } | undefined
+  readonly recentWindow?: { readonly avgDurationMs: number; readonly successRate: number; readonly totalTasks: number; readonly windowMs: number; } | undefined
   readonly recommendedMappings?: readonly RecommendedMapping[] | undefined
   readonly swarmHealth?: SwarmHealthMetrics | undefined
   readonly tierRecommendations: readonly TierRecommendationEntry[]
@@ -9782,7 +9784,7 @@ InterfaceDeclaration WorkflowAdapterConfig
 TypeAliasDeclaration WorkflowConfig
   = z.infer<typeof WorkflowConfigSchema>
 VariableDeclaration WorkflowConfigSchema
-  : z.ZodObject<{ templatesDir: z.ZodDefault<z.ZodString>; timeout: z.ZodDefault<z.ZodNumber>; maxParallel: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
+  : z.ZodObject<{ maxParallel: z.ZodDefault<z.ZodNumber>; templatesDir: z.ZodDefault<z.ZodString>; timeout: z.ZodDefault<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration WorkflowDefinition
   defaultBudget?: ContextBudget | undefined
   description?: string | undefined
@@ -9796,7 +9798,7 @@ TypeAliasDeclaration WorkflowDefinitionInput
 TypeAliasDeclaration WorkflowDefinitionOutput
   = z.output<typeof WorkflowDefinitionSchema>
 VariableDeclaration WorkflowDefinitionSchema
-  : z.ZodPipe<z.ZodObject<{ name: z.ZodString; version: z.ZodString; description: z.ZodOptional<z.ZodString>; inputs: z.ZodDefault<z.ZodArray<z.ZodObject<{ name: z.ZodString; type: z.ZodEnum<{ string: "string"; number: "number"; boolean: "boolean"; object: "object"; array: "array"; }>; description: z.ZodOptional<z.ZodString>; required: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; default: z.ZodOptional<z.ZodUnknown>; }, z.core.$strip>>>; steps: z.ZodArray<z.ZodObject<{ id: z.ZodString; agent: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; research_expert: "research_expert"; infrastructure_expert: "infrastructure_expert"; thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>; action: z.ZodString; description: z.ZodOptional<z.ZodString>; inputs: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodUnknown>>; dependsOn: z.ZodOptional<z.ZodArray<z.ZodString>>; parallel: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; retries: z.ZodOptional<z.ZodNumber>; timeout: z.ZodOptional<z.ZodNumber>; condition: z.ZodOptional<z.ZodString>; }, z.core.$strip>>; timeout: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>, z.ZodTransform<{ name: string; version: string; description: string | undefined; inputs: { name: string; type: "string" | "number" | "boolean" | "object" | "array"; description: string | undefined; required: boolean; default: unknown; }[]; steps: { id: string; agent: "custom" | "orchestrator" | "code_expert" | "architecture_expert" | "security_expert" | "documentation_expert" | "testing_expert" | "devops_expert" | "research_expert" | "infrastructure_expert" | "thinker" | "worker" | "verifier"; action: string; inputs: Record<string, unknown>; dependsOn: string[] | undefined; parallel: boolean; retries: number | undefined; timeout: number | undefined; condition: string | undefined; }[]; timeout: number | undefined; }, { name: string; version: string; inputs: { name: string; type: "string" | "number" | "boolean" | "object" | "array"; required: boolean; description?: string | undefined; default?: unknown; }[]; steps: { id: string; agent: "custom" | "orchestrator" | "code_expert" | "architecture_expert" | "security_expert" | "documentation_expert" | "testing_expert" | "devops_expert" | "research_expert" | "infrastructure_expert" | "thinker" | "worker" | "verifier"; action: string; inputs: Record<string, unknown>; parallel: boolean; description?: string | undefined; dependsOn?: string[] | undefined; retries?: number | undefined; timeout?: number | undefined; condition?: string | undefined; }[]; description?: string | undefined; timeout?: number | undefined; }>>
+  : z.ZodPipe<z.ZodObject<{ description: z.ZodOptional<z.ZodString>; inputs: z.ZodDefault<z.ZodArray<z.ZodObject<{ default: z.ZodOptional<z.ZodUnknown>; description: z.ZodOptional<z.ZodString>; name: z.ZodString; required: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; type: z.ZodEnum<{ array: "array"; boolean: "boolean"; number: "number"; object: "object"; string: "string"; }>; }, z.core.$strip>>>; name: z.ZodString; steps: z.ZodArray<z.ZodObject<{ action: z.ZodString; agent: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; research_expert: "research_expert"; security_expert: "security_expert"; testing_expert: "testing_expert"; thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>; condition: z.ZodOptional<z.ZodString>; dependsOn: z.ZodOptional<z.ZodArray<z.ZodString>>; description: z.ZodOptional<z.ZodString>; id: z.ZodString; inputs: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodUnknown>>; parallel: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; retries: z.ZodOptional<z.ZodNumber>; timeout: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>>; timeout: z.ZodOptional<z.ZodNumber>; version: z.ZodString; }, z.core.$strip>, z.ZodTransform<{ description: string | undefined; inputs: { default: unknown; description: string | undefined; name: string; required: boolean; type: "string" | "number" | "boolean" | "object" | "array"; }[]; name: string; steps: { action: string; agent: "custom" | "orchestrator" | "code_expert" | "architecture_expert" | "security_expert" | "documentation_expert" | "testing_expert" | "devops_expert" | "research_expert" | "infrastructure_expert" | "thinker" | "worker" | "verifier"; condition: string | undefined; dependsOn: string[] | undefined; id: string; inputs: Record<string, unknown>; parallel: boolean; retries: number | undefined; timeout: number | undefined; }[]; timeout: number | undefined; version: string; }, { description?: string | undefined; inputs: { default?: unknown; description?: string | undefined; name: string; required: boolean; type: "string" | "number" | "boolean" | "object" | "array"; }[]; name: string; steps: { action: string; agent: "custom" | "orchestrator" | "code_expert" | "architecture_expert" | "security_expert" | "documentation_expert" | "testing_expert" | "devops_expert" | "research_expert" | "infrastructure_expert" | "thinker" | "worker" | "verifier"; condition?: string | undefined; dependsOn?: string[] | undefined; description?: string | undefined; id: string; inputs: Record<string, unknown>; parallel: boolean; retries?: number | undefined; timeout?: number | undefined; }[]; timeout?: number | undefined; version: string; }>>
 InterfaceDeclaration WorkflowEngineDeps
   createExecutionPlan: (workflow: WorkflowDefinition) => Result<ExecutionPlan, WorkflowError>
   executePhase: (steps: WorkflowStep[], context: ExecutionContext, options: ExecutionOptions) => Promise<Result<StepResult[], WorkflowError>>
@@ -9872,7 +9874,7 @@ TypeAliasDeclaration WorkflowStepInput
 TypeAliasDeclaration WorkflowStepOutput
   = z.output<typeof WorkflowStepSchema>
 VariableDeclaration WorkflowStepSchema
-  : z.ZodObject<{ id: z.ZodString; agent: z.ZodEnum<{ custom: "custom"; orchestrator: "orchestrator"; code_expert: "code_expert"; architecture_expert: "architecture_expert"; security_expert: "security_expert"; documentation_expert: "documentation_expert"; testing_expert: "testing_expert"; devops_expert: "devops_expert"; research_expert: "research_expert"; infrastructure_expert: "infrastructure_expert"; thinker: "thinker"; worker: "worker"; verifier: "verifier"; }>; action: z.ZodString; description: z.ZodOptional<z.ZodString>; inputs: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodUnknown>>; dependsOn: z.ZodOptional<z.ZodArray<z.ZodString>>; parallel: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; retries: z.ZodOptional<z.ZodNumber>; timeout: z.ZodOptional<z.ZodNumber>; condition: z.ZodOptional<z.ZodString>; }, z.core.$strip>
+  : z.ZodObject<{ action: z.ZodString; agent: z.ZodEnum<{ architecture_expert: "architecture_expert"; code_expert: "code_expert"; custom: "custom"; devops_expert: "devops_expert"; documentation_expert: "documentation_expert"; infrastructure_expert: "infrastructure_expert"; orchestrator: "orchestrator"; research_expert: "research_expert"; security_expert: "security_expert"; testing_expert: "testing_expert"; thinker: "thinker"; verifier: "verifier"; worker: "worker"; }>; condition: z.ZodOptional<z.ZodString>; dependsOn: z.ZodOptional<z.ZodArray<z.ZodString>>; description: z.ZodOptional<z.ZodString>; id: z.ZodString; inputs: z.ZodDefault<z.ZodRecord<z.ZodString, z.ZodUnknown>>; parallel: z.ZodDefault<z.ZodOptional<z.ZodBoolean>>; retries: z.ZodOptional<z.ZodNumber>; timeout: z.ZodOptional<z.ZodNumber>; }, z.core.$strip>
 InterfaceDeclaration WorkflowTemplate
   category?: string | undefined
   description?: string | undefined
@@ -9905,10 +9907,10 @@ InterfaceDeclaration ZeroRoutingDecision
 InterfaceDeclaration ZodError
   addIssue(issue: core.$ZodIssue) => void
   addIssues(issues: core.$ZodIssue[]) => void
-  flatten{ (): core.$ZodFlattenedError<T>; <U>(mapper: (issue: core.$ZodIssue) => U): core.$ZodFlattenedError<T, U>; }
-  flatten{ (): core.$ZodFlattenedError<T>; <U>(mapper: (issue: core.$ZodIssue) => U): core.$ZodFlattenedError<T, U>; }
-  format{ (): core.$ZodFormattedError<T>; <U>(mapper: (issue: core.$ZodIssue) => U): core.$ZodFormattedError<T, U>; }
-  format{ (): core.$ZodFormattedError<T>; <U>(mapper: (issue: core.$ZodIssue) => U): core.$ZodFormattedError<T, U>; }
+  flatten{ (): core.$ZodFlattenedError<T>; <U>(mapper: (issue: core.$ZodIssue) => U): core.$ZodFlattenedError<T, U>;; }
+  flatten{ (): core.$ZodFlattenedError<T>; <U>(mapper: (issue: core.$ZodIssue) => U): core.$ZodFlattenedError<T, U>;; }
+  format{ (): core.$ZodFormattedError<T>; <U>(mapper: (issue: core.$ZodIssue) => U): core.$ZodFormattedError<T, U>;; }
+  format{ (): core.$ZodFormattedError<T>; <U>(mapper: (issue: core.$ZodIssue) => U): core.$ZodFormattedError<T, U>;; }
   isEmpty: boolean
 TypeAliasDeclaration ZodSafeParseResult
   = ZodSafeParseSuccess<T> | ZodSafeParseError<T>
@@ -9921,15 +9923,15 @@ InterfaceDeclaration ZodType
   apply<T>(fn: (schema: this) => T) => T
   array() => ZodArray<this>
   brand<T extends PropertyKey = PropertyKey, Dir extends "in" | "out" | "inout" = "out">(value?: T) => PropertyKey extends T ? this : core.$ZodBranded<this, T, Dir>
-  catch{ (def: core.output<this>): ZodCatch<this>; (def: (ctx: core.$ZodCatchCtx) => core.output<this>): ZodCatch<this>; }
-  catch{ (def: core.output<this>): ZodCatch<this>; (def: (ctx: core.$ZodCatchCtx) => core.output<this>): ZodCatch<this>; }
+  catch{ (def: (ctx: core.$ZodCatchCtx) => core.output<this>): ZodCatch<this>;; (def: core.output<this>): ZodCatch<this>; }
+  catch{ (def: (ctx: core.$ZodCatchCtx) => core.output<this>): ZodCatch<this>;; (def: core.output<this>): ZodCatch<this>; }
   check(...checks: (core.CheckFn<core.output<this>> | core.$ZodCheck<core.output<this>>)[]) => this
   clone(def?: Internals["def"], params?: { parent: boolean; }) => this
   decode(data: core.input<this>, params?: core.ParseContext<core.$ZodIssue>) => core.output<this>
   decodeAsync(data: core.input<this>, params?: core.ParseContext<core.$ZodIssue>) => Promise<core.output<this>>
   def: Internals["def"]
-  default{ (def: util.NoUndefined<core.output<this>>): ZodDefault<this>; (def: () => util.NoUndefined<core.output<this>>): ZodDefault<this>; }
-  default{ (def: util.NoUndefined<core.output<this>>): ZodDefault<this>; (def: () => util.NoUndefined<core.output<this>>): ZodDefault<this>; }
+  default{ (def: () => util.NoUndefined<core.output<this>>): ZodDefault<this>;; (def: util.NoUndefined<core.output<this>>): ZodDefault<this>; }
+  default{ (def: () => util.NoUndefined<core.output<this>>): ZodDefault<this>;; (def: util.NoUndefined<core.output<this>>): ZodDefault<this>; }
   describe(description: string) => this
   description?: string | undefined
   encode(data: core.output<this>, params?: core.ParseContext<core.$ZodIssue>) => core.input<this>
@@ -9948,8 +9950,8 @@ InterfaceDeclaration ZodType
   parse(data: unknown, params?: core.ParseContext<core.$ZodIssue>) => core.output<this>
   parseAsync(data: unknown, params?: core.ParseContext<core.$ZodIssue>) => Promise<core.output<this>>
   pipe<T extends core.$ZodType<any, core.output<this>>>(target: T | core.$ZodType<any, core.output<this>>) => ZodPipe<this, T>
-  prefault{ (def: () => core.input<this>): ZodPrefault<this>; (def: core.input<this>): ZodPrefault<this>; }
-  prefault{ (def: () => core.input<this>): ZodPrefault<this>; (def: core.input<this>): ZodPrefault<this>; }
+  prefault{ (def: () => core.input<this>): ZodPrefault<this>; (def: core.input<this>): ZodPrefault<this>;; }
+  prefault{ (def: () => core.input<this>): ZodPrefault<this>; (def: core.input<this>): ZodPrefault<this>;; }
   readonly() => ZodReadonly<this>
   refine<Ch extends (arg: core.output<this>) => unknown | Promise<unknown>>(check: Ch, params?: string | core.$ZodCustomParams) => Ch extends (arg: any) => arg is infer R ? this & ZodType<R, core.input<this>> : this
   register<R extends core.$ZodRegistry>(registry: R, ...meta: this extends R["_schema"] ? undefined extends R["_meta"] ? [core.$replace<R["_meta"], this>?] : [core.$replace<R["_meta"], this>] : ["Incompatible schema"]) => this

--- a/packages/nexus-agents/src/pipeline/agent-executor.ts
+++ b/packages/nexus-agents/src/pipeline/agent-executor.ts
@@ -610,7 +610,13 @@ export function createAgentStages(config: AgentExecutorConfig = {}): DevPipeline
         durationMs: r.durationMs,
       });
       await postProgress(config, 'Plan', `Done (${r.text.length} chars, ${r.durationMs}ms)`);
-      return r.text || prompt;
+      // #4772: do NOT fall back to `prompt`. Returning the input as the output
+      // made a failed planner indistinguishable from a successful one — the
+      // vote, and then decompose, ran against the prompt text as if it were a
+      // plan. `runExpert` already returns `{ success: false, text: '' }` on
+      // failure, so the empty string carries the signal; `planVoteLoop` stops
+      // on it rather than voting on nothing.
+      return r.text;
     },
 
     vote: async (plan, research) => {

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
@@ -239,6 +239,24 @@ describe('runDevPipeline', () => {
     expect(planCalls[1]?.[2]).toBe('Add retry logic'); // Second call: has feedback
   });
 
+  // #4772: found by running the same dry run twice — one planned well, one's
+  // planner returned nothing, and both produced identical result envelopes. The
+  // plan stage used to substitute the PROMPT when the model returned empty, so
+  // the vote (and then decompose) ran against the input text as if it were a plan.
+  it('reports planStatus empty when the planner returns nothing, and does not vote', async () => {
+    const stages = createMockStages({
+      plan: vi.fn().mockResolvedValue(''),
+    });
+
+    const result = await runDevPipeline('Build feature X', stages, { dryRun: true });
+
+    expect(result.planStatus).toBe('empty');
+    expect(result.plan).toBe('');
+    // Voting on an empty plan wastes a panel and yields a verdict about no
+    // proposal — the loop must stop before it.
+    expect(stages.vote).not.toHaveBeenCalled();
+  });
+
   it('stops after plan+vote in dryRun mode (#1717)', async () => {
     const stages = createMockStages();
     const result = await runDevPipeline('Build feature X', stages, { dryRun: true });
@@ -248,6 +266,11 @@ describe('runDevPipeline', () => {
     expect(result.tasks).toHaveLength(0);
     expect(result.qaIterations).toBe(0);
     expect(result.securityPassed).toBe(false);
+    // #4772: `securityPassed: false` here means the gate never ran, not that it
+    // rejected. Without this the two are indistinguishable to a caller.
+    expect(result.securityRan).toBe(false);
+    // A real plan came back, so no failure marker.
+    expect(result.planStatus).toBeUndefined();
     // Should NOT have called decompose, implement, qa, or security
     expect(stages.decompose).not.toHaveBeenCalled();
     expect(stages.implement).not.toHaveBeenCalled();

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -143,7 +143,31 @@ export interface DevPipelineResult {
   readonly tasks: readonly PipelineTask[];
   readonly voteIterations: number;
   readonly qaIterations: number;
+  /**
+   * Whether the security gate passed.
+   *
+   * Read together with {@link DevPipelineResult.securityRan} (#4772): `false`
+   * with `securityRan: false` means the gate never executed — a dry run stops
+   * after plan+vote — and is NOT a failed security review.
+   */
   readonly securityPassed: boolean;
+  /**
+   * Whether the security gate actually ran (#4772).
+   *
+   * Absent on results from before the distinction existed. `false` means the
+   * run stopped before security, so `securityPassed: false` reports absence,
+   * not a verdict.
+   */
+  readonly securityRan?: boolean;
+  /**
+   * Why planning produced no usable plan, when it did not (#4772).
+   *
+   * Absent means the plan is a real plan. `'empty'` means the planner returned
+   * nothing — previously the stage substituted the PROMPT for the plan, so a
+   * failed run was indistinguishable from a successful one and downstream
+   * stages voted on the input text.
+   */
+  readonly planStatus?: 'empty';
 }
 
 // ============================================================================
@@ -694,7 +718,11 @@ function buildDryRunResult(planResult: {
     tasks: [],
     voteIterations: planResult.iterations,
     qaIterations: 0,
+    // #4772: a dry run stops before security by design. `false` alone read as
+    // "the security gate rejected this"; `securityRan: false` says it never ran.
     securityPassed: false,
+    securityRan: false,
+    ...(planResult.plan.trim() === '' ? { planStatus: 'empty' as const } : {}),
   };
 }
 
@@ -982,6 +1010,14 @@ async function planVoteLoop(
       { name: `plan (i=${String(i)})`, kind: 'pipeline.stage', attrs: { iteration: i } },
       () => stages.plan(task, research, feedback)
     );
+
+    // #4772: the planner produced nothing. Voting on an empty plan wastes a
+    // panel and yields a verdict about no proposal, so stop and let the caller
+    // see `planStatus: 'empty'` instead of a plausible-looking result.
+    if (plan.trim() === '') {
+      logger.warn('Planner returned no plan — stopping before vote', { iteration: i, sessionId });
+      return { plan: '', iterations: i, conditional: false, conditions: [], caveats: [] };
+    }
 
     const vote = await withStep(
       { name: `vote (i=${String(i)})`, kind: 'consensus.vote', attrs: { iteration: i } },

--- a/scripts/extract-api-surface.ts
+++ b/scripts/extract-api-surface.ts
@@ -55,7 +55,7 @@ interface SurfaceEntry {
  * which is no better than one that never fires.
  */
 function normalizeTypeText(text: string): string {
-  return (
+  return sortTypeMembers(
     text
       .replace(/import\("[^"]*\/packages\/nexus-agents\/src\/([^"]*)"\)/g, 'import("src/$1")')
       // Collapse to ONE line. ts-morph wraps long signatures, and the snapshot
@@ -66,6 +66,65 @@ function normalizeTypeText(text: string): string {
       .replace(/\s*\n\s*/g, ' ')
       .trim()
   );
+}
+
+/**
+ * Sorts the members inside every `{ ... }` group of a printed type.
+ *
+ * TypeScript's type printer does not guarantee member ORDER for inferred
+ * object/enum types, and the order shifts with unrelated edits: adding two
+ * fields to `DevPipelineResult` reordered
+ * `z.ZodEnum<{ error; partial; empty }>` to `{ error; empty; partial }` in a
+ * completely different module. Same members, different text, spurious diff.
+ *
+ * That is the "gate that always fails" direction — a checker crying wolf on
+ * untouched code teaches people to regenerate the snapshot without reading it,
+ * which is worse than having no gate. Sorting makes the rendering canonical so
+ * only real membership changes show.
+ */
+/** Index of the brace matching the one at `open`, or -1. */
+function matchingBrace(text: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === '{') depth++;
+    else if (text[i] === '}' && --depth === 0) return i;
+  }
+  return -1;
+}
+
+/** Splits on `;` that are not inside a nested group. */
+function splitTopLevel(inner: string): string[] {
+  const OPENERS = '{(<[';
+  const CLOSERS = '})>]';
+  const out: string[] = [];
+  let buf = '';
+  let nest = 0;
+  for (const ch of inner) {
+    if (OPENERS.includes(ch)) nest++;
+    else if (CLOSERS.includes(ch)) nest--;
+    if (ch === ';' && nest === 0) {
+      out.push(buf.trim());
+      buf = '';
+    } else {
+      buf += ch;
+    }
+  }
+  out.push(buf.trim());
+  return out.filter((m) => m !== '');
+}
+
+function sortTypeMembers(text: string): string {
+  const open = text.indexOf('{');
+  if (open === -1) return text;
+  const close = matchingBrace(text, open);
+  if (close === -1) return text;
+
+  const sorted = splitTopLevel(text.slice(open + 1, close))
+    .map(sortTypeMembers)
+    .sort((a, b) => a.localeCompare(b));
+
+  const body = sorted.length > 0 ? ` ${sorted.join('; ')}; ` : ' ';
+  return `${text.slice(0, open + 1)}${body}${sortTypeMembers(text.slice(close))}`;
 }
 
 function propertyLines(node: Node): string[] {


### PR DESCRIPTION
Resolves #4772, plus a defect in the #4749 surface gate found while doing it.

## How this was found

I ran the same `run_dev_pipeline --dryRun` twice during end-to-end validation. One produced a detailed plan. The other's planner returned empty five times (`parse: Model returned empty response`) and its `plan` field held the prompt echoed back.

**Both returned identical envelopes**: `completed: false, securityPassed: false, voteIterations: 1, tasks: []`.

A single run of either looks fine. Only the comparison shows the problem.

## The defect

```ts
// agent-executor.ts:613
return r.text || prompt;
```

When the model produced nothing, the plan stage returned **the prompt as the plan**. The vote then ran against the input text, and outside a dry run decompose would have too.

`runExpert` already returns `{ success: false, text: '' }`, and the stage emits `plan/failed` one line earlier — so the failure was known and then discarded in favour of a fallback that looks like output. This was the only `|| prompt` fallback in the pipeline.

## What changes

- The plan stage returns `''` on failure rather than the prompt.
- `planVoteLoop` stops before voting on an empty plan. Convening seven voters on no proposal wastes a panel and produces a verdict about nothing.
- `DevPipelineResult.planStatus?: 'empty'` — why there is no plan.
- `DevPipelineResult.securityRan?: boolean` — separates "the gate rejected this" from "the gate never ran". A dry run stops after plan+vote by design (`dev-pipeline.ts:314`), so its hardcoded `securityPassed: false` was reporting absence as a verdict.

Both fields additive and optional.

**Checked and found sound:** dry runs do NOT pollute the learning loop. `recordPipelineHindsight` computes `outcomeMatched: completed && securityPassed`, permanently false for a dry run — but the dry-run path returns at `:316`, before the recorder. Worth stating because the arithmetic looks alarming in isolation.

## The gate defect this exposed

Adding these two fields produced a surface diff in `SkillLoaderConfigSchema` — a module I never touched:

```
OLD: z.ZodEnum<{ error: "error"; partial: "partial"; empty: "empty"; }>
NEW: z.ZodEnum<{ error: "error"; empty: "empty"; partial: "partial"; }>
```

Same members, different order. TypeScript's type printer does not guarantee member order, and it shifts with unrelated edits.

That is the **gate-always-fails** direction, and it is the more corrosive one: a checker that cries wolf on untouched code teaches people to regenerate the snapshot without reading it, which is worse than no gate because the ritual looks like verification.

Printed types are now canonically sorted. Re-verified all three properties: the spurious diff is gone, two runs are byte-identical, and it still catches the real #4744 change (exit 1 mutated, 0 clean).

I also nearly mis-diagnosed this — my first comparison stashed the sorter along with the code change, so the "after" run used the old extractor and the fix appeared not to work. Checking why the test disagreed, rather than assuming the fix was wrong, is what saved it.

## Verification

Full suite **28377 passed, 0 failed**. Pipeline suite 52 passing. Typecheck 0, lint clean. New tests mutation-verified — reverting the fix fails both the `planStatus` test and the dry-run `securityRan` assertion.