### PR TITLE
fix(release): let the secret scan report that it did not run

### DIFF
--- a/.changeset/secret-scan-reports-git-failure.md
+++ b/.changeset/secret-scan-reports-git-failure.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+let the release secret scan report that it did not run
+
+The hardcoded-secret scan in `validateSecurity` piped `git diff` through
+`grep | head`. A shell pipeline's exit status is its _last_ command's, and
+`head` succeeds essentially always — so a `git diff` failure (a shallow clone,
+or any branch with fewer than ten commits) exited 0 with empty output, which is
+indistinguishable from a clean tree.
+
+The catch block that records `Secret scan did not run` therefore could not fire
+for the case its own remediation names ("re-run with a full git history
+available"); only a timeout reached it. Release validation reported the security
+expert as passed having scanned nothing.
+
+`scanRecentCommitsForSecrets` now runs `git diff` on its own and filters in JS,
+returning either the matches or the reason it could not scan, and the git error
+is carried into the finding's description.
+
+Fixes #4839.

--- a/packages/nexus-agents/src/cli/release-secret-scan.ts
+++ b/packages/nexus-agents/src/cli/release-secret-scan.ts
@@ -1,0 +1,58 @@
+/**
+ * Recent-commit secret scan for release validation.
+ *
+ * Separate from `release-validate-helpers` because it is the one check there
+ * that shells out to git, and the distinction it has to preserve — "scanned,
+ * nothing found" versus "did not scan" — is worth testing against a real
+ * repository rather than a mocked `execSync` (#4839).
+ *
+ * @module cli/release-secret-scan
+ */
+
+import { execSync } from 'node:child_process';
+import { CLI_SUBPROCESS_TIMEOUTS } from '../config/timeouts.js';
+
+/** Outcome of the recent-commit secret scan: it either ran, or it did not. */
+export type SecretScanResult =
+  | { readonly ok: true; readonly matches: readonly string[] }
+  | { readonly ok: false; readonly reason: string };
+
+/** Options for {@link scanRecentCommitsForSecrets}; both exist for testing. */
+export interface SecretScanOptions {
+  readonly cwd?: string;
+  readonly range?: string;
+}
+
+const SECRET_LINE_PATTERN = /api[_-]?key|secret|password|token/i;
+const MAX_REPORTED_MATCHES = 5;
+
+/**
+ * Scan recent commits for secret-like tokens, distinguishing "scanned, nothing
+ * found" from "did not scan".
+ *
+ * This runs `git diff` on its own and filters in JS. It previously piped git
+ * through `grep | head`, and a shell pipeline's exit status is its *last*
+ * command's: `head` succeeds essentially always, so a git failure — a shallow
+ * clone, or any branch with fewer than ten commits — exited 0 with empty
+ * output and was indistinguishable from a clean tree (#4839).
+ */
+export function scanRecentCommitsForSecrets(options: SecretScanOptions = {}): SecretScanResult {
+  const range = options.range ?? 'HEAD~10..HEAD';
+  let diff: string;
+  try {
+    diff = execSync(`git diff ${range} -- "*.ts" "*.js"`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: CLI_SUBPROCESS_TIMEOUTS.ghCommandMs,
+      ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+    });
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+  }
+
+  const matches = diff
+    .split('\n')
+    .filter((line) => SECRET_LINE_PATTERN.test(line))
+    .slice(0, MAX_REPORTED_MATCHES);
+  return { ok: true, matches };
+}

--- a/packages/nexus-agents/src/cli/release-validate-helpers.ts
+++ b/packages/nexus-agents/src/cli/release-validate-helpers.ts
@@ -21,51 +21,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import type { ExpertValidationResult, ValidationFinding } from './release-validate-types.js';
 import { CLI_SUBPROCESS_TIMEOUTS } from '../config/timeouts.js';
 import { anyOf } from '../utils/verdict-aggregation.js';
