### PR TITLE
fix(hooks): record a failed tool call as FAILED

### DIFF
--- a/.changeset/task-status-reflects-tool-error.md
+++ b/.changeset/task-status-reflects-tool-error.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+record a failed tool call as FAILED, so failedCount can be non-zero
+
+`TaskStatus.FAILED` had exactly one occurrence in `src/` — the read in the stop
+hook's session summary. Nothing wrote it, so `failedCount` was structurally
+always 0 and an operator reviewing a session in which every tool errored saw
+zero failures.
+
+The error was already being detected on the line above the status that
+contradicted it: `result: summarizeToolResponse(...)` returned `"Error: …"`
+while `status:` was hardcoded `COMPLETED` in the same object literal.
+
+`summarizeToolResponse` becomes `classifyToolResponse`, returning the status and
+the summary together so "what counts as an error" stays in one place rather than
+being duplicated at the call site.
+
+Fixes #4842.

--- a/packages/nexus-agents/src/cli/hooks/handlers/post-tool.test.ts
+++ b/packages/nexus-agents/src/cli/hooks/handlers/post-tool.test.ts
@@ -21,14 +21,27 @@ vi.mock('../../../core/logger.js', () => ({
   })),
 }));
 
+// #4842: hoisted so a test can assert WHAT was written, not merely that the
+// handler exited 0. The previous mock returned a fresh object per construction
+// and an empty session list, so `recordToolTask` returned early at its
+// `activeSession === undefined` guard and the update path was never exercised.
+// `vi.hoisted` is required, not stylistic: `vi.mock` factories are hoisted
+// above module-scope consts, so a plain `const` here is in the temporal dead
+// zone when the factory runs. The ReferenceError is then swallowed by
+// trackToolMetrics' try/catch and the test fails with "0 calls" and no clue.
+const { updateTaskMock, listSessionsMock } = vi.hoisted(() => ({
+  updateTaskMock: vi.fn(),
+  listSessionsMock: vi.fn(),
+}));
+
 // Mock session storage
 vi.mock('../../session-storage.js', () => ({
   SQLiteSessionStorage: vi.fn().mockImplementation(function () {
     return {
       initialize: vi.fn().mockResolvedValue({ ok: true }),
-      listSessions: vi.fn().mockResolvedValue({ ok: true, value: [] }),
+      listSessions: listSessionsMock,
       addTask: vi.fn().mockResolvedValue({ ok: true, value: { id: 'tsk_123' } }),
-      updateTask: vi.fn().mockResolvedValue({ ok: true }),
+      updateTask: updateTaskMock,
       close: vi.fn(),
     };
   }),
@@ -236,6 +249,65 @@ describe('post-tool handler', () => {
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('Tool Bash completed');
+      });
+    });
+
+    // #4842: `TaskStatus.FAILED` had exactly one occurrence in src — the READ in
+    // stop.ts's summary. Nothing wrote it, so `failedCount` was structurally 0.
+    // The error was already detected one line above the status that contradicted
+    // it: `result: summarizeToolResponse(...)` returns "Error: …" while
+    // `status:` was hardcoded COMPLETED.
+    describe('task status reflects the tool outcome (#4842)', () => {
+      beforeEach(() => {
+        // The outer beforeEach calls vi.clearAllMocks(), so both implementations
+        // must be re-established here or listSessions resolves undefined and
+        // recordToolTask returns at its `!sessionsResult.ok` guard.
+        listSessionsMock.mockResolvedValue({ ok: true, value: [{ id: 'ses_active' }] });
+        updateTaskMock.mockResolvedValue({ ok: true });
+      });
+
+      it('records FAILED when the tool response carries stderr', async () => {
+        const input = createInput({ tool_response: { stderr: 'command not found' } });
+
+        void handlePostTool(input, { trackMetrics: true, dbPath: '/tmp/test.db' });
+
+        // `post-tool.ts:66` fires the write with `void trackToolMetrics(...)`,
+        // and handlePostTool is synchronous — so the assertion must wait for the
+        // detached promise rather than for the handler.
+        await vi.waitFor(() => {
+          expect(updateTaskMock).toHaveBeenCalledWith(
+            'tsk_123',
+            expect.objectContaining({ status: 'failed', result: expect.stringContaining('Error:') })
+          );
+        });
+      });
+
+      it('records FAILED when the tool response carries an error field', async () => {
+        const input = createInput({ tool_response: { error: 'permission denied' } });
+
+        void handlePostTool(input, { trackMetrics: true, dbPath: '/tmp/test.db' });
+
+        await vi.waitFor(() => {
+          expect(updateTaskMock).toHaveBeenCalledWith(
+            'tsk_123',
+            expect.objectContaining({ status: 'failed' })
+          );
+        });
+      });
+
+      it('still records COMPLETED for a clean response', async () => {
+        // The pair that must differ: a success and a failure cannot both be
+        // COMPLETED, which is exactly what the defect did.
+        const input = createInput({ tool_response: { stdout: 'all good' } });
+
+        void handlePostTool(input, { trackMetrics: true, dbPath: '/tmp/test.db' });
+
+        await vi.waitFor(() => {
+          expect(updateTaskMock).toHaveBeenCalledWith(
+            'tsk_123',
+            expect.objectContaining({ status: 'completed' })
+          );
+        });
       });
     });
 

--- a/packages/nexus-agents/src/cli/hooks/handlers/post-tool.ts
+++ b/packages/nexus-agents/src/cli/hooks/handlers/post-tool.ts
@@ -141,9 +141,10 @@ async function recordToolTask(
   const taskResult = await storage.addTask(activeSession.id, taskDescription);
   if (!taskResult.ok) return;
 
+  const outcome = classifyToolResponse(input.tool_response);
   await storage.updateTask(taskResult.value.id, {
-    result: summarizeToolResponse(input.tool_response),
-    status: TaskStatus.COMPLETED,
+    result: outcome.summary,
+    status: outcome.status,
     durationMs: metrics.durationMs,
     tokensUsed: metrics.tokensUsed,
   });
@@ -182,20 +183,41 @@ function summarizeToolInput(toolInput: Record<string, unknown>): string {
   return keys.length > 0 ? keys.join(', ') : '(no input)';
 }
 
-/** Creates a summary of tool response for logging. */
-function summarizeToolResponse(toolResponse: Record<string, unknown>): string {
+/**
+ * Classifies a tool response into the status to record and a human summary.
+ *
+ * Returns both from ONE function on purpose (#4842). The error condition
+ * previously lived only inside the summariser, so the caller wrote
+ * `status: COMPLETED` unconditionally on the line below `result:
+ * summarizeToolResponse(...)` — the failure was detected and then contradicted
+ * in the same object literal. `TaskStatus.FAILED` had no writer anywhere in
+ * `src/`, so the session summary's `failedCount` was structurally always 0.
+ *
+ * Splitting the check across two functions would leave the same two places to
+ * keep in step; returning a pair keeps "what counts as an error" in one spot.
+ */
+function classifyToolResponse(toolResponse: Record<string, unknown>): {
+  status: TaskStatus;
+  summary: string;
+} {
   const error = toolResponse.error ?? toolResponse.stderr;
   if (error !== undefined && error !== '') {
-    return `Error: ${safeString(error).substring(0, 100)}`;
+    return {
+      status: TaskStatus.FAILED,
+      summary: `Error: ${safeString(error).substring(0, 100)}`,
+    };
   }
 
   const stdout = toolResponse.stdout ?? toolResponse.output ?? toolResponse.content;
   if (stdout !== undefined) {
     const out = safeString(stdout);
-    return out.length > 100 ? `${out.substring(0, 100)}...` : out;
+    return {
+      status: TaskStatus.COMPLETED,
+      summary: out.length > 100 ? `${out.substring(0, 100)}...` : out,
+    };
   }
 
-  return 'completed';
+  return { status: TaskStatus.COMPLETED, summary: 'completed' };
 }
 
 /** Extracts file path from tool input. */


### PR DESCRIPTION
Fixes #4842.

## The defect

`TaskStatus.FAILED` had **exactly one occurrence** in `src/` — the read in the stop hook's session summary (`stop.ts:202`). Nothing wrote it, so `failedCount` was structurally always `0`. An operator reviewing a session in which every tool call errored saw zero failures.

The sharp part: the error was already detected **on the line above the status that contradicted it**.

```ts
result: summarizeToolResponse(input.tool_response),   // returns "Error: …"
status: TaskStatus.COMPLETED,                          // unconditional
```

Adjacent lines of the same object literal. The failure was recognised and immediately overwritten.

## The fix

`summarizeToolResponse` becomes `classifyToolResponse`, returning the status and the summary **together**. Splitting the check into a second predicate would leave two places to keep in step — which is how the two drifted apart in the first place.

The call site now takes both from one result. Three lines of production change.

## Verification

Red/green, three tests written first. The COMPLETED case passed immediately and the two FAILED cases were red — the correct starting state, since the old code always wrote COMPLETED. Mutation-verified: reclassifying the failure branch back to COMPLETED fails exactly those two.

Full hooks suite: **248 tests, 9 files, green.** `tsc`, eslint clean, API surface unchanged.

## Two things the test needed that are worth flagging

**`handlePostTool` fires the write with `void trackToolMetrics(...)` (`:66`) and is itself synchronous.** So `await handlePostTool(...)` returns before the write happens, and my first three assertions saw zero calls. They now `vi.waitFor` the detached promise. Anyone testing this path will hit the same thing.

**The existing storage mock could not observe writes** — it returned a fresh object per construction and an empty session list, so `recordToolTask` returned at its `activeSession === undefined` guard and the update path was never exercised by any test. The shared mocks are declared through `vi.hoisted`, which is required rather than stylistic: `vi.mock` factories are hoisted above module-scope `const`s, and the resulting TDZ `ReferenceError` is swallowed by `trackToolMetrics`' `try/catch`, surfacing only as an unexplained "0 calls".

Both cost me a wrong guess before I read the call path instead of theorising, which is the actual lesson.

## Out of scope, worth noting

That `void` also means a failed write is silently discarded and races process exit — a hook that returns immediately may lose the record entirely. Separate concern; not changed here.