### PR TITLE
fix(mcp): report the audit log lines verification could not read

### DIFF
--- a/.changeset/audit-verify-coverage.md
+++ b/.changeset/audit-verify-coverage.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+report how much of the audit log verify_audit_chain could not read
+
+`loadAuditEvents` dropped unreadable files and unparseable/schema-invalid lines
+with nothing but a `logger.warn`, and the response carried only `eventCount` —
+the number of events that _parsed_, not the size of the log. A verdict computed
+over 60 of 100 lines was reported identically to one computed over all 100.
+
+Counts the skips and surfaces them as `skippedLines` / `unreadableFiles`,
+omitted when zero so absence means full coverage rather than "unreported".
+Resilient reading stays the policy; the caller is now told what it cost.
+
+Fixes #4787.

--- a/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.test.ts
@@ -148,6 +148,70 @@ describe('verify_audit_chain handler behavior', () => {
     expect(body).toContain('empty');
   });
 
+  // #4787: the loader drops unreadable files and unparseable/invalid lines with
+  // nothing but a logger.warn, so a verdict computed over PART of the log was
+  // reported identically to one computed over all of it. A bounded read is
+  // fine; a bounded read recorded as complete is the failure.
+  describe('coverage reporting (#4787)', () => {
+    /** Invokes the registered handler and returns the parsed response body. */
+    async function callHandler(dir: string): Promise<VerifyAuditChainResponse> {
+      type Captured =
+        ((a: unknown, c: unknown) => Promise<{ content: Array<{ text: string }> }>) | undefined;
+      let captured: Captured;
+      const server = {
+        registerTool: (_n: string, _s: unknown, h: unknown) => {
+          captured = h as Captured;
+        },
+      };
+      registerVerifyAuditChainTool(server as never, {} as never);
+      const res = await captured?.({ logDir: dir }, {});
+      return JSON.parse(res?.content[0]?.text ?? '{}') as VerifyAuditChainResponse;
+    }
+
+    it('reports the number of lines it could not read', async () => {
+      const events = chain(3);
+      const good = events.map((e) => JSON.stringify(e));
+      // Two lines an adversary or a truncated write would leave behind: one
+      // that is not JSON at all, one that is JSON but not an AuditEvent.
+      fs.writeFileSync(
+        path.join(tmpDir, 'audit-2026-04-28-12-00-00.jsonl'),
+        [good[0]!, 'not json at all', good[1]!, '{"id":"x"}', good[2]!].join('\n') + '\n'
+      );
+
+      const body = await callHandler(tmpDir);
+
+      expect(body.skippedLines).toBe(2);
+      // The parsed subset still chains, so without the count this reads as a
+      // clean verdict over the whole log.
+      expect(body.eventCount).toBe(3);
+      expect(body.verification.ok).toBe(true);
+    });
+
+    it('omits the count when nothing was skipped, so absence stays meaningful', async () => {
+      writeAuditFile('audit-2026-04-28-12-00-00.jsonl', chain(3));
+
+      const body = await callHandler(tmpDir);
+
+      expect(body.skippedLines).toBeUndefined();
+      expect(body.unreadableFiles).toBeUndefined();
+    });
+
+    it('distinguishes a wholly unparseable log from an empty one', async () => {
+      // The worst case: every line is garbage. Before this the response was
+      // eventCount 0 + notVerified "empty" — identical to an empty directory.
+      fs.writeFileSync(
+        path.join(tmpDir, 'audit-2026-04-28-12-00-00.jsonl'),
+        ['garbage', 'more garbage'].join('\n') + '\n'
+      );
+
+      const body = await callHandler(tmpDir);
+
+      expect(body.eventCount).toBe(0);
+      expect(body.skippedLines).toBe(2);
+      expect(body.fileCount).toBe(1);
+    });
+  });
+
   it('verifies a clean multi-file chain in lexicographic order', async () => {
     const all = chain(6);
     writeAuditFile('audit-2026-04-28-12-00-00.jsonl', all.slice(0, 3));

--- a/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.ts
@@ -49,6 +49,17 @@ export interface VerifyAuditChainResponse {
   readonly logDir: string;
   readonly fileCount: number;
   readonly eventCount: number;
+  /**
+   * Lines the loader could not turn into an event (#4787).
+   *
+   * `eventCount` counts what parsed, not what the log contained, so a verdict
+   * over a partially-read log used to be reported identically to one over the
+   * whole thing. Omitted when zero: absent means full coverage, a number means
+   * the verdict below covers `eventCount` of `eventCount + skippedLines` lines.
+   */
+  readonly skippedLines?: number;
+  /** Files that could not be opened at all (#4787). Omitted when zero. */
+  readonly unreadableFiles?: number;
   readonly verification: ChainVerification;
 }
 
@@ -58,16 +69,28 @@ export type VerifyAuditChainDeps = BaseMcpToolDeps;
  * Read all audit-prefixed JSONL log files from `dir` in lexicographic order
  * and parse each line into an AuditEvent. Malformed lines are skipped with a
  * warning (matches the read-resilience policy in structured-task-state.ts).
+ *
+ * Skips are COUNTED as well as logged (#4787). Resilient reading is the right
+ * policy for an audit reader — one corrupt line should not blind the verifier
+ * to the rest — but the caller has to be told how much was dropped, or a
+ * partial verdict is indistinguishable from a complete one.
  */
 async function loadAuditEvents(
   dir: string,
   logger: HandlerContext['logger']
-): Promise<{ events: AuditEvent[]; fileCount: number }> {
+): Promise<{
+  events: AuditEvent[];
+  fileCount: number;
+  skippedLines: number;
+  unreadableFiles: number;
+}> {
   const entries = await fs.readdir(dir);
   const auditFiles = entries
     .filter((name) => name.startsWith('audit-') && name.endsWith('.jsonl'))
     .sort();
   const events: AuditEvent[] = [];
+  let skippedLines = 0;
+  let unreadableFiles = 0;
   for (const filename of auditFiles) {
     const fullPath = path.join(dir, filename);
     let content: string;
@@ -76,6 +99,7 @@ async function loadAuditEvents(
     } catch (cause) {
       const msg = cause instanceof Error ? cause.message : String(cause);
       logger.warn('Skipping unreadable audit log file', { filename, error: msg });
+      unreadableFiles++;
       continue;
     }
     for (const line of content.split('\n')) {
@@ -90,14 +114,16 @@ async function loadAuditEvents(
             filename,
             error: validated.error.message,
           });
+          skippedLines++;
         }
       } catch (cause) {
         const msg = cause instanceof Error ? cause.message : String(cause);
         logger.warn('Skipping unparseable audit event', { filename, error: msg });
+        skippedLines++;
       }
     }
   }
-  return { events, fileCount: auditFiles.length };
+  return { events, fileCount: auditFiles.length, skippedLines, unreadableFiles };
 }
 
 async function handler(args: unknown, ctx: HandlerContext): Promise<ToolResult> {
@@ -127,13 +153,19 @@ async function handler(args: unknown, ctx: HandlerContext): Promise<ToolResult> 
     });
   }
 