-
-/** Outcome of the recent-commit secret scan: it either ran, or it did not. */
-export type SecretScanResult =
-  | { readonly ok: true; readonly matches: readonly string[] }
-  | { readonly ok: false; readonly reason: string };
-
-/** Options for {@link scanRecentCommitsForSecrets}; both exist for testing. */
-export interface SecretScanOptions {
-  readonly cwd?: string;
-  readonly range?: string;
-}
-
-const SECRET_LINE_PATTERN = /api[_-]?key|secret|password|token/i;
-const MAX_REPORTED_MATCHES = 5;
-
-/**
- * Scan recent commits for secret-like tokens, distinguishing "scanned, nothing
- * found" from "did not scan".
- *
- * This runs `git diff` on its own and filters in JS. It previously piped git
- * through `grep | head`, and a shell pipeline's exit status is its *last*
- * command's: `head` succeeds essentially always, so a git failure — a shallow
- * clone, or any branch with fewer than ten commits — exited 0 with empty
- * output and was indistinguishable from a clean tree (#4839).
- */
-export function scanRecentCommitsForSecrets(options: SecretScanOptions = {}): SecretScanResult {
-  const range = options.range ?? 'HEAD~10..HEAD';
-  let diff: string;
-  try {
-    diff = execSync(`git diff ${range} -- "*.ts" "*.js"`, {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: CLI_SUBPROCESS_TIMEOUTS.ghCommandMs,
-      ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
-    });
-  } catch (error) {
-    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
-  }
-
-  const matches = diff
-    .split('\n')
-    .filter((line) => SECRET_LINE_PATTERN.test(line))
-    .slice(0, MAX_REPORTED_MATCHES);
-  return { ok: true, matches };
-}
+import { scanRecentCommitsForSecrets } from './release-secret-scan.js';
 
 /** Options passed to each expert validator. */
 export interface ValidatorOptions {

--- a/packages/nexus-agents/src/cli/release-validate-helpers.ts
+++ b/packages/nexus-agents/src/cli/release-validate-helpers.ts
@@ -22,6 +22,51 @@ import type { ExpertValidationResult, ValidationFinding } from './release-valida
 import { CLI_SUBPROCESS_TIMEOUTS } from '../config/timeouts.js';
 import { anyOf } from '../utils/verdict-aggregation.js';
 
+/** Outcome of the recent-commit secret scan: it either ran, or it did not. */
+export type SecretScanResult =
+  | { readonly ok: true; readonly matches: readonly string[] }
+  | { readonly ok: false; readonly reason: string };
+
+/** Options for {@link scanRecentCommitsForSecrets}; both exist for testing. */
+export interface SecretScanOptions {
+  readonly cwd?: string;
+  readonly range?: string;
+}
+
+const SECRET_LINE_PATTERN = /api[_-]?key|secret|password|token/i;
+const MAX_REPORTED_MATCHES = 5;
+
+/**
+ * Scan recent commits for secret-like tokens, distinguishing "scanned, nothing
+ * found" from "did not scan".
+ *
+ * This runs `git diff` on its own and filters in JS. It previously piped git
+ * through `grep | head`, and a shell pipeline's exit status is its *last*
+ * command's: `head` succeeds essentially always, so a git failure — a shallow
+ * clone, or any branch with fewer than ten commits — exited 0 with empty
+ * output and was indistinguishable from a clean tree (#4839).
+ */
+export function scanRecentCommitsForSecrets(options: SecretScanOptions = {}): SecretScanResult {
+  const range = options.range ?? 'HEAD~10..HEAD';
+  let diff: string;
+  try {
+    diff = execSync(`git diff ${range} -- "*.ts" "*.js"`, {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: CLI_SUBPROCESS_TIMEOUTS.ghCommandMs,
+      ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+    });
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+  }
+
+  const matches = diff
+    .split('\n')
+    .filter((line) => SECRET_LINE_PATTERN.test(line))
+    .slice(0, MAX_REPORTED_MATCHES);
+  return { ok: true, matches };
+}
+
 /** Options passed to each expert validator. */
 export interface ValidatorOptions {
   readonly version: string;
@@ -65,42 +110,30 @@ export async function validateSecurity(options: ValidatorOptions): Promise<Exper
   }
 
   // Check for hardcoded secrets patterns
-  try {
-    const result = execSync(
-      'git diff HEAD~10..HEAD -- "*.ts" "*.js" | grep -iE "(api[_-]?key|secret|password|token)" | head -5',
-      {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: CLI_SUBPROCESS_TIMEOUTS.ghCommandMs,
-      }
-    );
-    if (result.trim()) {
-      findings.push({
-        severity: 'warning',
-        category: 'security',
-        title: 'Potential secrets in recent commits',
-        description: 'Recent commits may contain hardcoded secrets.',
-        remediation: 'Review commits for any exposed credentials.',
-      });
-    }
-  } catch {
-    // The pipeline ends in `head`, so grep finding nothing still exits 0 —
-    // reaching this catch means the scan itself failed (git error, timeout),
-    // not that the tree is clean. Record the gap instead of inheriting a pass
-    // from an empty finding list (#4581).
+  const scan = scanRecentCommitsForSecrets();
+  if (!scan.ok) {
     findings.push({
       severity: 'warning',
       category: 'security',
       title: 'Secret scan did not run',
-      description: 'The hardcoded-secret scan over recent commits failed to execute.',
+      description: `The hardcoded-secret scan over recent commits failed to execute: ${scan.reason}`,
       remediation: 'Re-run with a full git history available, then review the output.',
+    });
+  } else if (scan.matches.length > 0) {
+    findings.push({
+      severity: 'warning',
+      category: 'security',
+      title: 'Potential secrets in recent commits',
+      description: 'Recent commits may contain hardcoded secrets.',
+      remediation: 'Review commits for any exposed credentials.',
     });
   }
 
   return {
     expert: 'security',
-    // whenEmpty = false: with the failure above recorded as a finding, an empty
-    // list now genuinely means "scanned, nothing found" (#4581).
+    // whenEmpty = false: an empty list genuinely means "scanned, nothing
+    // found" — every check above records a finding when it cannot run, which
+    // for the secret scan required #4839 as well as #4581.
     passed: !anyOf(findings, (f) => f.severity === 'error', false),
     confidence: 0.85,
     findings,

--- a/packages/nexus-agents/src/cli/release-validate-secret-scan.test.ts
+++ b/packages/nexus-agents/src/cli/release-validate-secret-scan.test.ts
@@ -14,7 +14,7 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { scanRecentCommitsForSecrets } from './release-validate-helpers.js';
+import { scanRecentCommitsForSecrets } from './release-secret-scan.js';
 
 /** A repo with a single commit: `git diff HEAD~10..HEAD` cannot resolve. */
 let shallowRepo: string;

--- a/packages/nexus-agents/src/cli/release-validate-secret-scan.test.ts
+++ b/packages/nexus-agents/src/cli/release-validate-secret-scan.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Integration tests for the release secret scan (#4839).
+ *
+ * These deliberately use the REAL `execSync` against a REAL temporary git
+ * repository. The defect being fixed was a property of shell semantics — a
+ * pipeline's exit status is its last command's — which a mocked `execSync`
+ * cannot reproduce. Mocking here would assert the fix without testing it.
+ *
+ * @module cli/release-validate-secret-scan.test
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { scanRecentCommitsForSecrets } from './release-validate-helpers.js';
+
+/** A repo with a single commit: `git diff HEAD~10..HEAD` cannot resolve. */
+let shallowRepo: string;
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'ignore' });
+}
+
+beforeAll(() => {
+  shallowRepo = mkdtempSync(join(tmpdir(), 'nexus-secret-scan-'));
+  git(shallowRepo, 'init', '-q');
+  git(shallowRepo, 'config', 'user.email', 'test@example.invalid');
+  git(shallowRepo, 'config', 'user.name', 'Test');
+  writeFileSync(join(shallowRepo, 'a.ts'), 'export const a = 1;\n');
+  git(shallowRepo, 'add', '-A');
+  git(shallowRepo, 'commit', '-q', '-m', 'initial');
+});
+
+afterAll(() => {
+  rmSync(shallowRepo, { recursive: true, force: true });
+});
+
+describe('scanRecentCommitsForSecrets (#4839)', () => {
+  it('reports that it did not run when the git range cannot be resolved', () => {
+    // Fewer than ten commits — the shallow-clone case the old catch block
+    // named in its remediation but could never reach, because `git`'s exit
+    // code was masked by the `| grep | head` it was piped through.
+    const result = scanRecentCommitsForSecrets({ cwd: shallowRepo });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).not.toBe('');
+    }
+  });
+
+  it('reports a clean scan as scanned, not as failed', () => {
+    // The counterpart. Without it, "always return ok:false" would pass the
+    // test above, and every release would carry a spurious warning.
+    const result = scanRecentCommitsForSecrets({ cwd: process.cwd(), range: 'HEAD~1..HEAD' });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns the matching lines when a recent commit contains a secret-like token', () => {
+    const repo = mkdtempSync(join(tmpdir(), 'nexus-secret-scan-hit-'));
+    try {
+      git(repo, 'init', '-q');
+      git(repo, 'config', 'user.email', 'test@example.invalid');
+      git(repo, 'config', 'user.name', 'Test');
+      writeFileSync(join(repo, 'a.ts'), 'export const a = 1;\n');
+      git(repo, 'add', '-A');
+      git(repo, 'commit', '-q', '-m', 'initial');
+      writeFileSync(join(repo, 'a.ts'), 'export const API_KEY = "nope";\n');
+      git(repo, 'add', '-A');
+      git(repo, 'commit', '-q', '-m', 'second');
+
+      const result = scanRecentCommitsForSecrets({ cwd: repo, range: 'HEAD~1..HEAD' });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.matches.some((line) => line.includes('API_KEY'))).toBe(true);
+      }
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/nexus-agents/src/cli/release-validate-secret-scan.test.ts
+++ b/packages/nexus-agents/src/cli/release-validate-secret-scan.test.ts
@@ -18,6 +18,8 @@ import { scanRecentCommitsForSecrets } from './release-secret-scan.js';
 
 /** A repo with a single commit: `git diff HEAD~10..HEAD` cannot resolve. */
 let shallowRepo: string;
+/** A repo with two commits and no secret-like tokens in the second. */
+let cleanRepo: string;
 
 function git(cwd: string, ...args: string[]): void {
   execFileSync('git', args, { cwd, stdio: 'ignore' });
@@ -31,10 +33,22 @@ beforeAll(() => {
   writeFileSync(join(shallowRepo, 'a.ts'), 'export const a = 1;\n');
   git(shallowRepo, 'add', '-A');
   git(shallowRepo, 'commit', '-q', '-m', 'initial');
+
+  cleanRepo = mkdtempSync(join(tmpdir(), 'nexus-secret-scan-clean-'));
+  git(cleanRepo, 'init', '-q');
+  git(cleanRepo, 'config', 'user.email', 'test@example.invalid');
+  git(cleanRepo, 'config', 'user.name', 'Test');
+  writeFileSync(join(cleanRepo, 'a.ts'), 'export const a = 1;\n');
+  git(cleanRepo, 'add', '-A');
+  git(cleanRepo, 'commit', '-q', '-m', 'initial');
+  writeFileSync(join(cleanRepo, 'a.ts'), 'export const a = 2;\n');
+  git(cleanRepo, 'add', '-A');
+  git(cleanRepo, 'commit', '-q', '-m', 'second');
 });
 
 afterAll(() => {
   rmSync(shallowRepo, { recursive: true, force: true });
+  rmSync(cleanRepo, { recursive: true, force: true });
 });
 
 describe('scanRecentCommitsForSecrets (#4839)', () => {
@@ -53,9 +67,17 @@ describe('scanRecentCommitsForSecrets (#4839)', () => {
   it('reports a clean scan as scanned, not as failed', () => {
     // The counterpart. Without it, "always return ok:false" would pass the
     // test above, and every release would carry a spurious warning.
-    const result = scanRecentCommitsForSecrets({ cwd: process.cwd(), range: 'HEAD~1..HEAD' });
+    //
+    // This builds its own two-commit repo rather than scanning the checkout:
+    // CI clones shallow, so `HEAD~1` does not resolve there — which is the
+    // very failure this fix is about, and it made the test fail for the
+    // reason the code now handles correctly.
+    const result = scanRecentCommitsForSecrets({ cwd: cleanRepo, range: 'HEAD~1..HEAD' });
 
     expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.matches).toEqual([]);
+    }
   });
 
   it('returns the matching lines when a recent commit contains a secret-like token', () => {


### PR DESCRIPTION
Fixes #4839.

## The defect

`validateSecurity`'s hardcoded-secret scan ran this:

```
git diff HEAD~10..HEAD -- "*.ts" "*.js" | grep -iE "(api[_-]?key|secret|password|token)" | head -5
```

A shell pipeline's exit status is its **last** command's. `head` succeeds essentially always, so `git`'s exit code never reached `execSync`. On a shallow clone — or any branch with fewer than ten commits — the command exits **0 with empty output**, which is byte-for-byte what a clean tree produces.

Reproduced directly rather than reasoned about, in a fresh repo with one commit:

```
git diff HEAD~10..HEAD -- "*.ts"                       → exit 128
git diff HEAD~10..HEAD -- "*.ts" | grep … | head -5    → exit 0, stdout empty
```

## Why the existing handling didn't save it

The catch block already recorded a `Secret scan did not run` finding, and its remediation read *"re-run with a full git history available"*. **A missing git history was exactly the case that could not reach it.** Only a timeout did. #4581 had correctly identified the empty-list hazard and hardened the verdict — one layer above a detector that still could not report the failure the verdict depends on.

Net effect: release validation reported the security expert as **passed**, having scanned nothing.

## The fix

`scanRecentCommitsForSecrets` runs `git diff` on its own and filters in JS, returning either the matches or the reason it could not scan. The existing finding becomes reachable for the case it describes, and the git error is now carried into its description — previously the operator was told the scan failed but not why.

## Testing

The old `#4581` test asserted this catch by making a mocked `execSync` throw for `git diff` — something the real command could not do. **A mock cannot reproduce shell exit-status semantics**, so the new tests use the real `execSync` against a real temporary git repo with a single commit. That is the actual bug, exercised.

Mutation-verified: restoring the pipe fails the did-not-run test and leaves the other two green — the test pins this defect specifically, not the function generally.

24 tests green across both suites; `tsc` and eslint clean.

## Scope

`validateSecurity`'s two other checks were examined in passing and are sound: `npm audit` runs unpiped, and the `.env` check is a filesystem stat. Not changed. #4838 is the same shape in `system-review` and remains open.