### PR TITLE
chore(ci): require the producer/consumer check and pin the wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,16 +388,33 @@ jobs:
   ci-success:
     name: CI Success
     needs:
-      [commitlint, changeset-check, lint, typecheck, build, test, fitness-audit, consolidation-test]
+      [
+        commitlint,
+        changeset-check,
+        lint,
+        typecheck,
+        build,
+        test,
+        fitness-audit,
+        consolidation-test,
+        producer-consumer-check,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()
     steps:
       - name: Check required jobs
         run: |
-          # commitlint + changeset-check are skipped on push (not a PR) — treat skipped as success
+          # commitlint, changeset-check and producer-consumer-check are skipped on
+          # push (not a PR) — treat skipped as success.
+          #
+          # #4784: producer-consumer-check was absent from this list, so the
+          # #3024 wiring gate and the #4757 API-surface gate could both go red
+          # while the PR stayed mergeable. Branch protection requires only
+          # "CI Success", so a gate not wired in here cannot fail by construction.
           if [[ "${{ needs.commitlint.result }}" != "success" && "${{ needs.commitlint.result }}" != "skipped" ]] || \
              [[ "${{ needs.changeset-check.result }}" != "success" && "${{ needs.changeset-check.result }}" != "skipped" ]] || \
+             [[ "${{ needs.producer-consumer-check.result }}" != "success" && "${{ needs.producer-consumer-check.result }}" != "skipped" ]] || \
              [[ "${{ needs.lint.result }}" != "success" ]] || \
              [[ "${{ needs.typecheck.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \

--- a/scripts/ci-required-jobs.test.ts
+++ b/scripts/ci-required-jobs.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Every CI job is either required or explicitly advisory (#4784/#4785).
+ *
+ * Branch protection requires exactly one context, "CI Success". A job absent
+ * from `ci-success.needs` therefore cannot block a merge no matter how red it
+ * goes — the can't-fail-by-construction shape. `producer-consumer-check` sat
+ * there for its whole life, taking the #3024 wiring gate and the #4757
+ * API-surface gate down with it.
+ *
+ * Being advisory is a legitimate choice. Being advisory by accident is not.
+ * This test forces a new job to declare which it is.
+ *
+ * @module scripts/ci-required-jobs.test
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+
+/**
+ * Jobs deliberately left out of `ci-success.needs`.
+ *
+ * Each entry is a decision to let this job go red without blocking a merge.
+ * Removing a job from this list makes it required; adding one to it needs a
+ * reason. Tracked for review in #4790.
+ */
+const ADVISORY_JOBS = new Set(['script-tests', 'model-string-drift', 'index-check', 'security']);
+
+interface CiWorkflow {
+  jobs: Record<string, { needs?: string[]; steps?: Array<{ run?: string }> }>;
+}
+
+const ci = parse(
+  readFileSync(join(process.cwd(), '.github', 'workflows', 'ci.yml'), 'utf8')
+) as CiWorkflow;
+const required = new Set(ci.jobs['ci-success']?.needs ?? []);
+const gateScript = (ci.jobs['ci-success']?.steps ?? []).map((s) => s.run ?? '').join('\n');
+
+describe('CI required-job wiring', () => {
+  it('finds the ci-success job and its gate script', () => {
+    // Guard the guard: a renamed job would make every assertion below vacuous.
+    expect(required.size).toBeGreaterThan(0);
+    expect(gateScript).toContain('needs.');
+  });
+
+  it('classifies every job as either required or explicitly advisory', () => {
+    const unclassified = Object.keys(ci.jobs).filter(
+      (job) => job !== 'ci-success' && !required.has(job) && !ADVISORY_JOBS.has(job)
+    );
+
+    expect(
+      unclassified,
+      `These jobs are in neither ci-success.needs nor ADVISORY_JOBS, so they cannot block a merge and nobody decided that: ${unclassified.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('checks the result of every job it depends on', () => {
+    // The inverse can't-fail shape: listing a job in `needs` only makes
+    // ci-success WAIT for it. Without a `needs.<job>.result` test in the gate
+    // script, a red job still yields a green CI Success.
+    const unchecked = [...required].filter((job) => !gateScript.includes(`needs.${job}.result`));
+
+    expect(
+      unchecked,
+      `In ci-success.needs but never checked in the gate script, so a failure is awaited and then ignored: ${unchecked.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('requires producer-consumer-check, which carries the API-surface gate', () => {
+    // Named explicitly: #4784 is why this file exists, and a regression here
+    // would silently un-gate the public API surface again.
+    expect(required.has('producer-consumer-check')).toBe(true);
+    expect(gateScript).toContain('needs.producer-consumer-check.result');
+  });
+
+  it('treats a skipped pull-request-only job as success', () => {
+    // These three are `if: github.event_name == 'pull_request'`, so on a push
+    // they are skipped. Without the skipped branch every push to main reddens.
+    for (const job of ['commitlint', 'changeset-check', 'producer-consumer-check']) {
+      expect(gateScript, `${job} must accept "skipped"`).toContain(
+        `needs.${job}.result }}" != "skipped"`
+      );
+    }
+  });
+});


### PR DESCRIPTION
Closes #4785. Implements the outcome of the #4784 vote.

## What

Adds `producer-consumer-check` to `ci-success.needs` and to the gate script's exit-code condition, treating `skipped` as success — the job is `if: github.event_name == 'pull_request'`, so it is skipped on push, exactly like `commitlint` and `changeset-check`.

No branch-protection change needed: `CI Success` is already the sole required context.

## Why now

The #4784 vote (`higher_order`, `absolute_quorum`, 7 voters) approved **6-1** with Option B — *test the scripts first, then require* — leading 5/6. #4786 landed those tests (18, mutation-verified against six deliberate breaks). The precondition is met.

Until this PR, the #3024 producer/consumer wiring gate and the #4757 API-surface gate could both go red while the PR stayed mergeable.

## The guard

`scripts/ci-required-jobs.test.ts` pins the wiring so it cannot silently regress. It asserts:

1. **Every job is either required or explicitly advisory.** A new job in neither `ci-success.needs` nor the `ADVISORY_JOBS` allowlist fails the test. Advisory is a fine choice; advisory *by accident* is what happened here.
2. **Every job in `needs` has its result checked.** The inverse can't-fail shape — listing a job in `needs` only makes `ci-success` *wait* for it. Without a `needs.<job>.result` test, a red job is awaited and then ignored.
3. `producer-consumer-check` specifically is required, named because a regression there silently un-gates the public API surface again.
4. The three pull-request-only jobs accept `skipped`, so pushes to `main` don't redden.
5. A guard-the-guard case: a renamed `ci-success` job would make the rest vacuous, so the parse is asserted first.

Mutation-verified — 3 of 5 tests fail under each:

| Mutation | Result |
|---|---|
| `producer-consumer-check` removed from `needs` (the #4784 state) | 3 failed |
| in `needs` but its result never checked | 3 failed |

## Discovered while doing this

Four more jobs are outside `needs` and cannot block a merge either — `security`, `script-tests`, `model-string-drift`, `index-check`. They are named in `ADVISORY_JOBS` so the status quo is at least explicit, and filed as **#4790** to be decided on their merits rather than flipped here. `security` is the one worth looking at first, and per the #4784 precedent it should not become blocking until its failure modes are understood.

## Ownership note

Touches `.github/workflows/` (CODEOWNERS: @williamzujkowski, "supply chain protection"). Not one of CLAUDE.md's never-auto-merge governor paths, and the change strengthens a gate rather than weakening one — but flagging the call rather than assuming it.