### PR TITLE
fix(verify): check the real config file, not a compiled constant

### DIFF
--- a/.changeset/verify-checks-the-real-config.md
+++ b/.changeset/verify-checks-the-real-config.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+make verify's Configuration check read the real config file
+
+`checkConfigLoading` read two properties off `defaultConfig`, a compiled-in
+imported constant. That cannot throw once the module has imported, so the
+failure branch added by #4181 was unreachable and both live branches returned a
+pass. A user with a malformed `nexus-agents.yaml` ran `verify` and saw
+Configuration succeed — no file was ever opened.
+
+#4181's own remediation text described the check it wanted ("if a local config
+override exists, check it for syntax errors"); the implementation hardened the
+verdict one layer away from the thing that can break.
+
+It now calls `loadConfig()` and reports three distinguishable outcomes: a parse
+or validation failure as a `warn` carrying the loader's message, a loaded file
+by path with its warning count, and — the common case — no config file as a
+pass that says defaults were used rather than implying a file was validated.
+
+Fixes #4844.

--- a/packages/nexus-agents/src/cli/verify-command.test.ts
+++ b/packages/nexus-agents/src/cli/verify-command.test.ts
@@ -5,6 +5,9 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { runVerify, printVerifyResult, verifyCommand } from './verify-command.js';
 import type { VerifyResult, VerifyCheck } from './verify-command.js';
 
@@ -272,30 +275,63 @@ describe('verify-command', () => {
       expect(failing.noHardFailures).toBe(false);
     });
 
