### PR TITLE
fix(collaboration): disclose that session confidence is unmeasured

### DIFF
--- a/.changeset/aggregation-confidence-measured.md
+++ b/.changeset/aggregation-confidence-measured.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': patch
+---
+
+stop reporting a perfect confidence for a session that never measured one
+
+`buildAggregatedResult` returned `averageConfidence: 1.0` — the best possible
+score — for every collaboration session, and `conflictCount: 0` as a literal.
+Its sibling `ResultAggregator.buildResult` computes both from the same
+`AggregatedResult` shape.
+
+The two are not symmetric, though, and the asymmetry is the point: **no input
+reaching the session builder carries a confidence signal at all.** Neither
+`TaskResult`, `ResultMetadata`, `VoteMessage` nor `ExpertParticipation` has the
+field; the aggregator path computes it from `ExpertResult.confidence`. So there
+was nothing to compute, and the value was a placeholder presented as a score.
+
+Following the precedent already in this interface (`unmeasuredResults`, #4743,
+and `ResultMetadata.tokensMeasured`, #4734), `AggregationMetadata` gains an
+optional `confidenceMeasured`. The session builder reports `0` with
+`confidenceMeasured: false`; the aggregator reports its computed value with
+`confidenceMeasured: true`. The placeholder now fails in the safe direction — a
+consumer thresholding on confidence previously passed unconditionally.
+
+`conflictCount` is now derived from the `conflicts` list so the two cannot
+drift. That path still performs no conflict detection, which is #4854.
+
+Fixes #4831.

--- a/.changeset/aggregation-confidence-measured.md
+++ b/.changeset/aggregation-confidence-measured.md
@@ -1,5 +1,5 @@
 ---
-'nexus-agents': patch
+'nexus-agents': minor
 ---
 
 stop reporting a perfect confidence for a session that never measured one
@@ -21,6 +21,9 @@ optional `confidenceMeasured`. The session builder reports `0` with
 `confidenceMeasured: false`; the aggregator reports its computed value with
 `confidenceMeasured: true`. The placeholder now fails in the safe direction — a
 consumer thresholding on confidence previously passed unconditionally.
+
+`AggregationMetadata` gaining an optional field is an additive public-API
+change, so this is a minor rather than a patch.
 
 `conflictCount` is now derived from the `conflicts` list so the two cannot
 drift. That path still performs no conflict detection, which is #4854.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -401,6 +401,7 @@ FunctionDeclaration aggregateResults
 InterfaceDeclaration AggregationMetadata
   aggregatedAt: string
   averageConfidence: number
+  confidenceMeasured?: boolean | undefined
   conflictCount: number
   resultCount: number
   totalTokensUsed: number

--- a/packages/nexus-agents/src/agents/collaboration/collaboration-types.ts
+++ b/packages/nexus-agents/src/agents/collaboration/collaboration-types.ts
@@ -263,6 +263,20 @@ export interface AggregationMetadata {
    * not zero.
    */
   unmeasuredResults?: number;
+  /**
+   * Whether `averageConfidence` is a measurement (#4831).
+   *
+   * `false` means no contributor carried a confidence signal, so
+   * `averageConfidence` is a placeholder `0` and NOT a score — a session whose
+   * confidence was never assessed must not read as a confident one. The
+   * collaboration-session builder is in that position: `TaskResult` has no
+   * confidence field, while the `ResultAggregator` path computes the value
+   * from `ExpertResult.confidence`.
+   *
+   * Absent means the producer predates the distinction — unknown, not
+   * measured. Mirrors `ResultMetadata.tokensMeasured` (#4734).
+   */
+  confidenceMeasured?: boolean;
   aggregatedAt: string;
 }
 

--- a/packages/nexus-agents/src/agents/collaboration/result-aggregator.ts
+++ b/packages/nexus-agents/src/agents/collaboration/result-aggregator.ts
@@ -149,6 +149,9 @@ export class ResultAggregator {
         resultCount: results.length,
         conflictCount: conflicts.length,
         averageConfidence: Math.round(avgConfidence * 100) / 100,
+        // Measured: ExpertResult carries confidence, and `aggregate` rejects
+        // an empty result list before reaching here (#4831).
+        confidenceMeasured: true,
         ...usage,
         aggregatedAt: getTimeProvider().nowIso(),
       },

--- a/packages/nexus-agents/src/agents/collaboration/session-helpers.test.ts
+++ b/packages/nexus-agents/src/agents/collaboration/session-helpers.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import type { TaskResult } from '../../core/index.js';
 import type {
+  AggregatedResult,
   CollaborationConfig,
   ExpertParticipation,
   VoteMessage,
@@ -22,6 +23,7 @@ import {
   calculateQualityScore,
   buildExpertResults,
   shouldFinalize,
+  buildAggregatedResult,
 } from './session-helpers.js';
 
 // ============================================================================
@@ -381,5 +383,47 @@ describe('shouldFinalize', () => {
 
   it('does not finalize an empty consensus session (#4585)', () => {
     expect(shouldFinalize('consensus', [], new Map(), [], [])).toBe(false);
+  });
+});
+
+// ============================================================================
+// buildAggregatedResult confidence disclosure (#4831)
+// ============================================================================
+
+describe('buildAggregatedResult does not report an unmeasured confidence (#4831)', () => {
+  function build(results: TaskResult[]): AggregatedResult {
+    return buildAggregatedResult({
+      pattern: 'parallel',
+      results,
+      participants: [makeParticipant({ status: 'submitted' })],
+      votes: [],
+      reviews: [],
+      endTime: new Date('2026-01-01T00:01:00.000Z'),
+    });
+  }
+
+  it('marks averageConfidence as unmeasured', () => {
+    // Nothing reaching this builder carries a confidence signal: TaskResult,
+    // ResultMetadata, VoteMessage and ExpertParticipation all lack the field.
+    // The sibling aggregator computes it from ExpertResult.confidence, which
+    // this path does not have. Same shape as `unmeasuredResults` (#4743).
+    const result = build([makeTaskResult()]);
+
+    expect(result.metadata.confidenceMeasured).toBe(false);
+  });
+
+  it('does not report a perfect confidence as the placeholder', () => {
+    // It reported 1.0 — the best possible score — for a session whose
+    // confidence was never measured. A consumer thresholding on it passed
+    // unconditionally; the placeholder has to fail in the safe direction.
+    expect(build([makeTaskResult()]).metadata.averageConfidence).toBe(0);
+  });
+
+  it('keeps conflictCount consistent with the conflicts it reports', () => {
+    // Derived rather than restated, so the two cannot drift. This path still
+    // performs no conflict detection — see #4854.
+    const result = build([makeTaskResult(), makeTaskResult({ taskId: 'task-2' })]);
+
+    expect(result.metadata.conflictCount).toBe(result.conflicts.length);
   });
 });

--- a/packages/nexus-agents/src/agents/collaboration/session-helpers.ts
+++ b/packages/nexus-agents/src/agents/collaboration/session-helpers.ts
@@ -280,15 +280,26 @@ export interface AggregatedResultInput {
 export function buildAggregatedResult(input: AggregatedResultInput): AggregatedResult {
   const { pattern, results, participants, votes, reviews, endTime } = input;
 
+  // This path performs no conflict detection — see #4854. The
+  // count is derived from the list rather than restated so that wiring
+  // detection in cannot leave the two disagreeing.
+  const conflicts: ResultConflict[] = [];
+
   return {
     output: aggregateOutputs(results),
     strategy: getAggregationStrategy(pattern),
     qualityScore: calculateQualityScore(pattern, participants, votes, reviews),
-    conflicts: [] as ResultConflict[],
+    conflicts,
     metadata: {
       resultCount: results.length,
-      conflictCount: 0,
-      averageConfidence: 1.0,
+      conflictCount: conflicts.length,
+      // Nothing reaching this builder carries a confidence signal: neither
+      // TaskResult, ResultMetadata, VoteMessage nor ExpertParticipation has
+      // the field. This reported 1.0 — a perfect score — for a session whose
+      // confidence was never assessed (#4831). The placeholder now fails in
+      // the safe direction and says it is a placeholder.
+      averageConfidence: 0,
+      confidenceMeasured: false,
       // #4743: shared with result-aggregator so the two cannot drift — they
       // were duplicate expressions computing the same thing.
       ...summarizeTokenUsage(results.map((r) => r.metadata)),


### PR DESCRIPTION
Fixes #4831. Splits #4854 out.

## What the issue said, and what turned out to be true

The report was: two producers implement `AggregatedResult`, and `session-helpers.buildAggregatedResult` hardcodes `conflictCount: 0` and `averageConfidence: 1.0` where `ResultAggregator.buildResult` computes both. That framing suggests copying the sibling's expressions across.

Tracing the inputs says otherwise. **No input reaching the session builder carries a confidence signal at all** — `TaskResult`, `ResultMetadata`, `VoteMessage` and `ExpertParticipation` all lack the field. The aggregator computes from `ExpertResult.confidence`, which this path never has. There was nothing to copy.

So `1.0` was not a lazy restatement of an available value; it was a **placeholder presented as a perfect score**, which is the worse of the two.

## The fix follows a precedent already in this interface

`AggregationMetadata` already carries `unmeasuredResults` (#4743) for exactly this situation on token counts, and `ResultMetadata.tokensMeasured` (#4734) is the same pattern one level down: a required numeric field that may be a placeholder, disclosed by an adjacent optional boolean. Adding a third instance of an established shape beats inventing a fourth.

`confidenceMeasured?: boolean` — optional, so no existing producer or consumer breaks. The session builder reports `0` / `false`; the aggregator reports its computed value / `true`.

**The placeholder moves from 1.0 to 0 deliberately.** It fails in the safe direction: a consumer thresholding on confidence previously passed unconditionally on this path. No in-tree consumer reads the field — `api-surface.txt` lists it as public API, so external ones may.

## conflictCount is honestly a smaller thing than the issue implies

`conflictCount: 0` was *consistent* with the `conflicts: []` on the line above it — not a contradiction within the object. It is now derived from that list so the two cannot drift, but that is drift-prevention, not detection: **the list is still always empty, because this path performs no conflict detection.** Wiring the existing `mergeObjects` detection in, or routing both producers through `ResultAggregator`, is #4854 — filed now rather than left as a comment.

Calling that fixed here would be the same class of misreport the change is about.

## Ruled out while verifying

`ResultAggregator.buildResult` divides by `results.length`, which looked like a NaN on empty input. It is not reachable: `aggregate` rejects an empty result list at `:73` before `buildResult` is called. Dropped rather than "fixed".

## Testing

Three tests, red first; each of the three production hunks reverted individually fails exactly one. Full collaboration suite: **979 tests, 38 files, green.** `tsc` and eslint clean.