### PR TITLE
chore(ci): add the security-audit exception ledger

### DIFF
--- a/.github/audit-exceptions.json
+++ b/.github/audit-exceptions.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Reviewed exceptions to the Security Audit gate (#4794). Every id here MUST also appear in package.json > pnpm.auditConfig, which is what actually mutes the advisory; this file is the attribution and expiry ledger that scripts/audit-exceptions.ts enforces. An exception with no owner, no issue, or a past expiry fails CI. Empty means full enforcement.",
+  "exceptions": []
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-node
 
+      # Advisory today (#4790). Approved to become required by consensus_vote
+      # 6-1, gated on the exception ledger landing first (#4794): `pnpm audit`
+      # answers to the npm advisory database, so requiring it with no reviewed
+      # escape path means a third-party publication can redden every open PR,
+      # and the recovery becomes admin-bypassing a required check.
+      #
+      # Suppressions go in package.json > pnpm.auditConfig, and EVERY id there
+      # needs a warrant in .github/audit-exceptions.json — owner, tracking
+      # issue, expiry — enforced by scripts/audit-exceptions.test.ts.
       - name: Run security audit
         run: pnpm audit --audit-level=high
         continue-on-error: true

--- a/scripts/audit-exceptions.test.ts
+++ b/scripts/audit-exceptions.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the Security Audit exception ledger (#4794).
+ *
+ * The panel that approved requiring this gate (6-1) warned that an allowlist
+ * decays into "a rubber-stamp graveyard of ignored exceptions". These are the
+ * tests that have to hold for that not to happen — above all the two that catch
+ * a suppression nobody owns and one that outlived its warrant.
+ *
+ * @module scripts/audit-exceptions.test
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  validateExceptions,
+  configuredIds,
+  loadLedger,
+  type AuditException,
+} from './audit-exceptions.js';
+
+const TODAY = '2026-08-24';
+
+function exception(overrides: Partial<AuditException> = {}): AuditException {
+  return {
+    id: 'GHSA-aaaa-bbbb-cccc',
+    reason: 'no reachable call path; upstream fix tracked',
+    owner: 'williamzujkowski',
+    issue: 4794,
+    expires: '2026-12-31',
+    ...overrides,
+  };
+}
+
+describe('validateExceptions', () => {
+  it('accepts a fully-warranted exception that is also muted', () => {
+    const problems = validateExceptions([exception()], ['GHSA-aaaa-bbbb-cccc'], TODAY);
+
+    expect(problems).toEqual([]);
+  });
+
+  // The whole point of the ledger. pnpm's config is a flat list of ids, so
+  // without this cross-check anyone can mute an advisory with no trace of who
+  // did it or why (#4690 — an escape path is only as strong as its attribution).
+  it('rejects an advisory muted in pnpm.auditConfig with no ledger entry', () => {
+    const problems = validateExceptions([], ['GHSA-dddd-eeee-ffff'], TODAY);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('no ledger entry');
+  });
+
+  it('rejects an exception that has passed its expiry', () => {
+    const problems = validateExceptions(
+      [exception({ expires: '2026-08-23' })],
+      ['GHSA-aaaa-bbbb-cccc'],
+      TODAY
+    );
+
+    expect(problems.some((p) => p.includes('expired 2026-08-23'))).toBe(true);
+    // The failure has to say who to go to, or it is just an obstacle.
+    expect(problems.some((p) => p.includes('@williamzujkowski') && p.includes('#4794'))).toBe(true);
+  });
+
+  it('accepts an exception expiring exactly today', () => {
+    // Boundary: `expires` is the last day it holds, not the first day it fails.
+    const problems = validateExceptions(
+      [exception({ expires: TODAY })],
+      ['GHSA-aaaa-bbbb-cccc'],
+      TODAY
+    );
+
+    expect(problems).toEqual([]);
+  });
+
+  it('rejects a ledger entry that mutes nothing', () => {
+    // The inverse: a warrant with no corresponding mute is dead paperwork, and
+    // reads as coverage that does not exist.
+    const problems = validateExceptions([exception()], [], TODAY);
+
+    expect(problems.some((p) => p.includes('suppresses nothing'))).toBe(true);
+  });
+
+  it.each([
+    ['reason', { reason: '   ' }, 'needs a reason'],
+    ['owner', { owner: '' }, 'needs an owner'],
+    ['issue', { issue: 0 }, 'needs a tracking issue'],
+    ['id format', { id: 'not-an-advisory-id' }, 'not a GHSA or CVE'],
+    ['expiry format', { expires: '31/12/2026' }, 'must be YYYY-MM-DD'],
+  ])('rejects a missing or malformed %s', (_label, override, expected) => {
+    const e = exception(override);
+    const problems = validateExceptions([e], [e.id], TODAY);
+
+    expect(problems.some((p) => p.includes(expected))).toBe(true);
+  });
+
+  it('reports every problem at once rather than stopping at the first', () => {
+    // Fixing these one CI run at a time is how a reviewer gives up and reaches
+    // for the bypass instead.
+    const problems = validateExceptions(
+      [exception({ reason: '', owner: '', issue: 0 })],
+      ['GHSA-aaaa-bbbb-cccc'],
+      TODAY
+    );
+
+    expect(problems.length).toBeGreaterThanOrEqual(3);
+  });
+
+  // Name the empty case: absence must mean full enforcement, and it must be an
+  // assertion rather than something the language decides for us.
+  it('treats an empty ledger AND empty mute-list as full enforcement', () => {
+    const problems = validateExceptions([], [], TODAY);
+
+    expect(problems).toEqual([]);
+  });
+});
+
+describe('configuredIds', () => {
+  it('reads both GHSA and CVE mute-lists', () => {
+    const ids = configuredIds({
+      pnpm: {
+        auditConfig: { ignoreGhsas: ['GHSA-aaaa-bbbb-cccc'], ignoreCves: ['CVE-2026-1234'] },
+      },
+    });
+
+    expect(ids).toEqual(['GHSA-aaaa-bbbb-cccc', 'CVE-2026-1234']);
+  });
+
+  it('returns nothing when no audit config exists', () => {
+    expect(configuredIds({})).toEqual([]);
+    expect(configuredIds({ pnpm: {} })).toEqual([]);
+  });
+});
+
+describe('the live repository state', () => {
+  const root = process.cwd();
+
+  it('has a ledger that parses', () => {
+    expect(() => loadLedger(root)).not.toThrow();
+  });
+
+  it('has no unwarranted, malformed, or expired suppressions', () => {
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')) as Record<
+      string,
+      unknown
+    >;
+    const today = new Date().toISOString().slice(0, 10);
+    const problems = validateExceptions(loadLedger(root), configuredIds(pkg), today);
+
+    expect(problems, problems.join('\n')).toEqual([]);
+  });
+});

--- a/scripts/audit-exceptions.ts
+++ b/scripts/audit-exceptions.ts
@@ -1,0 +1,112 @@
+/**
+ * Attribution and expiry ledger for Security Audit exceptions (#4794).
+ *
+ * `pnpm.auditConfig.ignoreGhsas` / `ignoreCves` is what actually mutes an
+ * advisory, but it is a flat list of ids with nowhere to record WHO suppressed
+ * a finding, WHY, or UNTIL WHEN. An escape path is only as strong as its
+ * attribution (#4690), and the panel that approved requiring this gate warned
+ * specifically that an allowlist decays into "a rubber-stamp graveyard of
+ * ignored exceptions".
+ *
+ * So the two are kept in lockstep: pnpm's list is the mechanism, this ledger is
+ * the warrant, and `validateExceptions` fails if they disagree or if a warrant
+ * has expired.
+ *
+ * @module scripts/audit-exceptions
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** One reviewed suppression, with the warrant that justifies it. */
+export interface AuditException {
+  /** GHSA or CVE identifier — must match an entry in `pnpm.auditConfig`. */
+  readonly id: string;
+  /** Why this advisory does not block us: no reachable path, upstream fix pending, etc. */
+  readonly reason: string;
+  /** GitHub handle accountable for retiring it. */
+  readonly owner: string;
+  /** Tracking issue number. Deferring is fine; untracked is not. */
+  readonly issue: number;
+  /** ISO date (YYYY-MM-DD) after which the exception fails CI. */
+  readonly expires: string;
+}
+
+const ID_PATTERN = /^(GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}|CVE-\d{4}-\d{4,})$/;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Reads the ids pnpm is actually configured to mute. */
+export function configuredIds(packageJson: Record<string, unknown>): string[] {
+  const pnpm = packageJson['pnpm'] as Record<string, unknown> | undefined;
+  const audit = pnpm?.['auditConfig'] as Record<string, unknown> | undefined;
+  const ghsas = Array.isArray(audit?.['ignoreGhsas']) ? (audit['ignoreGhsas'] as string[]) : [];
+  const cves = Array.isArray(audit?.['ignoreCves']) ? (audit['ignoreCves'] as string[]) : [];
+  return [...ghsas, ...cves];
+}
+
+/**
+ * Everything the warrant itself must carry, independent of the mute-list.
+ *
+ * `today` is injected rather than read from the clock so the expiry rule is
+ * testable in both directions.
+ */
+function warrantProblems(e: AuditException, today: string): string[] {
+  const problems: string[] = [];
+  const where = `exception ${e.id}`;
+  if (!ID_PATTERN.test(e.id)) problems.push(`${where}: not a GHSA or CVE identifier`);
+  if (e.reason.trim() === '') problems.push(`${where}: needs a reason`);
+  if (e.owner.trim() === '') problems.push(`${where}: needs an owner accountable for retiring it`);
+  if (!Number.isInteger(e.issue) || e.issue <= 0) problems.push(`${where}: needs a tracking issue`);
+  if (!DATE_PATTERN.test(e.expires)) {
+    problems.push(`${where}: expires must be YYYY-MM-DD`);
+  } else if (e.expires < today) {
+    problems.push(
+      `${where}: expired ${e.expires} — re-review it (owner @${e.owner}, issue #${String(e.issue)}), then extend or remove`
+    );
+  }
+  return problems;
+}
+
+/**
+ * Every way the ledger and the mute-list can disagree.
+ *
+ * Returns messages rather than throwing so a caller can report all of them at
+ * once — fixing these one CI run at a time is how a reviewer gives up and
+ * reaches for the bypass instead.
+ */
+export function validateExceptions(
+  exceptions: readonly AuditException[],
+  configured: readonly string[],
+  today: string
+): string[] {
+  const problems: string[] = [];
+  const ledgerIds = new Set(exceptions.map((e) => e.id));
+
+  for (const e of exceptions) {
+    problems.push(...warrantProblems(e, today));
+    if (!configured.includes(e.id)) {
+      problems.push(
+        `exception ${e.id}: in the ledger but NOT muted in pnpm.auditConfig — it suppresses nothing`
+      );
+    }
+  }
+
+  // The direction that actually matters: a mute with no warrant is an
+  // unattributed suppression, which is the shape this ledger exists to prevent.
+  for (const id of configured) {
+    if (!ledgerIds.has(id)) {
+      problems.push(
+        `${id}: muted in pnpm.auditConfig with no ledger entry — who suppressed this, and until when?`
+      );
+    }
+  }
+  return problems;
+}
+
+/** Loads the ledger. Absent `exceptions` is an error, not an empty list. */
+export function loadLedger(repoRoot: string): AuditException[] {
+  const raw = readFileSync(join(repoRoot, '.github', 'audit-exceptions.json'), 'utf8');
+  const parsed = JSON.parse(raw) as Record<string, unknown>;
+  const list = parsed['exceptions'];
+  if (!Array.isArray(list)) throw new Error('audit-exceptions.json: "exceptions" must be an array');
+  return list as AuditException[];
+}


