### PR TITLE
fix(adapters): arm the circuit breaker at construction

### DIFF
--- a/.changeset/arm-circuit-breaker.md
+++ b/.changeset/arm-circuit-breaker.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': minor
+---
+
+arm the resilient adapter's circuit breaker at construction
+
+`ResilientAdapter.recordBreakerFailure` returned early unless a
+`CircuitBreakerRegistry` had been attached, and **no production caller attached
+one** — both construction sites in `UnifiedAdapterRegistry` built the adapter
+and stopped. So the failover listener could never fire and a CLI whose circuit
+had opened kept being handed out.
+
+The reason it was never wired is worth recording: `attachCircuitBreakerRegistry`
+existed on the class but not on `IResilientAdapter`, which is what
+`createResilientAdapter` returns — so neither site could reach it without a cast.
+
+The registry is now supplied through `ResilientAdapterConfig` and armed during
+construction, so arming is part of building the adapter rather than a step
+someone must remember. Both sites pass the SHARED registry that already gates
+voter-panel availability (#4330), so one adapter cannot keep routing to a CLI
+another has seen fail. `IResilientAdapter` gains a read-only
+`getCircuitBreakerRegistry()` so a caller can verify the adapter is armed;
+`attach` is deliberately not exposed there.
+
+Fixes #4659.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -4717,6 +4717,7 @@ InterfaceDeclaration IRegistryStats
   total: number
 InterfaceDeclaration IResilientAdapter
   dispose() => void
+  getCircuitBreakerRegistry(() => import("../cli-adapters/circuit-breaker.js").CircuitBreakerRegistry | undefined) | undefined
   getHealth() => AdapterHealthInfo | undefined
   onFailover(cb: (info: AdapterHealthInfo) => void) => () => void
   refresh() => Promise<void>

--- a/packages/nexus-agents/src/adapters/resilient-adapter-types.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter-types.ts
@@ -40,6 +40,16 @@ export interface ResilientAdapterConfig {
   readonly preferredCli?: CliName;
   /** Default timeout for CLI subprocess calls (ms). Overrides auto-detection. */
   readonly defaultCliTimeoutMs?: number;
+  /**
+   * Circuit-breaker registry to arm this adapter's failover with (#4659).
+   *
+   * Supplied at CONSTRUCTION rather than through a separate `attach` call
+   * because the separate call is exactly what never happened: `attach` was on
+   * the class but not on {@link IResilientAdapter}, so the two production
+   * construction sites could not reach it without a cast, and the breaker sat
+   * disarmed. Arming is now part of building the thing.
+   */
+  readonly circuitBreakerRegistry?: import('../cli-adapters/circuit-breaker.js').CircuitBreakerRegistry;
 }
 
 /**
@@ -58,6 +68,16 @@ export interface IResilientAdapter extends IModelAdapter {
   setPreferredCli(cli: CliName | undefined): void;
   /** Register failover callback */
   onFailover(cb: (info: AdapterHealthInfo) => void): () => void;
+  /**
+   * The registry arming this adapter's failover, or `undefined` if none (#4659).
+   *
+   * Read-only on purpose: exposing `attach` here would re-create the "someone
+   * must remember to call it" shape that left the breaker disarmed. Supply it
+   * via {@link ResilientAdapterConfig.circuitBreakerRegistry} instead. This
+   * accessor exists so a caller can VERIFY the adapter is armed.
+   */
+  getCircuitBreakerRegistry?():
+    import('../cli-adapters/circuit-breaker.js').CircuitBreakerRegistry | undefined;
   /** Cleanup listeners and timers */
   dispose(): void;
 }

--- a/packages/nexus-agents/src/adapters/resilient-adapter.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.ts
@@ -87,6 +87,13 @@ export class ResilientAdapter implements IResilientAdapter {
     this.logger = config?.logger ?? createLogger({ component: 'resilient-adapter' });
     this.preferredCli = config?.preferredCli;
     this.defaultCliTimeoutMs = config?.defaultCliTimeoutMs;
+
+    // #4659: arm at construction. The previous `attach`-only API was not on
+    // IResilientAdapter, so neither production construction site could reach
+    // it and the breaker never fired.
+    if (config?.circuitBreakerRegistry !== undefined) {
+      this.attachCircuitBreakerRegistry(config.circuitBreakerRegistry);
+    }
   }
 
   // --- IModelAdapter properties (forwarded) ---
