### PR TITLE
fix(cli): point index diagram --output at the diagram

### DIFF
--- a/.changeset/index-diagram-output-path.md
+++ b/.changeset/index-diagram-output-path.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+make `index diagram --output` name the diagram, not the index
+
+On the `diagram` subcommand, `--output` set where the command READ its index
+from and the diagram destination was hardcoded, so there was no way to aim the
+generator at a repo's real docs location. That is why this repo's canonical
+`docs/architecture/dependency-graph.md` carried a `Generated: 2026-01-12` header
+no generator had touched in seven months.
+
+`--output` now names the diagram destination. The default stays cwd-relative, so
+a run inside another repository still writes into that repository's tree.
+
+Also fixes the self-heal path: when the index is missing it regenerates one, and
+it used to forward `--output` to the index generator — writing a multi-megabyte
+YAML index over the diagram the caller asked for.
+
+Fixes #4799.

--- a/.gitignore
+++ b/.gitignore
@@ -110,8 +110,8 @@ scratch*.ts
 # Not tracked: an 88k-line snapshot with no consumer drifted 6 months unnoticed,
 # and `index diagram` writes it as a side effect — untracked it would otherwise
 # dirty every working tree that runs the command.
-packages/nexus-agents/docs/codebase-index.yaml
-# Same reason: `index diagram` writes here, but this is the WRONG path — the
-# canonical, docs-linked graph is docs/architecture/dependency-graph.md. Ignored
-# so the stray output stops dirtying the tree; the generator is fixed in #4799.
-packages/nexus-agents/docs/dependency-graph.md
+**/docs/codebase-index.yaml
+# The generator's cwd-relative default. This repo's canonical, docs-linked graph
+# is docs/architecture/dependency-graph.md, produced with an explicit --output
+# (#4799); anything written to the default path here is a stray local run.
+**/packages/nexus-agents/docs/dependency-graph.md

--- a/docs/architecture/dependency-graph.md
+++ b/docs/architecture/dependency-graph.md
@@ -1,13 +1,13 @@
 # Module Dependency Graph
 
-> Generated: 2026-01-12T22:33:17-05:00
+> Generated: 2026-08-25T00:04:57-04:00
 
 ## Overview
 
-- **Total Modules:** 21
-- **Total Files:** 554
-- **Total Lines:** 177,780
-- **Total Exports:** 5995
+- **Total Modules:** 28
+- **Total Files:** 1491
+- **Total Lines:** 342,154
+- **Total Exports:** 19004
 
 ## Dependency Diagram
 
@@ -15,89 +15,243 @@
 flowchart LR
 
   %% Core modules
-  config["config<br/>2 files, 225 lines"]
-  core["core<br/>20 files, 5912 lines"]
+  config["config<br/>52 files, 11527 lines"]
+  core["core<br/>55 files, 11217 lines"]
 
   %% Agent modules
-  agents["agents<br/>131 files, 44970 lines"]
-  consensus["consensus<br/>12 files, 4460 lines"]
-  learning["learning<br/>10 files, 3277 lines"]
+  agents["agents<br/>273 files, 56104 lines"]
+  consensus["consensus<br/>22 files, 6610 lines"]
+  learning["learning<br/>18 files, 4785 lines"]
 
   %% Infrastructure modules
-  adapters["adapters<br/>31 files, 12695 lines"]
-  cli_adapters["cli-adapters<br/>54 files, 16041 lines"]
-  context["context<br/>35 files, 13362 lines"]
+  adapters["adapters<br/>35 files, 9203 lines"]
+  cli_adapters["cli-adapters<br/>105 files, 26718 lines"]
+  context["context<br/>60 files, 15639 lines"]
 
   %% Interface modules
-  cli["cli<br/>42 files, 13350 lines"]
-  mcp["mcp<br/>27 files, 9014 lines"]
-  workflows["workflows<br/>59 files, 17480 lines"]
+  cli["cli<br/>179 files, 42418 lines"]
+  mcp["mcp<br/>205 files, 54448 lines"]
+  workflows["workflows<br/>53 files, 12104 lines"]
 
   %% Other modules
-  root["root<br/>7 files, 2438 lines"]
-  api["api<br/>10 files, 2104 lines"]
-  audit["audit<br/>6 files, 1657 lines"]
-  benchmarks["benchmarks<br/>4 files, 1068 lines"]
-  dogfooding["dogfooding<br/>5 files, 1329 lines"]
-  indexer["indexer<br/>8 files, 2269 lines"]
-  observability["observability<br/>13 files, 4453 lines"]
-  security["security<br/>16 files, 3641 lines"]
-  self_eval["self-eval<br/>7 files, 2427 lines"]
-  testing["testing<br/>55 files, 15608 lines"]
+  root["root<br/>30 files, 7649 lines"]
+  audit["audit<br/>12 files, 3766 lines"]
+  benchmarks["benchmarks<br/>10 files, 2104 lines"]
+  dogfooding["dogfooding<br/>7 files, 2367 lines"]
+  exports["exports<br/>19 files, 2570 lines"]
+  governance["governance<br/>6 files, 1746 lines"]
+  indexer["indexer<br/>26 files, 5341 lines"]
+  observability["observability<br/>24 files, 4966 lines"]
+  orchestration["orchestration<br/>73 files, 16337 lines"]
+  pipeline["pipeline<br/>40 files, 10747 lines"]
+  replay["replay<br/>1 files, 139 lines"]
+  research["research<br/>12 files, 2530 lines"]
+  scm["scm<br/>6 files, 1335 lines"]
+  security["security<br/>61 files, 10804 lines"]
+  self_eval["self-eval<br/>12 files, 1841 lines"]
+  testing["testing<br/>84 files, 15120 lines"]
+  utils["utils<br/>11 files, 2019 lines"]
 
   %% Dependencies