-  const { events, fileCount } = await loadAuditEvents(resolvedDir, ctx.logger);
+  const { events, fileCount, skippedLines, unreadableFiles } = await loadAuditEvents(
+    resolvedDir,
+    ctx.logger
+  );
   const verification = verifyChain(events);
 
+  // Omitted when zero so absence means full coverage rather than "unreported".
   const response: VerifyAuditChainResponse = {
     logDir: resolvedDir,
     fileCount,
     eventCount: events.length,
+    ...(skippedLines > 0 ? { skippedLines } : {}),
+    ...(unreadableFiles > 0 ? { unreadableFiles } : {}),
     verification,
   };
   return toolSuccess(JSON.stringify(response, null, 2));
@@ -158,7 +190,9 @@ export function registerVerifyAuditChainTool(server: McpServer, deps: VerifyAudi
     'and runs `verifyChain()` to detect tampering. Returns a structured ' +
     'result with eventCount, fileCount, and one of three tamper signals if ' +
     'detected (hash_mismatch, previous_hash_mismatch, missing_hash). ' +
-    'Read-only — never writes or deletes events.';
+    'Reports skippedLines/unreadableFiles when part of the log could not be ' +
+    'read, so a verdict over a partial log is never mistaken for a complete ' +
+    'one. Read-only — never writes or deletes events.';
 
   const secureHandler = createSecureHandler(handler, {
     toolName: 'verify_audit_chain',


### PR DESCRIPTION
Fixes #4787.

## Problem

`loadAuditEvents` drops input on three paths, each writing only a `logger.warn`:

- an unreadable file (`verify-audit-chain-tool.ts:78`)
- a line that fails `JSON.parse` (`:96`)
- a line that parses but fails `AuditEventSchema` (`:88`)

The response carried `logDir`, `fileCount`, `eventCount`, `verification`. **Nothing said how much was dropped.** `eventCount` is what *parsed*, not what the log contained — so a 100-line log with 40 unreadable lines returned `eventCount: 60` and, if those 60 chain cleanly, `ok: true`. A verdict over 60% of the artifact was reported identically to one over all of it.

`fileCount` vs `eventCount` only exposes total loss (`3 files, 0 events`). It cannot express partial loss, which is the case an adversary produces.

Per CLAUDE.md: *"A partial review honestly labeled is fine; a partial review recorded as complete is the failure."* This is the audit chain — the instrument a human spot-check trusts most.

## Fix

Count the skips; surface them as `skippedLines` and `unreadableFiles`, **omitted when zero** so absence means full coverage rather than "unreported". Resilient reading stays the policy — one corrupt line shouldn't blind the verifier to the rest — the caller is just told what it cost. Tool description updated so an agent calling it knows the fields exist.

## Verification

Red/green — the three tests were written first, two failed against `main`:

```
× reports the number of lines it could not read
× distinguishes a wholly unparseable log from an empty one
  Tests  2 failed | 10 passed (12)
```

After: `12 passed`. Mutation-verified both directions:

| Mutation | Result |
|---|---|
| skip counting removed | 2 failed |
| zero no longer omitted | 1 failed |

The second matters: it proves the "omits when zero" test isn't passing vacuously on an absent field.

`tsc` clean. **API surface unchanged** — `VerifyAuditChainResponse` is not reachable from `src/index.ts`, so the snapshot doesn't move.

## Relationship to #4773

#4773 added `notVerified: 'empty' | 'unchained'` so a clean verdict could say it verified *nothing*. That covered the empty case. This covers the **partial** case — same defect class, found by adversarially reviewing that same PR.

## Ownership note

Touches `src/mcp/` (CODEOWNERS: @williamzujkowski). Not one of CLAUDE.md's never-auto-merge governor paths, but it is adjacent to the audit surface, so flagging the call explicitly rather than assuming.