### PR TITLE
fix(memory-eval): make the benchmark able to measure a scorer

### DIFF
--- a/.changeset/memory-eval-can-measure.md
+++ b/.changeset/memory-eval-can-measure.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': minor
+---
+
+make memory-eval able to tell its two scorers apart
+
+`memory-eval` exists to compare a baseline scorer against a reflective one, and
+reported a delta of **exactly 0** on every metric at every dataset size — for
+any pair of scorers. The comparison could not come out non-zero.
+
+`generateEvalDataset` gave every irrelevant pair a unique query, so grouping by
+query produced groups that were entirely relevant or entirely irrelevant, none
+larger than `k`. A scorer's only influence is the order within a group; when
+every item in a group shares one relevance label and the whole group fits inside
+the top-k cut, order cannot move any metric.
+
+- Irrelevant memories now answer the **same** query as their group, carrying
+  another topic's content, so each group mixes relevant and irrelevant items.
+- The number of distinct queries is capped so every group holds more than `k`
+  memories, making the rank cut meaningful.
+- A query with no relevant memory is excluded from the recall mean instead of
+  being credited 1.0 — that free perfect score was 17 of 27 queries at the
+  default size. `EvalMetrics` gains `recallQueries`, and the report says so when
+  it is lower than `totalQueries`.
+
+Reported numbers change substantially: at size 50, `Recall@5` moves from a
+constant 1.0 to 0.486 baseline / 0.676 reflective, and the deltas become
+non-zero. They were constants before, so any movement is the fix working.
+
+Fixes #4850.

--- a/packages/nexus-agents/src/cli/memory-eval.test.ts
+++ b/packages/nexus-agents/src/cli/memory-eval.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import type { EvalPair } from './memory-eval.js';
 import { runMemoryEval, formatMemoryEvalReport, generateEvalDataset } from './memory-eval.js';
 
 describe('memory-eval', () => {
@@ -118,5 +119,101 @@ describe('memory-eval', () => {
       expect(output).toContain('Precision@5');
       expect(output).toContain('MRR');
     });
+  });
+});
+
+// ============================================================================
+// The eval must be able to tell its two scorers apart (#4850)
+// ============================================================================
+
+describe('the dataset can measure a scorer (#4850)', () => {
+  const K = 5;
+
+  function groupByQuery(dataset: readonly EvalPair[]): Map<string, EvalPair[]> {
+    const groups = new Map<string, EvalPair[]>();
+    for (const p of dataset) groups.set(p.query, [...(groups.get(p.query) ?? []), p]);
+    return groups;
+  }
+
+  it('gives every query both relevant and irrelevant memories', () => {
+    // A scorer's only influence is the ORDER within a query group. When every
+    // item in a group carries the same relevance label, order cannot move any
+    // metric and the scorer is dead input.
+    for (const [query, pairs] of groupByQuery(generateEvalDataset(50))) {
+      const relevant = pairs.filter((p) => p.expectedRelevant).length;
+      expect(
+        relevant,
+        `query "${query}" has ${String(relevant)}/${String(pairs.length)} relevant`
+      ).toBeGreaterThan(0);
+      expect(relevant).toBeLessThan(pairs.length);
+    }
+  });
+
+  it('gives every query more memories than the top-k cut', () => {
+    // If a group fits entirely inside the top 5, the cut selects everything
+    // and ranking is irrelevant a second way.
+    for (const [query, pairs] of groupByQuery(generateEvalDataset(50))) {
+      expect(pairs.length, `query "${query}"`).toBeGreaterThan(K);
+    }
+  });
+
+  it('never pairs an irrelevant memory with its own matching content', () => {
+    // Otherwise "irrelevant" is only a label, and no scorer could be expected
+    // to rank the pair down.
+    const dataset = generateEvalDataset(50);
+    const contentForQuery = new Map<string, string>();
+    for (const p of dataset) {
+      if (p.expectedRelevant) contentForQuery.set(p.query, p.memoryContent);
+    }
+    for (const p of dataset) {
+      if (!p.expectedRelevant) {
+        const matching = contentForQuery.get(p.query);
+        // Without this the assertion below is vacuous: today's irrelevant
+        // pairs have queries no relevant pair shares, so the lookup misses
+        // and `not.toBe(undefined)` passes for the wrong reason.
+        expect(matching, `no relevant pair shares query "${p.query}"`).toBeDefined();
+        expect(p.memoryContent).not.toBe(matching);
+      }
+    }
+  });
+});
+
+describe('the metrics respond to the scorer (#4850)', () => {
+  it('does not report an identical result for both scorers', () => {
+    // The whole point of the report. This asserted nothing before: the deltas
+    // were exactly 0 at every dataset size because no query group was mixed.
+    const r = runMemoryEval(50);
+    const identical =
+      r.improvement.recallDelta === 0 &&
+      r.improvement.precisionDelta === 0 &&
+      r.improvement.mrrDelta === 0;
+
+    expect(identical).toBe(false);
+  });
+
+  it('does not credit perfect recall to a query with nothing to recall', () => {
+    // size 1 yields a single irrelevant pair — a group where recall is
+    // undefined. Scoring it 1.0 put a free 17/27 into the mean at size 50.
+    const r = runMemoryEval(1);
+
+    expect(r.baseline.recallAt5).not.toBe(1);
+  });
+
+  it('says so in the report when recall covered fewer queries than were run', () => {
+    // The field alone is not disclosure — the CLI prints `details`, and a
+    // Recall@5 describing a subset of the queries has to say which subset.
+    const covered = formatMemoryEvalReport(runMemoryEval(50));
+    const partial = formatMemoryEvalReport(runMemoryEval(1));
+
+    expect(partial).toContain('0 of 1');
+    expect(covered).not.toContain(' of ');
+  });
+
+  it('reports how many queries the recall mean was actually taken over', () => {
+    // Absence has to be visible, not averaged away.
+    const r = runMemoryEval(50);
+
+    expect(r.baseline.recallQueries).toBe(r.baseline.totalQueries);
+    expect(runMemoryEval(1).baseline.recallQueries).toBe(0);
   });
 });

