### PR TITLE
docs(consensus): stop advertising higher_order as a correlation-aware verdict

### DIFF
--- a/.changeset/higher-order-description-accuracy.md
+++ b/.changeset/higher-order-description-accuracy.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+stop advertising higher_order as a correlation-aware verdict
+
+The `consensus_vote` tool description told callers that `higher_order` provides
+"Bayesian-optimal aggregation with correlation awareness". It does not decide
+the verdict that way. `OWVoting.calculateOutcome` — the `IVotingStrategy` the
+`ConsensusEngine` calls — runs `aggregateSimpleInternal` and discards weights,
+so approve/reject is a simple tally and correlated voters each carry full
+independent weight.
+
+The Bayesian analysis is real and does run, but its `posteriorApproval` reaches
+only contrarian escalation, never the verdict.
+
+Corrects the tool description, the module docstring, and three docs that
+repeated the claim. No behaviour change — the aggregation itself is unchanged,
+and whether to wire it into the verdict is #4701.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -126,7 +126,7 @@ These are **sequential, not parallel**: `CompositeRouter` selects a CLI → CLI 
 - **supermajority**: ≥67% approval threshold
 - **unanimous**: 100% approval required
 - **proof_of_learning**: Weighted by agent performance
-- **higher_order**: Bayesian-optimal aggregation with correlation awareness
+- **higher_order**: simple tally for the verdict; the Bayesian correlation analysis feeds contrarian escalation only (#4701)
 - **opinion_wise**: Opinion-based aggregation
 
 ---

--- a/docs/design/components.md
+++ b/docs/design/components.md
@@ -83,7 +83,7 @@ Multi-agent voting and decision aggregation.
 
 - **Consensus Engine** (`consensus/engine.ts`): `createConsensusEngine()` — tallies votes, applies strategies
 - **Voting Strategies**: SimpleMajority, Supermajority, Unanimous, ProofOfLearning
-- **Higher-Order Voting** (`consensus/strategies/`, Issue #333): Bayesian-optimal aggregation with correlation awareness
+- **Higher-Order Voting** (`consensus/strategies/`, Issue #333): Bayesian-optimal aggregation with correlation awareness — implemented, but NOT on the verdict path; `calculateOutcome` tallies simply and the correlation posterior drives contrarian escalation only (#4701)
 - **Quorum Validator** (`consensus/quorum.ts`, Issue #576): Unified quorum requirements
 - **Correlation Tracker** (`consensus/correlation/`): Tracks agent agreement patterns
 

--- a/docs/design/flows.md
+++ b/docs/design/flows.md
@@ -115,7 +115,7 @@ Multi-agent voting with configurable strategies.
    |     supermajority: >=67%
    |     unanimous: 100%
    |     proof_of_learning: majority + evidence
-   |     higher_order: Bayesian with correlation awareness
+   |     higher_order: simple tally; correlation drives escalation only (#4701)
    |
 7. Returns { decision, votes[], reasoning, confidence }
 ```

--- a/packages/nexus-agents/src/consensus/higher-order-voting.ts
+++ b/packages/nexus-agents/src/consensus/higher-order-voting.ts
@@ -6,6 +6,11 @@
  *
  * Traditional voting assumes independence between voters. Higher-order voting
  * uses Bayesian-optimal aggregation that handles correlated agents better,
+ * BUT NOTE (#4701): `calculateOutcome` — the `IVotingStrategy` entry point the
+ * `ConsensusEngine` calls — uses `aggregateSimpleInternal` and ignores weights.
+ * `aggregateWithCorrelation` is reached only via `runHigherOrderVoting`, whose
+ * `posteriorApproval` feeds contrarian escalation, not the verdict. So selecting
+ * `higher_order` does not currently buy a correlation-weighted approve/reject.
  * resulting in more accurate consensus decisions.
  *
  * @module consensus/higher-order-voting

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -1199,7 +1199,10 @@ const CONSENSUS_VOTE_DESCRIPTION =
   'Execute multi-model consensus voting on a proposal. ' +
   'Uses 7 roles by default (architect, security, devex, ai_ml, pm, catfish, scope_steward) ' +
   'or 3 with quickMode (architect, security, scope_steward), voting with configurable strategies. ' +
-  'Supports higher_order strategy for Bayesian-optimal aggregation with correlation awareness (Issue #514). ' +
+  'higher_order does NOT decide the verdict by correlation-aware aggregation (#4701): approve/reject ' +
+  'is a simple tally of the panel, so correlated voters each carry full independent weight. The ' +
+  'Bayesian correlation analysis is computed and feeds contrarian escalation only. Choose it for the ' +
+  'escalation behaviour, not for a weighted verdict. ' +
   "Supports async mode (mode: 'async') — returns a jobId to poll via get_job_result. " +
   'Pass ratifies=<subject> to bind an authority-ladder ratification vote into its authentic record. ' +
   'If your proposal asks voters to choose among named alternatives, you MUST pass them in ' +


### PR DESCRIPTION
Part of #4701. Option 2 of the two paths on that issue — the honest-labelling half. Wiring the correlation aggregation into the verdict is Option 1 and is deliberately **not** in this PR.

## The misreport

`consensus-vote.ts:1202` told every caller:

> Supports higher_order strategy for **Bayesian-optimal aggregation with correlation awareness** (Issue #514).

That describes the verdict mechanism. The verdict does not use it.

`OWVoting.calculateOutcome` (`higher-order-voting.ts:82-85`) — the `IVotingStrategy` entry point the `ConsensusEngine` calls — runs `aggregateSimpleInternal(votes)` and discards `_weights`. `aggregateWithCorrelation` is never reached from that path.

## One correction to the issue's own framing

#4701 says the correlation analysis is "computed and discarded". Not quite: `runHigherOrderVoting` produces a `posteriorApproval` that feeds `maybeEscalateContrarian` (`consensus-vote.ts:728`). It is real and it does something — it just does not decide approve/reject, which comes from `engineResult.outcome`.

The accurate statement, now in the description: **the verdict is a simple tally; the Bayesian analysis affects contrarian escalation only.**

## Why this one is worth fixing immediately

This is the tool agents read when choosing how to run a governance decision. A caller selecting `higher_order` for an architecture or security question believes they are getting correlation-aware aggregation over the panel, and gets a plain tally in which correlated voters each carry full independent weight.

**I am one of those callers.** I used `higher_order` for nine `consensus_vote` calls in this session, including the ones deciding #4784, #4794, #4790, #4806, #4666 and the #4658 re-run, and I described the results as higher-order panel outcomes. They were tallies. The results stand — the reasoning is real and several were unanimous, where aggregation cannot change the answer — but the label was wrong and I propagated it. Disclosed on #4701.

## Changed

- the tool description, which now states plainly what the strategy does and does not do;
- the module docstring, so the next reader of `higher-order-voting.ts` sees that `calculateOutcome` bypasses the correlation path;
- three docs repeating the original claim (`architecture/README.md`, `design/components.md`, `design/flows.md`).

## Verification

No behaviour change — aggregation is untouched. 89 tests across the consensus-vote and higher-order suites green, `tsc` and eslint clean, **API surface 0 changed lines**, tool-reference drift gate green (the generated page carries the parameter table, not this prose).