### PR TITLE
fix(orchestration): stop passing a spec with no acceptance criteria

### DIFF
--- a/.changeset/spec-executor-no-vacuous-pass.md
+++ b/.changeset/spec-executor-no-vacuous-pass.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+stop execute_spec passing a spec that has no acceptance criteria
+
+`executeSpec` short-circuited an empty acceptance-criteria list to a hardcoded
+`satisfaction: 1, metCount: 0, allMet: true` — a perfect score for a spec that
+was never checked against anything.
+
+The empty list is reachable in production: `parseSpec` returns `[]` when the
+`## Acceptance Criteria` heading is absent or misspelled, and records the gap in
+`missingSections` without erroring. Nothing upstream rejects it — the decomposer
+requires only non-empty requirements, and the tool schema only checks the spec
+is a string.
+
+`validateScenario` already refuses this input; the short-circuit bypassed the
+sibling that got it right. It now returns a `validate`-stage error naming the
+missing section, so the caller is told what to add rather than told it passed.
+
+This matters beyond the returned value: `execute_spec` persists `satisfaction`
+into tool memory as a learning and appends a `success: true` outcome record used
+for adaptive routing. A vacuous pass was poisoning both.
+
+Fixes #4826.

--- a/packages/nexus-agents/src/orchestration/spec-executor.test.ts
+++ b/packages/nexus-agents/src/orchestration/spec-executor.test.ts
@@ -100,3 +100,48 @@ describe('executeSpec errors', () => {
     expect(result.error.stage).toBe('decompose');
   });
 });
+
+// ============================================================================
+// A spec with no acceptance criteria cannot pass (#4826)
+// ============================================================================
+
+describe('executeSpec with no acceptance criteria (#4826)', () => {
+  const NO_CRITERIA_SPEC = `# Add Auth
+
+## Overview
+Implement OAuth2 login for the app.
+
+## Requirements
+- Add login endpoint
+- Add logout endpoint
+`;
+
+  it('does not report a spec with nothing to check as fully satisfied', async () => {
+    // `## Acceptance Criteria` absent or misspelled yields an empty list from
+    // the parser with no error, and the executor short-circuited it to
+    // satisfaction 1 / allMet true — a perfect score for a spec that was
+    // never checked against anything.
+    const result = await executeSpec(NO_CRITERIA_SPEC);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.stage).toBe('validate');
+    expect(result.error.message).toContain('acceptance criteria');
+  });
+
+  it('still validates a spec that does have acceptance criteria', async () => {
+    // The pair: refusing everything would satisfy the test above.
+    const result = await executeSpec(`# Add Auth
+
+## Requirements
+- Add login endpoint
+
+## Acceptance Criteria
+- [ ] User can log in
+`);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.validation.totalCriteria).toBe(1);
+  });
+});

--- a/packages/nexus-agents/src/orchestration/spec-executor.ts
+++ b/packages/nexus-agents/src/orchestration/spec-executor.ts
@@ -23,15 +23,6 @@ import type {
 } from './spec-executor-types.js';
 import type { ScenarioResult } from './scenario-validator-types.js';
 
-/** Validation result when no acceptance criteria are defined. */
-const NO_CRITERIA_VALIDATION: ScenarioResult = {
-  satisfaction: 1,
-  totalCriteria: 0,
-  metCount: 0,
-  criteria: [],
-  allMet: true,
-};
-
 /** Executes a markdown specification end-to-end. */
 export async function executeSpec(
   markdown: string,
@@ -53,9 +44,22 @@ export async function executeSpec(
   if (!execResult.ok) return err({ message: execResult.error.message, stage: 'execute' });
 
   const outputs = extractOutputs(execResult.value.finalState);
-  const validation =
-    spec.acceptanceCriteria.length === 0 ? NO_CRITERIA_VALIDATION : validateOrErr(spec, outputs);
 
+  // A spec with no acceptance criteria has nothing to be validated against.
+  // This used to short-circuit to satisfaction 1 / allMet true — a perfect
+  // score for a check that never ran, which `execute_spec` then persisted as
+  // a successful outcome and a learning (#4826). `validateScenario` already
+  // refuses this input; the short-circuit was bypassing it.
+  if (spec.acceptanceCriteria.length === 0) {
+    return err({
+      message:
+        'Spec has no acceptance criteria, so the execution cannot be validated. ' +
+        'Add an "## Acceptance Criteria" section.',
+      stage: 'validate',
+    });
+  }
+
+  const validation = validateOrErr(spec, outputs);
   if (validation === null) {
     return err({ message: 'Scenario validation failed', stage: 'validate' });
   }


### PR DESCRIPTION
Fixes #4826.

## The defect

`executeSpec` short-circuited an empty acceptance-criteria list to a hardcoded verdict:

```ts
const NO_CRITERIA_VALIDATION: ScenarioResult = {
  satisfaction: 1,
  totalCriteria: 0,
  metCount: 0,
  criteria: [],
  allMet: true,
};
```

A perfect score for a spec that was never checked against anything.

## The empty list is reachable, and that is the part worth checking

`parseSpec` returns `[]` when the `## Acceptance Criteria` heading is absent or misspelled — it records the gap in `missingSections` and does not error. Nothing upstream rejects it: `decomposeSpec` requires only non-empty *requirements*, the schema for the field is a bare `z.array(z.string())` with no `.min(1)`, and the `execute_spec` tool schema only checks the spec is a 1–50k string.

So an ordinary spec with a typo'd heading reaches this branch. Confirmed by running one end-to-end in the test below, which returns `ok: true` on `main`.

## The sibling already got this right

`validateScenario` rejects the same input outright:

```ts
if (spec.acceptanceCriteria.length === 0) {
  return err({ message: 'No acceptance criteria to validate against' });
}
```

The short-circuit was **bypassing the validator that already refused it**. Deleting the constant alone therefore fixes the false pass. The explicit branch that replaces it exists for a second reason: routing through `validateOrErr` collapses every failure to `'Scenario validation failed'`, and the caller deserves to be told which section to add.

## Why this is more than a returned value

`execute_spec` persists `satisfaction` into tool memory as a task and a learning, and appends a `success: true` outcome record consumed by adaptive routing. A vacuous pass was poisoning both — the artifacts outlive the call and nothing downstream can tell that zero criteria were checked. The MCP envelope does carry `totalCriteria: 0`, so a caller parsing the full response *could* have noticed; the memory and outcome records keep only the score.

## Testing

Two tests, red first, plus its pair so that "refuse everything" cannot satisfy it. Mutation-verified against the actual pre-change file rather than a partial revert — the original returns `expected true to be false`, i.e. a genuine pass.

Nothing pinned the old behaviour: no existing test exercised an empty-criteria spec, so no assertion had to be rewritten to make this green. 8 tests green; `tsc` and eslint clean.

## Precedent

Same shape and same wording style as #4585 (`calculateConstraintScore` scoring a perfect 1 on a zero-step workflow). Per the scan, `spec-executor.ts` was the last site with this shape in the spec pipeline — `scenario-runner.ts` and `rubric-scorer.ts` already use `allOf(..., false)`.