### PR TITLE
fix(pipeline): report whether security ran on every return path

### DIFF
--- a/.changeset/security-ran-on-real-runs.md
+++ b/.changeset/security-ran-on-real-runs.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+report securityRan on every dev-pipeline return, not just dry runs
+
+#4774 added `securityRan` so a caller could tell a failed security review from
+one that never executed, but only assigned it in `buildDryRunResult`. On the
+paths that actually ship code — harness mode, a red quality gate in `blocking`
+mode, and the normal post-scan return — the field was absent, so a real security
+rejection stayed byte-identical to a run where the gate never ran.
+
+Sets it on all three: `false` where the run stops before the scan, `true` after
+the scan executes. Fixes #4782.

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
@@ -293,6 +293,10 @@ describe('runDevPipeline', () => {
     expect(stages.implement).not.toHaveBeenCalled();
     expect(stages.qaReview).not.toHaveBeenCalled();
     expect(stages.securityScan).not.toHaveBeenCalled();
+    // #4782: harness mode hands tasks back for someone else to build, so the
+    // scan cannot have run. Without this the envelope is byte-identical to a
+    // real security rejection.
+    expect(result.securityRan).toBe(false);
   });
 });
 
@@ -488,6 +492,9 @@ describe('runDevPipeline — quality gate (#3356)', () => {
     expect(stages.securityScan).not.toHaveBeenCalled();
     expect(result.completed).toBe(false);
     expect(result.securityPassed).toBe(false);
+    // #4782: the gate short-circuited BEFORE the scan, so `securityPassed:
+    // false` here is absence, not a verdict.
+    expect(result.securityRan).toBe(false);
     // Implementations still happened before the gate.
     expect(result.tasks).toHaveLength(2);
   });
@@ -498,6 +505,8 @@ describe('runDevPipeline — quality gate (#3356)', () => {
 
     expect(stages.qualityGate).toHaveBeenCalledTimes(1);
     expect(stages.securityScan).toHaveBeenCalledTimes(1);
+    // #4782: the one path where the scan DID run must say so.
+    expect(result.securityRan).toBe(true);
     expect(result.completed).toBe(true);
   });
 

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -147,16 +147,21 @@ export interface DevPipelineResult {
    * Whether the security gate passed.
    *
    * Read together with {@link DevPipelineResult.securityRan} (#4772): `false`
-   * with `securityRan: false` means the gate never executed — a dry run stops
-   * after plan+vote — and is NOT a failed security review.
+   * with `securityRan: false` means the gate never executed and is NOT a failed
+   * security review.
    */
   readonly securityPassed: boolean;
   /**
    * Whether the security gate actually ran (#4772).
    *
-   * Absent on results from before the distinction existed. `false` means the
-   * run stopped before security, so `securityPassed: false` reports absence,
-   * not a verdict.
+   * Set on every path `runDevPipeline` can return through, so
+   * `securityPassed: false` is always readable as verdict-vs-absence. Three
+   * paths stop before the scan: a dry run (plan+vote only), harness mode (tasks
+   * are handed back for external implementation), and a red quality gate in
+   * `blocking` mode. Only the post-scan return reports `true`.
+   *
+   * Absent means the producer predates the distinction (#4782), not that the
+   * scan's status is unknown — treat an absent value as unmeasured, not `false`.
    */
   readonly securityRan?: boolean;
   /**
@@ -826,7 +831,10 @@ function buildHarnessResult(
     tasks,
     voteIterations: planResult.iterations,
     qaIterations: 0,
+    // Harness mode hands the tasks back for someone else to implement, so the
+    // scan never ran. `securityPassed: false` alone would read as a rejection.
     securityPassed: false,
+    securityRan: false,
   };
 }
 
@@ -853,7 +861,9 @@ async function runImplSecurityPhase(
       tasks: implResult.completedTasks.length > 0 ? implResult.completedTasks : tasks,
       voteIterations: planResult.iterations,
       qaIterations: implResult.totalIterations,
+      // The gate short-circuited before the scan — absence, not a verdict.
       securityPassed: false,
+      securityRan: false,
     };
   }
 
@@ -877,6 +887,7 @@ async function runImplSecurityPhase(
     voteIterations: planResult.iterations,
     qaIterations: implResult.totalIterations,
     securityPassed: security.passed,
+    securityRan: true,
   };
 }
 


### PR DESCRIPTION
Fixes #4782.

## Problem

#4774 added `securityRan` so a caller could tell a **failed** security review from one that **never executed**. It was assigned in exactly one place — `buildDryRunResult`. Every path that actually ships code omitted it:

| Return site | `securityPassed` | scan ran? | `securityRan` was |
|---|---|---|---|
| `buildHarnessResult` | `false` | **no** | absent |
| quality gate red, `blocking` | `false` | **no** | absent |
| post-scan | `security.passed` | yes | absent |

A real security rejection was byte-identical to a run where the gate never executed — the exact defect the field was added to fix, fixed only for the mode that ships nothing.

## Fix

Sets `securityRan` on all three: `false` where the run stops before the scan, `true` after it executes. JSDoc now enumerates the three short-circuit paths and states that **absent means unmeasured, not `false`** (a pre-#4782 producer).

## Verification

Red/green, not assertion-after-the-fact — the three tests were written first and all three failed against `main`:

```
× returns tasks for external implementation in harness mode (#1704)
× fails the phase on a red gate in 'blocking' mode and skips security
× proceeds to ship on a green gate in 'blocking' mode
  Tests  3 failed | 49 passed (52)
```

After the fix: `Tests 52 passed (52)`; with the MCP tool suite, `80 passed`. `tsc --noEmit` clean. API surface diff empty (`securityRan` was already declared).

## Provenance

Found by an adversarial review of my own recently self-merged diffs, then verified independently by reading all four return sites before filing.