### PR TITLE
fix(mcp): say why the dev pipeline did not complete, and keep the verdict

### DIFF
--- a/.changeset/run-preserve-pipeline-verdict.md
+++ b/.changeset/run-preserve-pipeline-verdict.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+say why the dev pipeline did not complete on the `run` path, and keep the result
+
+Every non-completion reaching `run` collapsed to "the dev pipeline did not
+complete", and `exec.result` was discarded — so a caller could not tell a
+security gate that REJECTED the change from one that never ran, which is the
+distinction #4772/#4783 added `securityRan` to provide.
+
+The message now names the reason (empty plan, security rejected, stopped before
+the gate) and the engine's result travels in the error envelope's `detail`.
+`securityRan` is read as three-valued: absent means a producer predating the
+field, not `false`, so the generic message stands rather than claiming a reason
+we do not have.
+
+Fixes #4789.

--- a/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
@@ -9,15 +9,31 @@ import { join } from 'node:path';
 // #3712: capture the trustTier handed to runDevPipelineForGoal through the
 // run → dev-pipeline executor path (the "hole" — a real RequestContext that ran
 // a real research stage on a possibly-untrusted goal with an absent tier).
-const runDevPipelineForGoalMock = vi.fn((_goal: string, _trustTier?: string) =>
-  Promise.resolve({
-    completed: true,
-    plan: 'plan',
-    tasks: [],
-    voteIterations: 1,
-    qaIterations: 1,
-    securityPassed: true,
-  })
+/**
+ * The pipeline result shape the mock returns. Declared rather than inferred so
+ * a test can set the #4783 provenance fields — inference from the happy-path
+ * literal alone rejects `securityRan`/`planStatus` as unknown properties.
+ */
+interface FakeDevPipelineResult {
+  completed: boolean;
+  plan: string;
+  tasks: never[];
+  voteIterations: number;
+  qaIterations: number;
+  securityPassed: boolean;
+  securityRan?: boolean;
+  planStatus?: 'empty';
+}
+const runDevPipelineForGoalMock = vi.fn(
+  (_goal: string, _trustTier?: string): Promise<FakeDevPipelineResult> =>
+    Promise.resolve({
+      completed: true,
+      plan: 'plan',
+      tasks: [],
+      voteIterations: 1,
+      qaIterations: 1,
+      securityPassed: true,
+    })
 );
 vi.mock('./dev-pipeline-tool.js', () => ({
   runDevPipelineForGoal: (goal: string, trustTier?: string) =>
@@ -473,6 +489,102 @@ describe('run async dispatch (execute:true, #3732)', () => {
       });
       expect(result.isError).toBe(true);
       expect(errorEnvelope(result)?.['errorCategory']).toBe('business');
+    });
+
+    // #4789: both of the reachable non-completions on the `run` path produced
+    // the identical message and discarded `exec.result`, so a caller could not
+    // tell "security rejected your change" from "security never ran" — the
+    // distinction #4783 put into the result one layer down.
+    it('says the security gate REJECTED when the scan actually ran', async () => {
+      runDevPipelineForGoalMock.mockResolvedValueOnce({
+        completed: false,
+        plan: 'plan',
+        tasks: [],
+        voteIterations: 1,
+        qaIterations: 1,
+        securityPassed: false,
+        securityRan: true,
+      });
+      const handler = captureHandler();
+      const result = await handler({
+        goal: 'implement the feature',
+        forceStrategy: 'dev-pipeline',
+        execute: true,
+      });
+
+      const env = errorEnvelope(result);
+      expect(env?.['message']).toContain('security gate rejected');
+      // The verdict itself must survive, not just a sentence about it.
+      expect((env?.['detail'] as Record<string, unknown>)?.['securityRan']).toBe(true);
+    });
+
+    it('says the run stopped BEFORE the security gate when it never ran', async () => {
+      runDevPipelineForGoalMock.mockResolvedValueOnce({
+        completed: false,
+        plan: 'plan',
+        tasks: [],
+        voteIterations: 1,
+        qaIterations: 1,
+        securityPassed: false,
+        securityRan: false,
+      });
+      const handler = captureHandler();
+      const result = await handler({
+        goal: 'implement the feature',
+        forceStrategy: 'dev-pipeline',
+        execute: true,
+      });
+
+      const env = errorEnvelope(result);
+      expect(env?.['message']).toContain('stopped before the security gate');
+      expect(env?.['message']).not.toContain('rejected');
+      expect((env?.['detail'] as Record<string, unknown>)?.['securityRan']).toBe(false);
+    });
+
+    it('names an empty plan as the reason rather than a generic non-completion', async () => {
+      runDevPipelineForGoalMock.mockResolvedValueOnce({
+        completed: false,
+        plan: '',
+        tasks: [],
+        voteIterations: 0,
+        qaIterations: 0,
+        securityPassed: false,
+        securityRan: false,
+        planStatus: 'empty',
+      });
+      const handler = captureHandler();
+      const result = await handler({
+        goal: 'implement the feature',
+        forceStrategy: 'dev-pipeline',
+        execute: true,
+      });
+
+      const env = errorEnvelope(result);
+      expect(env?.['message']).toContain('planner returned no plan');
+      expect((env?.['detail'] as Record<string, unknown>)?.['planStatus']).toBe('empty');
+    });
+
+    it('still reports a bare non-completion when the result says nothing more', async () => {
+      // A producer predating #4783 sets neither field. The message must not
+      // claim a reason it does not have.
+      runDevPipelineForGoalMock.mockResolvedValueOnce({
+        completed: false,
+        plan: 'plan',
+        tasks: [],
+        voteIterations: 1,
+        qaIterations: 0,
+        securityPassed: false,
+      });
+      const handler = captureHandler();
+      const result = await handler({
+        goal: 'implement the feature',
+        forceStrategy: 'dev-pipeline',
+        execute: true,
+      });
+
+      const env = errorEnvelope(result);
+      expect(env?.['message']).toContain('did not complete');
+      expect(env?.['message']).not.toContain('security gate');
     });
 
     it('surfaces a pipeline that reported success:false as a structured error', async () => {

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -397,18 +397,47 @@ export async function executeGoal(
  * `ExtendedVotingResult` (consensus) is deliberately absent: a `rejected`
  * outcome is the verdict the caller asked for, not an engine fault.
  */
-function detectEngineFailure(result: unknown): string | null {
+function detectEngineFailure(
+  result: unknown
+): { message: string; detail?: Record<string, unknown> } | null {
   if (typeof result !== 'object' || result === null) return null;
   const record = result as Record<string, unknown>;
 
   if (record['success'] === false) {
     const detail = typeof record['error'] === 'string' ? record['error'] : 'no error message';
-    return `Engine reported failure: ${detail}`;
+    return { message: `Engine reported failure: ${detail}` };
   }
   if (record['completed'] === false) {
-    return 'Engine reported failure: the dev pipeline did not complete';
+    return { message: describeIncompletePipeline(record), detail: record };
   }
   return null;
+}
+
+/**
+ * Says WHY the dev pipeline did not complete (#4789).
+ *
+ * Every non-completion used to read `the dev pipeline did not complete`, and
+ * `exec.result` was dropped — so a caller could not tell a security gate that
+ * REJECTED the change from one that never ran, which is precisely the
+ * distinction #4772/#4783 put into `securityRan`. The reason has to survive the
+ * trip through the error envelope or it may as well not have been recorded.
+ *
+ * Reads `securityRan` as three-valued on purpose: absent means a producer that
+ * predates the field, NOT `false`, so the generic message stands rather than
+ * claiming a reason we do not have.
+ */
+function describeIncompletePipeline(record: Record<string, unknown>): string {
+  const prefix = 'Engine reported failure:';
+  if (record['planStatus'] === 'empty') {
+    return `${prefix} the planner returned no plan, so nothing was built`;
+  }
+  if (record['securityRan'] === true) {
+    return `${prefix} the security gate rejected the change`;
+  }
+  if (record['securityRan'] === false) {
+    return `${prefix} the run stopped before the security gate, which never ran`;
+  }
+  return `${prefix} the dev pipeline did not complete`;
 }
 
 /**
@@ -447,7 +476,13 @@ async function executeRunBody(
         decisionId: exec.decisionId,
         strategy: exec.strategy,
       });
-      return toolStructuredError({ errorCategory: 'business', message: engineFailure });
+      // #4789: carry the engine's own result through. The message names the
+      // reason; `detail` keeps the verdict a caller can act on.
+      return toolStructuredError({
+        errorCategory: 'business',
+        message: engineFailure.message,
+        ...(engineFailure.detail !== undefined ? { detail: engineFailure.detail } : {}),
+      });
     }
     return toolSuccess(JSON.stringify(exec, null, 2));
   } catch (err) {


### PR DESCRIPTION
Fixes #4789.

## Problem

`run-tool.ts` treated every dev-pipeline non-completion identically:

```ts
if (record['completed'] === false) {
  return 'Engine reported failure: the dev pipeline did not complete';
}
```

and at the call site discarded `exec.result` entirely. So a `run` caller could not distinguish **"the security gate rejected your change"** from **"the security gate never ran"** — exactly the distinction #4772 → #4783 put into `securityRan` one layer down, thrown away one layer up.

## Correction to the original report

The issue as filed cited dry-run and harness mode. **Those cannot occur on the `run` path** — `runDevPipelineForGoal` parses `{ task: goal }` only, so `dryRun` stays at its `false` default and harness mode is never selected. I verified this before building on it and corrected the issue.

The finding survives with a narrower, real failure. The two reachable non-completions are:

| Case | `securityRan` | Old message |
|---|---|---|
| scan ran, rejected the change | `true` | *did not complete* |
| quality gate short-circuited first | `false` | *did not complete* |

## Fix

`describeIncompletePipeline` names the reason — empty plan, security rejected, or stopped before the gate — and the engine's result travels in the error envelope's `detail`.

`securityRan` is read as **three-valued on purpose**: absent means a producer predating the field, *not* `false`, so the generic message stands rather than claiming a reason we don't have. That is the distinction the mutation table below tests.

## Verification

Red/green — four tests written first, three failed against `main`:

```
× says the security gate REJECTED when the scan actually ran
× says the run stopped BEFORE the security gate when it never ran
× names an empty plan as the reason rather than a generic non-completion
  Tests  3 failed | 31 passed (34)
```

After: `34 passed`. Mutation-verified:

| Mutation | Result |
|---|---|
| back to one generic message, no `detail` | 3 failed |
| absent `securityRan` treated as `false` | 1 failed |

The fourth test is the one that catches the second mutation — a pre-#4783 producer must not be reported as "the gate never ran".

`tsc` clean, API surface unchanged.

## Deliberately not in scope

`detectEngineFailure` already carves out consensus: *"a `rejected` outcome is the verdict the caller asked for, not an engine fault."* A security scan that correctly rejects unsafe code is arguably the same shape — the pipeline **worked**, and its answer was no. Reclassifying that away from `errorCategory: 'business'` is a wider behaviour change than this fix needs, so it stays open as a separate question on #4789 rather than being decided here.