### PR TITLE
test(mcp): pin the unreadable-file counter

### DIFF
--- a/.changeset/audit-unreadable-file-test.md
+++ b/.changeset/audit-unreadable-file-test.md
@@ -1,0 +1,13 @@
+---
+'nexus-agents': patch
+---
+
+pin the unreadable-file counter that shipped untested in #4788
+
+Every fixture in #4788 exercised unparseable LINES; none exercised a file the
+loader could not open. Deleting `unreadableFiles++` left all twelve tests green,
+so the counter shipped unverified in a PR that reported mutation verification of
+the two counters beside it.
+
+Adds the missing case — a directory named like a log file, so `readFile` throws
+EISDIR — and confirms it goes red when the counter is removed.

--- a/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.test.ts
@@ -196,6 +196,26 @@ describe('verify_audit_chain handler behavior', () => {
       expect(body.unreadableFiles).toBeUndefined();
     });
 
+    it('counts a file it could not open at all', async () => {
+      // A directory named like a log file: `readFile` throws EISDIR, taking the
+      // loader's unreadable-file path. Portable, and does not depend on running
+      // as a non-root user the way a chmod-000 fixture would.
+      //
+      // #4788 shipped this counter with no test — deleting `unreadableFiles++`
+      // left all twelve tests green, because every fixture exercised unparseable
+      // LINES and none an unopenable FILE.
+      writeAuditFile('audit-2026-04-28-12-00-00.jsonl', chain(2));
+      fs.mkdirSync(path.join(tmpDir, 'audit-2026-04-28-13-00-00.jsonl'));
+
+      const body = await callHandler(tmpDir);
+
+      expect(body.unreadableFiles).toBe(1);
+      // The readable file still verifies — resilient reading is the policy;
+      // the caller is just told what it cost.
+      expect(body.eventCount).toBe(2);
+      expect(body.fileCount).toBe(2);
+    });
+
     it('distinguishes a wholly unparseable log from an empty one', async () => {
       // The worst case: every line is garbage. Before this the response was
       // eventCount 0 + notVerified "empty" — identical to an empty directory.


### PR DESCRIPTION
Follow-up to #4788.

## The gap

#4788 added three coverage counters and I reported it as mutation-verified. I verified two of them. Every fixture exercised unparseable **lines**; none exercised a **file the loader could not open**.

```
M (unreadableFiles++ deleted):  Tests  12 passed (12)
```

The counter shipped with nothing pinning it.

## The lesson, stated plainly

I mutation-tested the paths my new tests targeted rather than every production line I changed. Those are different sets, and the difference is exactly where an unverified change hides. "Mutation-verified" in a PR description should mean every changed production line was reverted and observed to go red — not that the headline behaviour was.

## Fix

Adds the missing case: a **directory** named like a log file, so `readFile` throws `EISDIR` and takes the unreadable-file branch. Portable — unlike a `chmod 000` fixture, it does not silently pass when tests run as root.

Also asserts the readable file in the same directory still verifies, since resilient reading is the policy — the caller is told what it cost, not denied a verdict.

```
× counts a file it could not open at all
  Tests  1 failed | 12 passed (13)     # counter deleted
  Tests  13 passed (13)                # restored
```

## Separately filed

The reviewer that found this also flagged that `verification.ok` stays `true` when `skippedLines > 0`, so a caller reading only `ChainVerification` still gets a clean-looking verdict over a partially-read log. That one is a design question about where the coverage signal belongs — `notVerified` means "nothing was verified", which a partial read is not — and it touches audit semantics, so it is filed rather than patched here.