### PR TITLE
chore(consensus): remove quorum screening that could never exclude

### DIFF
--- a/.changeset/remove-unreachable-quorum-screening.md
+++ b/.changeset/remove-unreachable-quorum-screening.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+remove the quorum agent screening that could never exclude anyone
+
+`QuorumValidator.isAgentEligible` had three exclusion branches, all requiring an
+`AgentRecord`. No production caller supplied one, and no producer of trust
+scores or Byzantine flags exists anywhere in `src/` — `enableByzantineDetection`
+had zero writers. So every voter was always eligible.
+
+The breakdown nonetheless emitted an `eligibleAgents` list containing every
+voter. A source comment explaining that nothing was screened does not travel
+with a serialized record, so a machine consumer read screening-shaped output as
+evidence that screening ran.
+
+Removes the branches, `enableByzantineDetection`, `agentRecords`, `AgentRecord`,
+`EligibilityResult`, and the `eligibleAgents` field, so the breakdown no longer
+reports a measurement it never took. Git history holds the implementation for
+whenever a real trust-score producer appears.
+
+`consensus_vote` 7-0 unanimous. Fixes #4666.

--- a/packages/nexus-agents/src/consensus/index.ts
+++ b/packages/nexus-agents/src/consensus/index.ts
@@ -89,8 +89,6 @@ export type {
   QuorumValidationConfig,
   QuorumValidationResult,
   QuorumBreakdown,
-  EligibilityResult,
-  AgentRecord,
 } from './quorum-validator.js';
 
 export {

--- a/packages/nexus-agents/src/consensus/quorum-validator.test.ts
+++ b/packages/nexus-agents/src/consensus/quorum-validator.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for QuorumValidator - Unified quorum validation
  *
- * Covers: validateQuorum, getQuorumBreakdown, isAgentEligible, createQuorumValidator
+ * Covers: validateQuorum, getQuorumBreakdown, createQuorumValidator
  */
 
 import { describe, expect, it } from 'vitest';
@@ -12,7 +12,6 @@ import {
   DEFAULT_QUORUM_THRESHOLDS,
   QuorumValidator,
   createQuorumValidator,
-  type AgentRecord,
   type QuorumValidationConfig,
   type QuorumValidationInput,
 } from './quorum-validator.js';
@@ -36,15 +35,6 @@ function makeConfig(overrides: Partial<QuorumValidationConfig> = {}): QuorumVali
     algorithm: 'simple_majority',
     threshold: 0.5,
     minVoters: 1,
-    ...overrides,
-  };
-}
-
-function makeAgentRecord(overrides: Partial<AgentRecord> = {}): AgentRecord {
-  return {
-    agentId: 'agent-1',
-    weight: 1.0,
-    trustScore: 0.9,
     ...overrides,
   };
 }
@@ -81,7 +71,6 @@ describe('createQuorumValidator', () => {
     expect(validator).toBeDefined();
     expect(typeof validator.validateQuorum).toBe('function');
     expect(typeof validator.getQuorumBreakdown).toBe('function');
-    expect(typeof validator.isAgentEligible).toBe('function');
   });
 });
 
@@ -400,61 +389,6 @@ describe('QuorumValidator.getQuorumBreakdown', () => {
     }
   });
 
