### PR TITLE
test(agents): pin that a scope alone is not a measurement

### DIFF
--- a/.changeset/pin-scope-is-not-measurement.md
+++ b/.changeset/pin-scope-is-not-measurement.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+pin the "a scope is not a measurement" fix with a test that fails on revert
+
+#4758 removed the #4752 regression where opening a heartbeat scope marked the
+session measured, so every scoped expert task over 120s logged a false stall.
+Nothing pinned it: restoring the pre-fix `heartbeat-monitor.ts` wholesale left
+all 34 tests green, because every touched test calls `heartbeat()` (satisfying
+both predicates) and the one zero-heartbeat test never enters a scope.
+
+Adds the missing case — scope opened, no step emitted, clock advanced past the
+stalled threshold — which is the only test that goes red on that revert. Also
+drops a comment still instructing callers to use `markInstrumented`, removed in
+#4758.

--- a/packages/nexus-agents/src/agents/heartbeat-monitor.test.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-monitor.test.ts
@@ -417,5 +417,29 @@ describe('heartbeat-monitor', () => {
 
       expect(monitor.getSessionHealth(sid)?.heartbeatCount).toBe(0);
     });
+
+    it('stays unmeasured when a scope opens but never reports a step (#4758)', async () => {
+      // The regression this pins: #4752 marked a session measured the moment
+      // `runInHeartbeatSession` opened its scope. Nothing under `src/agents/`
+      // emits a step, so every scoped expert task over 120s fell through to the
+      // thresholds and logged a false stall. Opening a scope is an intent to
+      // report progress, not progress.
+      //
+      // This needs the SINGLETON: the regression lived in the module-level
+      // `runInHeartbeatSession`, which reaches the monitor via
+      // `getHeartbeatMonitor()`. A locally-constructed monitor never sees it.
+      const monitor = getHeartbeatMonitor();
+      const sid = monitor.startSession('expert-scoped-silent');
+
+      await runInHeartbeatSession(sid, async () => {
+        // The realistic case: real work runs, emitting nothing on `stepBus`.
+        return Promise.resolve();
+      });
+      vi.advanceTimersByTime(130_000);
+
+      expect(monitor.getSessionHealth(sid)?.health).toBe('unmeasured');
+      expect(monitor.isStalled(sid)).toBe(false);
+      expect(monitor.getHealth().stalledSessions).toBe(0);
+    });
   });
 });

--- a/packages/nexus-agents/src/agents/heartbeat-self-petting.test.ts
+++ b/packages/nexus-agents/src/agents/heartbeat-self-petting.test.ts
@@ -45,8 +45,8 @@ describe('heartbeat self-petting guard (#4665)', () => {
   });
 
   it('the health timers read but never write', () => {
-    // The three regions that own a heartbeat session. Each must call
-    // markInstrumented (via runInHeartbeatSession) and never heartbeat().
+    // The three regions that own a heartbeat session. Each must scope its work
+    // with runInHeartbeatSession and never heartbeat().
     const monitored = [
       join('mcp', 'tools', 'orchestrate.ts'),
       join('mcp', 'tools', 'execute-expert.ts'),


### PR DESCRIPTION
## Problem

#4758 removed the #4752 regression: `runInHeartbeatSession` marked a session *instrumented* the moment its scope opened, so a session that never received a heartbeat fell through to the stall thresholds. Nothing under `src/agents/` emits a `withStep`, so **every expert task over 120s logged a false stall**.

The fix was correct. It was not pinned.

## Evidence

Restoring the pre-fix file wholesale leaves the suite **green**:

```
git show 3720f85eba^:packages/nexus-agents/src/agents/heartbeat-monitor.ts > <path>
npx vitest run src/agents/heartbeat-monitor.test.ts src/agents/heartbeat-self-petting.test.ts
  Tests  34 passed (34)
```

Every test touched by #4758 calls `heartbeat(sid)`, which satisfies the old *and* new predicate; the one zero-heartbeat test (`heartbeat-monitor.test.ts:370`) never enters a session scope, so it returns `unmeasured` under the pre-fix code too. The regression could return silently.

## Fix

Adds the case that distinguishes them — scope opened, no step emitted, clock past the 120s threshold — using the **singleton** monitor, since the regression lived in module-level `runInHeartbeatSession` reaching the monitor via `getHeartbeatMonitor()`. A locally-constructed monitor never sees it.

Mutation-verified against the faithful revert — it is the only test that goes red:

```
× stays unmeasured when a scope opens but never reports a step (#4758) 5ms
  Tests  1 failed | 31 passed (32)
```

Also drops a comment in `heartbeat-self-petting.test.ts` still instructing callers to "call markInstrumented", a function #4758 deleted.

## Scope

Test-only plus one comment. No production change.

Found by an adversarial review of my own self-merged diffs, and verified independently before filing.