+  root --> adapters
+  root --> agents
+  root --> audit
   root --> cli
+  root --> cli_adapters
+  root --> config
   root --> core
+  root --> learning
   root --> mcp
   root --> observability
+  root --> orchestration
+  root --> pipeline
   root --> security
-  adapters --> agents
+  root --> workflows
   adapters --> cli_adapters
+  adapters --> config
+  adapters --> context
   adapters --> core
+  adapters --> learning
+  adapters --> security
+  adapters --> utils
+  agents --> adapters
   agents --> cli_adapters
+  agents --> config
+  agents --> context
   agents --> core
-  api --> agents
-  api --> core
+  agents --> indexer
+  agents --> orchestration
+  agents --> security
+  agents --> utils
+  audit --> cli
+  audit --> config
+  audit --> consensus
   audit --> core
   audit --> mcp
+  benchmarks --> cli_adapters
   benchmarks --> context
   benchmarks --> core
   cli --> adapters
   cli --> agents
   cli --> cli_adapters
+  cli --> config
   cli --> consensus
+  cli --> context
   cli --> core
   cli --> dogfooding
+  cli --> governance
   cli --> indexer
+  cli --> learning
+  cli --> mcp
+  cli --> observability
+  cli --> orchestration
+  cli --> pipeline
+  cli --> research
+  cli --> scm
+  cli --> security
   cli --> self_eval
+  cli --> testing
+  cli --> utils
   cli --> workflows
+  cli_adapters --> adapters
+  cli_adapters --> agents
+  cli_adapters --> cli
+  cli_adapters --> config
+  cli_adapters --> context
   cli_adapters --> core
+  cli_adapters --> learning
+  cli_adapters --> mcp
+  cli_adapters --> observability
+  cli_adapters --> orchestration
+  cli_adapters --> pipeline
+  cli_adapters --> security
+  cli_adapters --> utils
+  config --> cli_adapters
+  config --> context
+  config --> core
+  config --> security
   consensus --> agents
+  consensus --> config
   consensus --> core
+  consensus --> utils
+  context --> cli
   context --> cli_adapters
+  context --> config
   context --> core
+  context --> indexer
+  context --> learning
+  context --> mcp
+  context --> orchestration
+  context --> pipeline
+  context --> utils
+  core --> cli
   core --> cli_adapters
-  core --> context
+  core --> config
+  core --> mcp
+  core --> utils
   dogfooding --> agents
   dogfooding --> core
   dogfooding --> observability
+  dogfooding --> scm
+  dogfooding --> security
+  dogfooding --> utils
+  governance --> config
+  governance --> core
+  indexer --> cli
+  indexer --> core
+  indexer --> research
+  indexer --> utils
   learning --> cli_adapters
+  learning --> config
+  learning --> context
   learning --> core
   learning --> observability
+  learning --> orchestration
+  learning --> utils
+  mcp --> adapters
   mcp --> agents
+  mcp --> audit
+  mcp --> benchmarks
+  mcp --> cli
   mcp --> cli_adapters
+  mcp --> config
+  mcp --> consensus
+  mcp --> context
   mcp --> core
+  mcp --> dogfooding
+  mcp --> governance
+  mcp --> indexer
   mcp --> learning
+  mcp --> observability
+  mcp --> orchestration
+  mcp --> pipeline
+  mcp --> research
+  mcp --> scm
+  mcp --> security
+  mcp --> utils
+  mcp --> workflows
+  observability --> adapters
   observability --> cli_adapters
+  observability --> config
   observability --> core
+  observability --> learning
+  observability --> pipeline
+  observability --> utils
+  orchestration --> adapters
+  orchestration --> agents
+  orchestration --> cli
+  orchestration --> cli_adapters
+  orchestration --> config
+  orchestration --> core
+  orchestration --> dogfooding
+  orchestration --> mcp
+  orchestration --> pipeline
+  orchestration --> utils
+  orchestration --> workflows
+  pipeline --> adapters
+  pipeline --> agents
+  pipeline --> audit
+  pipeline --> cli
+  pipeline --> config
+  pipeline --> context
+  pipeline --> core
+  pipeline --> mcp
+  pipeline --> orchestration
+  pipeline --> security
+  pipeline --> utils
+  pipeline --> workflows
+  replay --> core
+  replay --> pipeline
+  research --> core
+  research --> indexer
+  research --> utils
+  scm --> config
+  scm --> core
+  security --> audit
+  security --> config
   security --> core
   security --> mcp