### PR DESCRIPTION
Stage 1 of #4794. Does **not** make the `security` job required — that is stage 2, once this mechanism has a clean cycle.

## Why a ledger at all

The vote (6-1, Option B 5/6) approved requiring `pnpm audit`, but only behind a reviewed exception path. The panel's design called for every exception to carry an **owner, a tracking issue, and an expiry** — the #4690 lesson that an escape path is only as strong as its attribution.

`pnpm.auditConfig.ignoreGhsas` / `ignoreCves` **cannot hold any of that.** It is a flat array of identifier strings. So pnpm's config alone satisfies the muting requirement and none of the accountability one.

This keeps the two in lockstep: pnpm's list is the mechanism, `.github/audit-exceptions.json` is the warrant, and `scripts/audit-exceptions.ts` fails CI when they disagree.

## The two checks that matter

**A mute with no warrant.** An id in `pnpm.auditConfig` with no ledger entry fails with *"who suppressed this, and until when?"*. Without this, anyone can silence a high-severity advisory leaving no trace of who did it or why.

**A warrant that outlived its review.** A past `expires` fails, naming the owner and issue. This is the direct answer to the contrarian voter's objection that an allowlist becomes *"a rubber-stamp graveyard of ignored exceptions"* — an entry nobody renews stops working.

