### PR TITLE
feat(mcp): let run request a dry run, and refuse when it cannot

### DIFF
--- a/.changeset/run-dry-run.md
+++ b/.changeset/run-dry-run.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': minor
+---
+
+let `run` request a dry run, and refuse where it cannot be honoured
+
+`run` is the documented default entry point, but it could not express the
+cautious caller's first request — plan and vote without implementing. It always
+built its pipeline input as `{ task: goal }`, so `dryRun` took its `false`
+default and `run` was strictly less capable than the tool it delegates to, with
+nothing saying so. (`execute: false` is not a substitute: it returns the
+selected strategy, having done no planning and no voting.)
+
+Adds `dryRun` to `run`. Only the dev-pipeline strategy stops after plan+vote, so
+when the router selects any other strategy the call is REFUSED with a `business`
+error before any executor runs — silently ignoring a do-not-act flag is the one
+outcome a governance substrate cannot allow.
+
+`mode` and `qualityGate` stay pipeline-specific vocabulary reachable through
+`run_dev_pipeline`; forwarding them would leak one strategy's config into a
+strategy-agnostic surface.
+
+Fixes #4806.

--- a/docs/reference/tools/run.md
+++ b/docs/reference/tools/run.md
@@ -22,4 +22,5 @@ DEFAULT ENTRY POINT (epic #3548): give a goal and nexus-agents selects the right
 | `dependencyStructure` | enum | no | one of: linear \| dag \| independent \| unknown | Hint: the dependency structure of the work. |
 | `isNovel` | boolean | no | — | Hint: this kind of task has not been seen before. |
 | `execute` | boolean | no | — | When true, actually run the selected strategy (if an executor is wired) and return its result; otherwise return the routing decision only (default false, read-only). |
+| `dryRun` | boolean | no | — | Plan and vote only, no implementation (#4806). Requires the dev-pipeline strategy — refused (never silently executed) when the router selects another. |
 | `dispatch` | enum | no | one of: sync \| async | Dispatch mode (#3732). 'sync' (default): run inline. 'async' (only with execute:true): return a jobId immediately + run in background (poll get_job_result). |

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -253,9 +253,16 @@ async function createStages(
  */
 export async function runDevPipelineForGoal(
   goal: string,
-  trustTier?: string
+  trustTier?: string,
+  dryRun?: boolean
 ): Promise<DevPipelineResult> {
-  const input = DevPipelineInputSchema.parse({ task: goal });
+  // #4806: `dryRun` is the one pipeline option `run` forwards. `mode` and
+  // `qualityGate` stay pipeline-specific vocabulary — a caller who wants those
+  // has already decided on the strategy and should call `run_dev_pipeline`.
+  const input = DevPipelineInputSchema.parse({
+    task: goal,
+    ...(dryRun !== undefined ? { dryRun } : {}),
+  });
   const stages = await createStages(input, trustTier);
   // #3712: thread the caller's real content-provenance trust tier into the
   // consensus→execute policy snapshot. Undefined ⇒ seam fail-closes to tier 4

--- a/packages/nexus-agents/src/mcp/tools/run-tool-dry-run.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool-dry-run.ts
@@ -1,0 +1,63 @@
+/**
+ * Dry-run support for the `run` entry point (#4806).
+ *
+ * `run` dispatches across several strategies, and only the dev pipeline can
+ * stop after plan+vote. Everything here exists to make the other case a
+ * REFUSAL rather than a silent full execution — the objection that decided the
+ * consensus vote was precisely that forwarding a do-not-act flag to a
+ * dynamically-selected strategy is dangerous unless the unsupported path fails
+ * closed.
+ *
+ * Lives beside `run-tool.ts` rather than inside it because that file is at its
+ * `max-lines` ceiling; this is one cohesive concern, not a grab-bag.
+ *
+ * @module mcp/tools/run-tool-dry-run
+ */
+import { MetaDispatchError } from '../../orchestration/meta-dispatcher.js';
+import { AuthorityRefusalError } from '../../orchestration/authority-tier-guard.js';
+
+/** The only strategy whose executor stops before implementing. */
+const DRY_RUN_CAPABLE = 'dev-pipeline';
+
+/**
+ * Raised when a dry run is requested of a strategy that cannot stop short of
+ * acting.
+ *
+ * A `business` outcome, not an internal fault: the caller asked for something
+ * coherent that this route cannot provide. Refusing is the point — executing a
+ * run the caller asked to be dry would be worse than any error.
+ */
+export class DryRunUnsupportedError extends Error {
+  constructor(readonly strategy: string) {
+    super(
+      `dryRun is not supported by the '${strategy}' strategy — only '${DRY_RUN_CAPABLE}' stops after plan+vote. ` +
+        `Refusing rather than running for real. Re-run without dryRun, or force the ${DRY_RUN_CAPABLE} strategy.`
+    );
+    this.name = 'DryRunUnsupportedError';
+  }
+}
+
+/**
+ * Throws before any executor runs when the selected strategy cannot honour a
+ * requested dry run. A no-op when `dryRun` is absent or false — the refusal
+ * keys on the request, never on the strategy alone.
+ */
+export function assertDryRunSupported(dryRun: boolean | undefined, strategy: string): void {
+  if (dryRun === true && strategy !== DRY_RUN_CAPABLE) {
+    throw new DryRunUnsupportedError(strategy);
+  }
+}
+
+/**
+ * `business` for outcomes the caller asked for and can act on; `internal` for
+ * genuine faults.
+ *
+ * A missing executor, an authority-ladder refusal (#3920) and a refused dry run
+ * (#4806) are all fail-closed POLICY results, not defects.
+ */
+export function classifyDispatchError(err: unknown): 'business' | 'internal' {
+  const noExecutor = err instanceof MetaDispatchError && err.code === 'no_executor';
+  const refused = err instanceof AuthorityRefusalError;
+  const dryRunUnsupported = err instanceof DryRunUnsupportedError;
+  return noExecutor || refused || dryRunUnsupported ? 'business' : 'internal';
+}

--- a/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
@@ -25,7 +25,7 @@ interface FakeDevPipelineResult {
   planStatus?: 'empty';
 }
 const runDevPipelineForGoalMock = vi.fn(
-  (_goal: string, _trustTier?: string): Promise<FakeDevPipelineResult> =>
+  (_goal: string, _trustTier?: string, _dryRun?: boolean): Promise<FakeDevPipelineResult> =>
     Promise.resolve({
       completed: true,
       plan: 'plan',
@@ -36,8 +36,10 @@ const runDevPipelineForGoalMock = vi.fn(
     })
 );
 vi.mock('./dev-pipeline-tool.js', () => ({
-  runDevPipelineForGoal: (goal: string, trustTier?: string) =>
-    runDevPipelineForGoalMock(goal, trustTier),
+  // Forwards all three parameters: a wrapper that drops `dryRun` would make the
+  // #4806 forwarding assertions unfalsifiable.
+  runDevPipelineForGoal: (goal: string, trustTier?: string, dryRun?: boolean) =>
+    runDevPipelineForGoalMock(goal, trustTier, dryRun),
 }));
 
 // #4362: drive the pipeline executor's reported success/failure. run-tool only
@@ -585,6 +587,90 @@ describe('run async dispatch (execute:true, #3732)', () => {
       const env = errorEnvelope(result);
       expect(env?.['message']).toContain('did not complete');
       expect(env?.['message']).not.toContain('security gate');
+    });
+
+    // #4806: `run` is the documented default entry point but could not express
+    // a dry run at all, so a cautious caller could not ask it to plan and vote
+    // without implementing. consensus_vote 6-1, Option B unanimous among
+    // approvers — forward dryRun only, and REFUSE where it cannot be honoured.
+    describe('dryRun (#4806)', () => {
+      it('forwards dryRun to the dev pipeline', async () => {
+        const handler = captureHandler();
+        await handler({
+          goal: 'implement the feature',
+          forceStrategy: 'dev-pipeline',
+          execute: true,
+          dryRun: true,
+        });
+
+        expect(runDevPipelineForGoalMock).toHaveBeenCalledWith(
+          'implement the feature',
+          undefined,
+          true
+        );
+      });
+
+      it('leaves the pipeline untouched when dryRun is omitted', async () => {
+        const handler = captureHandler();
+        await handler({
+          goal: 'implement the feature',
+          forceStrategy: 'dev-pipeline',
+          execute: true,
+        });
+
+        expect(runDevPipelineForGoalMock).toHaveBeenCalledWith(
+          'implement the feature',
+          undefined,
+          undefined
+        );
+      });
+
+      // The condition every voter attached, and the contrarian's whole
+      // objection: a strategy that cannot honour "do not act" must REFUSE.
+      // Silently executing a run the caller asked to be dry is the one
+      // unacceptable outcome for a governance substrate.
+      it('refuses rather than executing when the selected strategy cannot honour it', async () => {
+        const handler = captureHandler();
+        const result = await handler({
+          goal: 'analyze the repository',
+          forceStrategy: 'pipeline',
+          execute: true,
+          dryRun: true,
+        });
+
+        expect(result.isError).toBe(true);
+        expect(errorEnvelope(result)?.['errorCategory']).toBe('business');
+        expect(errorEnvelope(result)?.['message']).toContain('dryRun');
+        expect(errorEnvelope(result)?.['message']).toContain('pipeline');
+        // The point of refusing: the engine must not have run.
+        expect(runPipelineForGoalMock).not.toHaveBeenCalled();
+      });
+
+      it('refuses a dry run on the consensus strategy too', async () => {
+        const handler = captureHandler();
+        const result = await handler({
+          goal: 'decide A or B',
+          forceStrategy: 'consensus',
+          execute: true,
+          dryRun: true,
+        });
+
+        expect(result.isError).toBe(true);
+        expect(errorEnvelope(result)?.['message']).toContain('dryRun');
+      });
+
+      it('does not refuse those strategies when dryRun is absent', async () => {
+        // Guard the guard: the refusal must key on dryRun, not on the strategy.
+        const handler = captureHandler();
+        const result = await handler({
+          goal: 'analyze the repository',
+          forceStrategy: 'pipeline',
+          execute: true,
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(runPipelineForGoalMock).toHaveBeenCalled();
+      });
     });
 
     it('surfaces a pipeline that reported success:false as a structured error', async () => {

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -26,6 +26,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { IModelAdapter } from '../../core/index.js';
 
 import { createLogger, formatZodError, getErrorMessage, type ILogger } from '../../core/index.js';
+import { assertDryRunSupported, classifyDispatchError } from './run-tool-dry-run.js';
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import {
@@ -52,7 +53,6 @@ import { evaluateMetaStrategyReadiness } from '../../orchestration/meta-strategy
 import { isPersistenceEnabled } from '../../config/learning-persistence.js';
 import {
   createMetaDispatcher,
-  MetaDispatchError,
   type StrategyExecutorMap,
   type MetaOutcomeSink,
   type MetaOutcomeObserver,
@@ -60,7 +60,6 @@ import {
 import { entrypointToolFor } from '../../orchestration/strategy-manifest-registry.js';
 import {
   dispatchActionClass,
-  AuthorityRefusalError,
   type DispatchMode,
 } from '../../orchestration/authority-tier-guard.js';
 import { runDevPipelineForGoal } from './dev-pipeline-tool.js';
@@ -105,6 +104,25 @@ export const RunInputSchema = z.object({
     .describe(
       'When true, actually run the selected strategy (if an executor is wired) and return ' +
         'its result; otherwise return the routing decision only (default false, read-only).'
+    ),
+  /**
+   * Plan and vote without implementing (#4806).
+   *
+   * `run` is the documented default entry point, but until now it could not
+   * express the cautious caller's first request — "show me the plan, don't
+   * build it". `execute: false` is not a substitute: that returns the SELECTED
+   * STRATEGY, having done no planning and no voting.
+   *
+   * Only the dev-pipeline strategy can honour it. When the router selects any
+   * other, the call is REFUSED rather than executed: silently ignoring a
+   * do-not-act flag is the one outcome a governance substrate cannot allow.
+   */
+  dryRun: z
+    .boolean()
+    .optional()
+    .describe(
+      'Plan and vote only, no implementation (#4806). Requires the dev-pipeline strategy — ' +
+        'refused (never silently executed) when the router selects another.'
     ),
   /**
    * Dispatch mode (#3732). Only meaningful with `execute: true` — `run`
@@ -279,11 +297,12 @@ export function routeGoal(input: RunInput, logger?: ILogger): RunResponse {
  */
 export function buildDefaultExecutors(
   trustTier?: string,
-  gatewayAdapters?: readonly IModelAdapter[]
+  gatewayAdapters?: readonly IModelAdapter[],
+  dryRun?: boolean
 ): StrategyExecutorMap {
   return {
     'dev-pipeline': (_decision, metaInput: MetaOrchestratorInput) =>
-      runDevPipelineForGoal(metaInput.goal, trustTier),
+      runDevPipelineForGoal(metaInput.goal, trustTier, dryRun),
     pipeline: (_decision, metaInput: MetaOrchestratorInput) => runPipelineForGoal(metaInput.goal),
     // #3988: `research` deliberately ALIASES the `pipeline` engine — it runs the
     // SAME generic stage registry (selectStageRegistry only branches greenfield/
@@ -366,9 +385,15 @@ export async function executeGoal(
   // dispatch is refused fail-closed (AuthorityRefusalError) here, BEFORE any
   // executor runs.
   const decision = selectDecision(input, 'execute', opts.logger);
+  // #4806: fail closed BEFORE any executor runs. Only the dev pipeline stops
+  // after plan+vote; every other strategy would execute for real, so honouring
+  // the request is impossible and ignoring it would act against an explicit
+  // instruction not to.
+  assertDryRunSupported(input.dryRun, decision.strategy);
   const onOutcome = opts.onOutcome ?? buildShadowTrainObserver(opts.logger);
   const dispatcher = createMetaDispatcher({
-    executors: opts.executors ?? buildDefaultExecutors(opts.trustTier, opts.gatewayAdapters),
+    executors:
+      opts.executors ?? buildDefaultExecutors(opts.trustTier, opts.gatewayAdapters, input.dryRun),
     ...(opts.logger !== undefined ? { logger: opts.logger } : {}),
     ...(opts.outcomeSink !== undefined ? { outcomeSink: opts.outcomeSink } : {}),
     ...(onOutcome !== undefined ? { onOutcome } : {}),
@@ -486,13 +511,8 @@ async function executeRunBody(
     }
     return toolSuccess(JSON.stringify(exec, null, 2));
   } catch (err) {
-    const noExecutor = err instanceof MetaDispatchError && err.code === 'no_executor';
-    // #3920: an authority-ladder refusal is a fail-closed POLICY outcome (the
-    // caller asked an above-tier strategy to act), not an internal fault — it is
-    // a `business` error, same class as a missing executor.
-    const refused = err instanceof AuthorityRefusalError;
     return toolStructuredError({
-      errorCategory: noExecutor || refused ? 'business' : 'internal',
+      errorCategory: classifyDispatchError(err),
       message: err instanceof Error ? err.message : String(err),
     });
   }


### PR DESCRIPTION
Fixes #4806.

## The gap

CLAUDE.md tells callers to reach for `run` first. But when it selects the dev-pipeline strategy, it built its input as:

```ts
DevPipelineInputSchema.parse({ task: goal })
```

So `dryRun` took its `false` default and **`run` could not be asked to plan and vote without implementing** — the cautious caller's first request, and unavailable through the tool they're told to prefer. `execute: false` is not a substitute: it returns the *selected strategy*, having done no planning and no voting.

## Decision

`consensus_vote` (`higher_order`, `absolute_quorum`, 7 voters): approved **6-1**, and **Option B was unanimous among all six approvers** — forward `dryRun` only.

`mode: 'harness'` and `qualityGate` stay out. They are dev-pipeline vocabulary, and forwarding them through a strategy-agnostic entry point would force every future strategy to answer "what does qualityGate mean here?". A caller who wants those has already chosen the strategy and should call `run_dev_pipeline`.

## The refusal is the substance

Every voter attached the same condition, and the contrarian's entire reject rested on it: `run` selects its strategy dynamically, so forwarding a do-not-act flag is dangerous **unless the unsupported path fails closed**. Silently executing a run the caller asked to be dry is the one outcome a governance substrate cannot allow.

So `assertDryRunSupported` throws **before any executor runs**:

```
dryRun is not supported by the 'pipeline' strategy — only 'dev-pipeline' stops
after plan+vote. Refusing rather than running for real. Re-run without dryRun,
or force the dev-pipeline strategy.
```

Classified `business`, alongside a missing executor and an authority-ladder refusal — a policy outcome the caller can act on, not a fault.

## Verification

Red/green, six tests written first, four failed against `main`. Mutation-verified on both halves:

| Mutation | Result |
|---|---|
| refusal neutered (the contrarian's scenario — silently executes) | 2 failed |
| `dryRun` not forwarded to the pipeline | 1 failed |
| refusal misclassified as `internal` | 1 failed |

One test exists purely to guard the guard: **`does not refuse those strategies when dryRun is absent`**, so the refusal keys on the request rather than on the strategy. And the `vi.mock` wrapper had to be widened to forward three arguments — a two-arg wrapper would have made every forwarding assertion unfalsifiable.

67 tests green across `run-tool` and `dev-pipeline-tool`. `tsc` clean. **API surface unchanged.**

## Note on the new file

`run-tool.ts` was at its `max-lines` ceiling and `executeRunBody` at its complexity ceiling, so the error class and the dispatch-error classifier moved to `run-tool-dry-run.ts`. That is one cohesive concern rather than a grab-bag, and it takes `executeRunBody` back under the limit instead of raising it.

## Leftover from #4792, deliberately not addressed here

Two branches of `describeIncompletePipeline` remain unreachable via `run`: `planStatus: 'empty'` becomes reachable with this change (a dry run can now produce it), but `securityRan: false` still needs harness mode or a blocking quality gate. Tracked on #4806 rather than trimmed blind.