### PR TITLE
docs(pipeline): correct the trustTier doc — absent denies, not allows

### DIFF
--- a/.changeset/trust-tier-doc-fails-closed.md
+++ b/.changeset/trust-tier-doc-fails-closed.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+correct the trustTier field doc: absent denies, it does not allow
+
+`PipelineStateSnapshot.trustTier`'s doc said "When absent, `trustTierRule`
+allows (the existing fail-open default for unknown trust)". The rule coerces an
+absent or non-numeric value to `4` and DENIES — the behaviour was hardened in
+#2957/#2994 and this field doc kept describing the pre-hardening semantics.
+
+Stale in the unsafe direction: a reader planning enforcement work would conclude
+unwired producers are the safe case, when they are the deny case. Doc only —
+the fail-closed behaviour is already pinned by a test and is unchanged.
+
+Fixes #4821.

--- a/packages/nexus-agents/src/pipeline/policy-engine.ts
+++ b/packages/nexus-agents/src/pipeline/policy-engine.ts
@@ -47,8 +47,18 @@ export interface PipelineStateSnapshot {
    * include `trust-classifier`, `input-sanitizer`, `firewall-pipeline`, and
    * `mcp/middleware/request-context`; threading the value into
    * `TaskContract.metadata.trustTier` is owner-scoped follow-up work — see
-   * the corresponding issue. When absent, `trustTierRule` allows (the
-   * existing fail-open default for unknown trust).
+   * the corresponding issue.
+   *
+   * ABSENT MEANS UNTRUSTED, NOT ALLOWED (#4821). An absent or non-numeric
+   * value is coerced to `4` and DENIES — see `trustTierRule` below. This doc
+   * previously claimed the opposite ("fail-open default for unknown trust"),
+   * describing a pre-hardening behaviour the code no longer has.
+   *
+   * That is the correct default and should stay: fail-closed on unknown
+   * provenance is what `.rules/untrusted-input.md` requires. Do not "fix" the
+   * rule to match the old comment. The practical consequence, worth knowing
+   * before planning enforcement work, is that an UNWIRED producer is the DENY
+   * case rather than the safe one.
    */
   readonly trustTier?: string;
 }


### PR DESCRIPTION
Fixes #4821.

## The contradiction

`policy-engine.ts:45-53` documented the field:

> When absent, `trustTierRule` allows (the **existing fail-open default** for unknown trust).

The rule does the opposite:

```ts
const numericTier = tierVal === undefined ? Number.NaN : Number(tierVal);
const tier = Number.isFinite(numericTier) ? numericTier : 4;   // absent => 4
if (tier >= 3 && context.stageType === 'execute') { /* deny */ }
```

The behaviour was hardened to fail closed in #2957/#2994; this field doc was left describing the pre-hardening semantics.

## Why a stale comment is worth a PR here

It is stale **in the unsafe direction**. Someone planning the enforcement work reads "absent ⇒ allows", concludes unwired producers are the safe case, and expects to enable enforcement incrementally as producers land. The truth is the reverse — absent is the *deny* case.

That is not hypothetical: it is exactly the trap in #4657, where the tier half of the predicate turns out to be satisfied on **every** possible input (absent → 4, present → the constant `'3'` per #4733), so the only thing preventing universal denial is a stage-type mismatch. A doc pointing the wrong way makes that easier to walk into.

## Doc only, deliberately

**The behaviour is already correct and already pinned** — `policy-engine.test.ts:192` covers *"blocks execute stages when trustTier is missing (#2957/#2994 fail-closed default)"*. Nothing to fix in code and no test to add; the only defect was the description.

The replacement also states *why* fail-closed is right and says not to "fix" the rule to match the old comment — otherwise the next reader resolves the contradiction in the wrong direction, which is the failure mode this correction exists to prevent.

14 policy-engine tests green, `tsc` clean.