-  it('uses agent records for weights when agentWeights not provided', () => {
-    const agentRecords = new Map([
-      ['a1', makeAgentRecord({ agentId: 'a1', weight: 3.0 })],
-      ['a2', makeAgentRecord({ agentId: 'a2', weight: 1.0 })],
-    ]);
-    const breakdown = validator.getQuorumBreakdown({
-      votes: makeVotes([
-        ['a1', 'approve'],
-        ['a2', 'reject'],
-      ]),
-      agentRecords,
-      config: makeConfig({ algorithm: 'proof_of_learning', threshold: 0.5 }),
-    });
-
-    expect(breakdown.totalWeight).toBeCloseTo(4.0);
-  });
-
-  it('returns eligible agents list', () => {
-    const agentRecords = new Map([
-      ['a1', makeAgentRecord({ agentId: 'a1', trustScore: 0.9 })],
-      ['a2', makeAgentRecord({ agentId: 'a2', trustScore: 0.1 })], // low trust
-    ]);
-    const breakdown = validator.getQuorumBreakdown({
-      votes: makeVotes([
-        ['a1', 'approve'],
-        ['a2', 'approve'],
-      ]),
-      agentRecords,
-      config: makeConfig({ enableByzantineDetection: true }),
-    });
-
-    expect(breakdown.eligibleAgents).toContain('a1');
-    expect(breakdown.eligibleAgents).not.toContain('a2');
-  });
-
-  // #4666: the tests above prove exclusion WORKS when an AgentRecord is
-  // supplied. This one pins the production reality — no caller supplies one,
-  // so nothing is ever excluded. If a producer is wired, this test should fail
-  // and be replaced by one asserting the real screening.
-  it('excludes nobody when no agent records are supplied — the production shape', () => {
-    const breakdown = validator.getQuorumBreakdown({
-      votes: makeVotes([
-        ['a1', 'approve'],
-        ['a2', 'approve'],
-      ]),
-      config: makeConfig({ enableByzantineDetection: true }),
-    });
-
-    // Byzantine detection is ON and still excludes nothing: with no record the
-    // eligibility check returns early. A full eligible list is NOT evidence
-    // that screening ran.
-    expect(breakdown.eligibleAgents).toContain('a1');
-    expect(breakdown.eligibleAgents).toContain('a2');
-  });
-
   it('includes reasoning string', () => {
     const breakdown = validator.getQuorumBreakdown({
       votes: makeVotes([
@@ -471,118 +405,6 @@ describe('QuorumValidator.getQuorumBreakdown', () => {
 
 // ============================================================================
 // QuorumValidator.isAgentEligible
-// ============================================================================
-
-describe('QuorumValidator.isAgentEligible', () => {
-  const validator = new QuorumValidator();
-
-  it('returns eligible with default weight when no record exists', () => {
-    const result = validator.isAgentEligible('agent-1', undefined, makeConfig());
-    expect(result.eligible).toBe(true);
-    if (result.eligible) {
-      expect(result.weight).toBe(1.0);
-    }
-  });
-
-  it('returns eligible for valid agent record', () => {
-    const record = makeAgentRecord({ trustScore: 0.8, weight: 1.5 });
-    const result = validator.isAgentEligible('agent-1', record, makeConfig());
-    expect(result.eligible).toBe(true);
-    if (result.eligible) {
-      expect(result.weight).toBe(1.5);
-    }
-  });
-
-  it('rejects agent with Byzantine flags when detection enabled', () => {
-    const record = makeAgentRecord({ byzantineFlags: 3 });
-    const config = makeConfig({ enableByzantineDetection: true });
-    const result = validator.isAgentEligible('agent-1', record, config);
-    expect(result.eligible).toBe(false);
-    if (!result.eligible) {
-      expect(result.reason).toBe('byzantine_flagged');
-    }
-  });
-
-  it('allows Byzantine-flagged agent when detection disabled', () => {
-    const record = makeAgentRecord({ byzantineFlags: 3 });
-    const config = makeConfig({ enableByzantineDetection: false });
-    const result = validator.isAgentEligible('agent-1', record, config);
-    expect(result.eligible).toBe(true);
-  });
-
-  it('allows Byzantine-flagged agent when detection not configured', () => {
-    const record = makeAgentRecord({ byzantineFlags: 3 });
-    const config = makeConfig(); // enableByzantineDetection not set
-    const result = validator.isAgentEligible('agent-1', record, config);
-    expect(result.eligible).toBe(true);
-  });
-
-  it('rejects agent with low trust score', () => {
-    const record = makeAgentRecord({ trustScore: 0.2 }); // below 0.3 threshold
-    const result = validator.isAgentEligible('agent-1', record, makeConfig());
-    expect(result.eligible).toBe(false);
-    if (!result.eligible) {
-      expect(result.reason).toBe('low_trust');
-      expect(result.weight).toBe(record.weight);
-    }
-  });
-
-  it('allows agent at exactly the trust threshold boundary', () => {
-    const record = makeAgentRecord({ trustScore: 0.3 }); // exactly at 0.3
-    const result = validator.isAgentEligible('agent-1', record, makeConfig());
-    expect(result.eligible).toBe(true);
-  });
-
-  it('rejects agent with insufficient weight', () => {
-    const record = makeAgentRecord({ weight: 0.05 }); // below 0.1 threshold
-    const result = validator.isAgentEligible('agent-1', record, makeConfig());
-    expect(result.eligible).toBe(false);
-    if (!result.eligible) {
-      expect(result.reason).toBe('insufficient_weight');
-    }
-  });
-
-  it('allows agent at exactly the weight threshold boundary', () => {
-    const record = makeAgentRecord({ weight: 0.1 }); // exactly at 0.1
-    const result = validator.isAgentEligible('agent-1', record, makeConfig());
-    expect(result.eligible).toBe(true);
-  });
-
-  it('checks Byzantine before trust (order matters)', () => {
-    // Agent has both: Byzantine flag AND low trust
-    const record = makeAgentRecord({ byzantineFlags: 1, trustScore: 0.1 });
-    const config = makeConfig({ enableByzantineDetection: true });
-    const result = validator.isAgentEligible('agent-1', record, config);
-    expect(result.eligible).toBe(false);
-    if (!result.eligible) {
-      // Should return 'byzantine_flagged', not 'low_trust'
-      expect(result.reason).toBe('byzantine_flagged');
-    }
-  });
-
-  it('checks trust before weight (order matters)', () => {
-    // Agent has low trust AND low weight
-    const record = makeAgentRecord({ trustScore: 0.1, weight: 0.05 });
-    const result = validator.isAgentEligible('agent-1', record, makeConfig());
-    expect(result.eligible).toBe(false);
-    if (!result.eligible) {
-      // Should return 'low_trust', not 'insufficient_weight'
-      expect(result.reason).toBe('low_trust');
-    }
-  });
-
-  it('treats zero byzantineFlags as not flagged', () => {
-    const record = makeAgentRecord({ byzantineFlags: 0 });
-    const config = makeConfig({ enableByzantineDetection: true });
-    const result = validator.isAgentEligible('agent-1', record, config);
-    expect(result.eligible).toBe(true);
-  });
-});
-
-// ============================================================================
-// Weighted quorum scenarios
-// ============================================================================
-
 describe('QuorumValidator weighted quorum scenarios', () => {
   const validator = new QuorumValidator();
 

--- a/packages/nexus-agents/src/consensus/quorum-validator.ts
+++ b/packages/nexus-agents/src/consensus/quorum-validator.ts
@@ -13,11 +13,13 @@
  * is exported through `exports/consensus.ts` as public API and is constructed
  * only by tests. So this validator runs only for an external embedder.
  *
- * {@link QuorumValidator.isAgentEligible} in particular cannot exclude anyone
- * in practice: its sole caller passes no `record`, so it early-returns, and no
- * producer of trust scores or Byzantine flags exists anywhere in `src/`.
- * Removing it would be a breaking public-API change, so it stays — documented
- * as inert rather than presented as a working eligibility filter.
+ * Agent eligibility screening was REMOVED here under #4666 (consensus_vote 7-0).
+ * It could never exclude anyone: its sole caller passed no `AgentRecord`, and no
+ * producer of trust scores or Byzantine flags exists anywhere in `src/`. The
+ * breakdown nonetheless emitted an `eligibleAgents` list containing every voter,
+ * which a machine consumer reads as evidence that screening ran — a comment
+ * cannot travel with a serialized record. Git history holds the implementation
+ * for whenever a real trust-score producer appears.
  *
  * @module consensus/quorum-validator
  * (Source: Issue #576, ADR-0003; scope corrected #4666)
@@ -32,18 +34,6 @@ import { SUPERMAJORITY_THRESHOLD } from './types-core.js';
 // ============================================================================
 
 /**
- * Agent record for eligibility checks and Byzantine detection.
- */
-export interface AgentRecord {
-  readonly agentId: string;
-  readonly weight: number;
-  readonly trustScore: number;
-  readonly byzantineFlags?: number;
-  readonly successRate?: number;
-  readonly totalTasks?: number;
-}
-
-/**
  * Quorum validation configuration.
  */
 export interface QuorumValidationConfig {
@@ -53,8 +43,6 @@ export interface QuorumValidationConfig {
   readonly threshold: number;
   /** Minimum voters required */
   readonly minVoters: number;
-  /** Enable Byzantine detection */
-  readonly enableByzantineDetection?: boolean;
   /** Apply confidence multiplier to weights */
   readonly confidenceMultiplier?: boolean;
   /** Include abstentions in quorum calculation */
@@ -71,8 +59,6 @@ export interface QuorumValidationInput {
   readonly agentWeights?: ReadonlyMap<string, number>;
   /** Configuration */
   readonly config: QuorumValidationConfig;
-  /** Optional: Agent records for eligibility checks */
-  readonly agentRecords?: ReadonlyMap<string, AgentRecord>;
   /** Optional: Required participant count (for ratio-based quorum) */
   readonly requiredParticipants?: number;
 }
@@ -106,20 +92,8 @@ export interface QuorumBreakdown {
   readonly threshold: number;
   readonly actualQuorum: number;
   readonly quorumReached: boolean;
-  readonly eligibleAgents: readonly string[];
   readonly reasoning: string;
 }
-
-/**
- * Eligibility check result.
- */
-export type EligibilityResult =
-  | { readonly eligible: true; readonly weight: number }
-  | {
-      readonly eligible: false;
-      readonly reason: 'insufficient_weight' | 'low_trust' | 'byzantine_flagged' | 'excluded';
-      readonly weight: number;
-    };
 
 /**
  * Unified quorum validator interface.
@@ -127,11 +101,6 @@ export type EligibilityResult =
 export interface IQuorumValidator {
   validateQuorum(input: QuorumValidationInput): QuorumValidationResult;
   getQuorumBreakdown(input: QuorumValidationInput): QuorumBreakdown;
-  isAgentEligible(
-    agentId: string,
-    record: AgentRecord | undefined,
-    config: QuorumValidationConfig
-  ): EligibilityResult;
 }
 
 // ============================================================================
@@ -154,9 +123,6 @@ export const DEFAULT_QUORUM_THRESHOLDS: Readonly<
   // Byzantine fault tolerance also requires 2/3 — the same supermajority.
   weighted_byzantine: SUPERMAJORITY_THRESHOLD,
 };
-
-const DEFAULT_MIN_TRUST = 0.3;
-const DEFAULT_MIN_WEIGHT = 0.1;
 
 /**
  * Unified quorum validator implementation.
@@ -189,19 +155,13 @@ export class QuorumValidator implements IQuorumValidator {
   }
 
   getQuorumBreakdown(input: QuorumValidationInput): QuorumBreakdown {
-    const { votes, agentWeights, config, agentRecords, requiredParticipants } = input;
+    const { votes, agentWeights, config, requiredParticipants } = input;
 
     // Count votes
     const voteCounts = this.countVotes(votes);
-    const eligibleAgents = this.getEligibleAgents(votes, agentRecords, config);
 
     // Calculate weights if applicable
-    const { totalWeight, weightedCounts } = this.calculateWeights(
-      votes,
-      agentWeights,
-      agentRecords,
-      config
-    );
+    const { totalWeight, weightedCounts } = this.calculateWeights(votes, agentWeights, config);
 
     // Calculate quorum based on algorithm
     const { threshold, actualQuorum, quorumReached, reasoning } = this.calculateQuorumStatus(
@@ -220,65 +180,8 @@ export class QuorumValidator implements IQuorumValidator {
       threshold,
       actualQuorum,
       quorumReached,
-      eligibleAgents,
       reasoning,
     };
-  }
-
-  /**
-   * Decides whether an agent's vote counts, and with what weight.
-   *
-   * WIRING (#4666): this works and is tested, but **nothing in production can
-   * reach an exclusion**. The three exclusion branches all require an
-   * `AgentRecord`, and `getQuorumBreakdown`'s only production caller
-   * (`voting-protocol-helpers`) passes `{ votes, config }` with no
-   * `agentRecords` — `grep -rn agentRecords src --include=*.ts`, excluding
-   * tests and this file, returns nothing. With no record the method returns
-   * `{ eligible: true, weight: 1.0 }` on the first line.
-   *
-   * `enableByzantineDetection` additionally has zero writers anywhere in
-   * `src/`: only this read and its declaration.
-   *
-   * So `eligibleAgents` is every voter, always. Do NOT read a full eligible
-   * list as evidence that trust or Byzantine screening ran — nothing screened.
-   * Wiring it needs a producer for `AgentRecord` (trust scores, Byzantine
-   * flags), which the engine does not currently maintain.
-   *
-   * Kept rather than deleted: the behaviour is correct and covered by tests, so
-   * this is unwired capability, not dead code. Removing a working trust model
-   * is a decision about the resilience posture, not a cleanup — see #4666.
-   */
-  isAgentEligible(
-    agentId: string,
-    record: AgentRecord | undefined,
-    config: QuorumValidationConfig
-  ): EligibilityResult {
-    if (record === undefined) {
-      return { eligible: true, weight: 1.0 }; // Default eligibility
-    }
-
-    // Check Byzantine flags
-    if (config.enableByzantineDetection === true && (record.byzantineFlags ?? 0) > 0) {
-      this.logger.debug('Agent flagged as Byzantine', { agentId, flags: record.byzantineFlags });
-      return { eligible: false, reason: 'byzantine_flagged', weight: record.weight };
-    }
-
-    // Check trust score
-    if (record.trustScore < DEFAULT_MIN_TRUST) {
-      this.logger.debug('Agent trust score below threshold', {
-        agentId,
-        trustScore: record.trustScore,
-      });
-      return { eligible: false, reason: 'low_trust', weight: record.weight };
-    }
-
-    // Check weight
-    if (record.weight < DEFAULT_MIN_WEIGHT) {
-      this.logger.debug('Agent weight below threshold', { agentId, weight: record.weight });
-      return { eligible: false, reason: 'insufficient_weight', weight: record.weight };
-    }
-
-    return { eligible: true, weight: record.weight };
   }
 
   private countVotes(votes: ReadonlyMap<string, Vote>): VoteCounts {
@@ -303,28 +206,9 @@ export class QuorumValidator implements IQuorumValidator {
     return { approve, reject, abstain, total: votes.size };
   }
 
-  private getEligibleAgents(
-    votes: ReadonlyMap<string, Vote>,
-    agentRecords: ReadonlyMap<string, AgentRecord> | undefined,
-    config: QuorumValidationConfig
-  ): readonly string[] {
-    const eligible: string[] = [];
-
-    for (const agentId of votes.keys()) {
-      const record = agentRecords?.get(agentId);
-      const result = this.isAgentEligible(agentId, record, config);
-      if (result.eligible) {
-        eligible.push(agentId);
-      }
-    }
-
-    return eligible;
-  }
-
   private calculateWeights(
     votes: ReadonlyMap<string, Vote>,
     agentWeights: ReadonlyMap<string, number> | undefined,
-    agentRecords: ReadonlyMap<string, AgentRecord> | undefined,
     config: QuorumValidationConfig
   ): { totalWeight: number | undefined; weightedCounts: WeightedVoteCounts | undefined } {
     // Skip weight calculation for simple algorithms
@@ -335,7 +219,7 @@ export class QuorumValidator implements IQuorumValidator {
     const counts = { totalWeight: 0, approve: 0, reject: 0, abstain: 0 };
 
     for (const [agentId, vote] of votes.entries()) {
-      const weight = this.getVoteWeight(agentId, vote, agentWeights, agentRecords, config);
+      const weight = this.getVoteWeight(agentId, vote, agentWeights, config);
       counts.totalWeight += weight;
       this.addWeightToDecision(counts, vote.decision, weight);
     }
@@ -355,10 +239,9 @@ export class QuorumValidator implements IQuorumValidator {
     agentId: string,
     vote: Vote,
     agentWeights: ReadonlyMap<string, number> | undefined,
-    agentRecords: ReadonlyMap<string, AgentRecord> | undefined,
     config: QuorumValidationConfig
   ): number {
-    let weight = agentWeights?.get(agentId) ?? agentRecords?.get(agentId)?.weight ?? 1.0;
+    let weight = agentWeights?.get(agentId) ?? 1.0;
     if (config.confidenceMultiplier === true) {
       weight *= vote.confidence;
     }


### PR DESCRIPTION
Fixes #4666. `consensus_vote` **7-0 unanimous** (`higher_order`, `absolute_quorum`) — the first unanimous result in this series. Decided jointly with #4658, which is the same shape and gets its own PR.

## What was dead

`QuorumValidator.isAgentEligible` had three exclusion branches, all requiring an `AgentRecord`. Its only production caller passed none, so it early-returned `{ eligible: true, weight: 1.0 }` on line one. `enableByzantineDetection` had **zero writers** in `src/` — only its read and its declaration.

## Why documenting it was not enough — the argument that changed my vote

I argued for leaving it documented. `quorum-validator.ts` already carried a `WIRING (#4666)` block saying exclusion was unreachable, which I thought closed the misreporting risk.

Two voters independently found the hole:

> The 'honest sign' only protects human readers of the source. A machine consumer of `getQuorumBreakdown` — which is exactly what a self-improving consensus loop would be — receives `eligible: true, weight: 1.0` for every voter with no channel carrying the caveat. Comments do not travel with data structures.

`getQuorumBreakdown` **emitted** `eligibleAgents` containing every voter. In a substrate whose consumers are agents, protecting the human reader and not the machine one is the wrong half.

## A stale justification was holding it in place

The module docstring said:

> Removing it would be a breaking public-API change, so it stays — documented as inert rather than presented as a working eligibility filter.

**That is false.** `packages/nexus-agents/package.json` declares exactly one export entry (`.` → `dist/index.js`), and neither `EligibilityResult` nor `AgentRecord` is reachable from `src/index.ts` — confirmed by the API-surface extractor, which reports **0 changed lines** for this PR. The code was kept alive by a documented reason that did not hold.

## Removed

`isAgentEligible`, `getEligibleAgents`, the `eligibleAgents` breakdown field, `enableByzantineDetection`, the `agentRecords` input, `AgentRecord`, `EligibilityResult`, two now-unused threshold constants, and their barrel exports. `calculateWeights`/`getVoteWeight` lose the `agentRecords` fallback — behaviour is unchanged because nothing ever supplied it.

Also removed four tests that pinned the vacancy (they proved exclusion works *when a record is supplied*, which production never does) and a comment describing them.

## Verification

- **549 consensus tests green**; 624 with `src/exports/`. `tsc` and eslint clean.
- **API surface: 0 changed lines**, confirming nothing removed was public.
- Net −307/+12.

One thing worth recording: my first field-removal regex silently ate the adjacent `quorumReached` declaration. `tsc` caught it immediately. Deleting by pattern in a governance file is exactly where a compile check earns its keep.

## Ownership flag

`src/consensus/` is CODEOWNERS-reviewed (@williamzujkowski). It is not on CLAUDE.md's never-auto-merge list, and removing a check that cannot fire loses no protection that existed — but this is governance surface, so I am flagging the call rather than assuming it.