Also caught: a ledger entry that mutes nothing (dead paperwork reading as coverage), missing reason/owner/issue, malformed ids and dates.

## Deliberate choices

- **No in-repo wrapper around `pnpm audit`.** #4784 established that a new gate should not itself be untested code. pnpm does the muting; the only in-repo code is a validator that ships with 16 tests.
- **`package.json` is untouched.** With zero exceptions today, adding an empty `pnpm.auditConfig` would be speculative. `configuredIds({})` returns `[]`, tested — the config appears when the first exception needs it.
- **Errors are collected, not thrown at the first.** Fixing these one CI run at a time is how a reviewer gives up and reaches for the bypass.
- **`today` is injected, not read from the clock**, so the expiry rule is testable in both directions — including the boundary where `expires` is today and the exception still holds.

## Verification

16 tests, plus a live-repo check that the actual ledger and actual `package.json` agree. Mutation-verified against the two shapes it exists to catch:

| Mutation | Result |
|---|---|
| `GHSA-…` muted in `package.json` with no ledger entry | live-state test failed |
| ledger entry with `expires: 2020-01-01` | live-state test failed |

That second one matters because the live-state test would otherwise pass trivially — both lists are empty today, and an assertion over two empty collections is exactly the vacuous shape this repo keeps finding.

The validator runs under `script-tests`, which #4795 just made a required job, so the ledger is enforced from the moment this lands.

## Known limitation, stated plainly

I confirmed pnpm 9.15.0 **accepts** `auditConfig` without error, but with zero current vulnerabilities I could not demonstrate it actually **suppresses** a live advisory. The ledger logic is fully tested; pnpm's muting behaviour is vendor-verified only. Worth a real check when the first exception is filed — before relying on it.

## Owner-gated follow-up

The ledger should sit under CODEOWNERS: a mechanism that can silence security findings is a way for the governor to weaken its own governor. `CODEOWNERS` is on CLAUDE.md's never-auto-merge list, so I have **not** included that change here. Filing it separately for ratification.