### PR TITLE
test(ci): cover the api-surface gate before it becomes required

### DIFF
--- a/scripts/check-api-surface.test.ts
+++ b/scripts/check-api-surface.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the public API surface gate (#4784).
+ *
+ * The gate shipped in #4757 with no tests, and #4784 found it could not block a
+ * merge at all. Before it becomes a required check (#4785) its diff has to be
+ * pinned — above all in the two shapes that already went wrong once: a member
+ * change masked because the identical line exists under another symbol (#4744),
+ * and a block that differs while the membership diff comes back empty.
+ *
+ * @module scripts/check-api-surface.test
+ */
+import { describe, it, expect } from 'vitest';
+import { diffSurface } from './check-api-surface.js';
+
+/** Two symbols that deliberately share a member line — the #4744 shape. */
+const COMMITTED = [
+  'interface ResultMetadata',
+  '  tokensUsed?: number | undefined;',
+  '  model: string;',
+  'interface StepResult',
+  '  tokensUsed?: number | undefined;',
+  '  status: string;',
+].join('\n');
+
+describe('diffSurface', () => {
+  it('reports nothing when the surfaces are identical', () => {
+    const { added, removed } = diffSurface(COMMITTED, COMMITTED);
+
+    expect(added).toEqual([]);
+    expect(removed).toEqual([]);
+  });
+
+  it('names a widened member under the symbol that owns it, even when the old line survives elsewhere', () => {
+    // The #4744 regression: `tokensUsed?: number | undefined;` still appears
+    // verbatim under StepResult, so a global line-set diff reported
+    // "unchanged". Membership only means something inside one declaration.
+    const current = COMMITTED.replace(
+      'interface ResultMetadata\n  tokensUsed?: number | undefined;',
+      'interface ResultMetadata\n  tokensUsed?: number | null | undefined;'
+    );
+
+    const { added, removed } = diffSurface(COMMITTED, current);
+
+    expect(added).toEqual(['interface ResultMetadata >  tokensUsed?: number | null | undefined;']);
+    expect(removed).toEqual(['interface ResultMetadata >  tokensUsed?: number | undefined;']);
+  });
+
+  it('flags a new symbol', () => {
+    const current = `${COMMITTED}\ninterface FreshType\n  id: string;`;
+
+    const { added, removed } = diffSurface(COMMITTED, current);
+
+    expect(added).toEqual(['interface FreshType  [new symbol]']);
+    expect(removed).toEqual([]);
+  });
+
+  it('flags a removed symbol — the breaking direction', () => {
+    const current =
+      'interface ResultMetadata\n  tokensUsed?: number | undefined;\n  model: string;';
+
+    const { added, removed } = diffSurface(COMMITTED, current);
+
+    expect(removed).toEqual(['interface StepResult  [symbol gone]']);
+    expect(added).toEqual([]);
+  });
+
+  it('falls back to [block changed] when the blocks differ but membership does not', () => {
+    // `changedLines` compares membership, so dropping ONE of two identical
+    // member lines yields an empty line diff. Without the fail-safe the gate
+    // would report a real change as unchanged — the vacuous-pass shape.
+    const committed = 'interface Dup\n  a: string;\n  a: string;';
+    const current = 'interface Dup\n  a: string;';
+
+    const { added, removed } = diffSurface(committed, current);
+
+    expect(added).toEqual(['interface Dup  [block changed]']);
+    expect(removed).toEqual([]);
+  });
+
+  // #4784 / name-the-empty-case: absence must not render as health. An empty
+  // snapshot is the state a truncated write or a failed extraction leaves
+  // behind, and it is exactly when the gate must shout.
+  describe('the empty case', () => {
+    it('reports every symbol as removed when the CURRENT surface is empty', () => {
+      const { added, removed } = diffSurface(COMMITTED, '');
+
+      expect(removed).toEqual([
+        'interface ResultMetadata  [symbol gone]',
+        'interface StepResult  [symbol gone]',
+      ]);
+      expect(added).toEqual([]);
+      // The point of the case: a failed extraction must not read as "no change".
+      expect(removed.length).toBeGreaterThan(0);
+    });
+
+    it('reports every symbol as new when the COMMITTED snapshot is empty', () => {
+      const { added, removed } = diffSurface('', COMMITTED);
+
+      expect(added).toEqual([
+        'interface ResultMetadata  [new symbol]',
+        'interface StepResult  [new symbol]',
+      ]);
+      expect(removed).toEqual([]);
+    });
+
+    it('reports nothing when BOTH are empty — the only honest silent pass', () => {
+      const { added, removed } = diffSurface('', '');
+
+      expect(added).toEqual([]);
+      expect(removed).toEqual([]);
+    });
+  });
+
+  it('ignores blank lines and comments so header churn is not a diff', () => {
+    const withNoise = `# Exported symbols: 2\n\n${COMMITTED}\n\n`;
+
+    const { added, removed } = diffSurface(withNoise, COMMITTED);
+
+    expect(added).toEqual([]);
+    expect(removed).toEqual([]);
+  });
+});

--- a/scripts/extract-api-surface.test.ts
+++ b/scripts/extract-api-surface.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the public API surface extractor (#4784).
+ *
+ * #4757 shipped this untested. Three properties are load-bearing and each one
+ * has already failed once in some form: the walk must follow type references
+ * transitively (a type public only through another type's signature — the
+ * #4744 shape), the output must be byte-stable across runs (member order and
+ * symbol order), and printed types must not carry machine-specific absolute
+ * paths (the gate failed on its own first CI run because /home/runner is not
+ * the author's home directory — a gate that always fails gets switched off).
+ *
+ * @module scripts/extract-api-surface.test
+ */
+import { describe, it, expect } from 'vitest';
+import { Project } from 'ts-morph';
+import { extractSurface, renderSurface } from './extract-api-surface.js';
+
+/**
+ * `referencedDeclarations` only follows into this package's own source, so the
+ * in-memory files must live at the path the extractor recognises.
+ */
+const SRC = '/packages/nexus-agents/src';
+
+/** Builds an in-memory entry point so the test never touches the real package. */
+function surfaceOf(files: Record<string, string>): string {
+  const project = new Project({ useInMemoryFileSystem: true });
+  for (const [path, text] of Object.entries(files)) project.createSourceFile(SRC + path, text);
+  const entry = project.getSourceFileOrThrow(`${SRC}/index.ts`);
+  return renderSurface(extractSurface(entry));
+}
+
+describe('extractSurface', () => {
+  it('captures a directly exported interface and its members', () => {
+    const out = surfaceOf({
+      '/index.ts': 'export interface Direct { id: string; count?: number; }',
+    });
+
+    expect(out).toContain('InterfaceDeclaration Direct');
+    expect(out).toContain('id: string');
+    expect(out).toContain('count?: number');
+  });
+
+  it('follows a type that is public ONLY through another type’s signature', () => {
+    // The #4744 shape, and the whole reason the extractor walks references
+    // instead of reading the export list: `Hidden` is never exported by name,
+    // but a consumer reaches it through `Exposed.payload`, so changing it is a
+    // public break. An export-list-only gate calls it internal.
+    const out = surfaceOf({
+      '/types.ts': 'export interface Hidden { secret: string; }',
+      '/index.ts':
+        "import type { Hidden } from './types.js';\nexport interface Exposed { payload: Hidden; }",
+    });
+
+    expect(out).toContain('InterfaceDeclaration Exposed');
+    expect(out).toContain('InterfaceDeclaration Hidden');
+    expect(out).toContain('secret: string');
+  });
+
+  it('is byte-identical across two extractions of the same source', () => {
+    // Nondeterminism in a snapshot gate is indistinguishable from a real
+    // surface change, and would make every PR red for no reason.
+    const files = {
+      '/index.ts':
+        'export interface A { z: string; a: number; m: boolean; }\nexport interface B { q: A; }',
+    };
+
+    expect(surfaceOf(files)).toBe(surfaceOf(files));
+  });
+
+  it('does not depend on the order members are declared in', () => {
+    // Members are sorted so a pure reordering in source is not a spurious diff.
+    const declared = surfaceOf({ '/index.ts': 'export interface S { a: string; b: string; }' });
+    const reordered = surfaceOf({ '/index.ts': 'export interface S { b: string; a: string; }' });
+
+    expect(reordered).toBe(declared);
+  });
+
+  it('orders symbols alphabetically, not by traversal order', () => {
+    // The walk pops its queue LIFO, so discovery order is the reverse of
+    // declaration order. Only the sort makes the snapshot depend on the source
+    // rather than on how the extractor happened to walk it — and a snapshot
+    // whose order drifts is indistinguishable from a real surface change.
+    const out = surfaceOf({
+      '/index.ts': 'export interface Alpha { a: string; }\nexport interface Beta { b: string; }',
+    });
+    const symbols = out.split('\n').filter((l) => l.startsWith('InterfaceDeclaration '));
+
+    expect(symbols).toEqual(['InterfaceDeclaration Alpha', 'InterfaceDeclaration Beta']);
+  });
+
+  it('reports the symbol count in the header', () => {
+    const out = surfaceOf({ '/index.ts': 'export interface One { a: string; }' });
+
+    expect(out).toContain('# Exported symbols: 1');
+  });
+
+  // Name the empty case: an entry point that exports nothing is a legitimate
+  // input, and it must render as an explicit zero rather than throwing or
+  // producing something a diff would read as unchanged.
+  it('renders an entry point with no exports as zero symbols', () => {
+    const out = surfaceOf({ '/index.ts': 'const internal = 1;\nvoid internal;' });
+
+    expect(out).toContain('# Exported symbols: 0');
+  });
+});
+
+describe('renderSurface', () => {
+  it('renders nothing but the header for an empty entry list', () => {
+    const out = renderSurface([]);
+
+    expect(out).toContain('# Exported symbols: 0');
+    expect(out.split('\n').filter((l) => l !== '' && !l.startsWith('#'))).toEqual([]);
+  });
+
+  it('sorts members so source order cannot produce a spurious diff', () => {
+    const out = renderSurface([
+      { name: 'T', kind: 'InterfaceDeclaration', lines: ['  z: 1;', '  a: 2;'] },
+    ]);
+
+    expect(out.split('\n').slice(4, 7)).toEqual(['InterfaceDeclaration T', '  a: 2;', '  z: 1;']);
+  });
+});


### PR DESCRIPTION
Part of #4784. Unblocks #4785.

## Why

#4757 shipped `scripts/extract-api-surface.ts` and `scripts/check-api-surface.ts` with **zero tests**, and #4784 found the job running them cannot block a merge at all. The `consensus_vote` on making it required came back **Option B, 5/6** — test the scripts first, then flip. This is that step.

## What is pinned

`diffSurface` (9 tests):
- identical surfaces report nothing
- **the #4744 masking shape** — a widened member is named under the symbol that owns it even when the identical old line still exists under a different symbol. This is the defect that made the first version of the gate report "unchanged" for a real widening.
- new symbol / removed symbol
- **the `[block changed]` fail-safe** — blocks differ but the membership diff comes back empty (a duplicate member line dropped). Without it a real change reports as unchanged.
- **the empty case**, three ways: empty current (every symbol removed — a failed extraction must not read as "no change"), empty committed (every symbol new), both empty (the only honest silent pass)
- header/blank-line noise is not a diff

`extractSurface` / `renderSurface` (9 tests):
- **the transitive walk** — a type public *only* through another type's signature is captured. An export-list-only gate calls it internal; that is the #4744 shape.
- **determinism** — two extractions byte-identical; member order independent of source order; **symbols ordered alphabetically rather than by traversal order** (the walk pops LIFO, so discovery order is the reverse of declaration order)
- empty entry point renders an explicit `# Exported symbols: 0`

## Mutation-verified

Every test was checked against a deliberate break of the thing it claims to pin:

| Mutation | Result |
|---|---|
| `[block changed]` fail-safe removed | 1 failed |
| `parseBlocks` degraded to a global line-set diff (pre-#4744 behaviour) | 6 failed |
| removals suppressed | 2 failed |
| transitive reference walk disabled | 1 failed |
| member sort removed | 2 failed |
| symbol sort removed | 1 failed |

The symbol-sort mutation initially passed — the first draft asserted only that two runs agreed, which a deterministic-but-unsorted extractor also satisfies. Added the explicit ordering assertion, then re-ran the mutation to confirm it goes red.

## Scope

Tests only. No production or script changes. `tsc` clean (two pre-existing unrelated errors in `check-harness-alignment.ts` and the website config), eslint clean, and the committed snapshot still matches HEAD exactly.