### PR TITLE
chore(repo): ignore browser-tool console logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,11 @@ packages/nexus-agents/coverage.json
 
 # User-specific configuration
 .mcp.json
+# Browser-tool console logs (15 files / 1.6MB and growing). Untracked and
+# unignored, so a `git add -A` sweeps them into a commit — which has already
+# happened once in this repo with stray scratch files, caught only by the
+# Orphan Detection gate.
+.playwright-mcp/
 nexus-agents.yaml
 opencode.json
 .claude/settings.local.json


### PR DESCRIPTION
`.playwright-mcp/` accumulates console logs from the browser MCP tool — currently **15 files, 1.6MB** — and is neither tracked nor ignored.

That combination is the problem: `git status` shows it as untracked, so a `git add -A` commits it. That has already happened once in this repo, when stray scratch files were swept into a commit and caught only by the Orphan Detection gate rather than by me.

One line, with the reason recorded next to it so it does not read as arbitrary.

No source or behaviour change.