### PR TITLE
fix(mcp): put the pipeline's new fields where callers can see them

### DIFF
--- a/.changeset/surface-pipeline-fields.md
+++ b/.changeset/surface-pipeline-fields.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): surface securityRan and planStatus in the run_dev_pipeline response
+
+#4774 added `securityRan` and `planStatus` to `DevPipelineResult` so a caller
+could tell a failed planner from a successful one, and a security gate that
+never ran from one that rejected. The MCP tool builds its response from an
+explicit field list and did not include them, so neither reached any caller —
+which is the one consumer that matters, since an agent loop reads the MCP
+envelope, not the internal type.
+
+Found by running `run_dev_pipeline --dryRun` against the published 4.1.1 build
+and reading the actual response. The unit tests passed throughout: they asserted
+the fields on the result object, not in the serialized envelope.
+
+Both are spread conditionally, so absent still means "the producer predates the
+distinction" rather than `false` / `'empty'`.

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -321,6 +321,43 @@ describe('run_dev_pipeline simulateVotes fail-closed gate (#4170)', () => {
     expect(output['simulated']).toBe(true);
   });
 
+  // #4772: the fields exist on DevPipelineResult and must reach the MCP
+  // envelope. A live dry run on 4.1.1 showed they did not — the response is
+  // built from an explicit field list, so adding them to the result type was
+  // not enough. "The field exists" and "a caller sees it" are different claims.
+  it('surfaces securityRan and planStatus in the response envelope', async () => {
+    runDevPipelineMock.mockResolvedValueOnce({
+      completed: false,
+      plan: '',
+      tasks: [],
+      voteIterations: 1,
+      qaIterations: 0,
+      securityPassed: false,
+      securityRan: false,
+      planStatus: 'empty',
+    } as never);
+    const handler = captureHandler();
+
+    const result = await handler({ task: 'Build feature X', dryRun: true }, STDIO_CTX);
+    const output = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+
+    // securityPassed:false alone reads as "security rejected this".
+    expect(output['securityPassed']).toBe(false);
+    expect(output['securityRan']).toBe(false);
+    expect(output['planStatus']).toBe('empty');
+  });
+
+  it('omits both fields when the pipeline did not report them', async () => {
+    // Absent means the producer predates the distinction — not false, not 'empty'.
+    const handler = captureHandler();
+
+    const result = await handler({ task: 'Build feature X' }, STDIO_CTX);
+    const output = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+
+    expect(output).not.toHaveProperty('securityRan');
+    expect(output).not.toHaveProperty('planStatus');
+  });
+
   it('stays allowed inside a test runner with no simulated flag (existing suites unaffected)', async () => {
     // Default vitest env: VITEST=true.
     const handler = captureHandler();

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -280,6 +280,13 @@ function buildStructuredOutput(
     ...(simulated ? { simulated: true } : {}),
     completed: result.completed,
     securityPassed: result.securityPassed,
+    // #4772: these two are what make `completed: false` legible. Without them a
+    // caller cannot tell a failed planner from a successful dry run, or a
+    // security rejection from a gate that never ran — which is the whole point
+    // of the fields. They were added to DevPipelineResult and then not listed
+    // here, so they never reached the MCP surface.
+    ...(result.securityRan !== undefined ? { securityRan: result.securityRan } : {}),
+    ...(result.planStatus !== undefined ? { planStatus: result.planStatus } : {}),
     voteIterations: result.voteIterations,
     qaIterations: result.qaIterations,
     plan: result.plan,


### PR DESCRIPTION
Completes #4772. **My own #4774 fix did not reach any caller.**

## What happened

#4774 added `securityRan` and `planStatus` to `DevPipelineResult` so a caller could distinguish a failed planner from a successful one, and a security gate that never ran from one that rejected.

`dev-pipeline-tool.ts` builds its MCP response from an **explicit field list**, and neither was in it. So the fields existed on the internal type and reached nobody — and the MCP envelope is the consumer that matters, since an agent loop reads that, not the TypeScript interface.

## How it was found

Running `run_dev_pipeline --dryRun` against the published 4.1.1 build and reading the actual response:

```json
{ "completed": false, "securityPassed": false, "voteIterations": 1, "qaIterations": 0 }
```

No `securityRan`, no `planStatus`. The envelope was exactly as uninformative as before #4774.

**The unit tests passed throughout.** They asserted the fields on the result object, never in the serialized envelope. That is the gap: `expect(result.planStatus).toBe('empty')` and "a caller can see planStatus" are different claims, and only the first was tested.

I applied precisely this lesson in #4773, where I wrote a handler-level test *because* "the field exists" and "a caller sees it" differ — then failed to apply it one PR later.

## The fix

Both fields spread conditionally into the response, so absent still means "the producer predates the distinction" rather than `false` / `'empty'`.

Two tests, mutation-verified — removing the spreads turns the envelope test red:

- a dry run with `securityRan: false, planStatus: 'empty'` surfaces both in the parsed JSON;
- a normal run omits both rather than emitting defaults.

## Verification

Tool suite 28 passing, typecheck 0, lint clean, surface gate unchanged.

## Related finding, not fixed here

The same live run's plan surfaced a separate defect in `security.audit.enabled`, which I verified empirically. Recorded on #4768 — it changes that issue's framing from "audit is opt-in" to "audit is declared on and silently delivers off".