-    it('reports Configuration as failed (warn) with a fix hint when config access throws (#4181)', async () => {
-      vi.resetModules();
-      vi.doMock('../config/index.js', async (importOriginal) => {
-        const actual = await importOriginal<typeof import('../config/index.js')>();
-        return {
-          ...actual,
-          get defaultConfig(): never {
-            throw new Error('simulated config loader failure');
-          },
-        };
-      });
+    it('reports Configuration as failed (warn) when the project config file is malformed (#4844)', async () => {
+      // #4181 added this failure branch, and #4181's test reached it by
+      // turning `defaultConfig` into a throwing getter — something a plain
+      // object export cannot do in production. The branch was guarding a
+      // step that could not break. This drives the failure the remediation
+      // text actually describes: a real config file that does not parse.
+      const dir = mkdtempSync(join(tmpdir(), 'nexus-verify-cfg-'));
+      writeFileSync(join(dir, 'nexus-agents.yaml'), 'models: [unclosed\n  bad: : :\n');
+      const original = process.cwd();
+      process.chdir(dir);
       try {
-        const mod = await import('./verify-command.js');
-        const result = await mod.runVerify();
+        const result = await runVerify();
         const configCheck = result.checks.find((c) => c.name === 'Configuration');
-        expect(configCheck).toBeDefined();
+
         expect(configCheck?.passed).toBe(false);
         // Diagnostic-only: degraded, not a hard gate.
         expect(configCheck?.severity).toBe('warn');
-        expect(configCheck?.message).toBe('Failed to load default configuration');
-        expect(configCheck?.fix).toContain('Reinstall nexus-agents');
+        expect(configCheck?.message).toContain('nexus-agents.yaml');
       } finally {
-        vi.doUnmock('../config/index.js');
-        vi.resetModules();
+        process.chdir(original);
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('reports Configuration as passed when a project config file parses (#4844)', async () => {
+      // The pair. Without it, "always fail" satisfies the test above.
+      const dir = mkdtempSync(join(tmpdir(), 'nexus-verify-cfg-ok-'));
+      writeFileSync(join(dir, 'nexus-agents.yaml'), 'version: "1.0"\n');
+      const original = process.cwd();
+      process.chdir(dir);
+      try {
+        const configCheck = (await runVerify()).checks.find((c) => c.name === 'Configuration');
+
+        expect(configCheck?.passed).toBe(true);
+        expect(configCheck?.message).toContain('nexus-agents.yaml');
+      } finally {
+        process.chdir(original);
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('reports Configuration as passed, and says so, when there is no config file (#4844)', async () => {
+      // The benign population: most installs have no config file at all and
+      // must not be told their configuration is broken. The message has to
+      // distinguish "defaults" from "your file is fine" — otherwise a pass
+      // implies a validation that never happened.
+      const dir = mkdtempSync(join(tmpdir(), 'nexus-verify-cfg-none-'));
+      const original = process.cwd();
+      process.chdir(dir);
+      try {
+        const configCheck = (await runVerify()).checks.find((c) => c.name === 'Configuration');
+
+        expect(configCheck?.passed).toBe(true);
+        expect(configCheck?.message).toContain('default');
+      } finally {
+        process.chdir(original);
+        rmSync(dir, { recursive: true, force: true });
       }
     });
 

--- a/packages/nexus-agents/src/cli/verify-command.ts
+++ b/packages/nexus-agents/src/cli/verify-command.ts
@@ -10,7 +10,7 @@
 
 import { VERSION } from '../version.js';
 import { getTimeProvider } from '../core/index.js';
-import { defaultConfig } from '../config/index.js';
+import { defaultConfig, loadConfig } from '../config/index.js';
 import { BUILT_IN_EXPERTS } from '../agents/experts/expert-config.js';
 import { colors, symbols } from './ansi-output.js';
 import { checkSqlite, checkDataDirectory, checkApiKeys } from './doctor.js';
@@ -134,37 +134,47 @@ function checkPackageExports(): VerifyCheck {
 }
 
 /**
- * Checks if default configuration is accessible.
+ * Checks that the project's configuration file loads and validates.
+ *
+ * #4844: this used to read two properties off the compiled-in `defaultConfig`
+ * constant. That cannot throw once the module has imported, so the failure
+ * branch #4181 added was unreachable and both live branches returned a pass —
+ * a user with a malformed `nexus-agents.yaml` saw Configuration succeed. It
+ * now loads the real file, which is what #4181's own remediation text
+ * described ("if a local config override exists, check it for syntax errors").
  */
 function checkConfigLoading(): VerifyCheck {
-  try {
-    const hasModels = typeof defaultConfig.models === 'object';
-    const hasSecurity = typeof defaultConfig.security === 'object';
+  const result = loadConfig();
 
-    if (hasModels && hasSecurity) {
-      return {
-        name: 'Configuration',
-        passed: true,
-        message: 'Default config accessible',
-      };
-    }
-
-    return {
-      name: 'Configuration',
-      passed: true, // Config errors are not fatal for verification
-      message: 'Using default configuration',
-    };
-  } catch {
-    // #4181: config breakage must SURFACE in the diagnostic instead of being
-    // reported as a pass. Warn severity — degraded, not a hard gate (exit 0).
+  if (!result.ok) {
+    // Degraded, not a hard gate: the CLI still runs on defaults (exit 0).
     return {
       name: 'Configuration',
       passed: false,
       severity: 'warn',
-      message: 'Failed to load default configuration',
-      fix: 'Reinstall nexus-agents (npm install -g nexus-agents); if a local config override exists, check it for syntax errors',
+      message: `Failed to load nexus-agents.yaml: ${result.error.message}`,
+      fix: 'Fix the syntax errors in nexus-agents.yaml, or remove it to fall back to defaults',
     };
   }
+
+  const { configPath, warnings } = result.value;
+
+  // No config file is the common case and is genuinely healthy — but the
+  // message must not imply a file was validated when none was read.
+  if (configPath === undefined) {
+    return {
+      name: 'Configuration',
+      passed: true,
+      message: 'No config file found — using defaults',
+    };
+  }
+
+  const suffix = warnings.length > 0 ? ` (${String(warnings.length)} warning(s))` : '';
+  return {
+    name: 'Configuration',
+    passed: true,
+    message: `Loaded ${configPath}${suffix}`,
+  };
 }
 
 /**


### PR DESCRIPTION
Fixes #4844.

## The defect

`checkConfigLoading` read two properties off `defaultConfig` — a compiled-in imported constant:

```ts
const hasModels = typeof defaultConfig.models === 'object';
const hasSecurity = typeof defaultConfig.security === 'object';
```

Property reads on an imported object cannot throw once the module has imported, so the `catch` was unreachable and **both live branches returned `passed: true`**. No file was opened; the command contained no `loadConfig`, no `readFile`, and no reference to `nexus-agents.yaml` in any of its five checks.

A user with a malformed `nexus-agents.yaml` ran `verify` and saw Configuration pass.

## #4181 named the right requirement and guarded the wrong step

The comment on the dead branch states the intent exactly — *"config breakage must SURFACE in the diagnostic instead of being reported as a pass"* — and the remediation text describes the check it wanted: *"if a local config override exists, check it for syntax errors."* Advice about a file this code never read.

Same shape as #4839: hardening applied one layer away from the thing that can actually break.

## The test was the tell, and it had to go

The #4181 test reached that catch by replacing `defaultConfig` with a **throwing getter**:

```ts
get defaultConfig(): never { throw new Error('simulated config loader failure'); }
```

A plain object export cannot do that in production. The test proved the handler worked while the branch remained unreachable — which is precisely how a check that cannot fail survives review with green tests. It is replaced rather than kept, because keeping it would keep asserting a scenario that cannot occur.

## Now

`loadConfig()` is called, and three outcomes are distinguishable:

- parse/validation failure → `warn` (degraded, exit 0) carrying the loader's own message and a fix that says to correct or remove the file
- a file that loads → passes, naming the path and its warning count
- no config file → passes, saying **defaults were used** rather than implying a file was validated

That last one is the benign majority and it is the one most easily got wrong: a bare pass on an install with no config file reads as "your configuration is fine", which is a claim about a file nobody read. It has its own test.

## Testing

Three tests against real temp directories with real YAML — a malformed file, a valid file, and no file — since the failure is a property of file contents that a mocked import cannot produce.

Both production hunks mutation-verified. Worth noting: my first attempt at the second mutation silently no-oped because a `sed` pattern did not match an em-dash, and reported a false "test does not fail". Redone with an exact-match assertion, it fails as expected — a mutation run that quietly changes nothing looks identical to a test that does not pin anything.

27 tests green; `tsc` and eslint clean.