@@ -188,6 +195,11 @@ export class ResilientAdapter implements IResilientAdapter {
    * When the current adapter's circuit opens, the cached adapter
    * is cleared so the next call triggers re-detection.
    */
+  /** The registry arming failover, or undefined if this adapter is unarmed (#4659). */
+  getCircuitBreakerRegistry(): CircuitBreakerRegistry | undefined {
+    return this.circuitBreakerRegistry;
+  }
+
   attachCircuitBreakerRegistry(registry: CircuitBreakerRegistry): void {
     this.detachCircuitBreakerRegistry();
     this.circuitBreakerRegistry = registry;

--- a/packages/nexus-agents/src/adapters/unified-registry.test.ts
+++ b/packages/nexus-agents/src/adapters/unified-registry.test.ts
@@ -19,6 +19,7 @@ import {
   getGlobalRegistry,
   resetGlobalRegistry,
 } from './unified-registry.js';
+import { getDefaultCliCircuitBreakerRegistry } from '../cli-adapters/cli-circuit-breaker.js';
 import { TASK_SPECIALIZATION_MATRIX } from '../config/task-specialization.js';
 import { DEFAULT_MODEL_CAPABILITIES } from '../config/in-tree-data.js';
 import * as modelConfigHelpers from '../config/model-config-helpers.js';
@@ -45,6 +46,30 @@ describe('UnifiedAdapterRegistry', () => {
 
   afterEach(() => {
     registry.dispose();
+  });
+
+  // #4659: the ResilientAdapter's failover listener could never fire. Its
+  // `recordBreakerFailure` returns early unless a CircuitBreakerRegistry was
+  // attached, and NO production caller attached one — both construction sites
+  // here built the adapter and stopped. A shared registry already existed and
+  // already gated voter-panel availability (#4330); the adapter simply never
+  // saw it, so a CLI whose circuit opened kept being handed out.
+  describe('circuit-breaker arming (#4659)', () => {
+    it('arms the CLI-specific adapter with the shared registry', () => {
+      const adapter = registry.getAdapterForCli('claude');
+
+      expect(adapter.getCircuitBreakerRegistry?.()).toBe(getDefaultCliCircuitBreakerRegistry());
+    });
+
+    it('arms the default adapter with the SAME shared registry', () => {
+      // Same instance, not merely a registry: a per-adapter registry would let
+      // one adapter keep routing to a CLI another already saw fail.
+      const viaDefault = registry.getDefault();
+      const viaCli = registry.getAdapterForCli('codex');
+
+      expect(viaDefault.getCircuitBreakerRegistry?.()).toBe(viaCli.getCircuitBreakerRegistry?.());
+      expect(viaDefault.getCircuitBreakerRegistry?.()).toBe(getDefaultCliCircuitBreakerRegistry());
+    });
   });
 
   describe('constructor', () => {

--- a/packages/nexus-agents/src/adapters/unified-registry.ts
+++ b/packages/nexus-agents/src/adapters/unified-registry.ts
@@ -18,6 +18,7 @@
  */
 
 import type { ILogger } from '../core/index.js';
+import { getDefaultCliCircuitBreakerRegistry } from '../cli-adapters/cli-circuit-breaker.js';
 import { createLogger } from '../core/index.js';
 import { createResilientAdapter } from './resilient-adapter.js';
 import type { IResilientAdapter } from './resilient-adapter-types.js';
@@ -143,6 +144,10 @@ export class UnifiedAdapterRegistry {
     const raw = createResilientAdapter({
       logger: this.logger,
       preferredCli: cli,
+      // #4659: the SHARED registry — the same one that already gates
+      // voter-panel availability (#4330). Per-adapter registries would let one
+      // adapter keep routing to a CLI another has already seen fail.
+      circuitBreakerRegistry: getDefaultCliCircuitBreakerRegistry(),
       ...(this.defaultCliTimeoutMs !== undefined && {
         defaultCliTimeoutMs: this.defaultCliTimeoutMs,
       }),
@@ -209,6 +214,7 @@ export class UnifiedAdapterRegistry {
     if (this.defaultAdapter !== undefined) return this.defaultAdapter;
     const raw = createResilientAdapter({
       logger: this.logger,
+      circuitBreakerRegistry: getDefaultCliCircuitBreakerRegistry(),
       ...(this.defaultCliTimeoutMs !== undefined && {
         defaultCliTimeoutMs: this.defaultCliTimeoutMs,
       }),


### PR DESCRIPTION
Fixes #4659. Premise re-verified against main at v4.2.1 before starting.

## The defect

`ResilientAdapter.recordBreakerFailure` (`resilient-adapter.ts:303`) returns early unless a `CircuitBreakerRegistry` was attached:

```ts
if (this.circuitBreakerRegistry === undefined || this.currentSelection === undefined) return;
```

The only writer is `attachCircuitBreakerRegistry` (`:191`). **No production caller ever called it.** Both construction sites in `UnifiedAdapterRegistry` — `getAdapterForCli` (`:143`) and `getDefault` (`:210`) — built the adapter and stopped, and the file had zero references to a registry.

So the failover listener could never fire, and a CLI whose circuit had opened kept being handed out.

## Why it was never wired — the part worth keeping

`attachCircuitBreakerRegistry` is on the **class** but not on `IResilientAdapter`, which is what `createResilientAdapter` returns. Neither construction site could reach it without a cast.

That is the actual root cause: not an oversight, an unreachable API. Fixing only the call sites would leave the same trap for the next adapter.

## The fix

The registry is supplied through `ResilientAdapterConfig` and armed **during construction**, so arming is part of building the adapter rather than a step someone must remember.

Both sites pass the **shared** registry — `getDefaultCliCircuitBreakerRegistry()`, the same one that already gates voter-panel availability under #4330. Per-adapter registries would let one adapter keep routing to a CLI another had already seen fail.

`IResilientAdapter` gains a read-only `getCircuitBreakerRegistry()` so a caller can *verify* an adapter is armed. `attach` is deliberately **not** exposed there — putting it on the interface would recreate the "someone must remember to call it" shape that caused this.

## Verification

Red/green — two tests written first, both failed against `main`. Mutation-verified on both halves:

| Mutation | Result |
|---|---|
| CLI-specific site unarmed | 2 failed |
| constructor arming removed | 2 failed |

The second test asserts the two adapters hold the **same instance**, not merely some registry — a per-adapter registry would pass a weaker assertion while reintroducing the bug.

Full adapter suite: **929 tests, 31 files, green.** `tsc` clean.

## API surface

One line, additive and optional: `IResilientAdapter.getCircuitBreakerRegistry?()`. Snapshot regenerated; changeset is `minor` per the gate's own guidance that additive optional members are minor.

## Backlog note

Found by verifying seven older can't-fire issues against current main before picking any of them up. That sweep also closed **#4734** as genuinely fixed by other work, and reframed **#4666** and **#4658**, whose premises are now documented in the code they complain about. #4713, #4701 and #4657 remain true but need judgement calls rather than a self-contained fix.