### PR TITLE
test(config): pin that an absent audit block yields no audit config

### DIFF
--- a/.changeset/pin-audit-default-reality.md
+++ b/.changeset/pin-audit-default-reality.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+test(config): pin what the audit default actually does
+
+`SecurityConfigSchema` declares `audit.enabled: z.boolean().default(true)` and
+its JSDoc says "default: true", but the enclosing `audit` object is `.optional()`
+— so a config with no audit block parses to `audit: undefined`, the inner
+default never fires, and `initializeAuditLogger` treats it as disabled.
+
+The existing test parses `{ audit: {} }`, supplying a key a real deployment never
+writes, so it asserts the declared intent rather than the production result.
+
+Adds a sibling that parses `{}` and pins the actual shape, and a comment on the
+original explaining what it does and does not cover. Characterization only — no
+behaviour change, and deliberately not an endorsement of either resolution in
+#4768.
+
+Useful for whoever implements that fix: making the default real (`.default(() =>
+({}))`) fails BOTH this new test and `parses valid security config with
+defaults`, so the change is one line with two deliberate test updates.

--- a/packages/nexus-agents/src/config/schemas-security.test.ts
+++ b/packages/nexus-agents/src/config/schemas-security.test.ts
@@ -285,6 +285,10 @@ describe('SecurityConfigSchema', () => {
     ).toThrow();
   });
 
+  // #4768: this test supplies `audit: {}` — a key a real deployment never
+  // writes. The inner defaults only fire once the object EXISTS, so this
+  // asserts the declared intent, not what production gets. Read it together
+  // with the sibling below, which pins the actual behaviour.
   it('parses audit config with defaults', () => {
     const result = SecurityConfigSchema.parse({
       audit: {},
@@ -296,6 +300,24 @@ describe('SecurityConfigSchema', () => {
       maxFileSizeBytes: 10485760,
       maxFiles: 10,
     });
+  });
+
+  // #4768: the seam the test above cannot see. `audit` is `.optional()`, so a
+  // config with no audit block parses to `undefined` and the inner
+  // `enabled: default(true)` never runs — `initializeAuditLogger` then returns
+  // null and audit logging is OFF, while the schema, its JSDoc and the test
+  // above all say the default is `true`.
+  //
+  // Pinned as characterization, NOT as endorsement: whichever way #4768 is
+  // resolved — make the default real, or document audit as opt-in — this test
+  // should change deliberately rather than a future reader inferring the
+  // default is live because `parse({audit:{}})` says so.
+  it('yields NO audit config when the block is absent — the production shape', () => {
+    const result = SecurityConfigSchema.parse({});
+
+    expect(result.audit).toBeUndefined();
+    // The consequence: the guard in cli-server-audit.ts reads this as disabled.
+    expect(result.audit?.enabled).not.toBe(true);
   });
 
   it('validates audit minSeverity enum', () => {


### PR DESCRIPTION
Characterization test for the #4768 finding. **No behaviour change**, and deliberately not an endorsement of either resolution.

## The gap it closes

`SecurityConfigSchema` says audit is on:

```ts
audit: z.object({
  /** Enable audit logging (default: true) */
  enabled: z.boolean().default(true),
  ...
}).optional(),          // <- the inner defaults only fire if the object exists
```

Production gets off:

```
SecurityConfigSchema.parse({})         -> audit = undefined
SecurityConfigSchema.parse({audit:{}}) -> enabled = true
```

`initializeAuditLogger` reads `securityConfig?.audit?.enabled !== true` and returns `null`, so a deployment with no audit block runs with the chain disabled — while the schema, the JSDoc, and the existing test all say the default is `true`.

The existing test supplies `{ audit: {} }`, a key a real deployment never writes. It asserts the declared intent, not the production result — the same seam-vs-parts shape as #4734, where a unit test proved a branch production could not reach.

## What this adds

- A sibling that parses `{}` and pins the actual shape.
- A comment on the original saying what it does and does not cover, so the two are read together.

Mutation-verified: making the default real (`.default(() => ({}))`) turns the new test red — it genuinely pins current behaviour rather than passing regardless.

## Useful for whoever fixes #4768

That same mutation also fails `parses valid security config with defaults`. So reconciling upward is a **one-line schema change with two deliberate test updates**, not one. Worth knowing before someone changes the line and is surprised.

## Why characterization rather than the fix

Which direction to reconcile — make the declared default real, or document audit as opt-in — is a behaviour decision on a governor path and belongs with the owner (#4768). This test is correct under either outcome: it should change deliberately, rather than a future reader inferring the default is live because `parse({audit:{}})` says so.

Typecheck 0, lint clean, surface unchanged, 53 tests passing in the file.