### PR TITLE
chore(ci): require script tests and the model-string drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,8 @@ jobs:
         fitness-audit,
         consolidation-test,
         producer-consumer-check,
+        script-tests,
+        model-string-drift,
       ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -420,7 +422,9 @@ jobs:
              [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
              [[ "${{ needs.consolidation-test.result }}" != "success" ]] || \
-             [[ "${{ needs.fitness-audit.result }}" != "success" ]]; then
+             [[ "${{ needs.fitness-audit.result }}" != "success" ]] || \
+             [[ "${{ needs.script-tests.result }}" != "success" ]] || \
+             [[ "${{ needs.model-string-drift.result }}" != "success" ]]; then
             echo "One or more required jobs failed"
             exit 1
           fi

--- a/scripts/ci-required-jobs.test.ts
+++ b/scripts/ci-required-jobs.test.ts
@@ -24,7 +24,17 @@ import { parse } from 'yaml';
  * Removing a job from this list makes it required; adding one to it needs a
  * reason. Tracked for review in #4790.
  */
-const ADVISORY_JOBS = new Set(['script-tests', 'model-string-drift', 'index-check', 'security']);
+const ADVISORY_JOBS = new Set([
+  // Cannot fail even if required: `continue-on-error: true` at the job level
+  // AND `|| echo` swallowing the CLI's exit code at the step level. Adding it
+  // to `needs` would wait on a job structurally incapable of reporting failure.
+  // Decide whether index staleness should block, then remove both layers — #4790.
+  'index-check',
+  // Runs `pnpm audit`, a function of (tree x npm advisory DB at time t), so a
+  // third-party publication can redden every open PR. Requiring it is approved
+  // (consensus_vote 6-1) but gated on the reviewed-allowlist mechanism — #4794.
+  'security',
+]);
 
 interface CiWorkflow {
   jobs: Record<string, { needs?: string[]; steps?: Array<{ run?: string }> }>;


### PR DESCRIPTION
Part of #4790.

## What

Adds `script-tests` and `model-string-drift` to `ci-success.needs` and the gate script's exit-code check, and narrows `ADVISORY_JOBS` in `scripts/ci-required-jobs.test.ts` to the two jobs that still need a decision.

## Why these two, and not the other two

I looked at each of the four jobs individually rather than voting on them as a block, because they turned out to be four different questions. All four are **18/18 green over the last 20 PR runs, zero flakes**, so reliability is not what separates them.

| Job | Can it genuinely fail? | Verdict |
|---|---|---|
| `script-tests` | yes — `pnpm test:scripts`, deterministic | **require** |
| `model-string-drift` | yes — CI sets `NEXUS_DRIFT_ADVISORY=0`, so `exit 1` on violations | **require** |
| `index-check` | **no** | see below |
| `security` | yes, but externally time-varying | #4794 |

**`script-tests`** is the clearest case: `scripts/` now carries real gate logic — the API-surface extractor and checker, `ci-required-jobs.test.ts`, `workflow-output-wiring.test.ts`. Tests for the code that guards merges are load-bearing, and the #4784 bar ("don't require a gate until the code it runs is tested") is met trivially, since the job *is* the tests.

**`model-string-drift`** I initially suspected couldn't fail — the script's own header says *"Advisory by default — exits 0 even when violations are found."* But the CI step sets `NEXUS_DRIFT_ADVISORY: '0'` (`ci.yml:328`), which flips it to `process.exit(1)`. Verified before requiring it rather than trusting either the header or my first read.

**`index-check` cannot fail even if required** — `continue-on-error: true` at the job level *and* `|| echo` swallowing the CLI's exit code at the step level. Adding it to `needs` would wait on a job structurally incapable of reporting failure. That needs a decision (should index staleness block a merge?) and the removal of both layers first, so it stays in `ADVISORY_JOBS` with the reason recorded inline. Tracked in #4790.

**`security`** is approved for requiring by `consensus_vote` (6-1) but gated on building the reviewed-allowlist mechanism first — `pnpm audit` is a function of *(tree × npm advisory DB at time t)*, so requiring it bare lets a third-party publication redden every open PR. Tracked in #4794.

## Verification

`ADVISORY_JOBS` now carries an inline reason per entry, so the two remaining exemptions are documented decisions rather than omissions.

Mutation-verified — adding a job to `needs` while forgetting its exit-code check (the awaited-then-ignored shape) fails the guard:

```
M (script-tests in needs, never checked):  Tests  1 failed | 4 passed (5)
```

YAML parses; `ci-required-jobs.test.ts` green at 5/5.