-  security --> workflows
+  security --> scm
+  self_eval --> config
   self_eval --> core
+  self_eval --> orchestration
+  self_eval --> utils
+  testing --> agents
   testing --> cli_adapters
+  testing --> config
+  testing --> context
   testing --> core
+  testing --> orchestration
+  testing --> utils
+  testing --> workflows
+  utils --> context
+  utils --> core
+  workflows --> adapters
   workflows --> agents
+  workflows --> config
   workflows --> core
+  workflows --> security
+  workflows --> utils
 ```
 
 ## Module Details
@@ -106,15 +260,15 @@ flowchart LR
 
 **Purpose:** Model adapters (Claude, OpenAI, Gemini, Ollama)
 
-| Metric        | Value  |
-| ------------- | ------ |
-| Files         | 31     |
-| Lines         | 12,695 |
-| Exports       | 237    |
-| Internal Deps | 64     |
-| External Deps | 21     |
+| Metric        | Value |
+| ------------- | ----- |
+| Files         | 35    |
+| Lines         | 9,203 |
+| Exports       | 337   |
+| Internal Deps | 105   |
+| External Deps | 15    |
 
-**Depends on:** agents, cli-adapters, core
+**Depends on:** cli-adapters, config, context, core, learning, security, utils
 
 ### agents
 
@@ -122,55 +276,41 @@ flowchart LR
 
 | Metric        | Value  |
 | ------------- | ------ |
-| Files         | 131    |
-| Lines         | 44,970 |
-| Exports       | 1479   |
-| Internal Deps | 312    |
-| External Deps | 60     |
+| Files         | 273    |
+| Lines         | 56,104 |
+| Exports       | 3387   |
+| Internal Deps | 709    |
+| External Deps | 52     |
 
-**Depends on:** cli-adapters, core
+**Depends on:** adapters, cli-adapters, config, context, core, indexer, orchestration, security, utils
 
-### api
+### audit
 
-**Purpose:** nexus-agents/api - REST API Module Fastify-based REST API gateway for non-MCP clients; REST API Server Tests; nexus-agents/api - REST API Server Fastify-based REST API gateway exposing nexus-agents capabilities
+**Purpose:** nexus-agents/audit - Audit Logger Implementation Structured audit logger with file rotation and hash chain support.; nexus-agents/audit - Audit Storage Query Operations Query criteria matching and file reading operations for audit storage.; nexus-agents/audit - File-based Audit Storage JSON-L file storage with rotation for audit events.
+
+| Metric        | Value |
+| ------------- | ----- |
+| Files         | 12    |
+| Lines         | 3,766 |
+| Exports       | 205   |
+| Internal Deps | 21    |
+| External Deps | 15    |
+
+**Depends on:** cli, config, consensus, core, mcp
+
+### benchmarks
+
+**Purpose:** nexus-agents/benchmarks - Adapter Latency Benchmark Measures latency overhead of CLI subprocess invocation vs direct API adapter calls.; BenchmarkAdapter — public contract for benchmark integrations.; nexus-agents/benchmarks - Benchmark Report Generator Generates structured JSON reports from benchmark results.
 
 | Metric        | Value |
 | ------------- | ----- |
 | Files         | 10    |
 | Lines         | 2,104 |
 | Exports       | 70    |
-| Internal Deps | 24    |
-| External Deps | 14    |
-
-**Depends on:** agents, core
-
-### audit
-
-**Purpose:** nexus-agents/audit - Audit Logger Implementation Structured audit logger with file rotation and hash chain support; nexus-agents/audit - File-based Audit Storage JSON-L file storage with rotation for audit events; nexus-agents/audit - Audit Event Types Zod schemas and TypeScript types for structured audit logging
-
-| Metric        | Value |
-| ------------- | ----- |
-| Files         | 6     |
-| Lines         | 1,657 |
-| Exports       | 76    |
-| Internal Deps | 10    |
-| External Deps | 9     |
-
-**Depends on:** core, mcp
-
-### benchmarks
-
-**Purpose:** nexus-agents/benchmarks - Benchmark Runner Utilities for running benchmarks and collecting metrics; nexus-agents/benchmarks - Type Definitions Types for performance benchmarking and metrics collection; nexus-agents/benchmarks - Module Exports Performance benchmarking for memory backends and other components
-
-| Metric        | Value |
-| ------------- | ----- |
-| Files         | 4     |
-| Lines         | 1,068 |
-| Exports       | 50    |
-| Internal Deps | 6     |
+| Internal Deps | 30    |
 | External Deps | 2     |
 
-**Depends on:** context, core
+**Depends on:** cli-adapters, context, core
 
 ### cli
 
@@ -178,13 +318,13 @@ flowchart LR
 
 | Metric        | Value  |
 | ------------- | ------ |
-| Files         | 42     |
-| Lines         | 13,350 |
-| Exports       | 383    |
-| Internal Deps | 77     |
-| External Deps | 44     |
+| Files         | 179    |
+| Lines         | 42,418 |
+| Exports       | 1836   |
+| Internal Deps | 555    |
+| External Deps | 137    |
 
-**Depends on:** adapters, agents, cli-adapters, consensus, core, dogfooding, indexer, self-eval, workflows
+**Depends on:** adapters, agents, cli-adapters, config, consensus, context, core, dogfooding, governance, indexer, learning, mcp, observability, orchestration, pipeline, research, scm, security, self-eval, testing, utils, workflows
 
 ### cli-adapters
 
@@ -192,25 +332,27 @@ flowchart LR
 
 | Metric        | Value  |
 | ------------- | ------ |
-| Files         | 54     |
-| Lines         | 16,041 |
-| Exports       | 351    |
-| Internal Deps | 122    |
-| External Deps | 36     |
+| Files         | 105    |
+| Lines         | 26,718 |
+| Exports       | 1197   |
+| Internal Deps | 420    |
+| External Deps | 31     |
 
-**Depends on:** core
+**Depends on:** adapters, agents, cli, config, context, core, learning, mcp, observability, orchestration, pipeline, security, utils
 
 ### config
 
 **Purpose:** Configuration loading, validation, Zod schemas
 
-| Metric        | Value |
-| ------------- | ----- |
-| Files         | 2     |
-| Lines         | 225   |
-| Exports       | 44    |
-| Internal Deps | 0     |
-| External Deps | 1     |
+| Metric        | Value  |
+| ------------- | ------ |
+| Files         | 52     |
+| Lines         | 11,527 |
+| Exports       | 774    |
+| Internal Deps | 98     |
+| External Deps | 51     |
+
+**Depends on:** cli-adapters, context, core, security
 
 ### consensus
 
@@ -218,13 +360,13 @@ flowchart LR
 
 | Metric        | Value |
 | ------------- | ----- |
-| Files         | 12    |
-| Lines         | 4,460 |
-| Exports       | 159   |
-| Internal Deps | 23    |
-| External Deps | 4     |
+| Files         | 22    |
+| Lines         | 6,610 |
+| Exports       | 408   |
+| Internal Deps | 57    |
+| External Deps | 6     |
 
-**Depends on:** agents, core
+**Depends on:** agents, config, core, utils
 
 ### context
 
@@ -232,41 +374,67 @@ flowchart LR
 
 | Metric        | Value  |
 | ------------- | ------ |
-| Files         | 35     |
-| Lines         | 13,362 |
-| Exports       | 419    |
-| Internal Deps | 97     |
-| External Deps | 30     |
+| Files         | 60     |
+| Lines         | 15,639 |
+| Exports       | 840    |
+| Internal Deps | 228    |
+| External Deps | 43     |
 
-**Depends on:** cli-adapters, core
+**Depends on:** cli, cli-adapters, config, core, indexer, learning, mcp, orchestration, pipeline, utils
 
 ### core
 
 **Purpose:** Types, Result<T,E>, errors, logger
 
-| Metric        | Value |
-| ------------- | ----- |
-| Files         | 20    |
-| Lines         | 5,912 |
-| Exports       | 270   |
-| Internal Deps | 23    |
-| External Deps | 15    |
+| Metric        | Value  |
+| ------------- | ------ |
+| Files         | 55     |
+| Lines         | 11,217 |
+| Exports       | 749    |
+| Internal Deps | 83     |
+| External Deps | 13     |
 
-**Depends on:** cli-adapters, context
+**Depends on:** cli, cli-adapters, config, mcp, utils
 
 ### dogfooding
 
-**Purpose:** nexus-agents/dogfooding - GitHub API Client Minimal GitHub REST API client for PR review operations; nexus-agents/dogfooding - Module Exports Self-referential tooling for nexus-agents to develop itself; nexus-agents/dogfooding - PR Review Types Type definitions for automated pull request review using multi-agent collaboration
+**Purpose:** nexus-agents/dogfooding - Module Exports Self-referential tooling for nexus-agents to develop itself.; nexus-agents/dogfooding - Issue Triage Helpers Pure helper functions for issue classification, label extraction, and result formatting.; nexus-agents/dogfooding - Issue Triage Types Type definitions for automated GitHub issue triage using the security pipeline (trust classification, cor...
 
 | Metric        | Value |
 | ------------- | ----- |
-| Files         | 5     |
-| Lines         | 1,329 |
-| Exports       | 60    |
-| Internal Deps | 11    |
-| External Deps | 2     |
+| Files         | 7     |
+| Lines         | 2,367 |
+| Exports       | 92    |
+| Internal Deps | 38    |
+| External Deps | 3     |
 
-**Depends on:** agents, core, observability
+**Depends on:** agents, core, observability, scm, security, utils
+
+### exports
+
+**Purpose:** Adapters exports - Model adapters (Claude, OpenAI, Gemini, Ollama) Split from index.ts for file size compliance (Issue #285); nexus-agents - ICTM Module Exports AOrchestra ICTM (Instructions, Context, Tools, Model) pattern for dynamic sub-agent creation.; Skills module exports (Voyager-style skill library) - Issue #528 Split from agents.ts for file size compliance (Issue #285)
+
+| Metric        | Value |
+| ------------- | ----- |
+| Files         | 19    |
+| Lines         | 2,570 |
+| Exports       | 1898  |
+| Internal Deps | 0     |
+| External Deps | 0     |
+
+### governance
+
+**Purpose:** nexus-agents/governance - Claims coverage (anti-gaming) scanner.; nexus-agents/governance - Claims Registry schema + loader.; nexus-agents/governance - Claims verification runner.
+
+| Metric        | Value |
+| ------------- | ----- |
+| Files         | 6     |
+| Lines         | 1,746 |
+| Exports       | 77    |
+| Internal Deps | 5     |
+| External Deps | 8     |
+
+**Depends on:** config, core
 
 ### indexer
 
@@ -274,11 +442,13 @@ flowchart LR
 
 | Metric        | Value |
 | ------------- | ----- |
-| Files         | 8     |
-| Lines         | 2,269 |
-| Exports       | 86    |
-| Internal Deps | 8     |
-| External Deps | 11    |
+| Files         | 26    |
+| Lines         | 5,341 |
+| Exports       | 352   |
+| Internal Deps | 38    |
+| External Deps | 33    |
+
+**Depends on:** cli, core, research, utils
 
 ### learning
 
@@ -286,97 +456,181 @@ flowchart LR
 
 | Metric        | Value |
 | ------------- | ----- |
-| Files         | 10    |
-| Lines         | 3,277 |
-| Exports       | 89    |
-| Internal Deps | 35    |
-| External Deps | 7     |
+| Files         | 18    |
+| Lines         | 4,785 |
+| Exports       | 216   |
+| Internal Deps | 72    |
+| External Deps | 9     |
 
-**Depends on:** cli-adapters, core, observability
+**Depends on:** cli-adapters, config, context, core, observability, orchestration, utils
 
 ### mcp
 
 **Purpose:** MCP server, tool definitions
 
-| Metric        | Value |
-| ------------- | ----- |
-| Files         | 27    |
-| Lines         | 9,014 |
-| Exports       | 302   |
-| Internal Deps | 56    |
-| External Deps | 32    |
+| Metric        | Value  |
+| ------------- | ------ |
+| Files         | 205    |
+| Lines         | 54,448 |
+| Exports       | 2393   |
+| Internal Deps | 959    |
+| External Deps | 221    |
 
-**Depends on:** agents, cli-adapters, core, learning
+**Depends on:** adapters, agents, audit, benchmarks, cli, cli-adapters, config, consensus, context, core, dogfooding, governance, indexer, learning, observability, orchestration, pipeline, research, scm, security, utils, workflows
 
 ### observability
 
-**Purpose:** nexus-agents/observability - Dashboard Renderer Tests Tests for dashboard rendering in various formats; nexus-agents/observability - Dashboard Renderer Renders dashboard snapshots to various output formats (text, JSON, markdown); nexus-agents/observability - Dashboard Types Type definitions for the execution dashboard that visualizes OrchestrationObserver data in real-time
+**Purpose:** nexus-agents/observability - Dashboard Helpers Helper functions for dashboard event summarization and processing.; nexus-agents/observability - Dashboard Renderer Renders dashboard snapshots to various output formats (text, JSON, markdown).; nexus-agents/observability - Dashboard Types Type definitions for the execution dashboard that visualizes SwarmObserver data in real-time.
 
 | Metric        | Value |
 | ------------- | ----- |
-| Files         | 13    |
-| Lines         | 4,453 |
-| Exports       | 120   |
-| Internal Deps | 23    |
-| External Deps | 8     |
+| Files         | 24    |
+| Lines         | 4,966 |
+| Exports       | 281   |
+| Internal Deps | 56    |
+| External Deps | 5     |
 
-**Depends on:** cli-adapters, core
+**Depends on:** adapters, cli-adapters, config, core, learning, pipeline, utils
+
+### orchestration
+
+**Purpose:** nexus-agents/orchestration - Authority-tier enforcement guard (Epic D, #3841).; nexus-agents/orchestration - Consensus Planning Types Types for multi-CLI plan generation and synthesis.; nexus-agents/orchestration - Consensus Planning Dispatches planning tasks to multiple CLIs independently, then synthesizes their plans identifying agr...
+
+| Metric        | Value  |
+| ------------- | ------ |
+| Files         | 73     |
+| Lines         | 16,337 |
+| Exports       | 858    |
+| Internal Deps | 203    |
+| External Deps | 21     |
+
+**Depends on:** adapters, agents, cli, cli-adapters, config, core, dogfooding, mcp, pipeline, utils, workflows
+
+### pipeline
+
+**Purpose:** Adaptive Orchestrator — Task-driven pipeline selection (#1736, Phase 3) Analyzes incoming tasks, selects the appropriate pipeline template, and execut...; Agent Executor — Connects pipeline stages to nexus-agents infrastructure (#1684) DRY integration (Issue #1691): - CompositeRouter for intelligent mult...; ArtifactStore — V2 Pipeline Artifact Storage (Issue #912, Phase 4-3) In-memory artifact store with bounded capacity and FIFO eviction.
+
+| Metric        | Value  |
+| ------------- | ------ |
+| Files         | 40     |
+| Lines         | 10,747 |
+| Exports       | 472    |
+| Internal Deps | 156    |
+| External Deps | 11     |
+
+**Depends on:** adapters, agents, audit, cli, config, context, core, mcp, orchestration, security, utils, workflows
+
+### replay
+
+**Purpose:** Replay Executor (#1688) Reads decision traces from JSONL and verifies that the current routing pipeline produces the same decisions.
+
+| Metric        | Value |
+| ------------- | ----- |
+| Files         | 1     |
+| Lines         | 139   |
+| Exports       | 6     |
+| Internal Deps | 2     |
+| External Deps | 0     |
+
+**Depends on:** core, pipeline
+
+### research
+
+**Purpose:** nexus-agents/research - Research Index Module Provides deterministic generation and validation of RESEARCH_INDEX.md from YAML registry files.; Negative results enforcement.; nexus-agents/research - Research Index Generator Generates RESEARCH_INDEX.md deterministically from YAML registry files.
+
+| Metric        | Value |
+| ------------- | ----- |
+| Files         | 12    |
+| Lines         | 2,530 |
+| Exports       | 168   |
+| Internal Deps | 20    |
+| External Deps | 10    |
+
+**Depends on:** core, indexer, utils
 
 ### root
 
-**Purpose:** nexus-agents CLI Commands Command handlers for the CLI; nexus-agents CLI Server Server startup and shutdown handling for the CLI; nexus-agents CLI Types Type definitions and constants for the CLI
+**Purpose:** nexus-agents CLI Auth Handler Handler for authentication-related CLI commands.; nexus-agents CLI command catalog (Issue #2135).; nexus-agents Per-Command Help Structured help metadata for individual CLI commands.
 
 | Metric        | Value |
 | ------------- | ----- |
-| Files         | 7     |
-| Lines         | 2,438 |
-| Exports       | 669   |
-| Internal Deps | 19    |
-| External Deps | 4     |
+| Files         | 30    |
+| Lines         | 7,649 |
+| Exports       | 217   |
+| Internal Deps | 175   |
+| External Deps | 5     |
 
-**Depends on:** cli, core, mcp, observability, security
+**Depends on:** adapters, agents, audit, cli, cli-adapters, config, core, learning, mcp, observability, orchestration, pipeline, security, workflows
+
+### scm
+
+**Purpose:** nexus-agents/scm - Provider Factory Creates IScmProvider instances based on platform and configuration.; nexus-agents/scm - GitHub Provider Trait Implementations Implements IScmReviewer and IScmUserInfo trait interfaces for GitHub.; nexus-agents/scm - GitHub Provider Unified GitHub provider using gh CLI.
+
+| Metric        | Value |
+| ------------- | ----- |
+| Files         | 6     |
+| Lines         | 1,335 |
+| Exports       | 36    |
+| Internal Deps | 15    |
+| External Deps | 5     |
+
+**Depends on:** config, core
 
 ### security
 
 **Purpose:** Sandbox execution, secrets management
 
-| Metric        | Value |
-| ------------- | ----- |
-| Files         | 16    |
-| Lines         | 3,641 |
-| Exports       | 109   |
-| Internal Deps | 37    |
-| External Deps | 12    |
+| Metric        | Value  |
+| ------------- | ------ |
+| Files         | 61     |
+| Lines         | 10,804 |
+| Exports       | 438    |
+| Internal Deps | 114    |
+| External Deps | 37     |
 
-**Depends on:** core, mcp, workflows
+**Depends on:** audit, config, core, mcp, scm
 
 ### self-eval
 
-**Purpose:** Tests for Aggregation Logic; Aggregation Logic for Self-Evaluation MVP Combines evaluator votes into final recommendations using tiered thresholds; Tests for Component Scanner
+**Purpose:** Aggregation Helpers for Self-Evaluation Helper functions for formatting and displaying aggregation results.; Aggregation Logic for Self-Evaluation MVP Combines evaluator votes into final recommendations using tiered thresholds.; Aggregation Types for Self-Evaluation Type definitions and constants for evaluation aggregation.
 
 | Metric        | Value |
 | ------------- | ----- |
-| Files         | 7     |
-| Lines         | 2,427 |
-| Exports       | 52    |
-| Internal Deps | 10    |
-| External Deps | 7     |
+| Files         | 12    |
+| Lines         | 1,841 |
+| Exports       | 83    |
+| Internal Deps | 30    |
+| External Deps | 3     |
 
-**Depends on:** core
+**Depends on:** config, core, orchestration, utils
 
 ### testing
 
-**Purpose:** nexus-agents/testing - Testing Utilities Provides mock implementations, test helpers, and type definitions for the CLI integration testing framework; nexus-agents/testing - Result Storage Types and Schemas Type definitions and Zod schemas for CLI testing framework results; nexus-agents/testing - Task Definition Types Types for defining evaluation tasks, expected outcomes, and scoring rubrics
+**Purpose:** Installs the CLI-spawn guard for every test file (#4639).; Fails any unit test that spawns a real agent-CLI binary (#4639).; Vitest global setup: reap stale test scratch before the run (#4413).
 
 | Metric        | Value  |
 | ------------- | ------ |
-| Files         | 55     |
-| Lines         | 15,608 |
-| Exports       | 486    |
-| Internal Deps | 115    |
-| External Deps | 16     |
+| Files         | 84     |
+| Lines         | 15,120 |
+| Exports       | 755    |
+| Internal Deps | 185    |
+| External Deps | 23     |
 
-**Depends on:** cli-adapters, core
+**Depends on:** agents, cli-adapters, config, context, core, orchestration, utils, workflows
+
+### utils
+
+**Purpose:** nexus-agents/utils - ID Generation Utilities Shared utility functions for generating unique identifiers.; nexus-agents/utils - Shared Utilities Common utility functions extracted from multiple modules per ADR-0013 (Memory Helpers Consolidation).; nexus-agents/utils - Math Utilities Common mathematical utility functions extracted from multiple modules.
+
+| Metric        | Value |
+| ------------- | ----- |
+| Files         | 11    |
+| Lines         | 2,019 |
+| Exports       | 145   |
+| Internal Deps | 4     |
+| External Deps | 3     |
+
+**Depends on:** context, core
 
 ### workflows
 
@@ -384,10 +638,10 @@ flowchart LR
 
 | Metric        | Value  |
 | ------------- | ------ |
-| Files         | 59     |
-| Lines         | 17,480 |
-| Exports       | 484    |
-| Internal Deps | 143    |
-| External Deps | 45     |
+| Files         | 53     |
+| Lines         | 12,104 |
+| Exports       | 714    |
+| Internal Deps | 148    |
+| External Deps | 15     |
 
-**Depends on:** agents, core
+**Depends on:** adapters, agents, config, core, security, utils

--- a/packages/nexus-agents/src/cli/index-command.test.ts
+++ b/packages/nexus-agents/src/cli/index-command.test.ts
@@ -329,6 +329,95 @@ describe('index-command', () => {
 
       expect(result.success).toBe(true);
     });
+
+    // #4799: `--output` set where the diagram READ FROM, not where it wrote to,
+    // and the destination was hardcoded. That is why this repo's canonical
+    // docs/architecture/dependency-graph.md still says `Generated: 2026-01-12` —
+    // there was no way to aim the generator at it.
+    it('writes the diagram to --output when given', async () => {
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue('yaml');
+      mockYaml.parse.mockReturnValue({ modules: {} });
+      mockCodebaseIndexSchema.parse.mockReturnValue({} as never);
+      mockGenerateDiagram.mockReturnValue('```mermaid\ngraph TD\n```');
+
+      const result = await indexCommand({
+        subcommand: 'diagram',
+        output: 'docs/architecture/dependency-graph.md',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockFs.writeFile).toHaveBeenCalledWith(
+        'docs/architecture/dependency-graph.md',
+        expect.stringContaining('mermaid'),
+        'utf-8'
+      );
+    });
+
+    it('still reads the index from its default location when --output is given', async () => {
+      // The half that would break if `--output` simply moved from one path to
+      // the other: the index it reads must NOT follow the diagram destination.
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue('yaml');
+      mockYaml.parse.mockReturnValue({ modules: {} });
+      mockCodebaseIndexSchema.parse.mockReturnValue({} as never);
+      mockGenerateDiagram.mockReturnValue('```mermaid```');
+
+      await indexCommand({ subcommand: 'diagram', output: 'somewhere/else.md' });
+
+      expect(mockFs.readFile).toHaveBeenCalledWith('docs/codebase-index.yaml', 'utf-8');
+    });
+
+    it('does not write the regenerated INDEX over the --output diagram', async () => {
+      // Found by running the real CLI, not by a mock: the self-heal forwarded
+      // `output` to generateIndex, which reads it as the index destination, so
+      // a missing index caused a 3.4MB YAML to be written over the caller's
+      // requested diagram path. It clobbered a real committed doc.
+      mockFs.access.mockRejectedValueOnce(new Error('ENOENT')).mockResolvedValue(undefined);
+      mockExtractProject.mockReturnValue({ files: [], errors: [], durationMs: 10 });
+      mockBuildIndex.mockReturnValue({
+        stats: { totalFiles: 0, moduleCount: 0 },
+        modules: {},
+      } as never);
+      mockIndexToYaml.mockReturnValue('yaml-index-content');
+      mockFs.readFile.mockResolvedValue('yaml');
+      mockYaml.parse.mockReturnValue({ modules: {} });
+      mockCodebaseIndexSchema.parse.mockReturnValue({} as never);
+      mockGenerateDiagram.mockReturnValue('```mermaid```');
+
+      await indexCommand({ subcommand: 'diagram', output: 'docs/architecture/graph.md' });
+
+      // The index goes to the index path...
+      expect(mockFs.writeFile).toHaveBeenCalledWith(
+        'docs/codebase-index.yaml',
+        'yaml-index-content',
+        'utf-8'
+      );
+      // ...and the requested path receives the DIAGRAM, not the index.
+      expect(mockFs.writeFile).toHaveBeenCalledWith(
+        'docs/architecture/graph.md',
+        expect.stringContaining('mermaid'),
+        'utf-8'
+      );
+    });
+
+    it('keeps the cwd-relative default so other repos are unaffected', async () => {
+      // This CLI ships to other projects. The default must stay relative to the
+      // user's tree, never this repository's layout.
+      mockFs.access.mockResolvedValue(undefined);
+      mockFs.readFile.mockResolvedValue('yaml');
+      mockYaml.parse.mockReturnValue({ modules: {} });
+      mockCodebaseIndexSchema.parse.mockReturnValue({} as never);
+      mockGenerateDiagram.mockReturnValue('```mermaid```');
+
+      await indexCommand({ subcommand: 'diagram' });
+
+      expect(mockFs.writeFile).toHaveBeenCalledWith(
+        'docs/dependency-graph.md',
+        expect.anything(),
+        'utf-8'
+      );
+    });
   });
 
   describe('validate subcommand', () => {

--- a/packages/nexus-agents/src/cli/index-command.ts
+++ b/packages/nexus-agents/src/cli/index-command.ts
@@ -163,16 +163,32 @@ async function checkIndex(options: IndexCommandOptions): Promise<IndexCommandRes
  * Generates a Mermaid dependency diagram.
  */
 async function generateDiagram(options: IndexCommandOptions): Promise<IndexCommandResult> {
-  const indexPath = options.output ?? 'docs/codebase-index.yaml';
-  const diagramPath = 'docs/dependency-graph.md';
+  // #4799: `--output` names this subcommand's PRODUCT — the diagram — not the
+  // index it happens to read. It used to mean the index, and the destination
+  // was hardcoded, so there was no way to aim the generator at a repo's real
+  // docs location; nexus-agents' own canonical graph went seven months without
+  // a regeneration for exactly that reason.
+  //
+  // The default stays cwd-relative. This CLI runs inside other people's
+  // repositories, so it must write into their tree, never a layout of ours.
+  const indexPath = 'docs/codebase-index.yaml';
+  const diagramPath = options.output ?? 'docs/dependency-graph.md';
 
   // Check if index file exists
   try {
     await fs.access(indexPath);
   } catch {
-    // Generate index first
+    // Generate index first.
+    //
+    // `output` is deliberately dropped here (#4799): it now names the DIAGRAM
+    // destination, and `generateIndex` reads the same field as the INDEX
+    // destination. Forwarding it makes the self-heal write a multi-megabyte
+    // YAML index over the diagram the caller asked for — which is exactly what
+    // happened the first time this ran against a real tree.
     logger.info('Index not found, generating...');
-    await generateIndex({ ...options, subcommand: 'generate' });
+    const indexOptions: IndexCommandOptions = { ...options, subcommand: 'generate' };
+    delete (indexOptions as { output?: string }).output;
+    await generateIndex(indexOptions);
   }
 
   // Load index


### PR DESCRIPTION
Fixes #4799.

## Problem

On the `diagram` subcommand, `--output` set the path the command **read its index from**, and the diagram destination was hardcoded:

```ts
const indexPath = options.output ?? 'docs/codebase-index.yaml';
const diagramPath = 'docs/dependency-graph.md';   // not configurable
```

So `--output` on a command whose product is a diagram meant "where to read", and there was no way to say "where to write". That is why this repo's canonical `docs/architecture/dependency-graph.md` — linked from `docs/README.md` and labelled **Generated** — carried a `Generated: 2026-01-12` header no generator had touched in seven months. Nothing could aim at it.

## Correction to the issue's own proposal

I originally wrote "point the diagram output at `docs/architecture/dependency-graph.md`". **That would have been a bug.** This CLI ships to other repositories, and its paths are cwd-relative on purpose — hardcoding our layout would write nexus-agents' directory structure into other people's projects. The default stays cwd-relative; only the ability to override it is new.

## The bug the live run caught

After the unit tests were green, I ran the real CLI against this repo — and it **wrote a 3.4MB YAML index over `docs/architecture/dependency-graph.md`**, clobbering a committed document. (Restored; the regeneration in this PR is the legitimate one.)

The self-heal path regenerates the index when it's missing and forwarded `options.output` straight into `generateIndex`, which reads that same field as the *index* destination. So the caller's requested diagram path received the index instead.

Every mocked test passed through this, because none exercised **missing index + explicit output** together. It only appeared against a real tree. Now pinned by `does not write the regenerated INDEX over the --output diagram`, mutation-verified: restoring the forward fails that test alone.

## What's in here

- `--output` names the diagram destination; the index keeps its own default.
- The self-heal drops `output` before delegating to the index generator.
- **This repo's canonical graph regenerated** — `Generated: 2026-08-25`, 28 modules, 1,491 files, +464/−210. The "Generated" label is true again.
- `.gitignore` broadened to `**/docs/codebase-index.yaml`: with the artifact retired in #4800, a `diagram` run from the repo root would otherwise leave an untracked 3.4MB file at a *second* path. Verified by touching the file and confirming `git status` stays clean.

## Verification

Red/green — 3 tests written first, 2 failed against `main`; the clobber regression added after the live run. 31 passing. `tsc` and eslint clean.

| Mutation | Result |
|---|---|
| self-heal forwards `output` again | 1 failed |

Also asserts the default stays `docs/dependency-graph.md`, so the change cannot silently start writing this repo's layout into someone else's tree.