### PR TITLE
fix(mcp): let memory_stats distinguish a broken backend from an empty one

### DIFF
--- a/.changeset/memory-stats-corrupt-vs-empty.md
+++ b/.changeset/memory-stats-corrupt-vs-empty.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+let memory_stats tell a broken backend from an empty one
+
+Every registry-attached `count()` collapsed a failed Result into `0`, so
+`StatsOnlyAdapter.stats()` never rejected, `collectRegistryStats`'s catch never
+fired, and `memory_stats` returned `{count: 0, error: null}` for a corrupt or
+locked SQLite backend — byte-identical to a healthy empty store.
+`RegistryDomainStats.error`, documented as "Error message when the backend's
+stats() rejected", described a state nothing could produce.
+
+`extractCount` now throws on an explicit `{ok: false}` Result and the four
+call sites hand the Result through unchanged, so the catch that was already
+written and correct can populate `error`. An unrecognised shape still yields
+`0` — that is genuinely unknown rather than a reported failure.
+
+Verified from #4827.

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.test.ts
@@ -16,10 +16,7 @@ import {
   hasMemoryRegistry,
   setMemoryRegistry,
 } from 'nexus-memory';
-import {
-  StatsOnlyAdapter,
-  ensureSharedMemoryRegistry,
-} from './tool-memory-registry-adapters.js';
+import { StatsOnlyAdapter, ensureSharedMemoryRegistry } from './tool-memory-registry-adapters.js';
 
 describe('StatsOnlyAdapter', () => {
   beforeEach(() => {
@@ -51,6 +48,26 @@ describe('StatsOnlyAdapter', () => {
     });
     const stats = await adapter.stats();
     expect(stats.count).toBe(13);
+  });
+
+  // #4827: a FAILED Result was collapsed to 0, so `memory_stats` reported
+  // {count: 0, error: null} for a corrupt or locked backend — byte-identical
+  // to a healthy empty store. The catch that populates `error`
+  // (memory-stats.ts:213) was therefore unreachable, and
+  // `RegistryDomainStats.error` documented a state nothing could produce.
+  it('rejects rather than reporting 0 when count() returns a FAILED Result', async () => {
+    const adapter = new StatsOnlyAdapter('belief', {
+      count: () => ({ ok: false, error: new Error('database is locked') }),
+    });
+
+    await expect(adapter.stats()).rejects.toThrow(/locked|count/i);
+  });
+
+  it('still reports 0 for a genuinely empty backend', async () => {
+    // The pair that matters: empty must stay distinguishable from broken.
+    const adapter = new StatsOnlyAdapter('belief', { count: () => ({ ok: true, value: 0 }) });
+
+    await expect(adapter.stats()).resolves.toMatchObject({ count: 0 });
   });
 
   it('returns 0 when count() shape is unrecognized', async () => {

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-registry-adapters.ts
@@ -137,9 +137,26 @@ export class StatsOnlyAdapter implements IMemoryBackend<string, unknown> {
 function extractCount(value: unknown): number {
   if (typeof value === 'number') return value;
   if (value !== null && typeof value === 'object') {
-    const v = value as { ok?: boolean; value?: unknown };
+    const v = value as { ok?: boolean; value?: unknown; error?: unknown };
     if (v.ok === true && typeof v.value === 'number') return v.value;
+    // #4827: a FAILED Result must NOT collapse to 0. Doing so made a corrupt
+    // or locked backend report `{count: 0, error: null}` — byte-identical to a
+    // healthy empty store — and left `collectRegistryStats`'s catch
+    // (memory-stats.ts:213) unreachable, so `RegistryDomainStats.error`
+    // documented a state nothing could produce. Throwing lets that catch,
+    // which is already written and correct, do its job.
+    if (v.ok === false) {
+      const detail =
+        v.error instanceof Error
+          ? v.error.message
+          : typeof v.error === 'string'
+            ? v.error
+            : 'unknown error';
+      throw new Error(`backend count() failed: ${detail}`);
+    }
   }
+  // An unrecognised shape is genuinely unknown, not a reported failure — 0 is
+  // the long-standing behaviour and callers have no error to surface.
   return 0;
 }
 

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -48,10 +48,7 @@ import {
   getSharedMobiMem,
   setSharedMobiMemDbPathResolver,
 } from '../../context/mobimem.js';
-import {
-  StatsOnlyAdapter,
-  ensureSharedMemoryRegistry,
-} from './tool-memory-registry-adapters.js';
+import { StatsOnlyAdapter, ensureSharedMemoryRegistry } from './tool-memory-registry-adapters.js';
 import type { MobiMemStats } from '../../context/mobimem-types.js';
 import {
   MemoryPromoter,
@@ -207,8 +204,10 @@ export class ToolMemoryManager {
     const beliefs = this.beliefs;
     attachToRegistry('belief', {
       count: async () => {
+        // #4827: propagate failure rather than collapsing it to 0.
         const stats = await beliefs.getStats();
-        return stats.ok ? stats.value.totalBeliefs : 0;
+        if (!stats.ok) throw new Error(`belief getStats failed: ${String(stats.error)}`);
+        return stats.value.totalBeliefs;
       },
       // Phase 1 of #2792 — text search delegates to recallBySubject.
       search: async (query, limit) => {
@@ -290,8 +289,10 @@ export class ToolMemoryManager {
         this.agentic = backend;
         attachToRegistry('agentic', {
           count: async () => {
-            const res = await backend.count();
-            return res.ok ? res.value : 0;
+            // #4827: hand the Result through unchanged. `extractCount` turns a
+            // failure into a throw so `memory_stats` can report it; collapsing
+            // to 0 here made a broken backend look like an empty one.
+            return backend.count();
           },
           // Phase 1 of #2792 — A-MEM text search returns attribute-rich entries.
           search: async (query, limit) => {
@@ -322,8 +323,10 @@ export class ToolMemoryManager {
         this.adaptive = backend;
         attachToRegistry('adaptive', {
           count: async () => {
-            const res = await backend.count();
-            return res.ok ? res.value : 0;
+            // #4827: hand the Result through unchanged. `extractCount` turns a
+            // failure into a throw so `memory_stats` can report it; collapsing
+            // to 0 here made a broken backend look like an empty one.
+            return backend.count();
           },
           // Phase 1 of #2792 — adaptive memory returns priority-scored entries.
           search: async (query, limit) => {
@@ -356,8 +359,10 @@ export class ToolMemoryManager {
         this.typed = createTypedMemory(backend);
         attachToRegistry('typed', {
           count: async () => {
-            const res = await backend.count();
-            return res.ok ? res.value : 0;
+            // #4827: hand the Result through unchanged. `extractCount` turns a
+            // failure into a throw so `memory_stats` can report it; collapsing
+            // to 0 here made a broken backend look like an empty one.
+            return backend.count();
           },
           // Phase 1 of #2792 — typed search uses the underlying hybrid backend.
           search: async (query, limit) => {


### PR DESCRIPTION
Implements the one #4827 entry confirmed at full severity with **no compensating disclosure**. Verification is on that issue.

## The defect

All five registry-attached `count()` implementations were non-throwing — four collapsed a failed Result into `0`:

```ts
count: async () => {
  const res = await backend.count();
  return res.ok ? res.value : 0;      // a locked database reports zero rows
}
```

So `StatsOnlyAdapter.stats()` never rejected, `collectRegistryStats`'s catch (`memory-stats.ts:213`) never fired, and **`memory_stats` returned `{count: 0, error: null}` for a corrupt or locked SQLite backend — byte-identical to a healthy empty store.**

`RegistryDomainStats.error` is documented as *"Error message when the backend's stats() rejected"*. Nothing could produce that state. So was `count: null`.

## The fix is small because the receiving code was already right

The catch is written and correct; it simply had nothing to catch. `extractCount` now throws on an explicit `{ok: false}`, and the four call sites hand the Result through unchanged rather than pre-flattening it.

An **unrecognised** shape still yields `0`, deliberately — that is genuinely unknown rather than a reported failure, and no error exists to surface. Only an explicit failure propagates.

## Verification

Red/green on the pair that has to differ:

```
× rejects rather than reporting 0 when count() returns a FAILED Result
  Tests  1 failed | 18 passed (19)
```

after: `19 passed`. The companion test asserts a genuinely empty backend still reports `count: 0` — the two must not be equal, which is the property the old code violated.

Mutation-verified: restoring the collapse fails the corrupt-backend test alone.

**Full MCP tools suite: 2,617 tests across 144 files, green.** `tsc` and eslint clean, API surface 0 changed lines.

## Provenance

From the `src/orchestration` / `src/learning` / `src/memory` sweep. Of seven reported findings I verified all seven; **two survived exactly as written** and this was the clearest — two others were downgraded because a disclosure sat adjacent, one was partly retracted, one narrowed. That verification is recorded per-entry on #4827, along with a calibration note for future sweeps: check for adjacent disclosure *before* classifying something a misreport. This one has none, which is why it is the one being fixed.