### PR TITLE
fix(context): find beliefs for a multi-word task description

### DIFF
--- a/.changeset/belief-recall-keyword-fallback.md
+++ b/.changeset/belief-recall-keyword-fallback.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': patch
+---
+
+let belief recall find beliefs for a real task description
+
+`fetchBeliefs` called `recallBySubject(task)`, an exact lookup against the
+subject index. Subjects are written by producers like `skill:${name}` and
+`learning.context` — never the caller's prose — so for any ordinary multi-word
+task the lookup missed and the Beliefs section was silently dropped from the
+context prefix.
+
+It was intermittent rather than total: a task of three words or fewer matches
+`orchestrate`'s `slice(0, 3).join(' ')` subject exactly, and identifier-shaped
+tasks (`arXiv:2502.12110`) are their own subject. Those paths kept working,
+which is part of why it went unnoticed.
+
+`fetchBeliefs` now falls back to the keyword scan that `queryBeliefMemory`
+already uses against the same store (#1225), behind the exact lookup so the
+paths that worked are unchanged and the scan only runs when the result would
+otherwise be empty. An empty result is logged with the scan size, since it was
+previously indistinguishable from "no beliefs stored".
+
+The three existing belief tests all wrote and read the same literal string, so
+they stayed green throughout. Added a case that drives a realistic task against
+a `skill:`-shaped subject, plus its negative.
+
+Fixes #4845.

--- a/packages/nexus-agents/src/context/context-retriever.test.ts
+++ b/packages/nexus-agents/src/context/context-retriever.test.ts
@@ -940,3 +940,62 @@ describe('summarizeContextForPrompt — repo-map section + ledger (#4254)', () =
     expect(getTokenLedger().summarize().bySource['repo-map']).toBeUndefined();
   });
 });