--- a/packages/nexus-agents/src/cli/memory-eval.ts
+++ b/packages/nexus-agents/src/cli/memory-eval.ts
@@ -29,6 +29,14 @@ export interface EvalMetrics {
   readonly avgLatencyMs: number;
   readonly p95LatencyMs: number;
   readonly totalQueries: number;
+  /**
+   * Queries the recall mean was actually taken over (#4850).
+   *
+   * A query with no relevant memory cannot measure recall. Such a query is
+   * excluded rather than credited 1.0, so this can be lower than
+   * `totalQueries` — and when it is, `recallAt5` describes a subset.
+   */
+  readonly recallQueries: number;
 }
 
 /** Comparative evaluation report. */
@@ -52,6 +60,9 @@ export interface EvalImprovement {
 // Evaluation Dataset
 // ============================================================================
 
+/** Rank cut for recall@k / precision@k. */
+const TOP_K = 5;
+
 /** Generate synthetic evaluation dataset. */
 export function generateEvalDataset(size: number = 50): readonly EvalPair[] {
   const pairs: EvalPair[] = [];
@@ -69,17 +80,29 @@ export function generateEvalDataset(size: number = 50): readonly EvalPair[] {
     { query: 'security vulnerability scan', content: 'Dependabot and CodeQL automated scans' },
   ];
 
+  // Distinct queries are capped so that every query group holds more than
+  // TOP_K memories. A group that fits inside the top-k cut is returned whole
+  // however it is ordered, and ordering is the only thing a scorer controls
+  // (#4850).
+  const queryCount = Math.max(1, Math.min(topics.length, Math.floor(size / (TOP_K * 2))));
+
   for (let i = 0; i < size; i++) {
-    const topicIdx = i % topics.length;
+    const topicIdx = i % queryCount;
     const topic = topics[topicIdx];
     const source = sources[i % sources.length] ?? 'session';
     const isRelevant = i % 3 !== 0; // ~67% relevant, ~33% irrelevant
 
-    if (topic !== undefined) {
+    // An irrelevant memory answers the SAME query with ANOTHER topic's
+    // content. Giving it a query of its own instead — as this did — made
+    // every group homogeneous, so no scorer could change any metric.
+    const offset = 1 + (i % (topics.length - 1));
+    const contentTopic = isRelevant ? topic : topics[(topicIdx + offset) % topics.length];
+
+    if (topic !== undefined && contentTopic !== undefined) {
       pairs.push({
-        query: isRelevant ? topic.query : `unrelated query ${String(i)}`,
+        query: topic.query,
         memoryKey: `mem-${String(i)}-${source}`,
-        memoryContent: topic.content,
+        memoryContent: contentTopic.content,
         source,
         expectedRelevant: isRelevant,
       });
@@ -149,8 +172,9 @@ function evaluateScorer(
   dataset: readonly EvalPair[],
   scorer: (q: string, c: string) => number
 ): EvalMetrics {
-  const k = 5;
+  const k = TOP_K;
   let totalRecall = 0;
+  let recallQueries = 0;
   let totalPrecision = 0;
   let totalMrr = 0;
   const latencies: number[] = [];
@@ -177,7 +201,13 @@ function evaluateScorer(
     const relevantInTopK = topK.filter((s) => s.relevant).length;
     const totalRelevant = pairs.filter((p) => p.expectedRelevant).length;
 
-    totalRecall += totalRelevant > 0 ? relevantInTopK / totalRelevant : 1;
+    // A query with nothing relevant cannot measure recall. Crediting it 1.0
+    // put a free perfect score into the mean for every such query (#4850);
+    // it is excluded from both numerator and denominator instead.
+    if (totalRelevant > 0) {
+      totalRecall += relevantInTopK / totalRelevant;
+      recallQueries += 1;
+    }
     totalPrecision += topK.length > 0 ? relevantInTopK / topK.length : 0;
 
     // MRR: rank of first relevant
@@ -190,12 +220,13 @@ function evaluateScorer(
   const p95Idx = Math.floor(latencies.length * 0.95);
 
   return {
-    recallAt5: n > 0 ? round(totalRecall / n) : 0,
+    recallAt5: recallQueries > 0 ? round(totalRecall / recallQueries) : 0,
     precisionAt5: n > 0 ? round(totalPrecision / n) : 0,
     mrr: n > 0 ? round(totalMrr / n) : 0,
     avgLatencyMs: round(average(latencies)),
     p95LatencyMs: round(latencies[p95Idx] ?? 0),
     totalQueries: n,
+    recallQueries,
   };
 }
 
@@ -254,6 +285,15 @@ function formatEvalDetails(
   datasetSize: number
 ): string[] {
   const lines: string[] = [`Dataset: ${String(datasetSize)} query-memory pairs`];
+  if (baseline.recallQueries < baseline.totalQueries) {
+    // Recall is undefined for a query with no relevant memory, so those are
+    // excluded from the mean. Printing the bare number would present a
+    // partial measurement as a complete one (#4850).
+    lines.push(
+      `Recall measured over ${String(baseline.recallQueries)} of ` +
+        `${String(baseline.totalQueries)} queries — the rest had no relevant memory.`
+    );
+  }
 
   lines.push('\nBaseline (keyword search):');
   lines.push(`  Recall@5:    ${baseline.recallAt5.toFixed(3)}`);


### PR DESCRIPTION
Fixes #4850.

## What was wrong

`memory-eval` exists to compare a baseline scorer against a reflective one. It reported a delta of **exactly 0** on every metric, at every dataset size. Measured against `main`, not inferred:

```
n=50   baseRecall=1     reflRecall=1     deltas r=0 p=0 m=0
n=120  baseRecall=0.925 reflRecall=0.925 deltas r=0 p=0 m=0
n=300  baseRecall=0.932 reflRecall=0.932 deltas r=0 p=0 m=0
```

`generateEvalDataset` gave every *irrelevant* pair a unique query (`unrelated query ${i}`) while relevant pairs shared ten topic queries. Grouping by query therefore produced **homogeneous** groups:

```
groups=27  mixedGroups=0  groupsLargerThanK=0
sizes= 0/1 4/4 3/3 0/1 4/4 3/3 … 0/1 (×17)
```

A scorer's only influence is the **order within a group**. When every item in a group carries the same relevance label — and the whole group fits inside the top-k cut anyway — order cannot move `relevantInTopK`, precision, or the rank of the first relevant item. The scorer was dead input.

## The vacuous recall credit was the symptom, not the cause

The finding started as "`Recall@5` has a floor of ~0.63", from the `: 1` fallback crediting perfect recall to the 17 groups that had nothing to recall. Measuring showed that was not the story: the remaining ten groups are all-relevant and no larger than `k`, so they score 1.0 too. Fixing the fallback alone would have moved the number from 1.0 to 1.0.

Worth stating plainly, because it is the reusable part: **the can't-fail default was real and fixing it would have changed nothing.** The defect was one layer down, in the data the metric was computed over.

## Three changes

1. Irrelevant memories answer the **same** query as their group, carrying another topic's content — so each group mixes relevant and irrelevant items and ranking decides the top-k.
2. Distinct queries are capped so every group holds **more than** `k` memories. A group that fits inside the cut is returned whole however it is ordered.
3. A query with no relevant memory is excluded from the recall mean rather than credited 1.0. `EvalMetrics` gains `recallQueries`, and the report states the coverage when it is lower than `totalQueries` — the field alone is not disclosure, since the CLI prints `details`.

## Result

```
n=50   q=5/5    baseR=0.486  reflR=0.676  deltas r=+0.19 p=+0.24 m=+0.20
n=120  q=10/10  baseR=0.45   reflR=0.55   deltas r=+0.10 p=+0.16 m=+0.10
n=300  q=10/10  baseR=0.18   reflR=0.22   deltas r=+0.04 p=+0.16 m=+0.10
```

The numbers move a lot. They were constants, so any movement is the fix working — but reviewers should read this as a **behaviour change to a reported metric**, not a no-op refactor, which is why it is a minor rather than a patch.

## Testing

Six tests, red first, over both the dataset's measurability properties and the report's output. Each of the five production hunks reverted individually fails a specific test.

One of them was worth catching: the "an irrelevant memory never carries its own matching content" assertion passed **vacuously** on `main`, because irrelevant pairs had queries no relevant pair shared, so the lookup returned `undefined` and `not.toBe(undefined)` was trivially true. It now asserts the lookup found something first.

The mutation run also showed the content-diversity change is load-bearing rather than cosmetic: restoring matching content on irrelevant pairs collapses the deltas back to 0 on its own.

22 tests green; `tsc`, eslint and the producer/consumer ratchet clean.