+
+// ============================================================================
+// Belief recall must survive a realistic task string (#4845)
+// ============================================================================
+
+describe('belief recall for a real task description (#4845)', () => {
+  it('finds a belief whose subject is not the whole task string', async () => {
+    // Every existing belief test writes and reads the SAME literal, so they
+    // stayed green while an exact `subjectIndex.get(task)` lookup missed for
+    // any multi-word task. Real subjects come from producers like
+    // `skill:${name}` (cli-server-skills) and `learning.context`
+    // (tool-memory) — never the caller's prose.
+    const { getToolMemory, shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+    const tm = getToolMemory();
+    await tm.recordBelief('skill:oauth-login', 'is_reliable_for', 'authentication', 'high');
+
+    const ctx = await getContextForTask({
+      task: 'add an oauth login flow to the settings page',
+      category: 'security_review',
+    });
+
+    expect(ctx.beliefs.some((b) => b.subject === 'skill:oauth-login')).toBe(true);
+  });
+
+  it('does not return beliefs that share no words with the task', async () => {
+    // The pair. Returning everything would satisfy the test above and make
+    // the belief section noise.
+    const { getToolMemory, shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+    const tm = getToolMemory();
+    await tm.recordBelief('skill:database-migration', 'is_reliable_for', 'schema', 'high');
+
+    const ctx = await getContextForTask({
+      task: 'render the marketing homepage hero',
+      category: 'documentation',
+    });
+
+    // Asserting only that this ONE subject is absent proved too weak: with
+    // the filter disabled the list is truncated by `limit`, so the unrelated
+    // belief can fall off the end and the assertion passes for the wrong
+    // reason. The task shares no non-stopword token with anything stored, so
+    // the honest expectation is nothing at all.
+    expect(ctx.beliefs).toEqual([]);
+  });
+
+  it('still returns an exact-subject match', async () => {
+    // The path that already worked must keep working — short and
+    // identifier-shaped tasks do hit the exact index.
+    const { getToolMemory, shutdownToolMemory } = await import('../mcp/tools/tool-memory.js');
+    shutdownToolMemory();
+    const tm = getToolMemory();
+    await tm.recordBelief('arXiv:2502.12110', 'has_topic', 'agentic memory', 'high');
+
+    const ctx = await getContextForTask({ task: 'arXiv:2502.12110', category: 'research' });
+
+    expect(ctx.beliefs.some((b) => b.subject === 'arXiv:2502.12110')).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/context/context-retriever.ts
+++ b/packages/nexus-agents/src/context/context-retriever.ts
@@ -47,6 +47,7 @@ import {
 import { createTokenCounter } from './token-counter.js';
 import { getTokenLedger } from './token-ledger.js';
 import { getRepoMapForTask, REPO_MAP_FLAG } from './repo-map.js';
+import { tokenizeFiltered } from '../utils/text-utils.js';
 
 /**
  * What we know about a task, derived from every shared memory backend.
@@ -314,6 +315,24 @@ function fetchPriorStrategies(
   }
 }
 
+/** Upper bound on the belief scan behind the keyword fallback. */
+const BELIEF_KEYWORD_SCAN_LIMIT = 1000;
+
+/**
+ * Fetch beliefs relevant to a task.
+ *
+ * `recallBySubject` is an exact lookup against the subject index, and subjects
+ * are written by producers like `skill:${name}` and `learning.context` — never
+ * the caller's prose. So for any ordinary multi-word task the exact lookup
+ * missed and the Beliefs section was silently dropped from the prompt (#4845).
+ * Short or identifier-shaped tasks did match, which is why this was
+ * intermittent rather than total.
+ *
+ * The fallback is the one `queryBeliefMemory` already uses for the same store
+ * (#1225): when the exact lookup misses, scan and keyword-match the belief
+ * text. Kept behind the exact lookup so the path that already worked is
+ * unchanged and the scan only runs when it would otherwise return nothing.
+ */
 async function fetchBeliefs(
   task: string,
   limit: number,
@@ -322,8 +341,28 @@ async function fetchBeliefs(
   try {
     const tm = getToolMemory(logger);
     const beliefs = tm.getBeliefMemory();
-    const result = await beliefs.recallBySubject(task, limit);
-    return result.ok ? result.value : [];
+    const exact = await beliefs.recallBySubject(task, limit);
+    if (exact.ok && exact.value.length > 0) return exact.value;
+
+    const keywords = tokenizeFiltered(task);
+    if (keywords.length === 0) return [];
+
+    const all = await beliefs.query({ includeSuperseded: false, limit: BELIEF_KEYWORD_SCAN_LIMIT });
+    if (!all.ok) return [];
+
+    const matched = all.value.filter((b) => {
+      const text = `${b.subject} ${b.predicate} ${b.object}`.toLowerCase();
+      return keywords.some((k) => text.includes(k));
+    });
+    if (matched.length === 0) {
+      // An empty belief list is indistinguishable from "nothing stored", so
+      // say which one happened rather than leaving the caller to guess.
+      logger.debug('ContextRetriever: no beliefs matched', {
+        scanned: all.value.length,
+        keywords: keywords.length,
+      });
+    }
+    return matched.slice(0, limit);
   } catch (error: unknown) {
     logger.debug('ContextRetriever: belief fetch failed', { error: formatError(error) });
     return [];


### PR DESCRIPTION
Fixes #4845 — and corrects two claims in that issue, which I posted as a comment there before implementing.

## The defect

`fetchBeliefs` called `recallBySubject(task)`, an exact `Map.get` against the subject index. Subjects come from producers like `skill:${name}` (`cli-server-skills`) and `learning.context` (`tool-memory`) — **never the caller's prose**. So for an ordinary multi-word task the lookup missed, `ctx.beliefs` came back empty, and the `### Beliefs` section was dropped from the context prefix with nothing said about it.

## It is intermittent, not total — which is why the issue was overstated

My original write-up said "never matches". That is wrong, and the correction matters for anyone reading the issue:

- `orchestrate` writes `subject = taskDescription.split(/\s+/).slice(0, 3).join(' ')`. Any task of three words or fewer is byte-identical to that, so it hits.
- `memory_write` writes `subject = key`, caller-supplied.
- Identifier-shaped tasks (`arXiv:2502.12110`) are their own subject.

Those paths worked. An intermittent silent miss is arguably worse than a total one — it is why nobody noticed.

The issue also claimed `tool-memory-query.ts` had the same problem. **It does not** — it already carries the #1225 keyword fallback. It is the precedent, not a second site.

## The fix

The fallback `queryBeliefMemory` already uses against the same store: when the exact lookup misses, scan (`limit: 1000`, `includeSuperseded: false`) and keyword-match `subject + predicate + object` using the existing `tokenizeFiltered` so stopwords do not match everything.

Kept **behind** the exact lookup, so the paths that already worked are untouched and the scan only runs when the result would otherwise be empty.

An empty result is now logged with the scan size and keyword count. Previously `[]` meant either "nothing matched" or "nothing stored", and `context-retriever` renders `''` when every section is empty, so neither the caller nor the log could tell.

## The tests were the reason this survived

All three existing belief tests write and read **the same literal string**:

```ts
await tm.recordBelief('authentication token refresh', …);
await getContextForTask({ task: 'authentication token refresh', … });
```

They would stay green with the bug present, and never exercise a realistic key. Added a case driving a real task against a `skill:`-shaped subject, plus a negative, plus a regression case keeping the exact-match path.

**One of those new tests was itself too weak and the mutation run caught it.** The negative case originally asserted only that one specific subject was absent — and it passed with the keyword filter disabled, because `limit` truncation dropped the unrelated belief off the end anyway. It now asserts the list is empty, since the task shares no non-stopword token with anything stored. With that change, disabling the filter fails it.

That is the second time today a mutation run has caught an assertion passing for the wrong reason; both times the test looked fine on the page.

## Verification

Full `src/context` suite: **1203 tests, 44 files, green.** Both production hunks mutation-verified. `tsc` and eslint clean.