### PR TITLE
fix(collaboration): stop the protocol selector claiming a decision it cannot make

### DIFF
--- a/.changeset/adaptive-selector-honest-recommendation.md
+++ b/.changeset/adaptive-selector-honest-recommendation.md
@@ -1,0 +1,33 @@
+---
+'nexus-agents': minor
+---
+
+stop AdaptiveProtocolSelector reporting a decision it cannot make
+
+`selectProtocol` returned `wasOverridden ? explicitPattern : selectedPattern`.
+The false branch is reached only when the two are equal, so the returned
+pattern was always `config.pattern` — the classification was computed and
+discarded. `CollaborationPattern` has no `auto` member, so a caller has no way
+to defer to adaptation.
+
+`getRecommendation`, documented as a "preview of what protocol would be
+selected", returned that same value: the caller's own input, with reasoning
+attached that read as an answer.
+
+- `SelectionResult` gains `adaptivePattern` — what adaptation would choose.
+  `pattern` is unchanged and now documented as always being the caller's.
+- `getRecommendation` returns the adaptive choice, so a recommendation is a
+  recommendation.
+- The log line was `'Protocol selection'` carrying `wasOverridden`, which read
+  as a live choice that had been reversed. It is now
+  `'Protocol classification (advisory)'` with the pattern in use named
+  separately from the adaptive one.
+- `TechLeadCollaboration.executeCollaboration` — the real consumer — passed
+  `recommendedPattern` into `execute`. That was a no-op while the
+  recommendation echoed the config. It now explicitly passes `config.pattern`,
+  so behaviour is unchanged: making the recommendation real must not silently
+  activate adaptive selection in production, where nothing measures it.
+
+Whether that consumer should act on the recommendation is #4833.
+
+Fixes #4833 (the misreporting).

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -7869,6 +7869,7 @@ TypeAliasDeclaration|InterfaceDeclaration SelectionResult
   alternatives: ExpertMatch[]
   confidence: number
   primary: ExpertMatch
+  readonly adaptivePattern: CollaborationPattern
   readonly classification: ClassificationResult
   readonly pattern: CollaborationPattern
   readonly wasOverridden: boolean

--- a/packages/nexus-agents/src/agents/collaboration/adaptive-protocol-selector.test.ts
+++ b/packages/nexus-agents/src/agents/collaboration/adaptive-protocol-selector.test.ts
@@ -221,3 +221,49 @@ describe('AdaptiveProtocolSelector', () => {
     });
   });
 });
+
+// ============================================================================
+// The selector must not claim a decision it did not make (#4833)
+// ============================================================================
+
+describe('adaptive selection is advisory and says so (#4833)', () => {
+  // A reasoning task maps to 'parallel'. Passing 'sequential' makes the
+  // caller's pattern differ from what adaptation would choose — the case the
+  // existing tests never covered, because each of them passed the pattern the
+  // mapping already returns, so caller-echo and adaptive-choice were the same
+  // value and neither could be distinguished from the other.
+  const REASONING_TASK = 'Analyze why this fails and debug the problem to solve it';
+
+  it('exposes what adaptation would have chosen, separately from what is used', () => {
+    const selector = new AdaptiveProtocolSelector();
+    const config = createTestConfig(createTestTask(REASONING_TASK), 'sequential');
+
+    const result = selector.selectProtocol(config);
+
+    expect(result.adaptivePattern).toBe('parallel');
+    // Unchanged and now documented: the caller's pattern is always used.
+    expect(result.pattern).toBe('sequential');
+  });
+
+  it('recommends the adaptive choice, not the pattern it was handed', () => {
+    // getRecommendation is documented as a "preview of what protocol would be
+    // selected". It returned `selection.pattern`, which is the caller's own
+    // input — so it previewed the question, not the answer, while attaching
+    // reasoning that read as a recommendation.
+    const selector = new AdaptiveProtocolSelector();
+    const config = createTestConfig(createTestTask(REASONING_TASK), 'sequential');
+
+    const recommendation = selector.getRecommendation(config);
+
+    expect(recommendation.recommendedPattern).toBe('parallel');
+  });
+
+  it('does not report an override when the caller matches the adaptive choice', () => {
+    // The pair for wasOverridden: it is a comparison, not evidence that a
+    // selection was applied and then overridden.
+    const selector = new AdaptiveProtocolSelector();
+    const config = createTestConfig(createTestTask(REASONING_TASK), 'parallel');
+
+    expect(selector.selectProtocol(config).wasOverridden).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/agents/collaboration/adaptive-protocol-selector.ts
+++ b/packages/nexus-agents/src/agents/collaboration/adaptive-protocol-selector.ts
@@ -70,16 +70,45 @@ const logger = createLogger({ component: 'adaptive-protocol-selector' });
  * Selection result with metadata.
  */
 export interface SelectionResult {
-  /** Selected protocol pattern */
+  /**
+   * The pattern that will be used.
+   *
+   * This is always `config.pattern`. `CollaborationPattern` has no `auto`
+   * member, so a caller cannot ask for adaptive selection and adaptation can
+   * never win — see {@link adaptivePattern} for what it would have chosen
+   * (#4833).
+   */
   readonly pattern: CollaborationPattern;
-  /** Classification that led to selection */
+  /**
+   * The pattern adaptation would choose from the task classification (#4833).
+   *
+   * Advisory. Previously computed and discarded, which left the caller unable
+   * to see the one thing this class exists to produce.
+   */
+  readonly adaptivePattern: CollaborationPattern;
+  /** Classification that led to {@link adaptivePattern}. */
   readonly classification: ClassificationResult;
-  /** Whether an explicit override was applied */
+  /**
+   * Whether the caller's pattern differs from {@link adaptivePattern}.
+   *
+   * A comparison, NOT evidence that a selection was applied and then
+   * overridden — nothing is applied. It was logged as though a live decision
+   * had been made and reversed (#4833).
+   */
   readonly wasOverridden: boolean;
 }
 
 /**
- * Adaptive protocol selector that chooses protocols based on task type.
+ * Adaptive protocol selector that classifies tasks and recommends protocols.
+ *
+ * Advisory: `selectProtocol` cannot change the protocol in use, because
+ * `CollaborationPattern` has no `auto` member and so a caller has no way to
+ * defer to adaptation. `getRecommendation` reports what adaptation would
+ * choose; acting on it is the caller's decision.
+ *
+ * Whether to add that sentinel so adaptation can win is #4833. Its named
+ * consumer is `TechLeadCollaboration.executeCollaboration`, which currently
+ * declines the recommendation on purpose.
  */
 export class AdaptiveProtocolSelector {
   private readonly factory: ProtocolFactory;
@@ -100,14 +129,16 @@ export class AdaptiveProtocolSelector {
   }
 
   /**
-   * Select the optimal protocol for a task.
+   * Classify a task and report which protocol adaptation would choose.
    *
-   * @param config - Collaboration config (pattern may be overridden)
-   * @returns Selection result with chosen pattern and reasoning
+   * The returned `pattern` is always `config.pattern`: `CollaborationPattern`
+   * has no `auto` member, so there is no way for a caller to defer to
+   * adaptation. `adaptivePattern` carries the advisory choice (#4833).
+   *
+   * @param config - Collaboration config; its `pattern` is always honoured
+   * @returns The pattern in use, the advisory choice, and the classification
    */
   selectProtocol(config: CollaborationConfig): SelectionResult {
-    // If pattern is explicitly set to something other than 'auto', respect it
-    // Note: 'auto' is not currently in CollaborationPattern, so this is for future extension
     const explicitPattern = config.pattern;
 
     // Classify the task using SharedTaskAnalyzer (canonical path per ADR-0004)
@@ -122,22 +153,27 @@ export class AdaptiveProtocolSelector {
     const selectedPattern =
       mapping[classification.type] ?? DEFAULT_PROTOCOL_MAPPING[classification.type];
 
-    // If explicit pattern matches what we'd select, it's not really an override
     const wasOverridden = explicitPattern !== selectedPattern;
 
     if (this.config.logDecisions) {
-      this.log.info('Protocol selection', {
+      // Named as advisory: this logged 'Protocol selection' with
+      // `wasOverridden`, which read as a live choice that had been reversed.
+      // No choice is made here — `explicitPattern` is always what runs.
+      this.log.info('Protocol classification (advisory)', {
         taskType: classification.type,
         confidence: classification.confidence,
-        selectedPattern,
-        explicitPattern,
-        wasOverridden,
+        adaptivePattern: selectedPattern,
+        patternInUse: explicitPattern,
+        differsFromAdaptive: wasOverridden,
       });
     }
 
-    // Use explicit pattern if provided, otherwise use adaptive selection
     return {
-      pattern: wasOverridden ? explicitPattern : selectedPattern,
+      // Always the caller's pattern — the ternary this replaced returned
+      // `explicitPattern` in both branches, since the false branch is reached
+      // only when the two are equal (#4833).
+      pattern: explicitPattern,
+      adaptivePattern: selectedPattern,
       classification,
       wasOverridden,
     };
@@ -176,9 +212,11 @@ export class AdaptiveProtocolSelector {
   }
 
   /**
-   * Get recommended protocol for a task without executing.
+   * Get the recommended protocol for a task without executing.
    *
-   * Useful for preview/explanation of what protocol would be selected.
+   * Returns the *adaptive* choice. It previously returned `selection.pattern`
+   * — the caller's own input — so the "recommendation" echoed the question
+   * back with reasoning attached that read as an answer (#4833).
    */
   getRecommendation(config: CollaborationConfig): {
     recommendedPattern: CollaborationPattern;
@@ -199,7 +237,7 @@ export class AdaptiveProtocolSelector {
           }`;
 
     return {
-      recommendedPattern: selection.pattern,
+      recommendedPattern: selection.adaptivePattern,
       taskType: type,
       confidence,
       reasoning,

--- a/packages/nexus-agents/src/agents/tech-lead-collaboration.test.ts
+++ b/packages/nexus-agents/src/agents/tech-lead-collaboration.test.ts
@@ -28,14 +28,20 @@ vi.mock('../core/index.js', async (importOriginal) => {
   };
 });
 
+// Hoisted so the execute call can be inspected (#4833). The recommendation
+// is deliberately 'parallel', which DIFFERS from the 'consensus' pattern
+// buildCollabConfig sets — with both the same, a test cannot tell whether the
+// executed pattern came from the config or from the recommendation.
+const { executeSelectorMock } = vi.hoisted(() => ({ executeSelectorMock: vi.fn() }));
+
 vi.mock('./collaboration/adaptive-protocol-selector.js', () => ({
   createAdaptiveProtocolSelector: () => ({
     getRecommendation: vi.fn(() => ({
-      recommendedPattern: 'consensus',
+      recommendedPattern: 'parallel',
       taskType: 'synthesis',
       confidence: 0.9,
     })),
-    execute: vi.fn(() =>
+    execute: executeSelectorMock.mockImplementation(() =>
       Promise.resolve({
         ok: true,
         value: {
@@ -199,6 +205,28 @@ describe('collaborativeSynthesis', () => {
       expect(result.value.resultSummaries).toHaveLength(3);
       expect(result.value.qualityScore).toBeGreaterThan(0);
     }
+  });
+
+  it('executes the configured pattern, not the recommended one (#4833)', async () => {
+    // Before #4833, `getRecommendation` returned this call's own
+    // `config.pattern`, so forwarding it into `execute` was a no-op and
+    // adaptive selection never affected what ran. Now that the recommendation
+    // is a real adaptive choice, forwarding it would silently activate that
+    // selection in production, with nothing measuring whether it helps. The
+    // mock recommends 'parallel'; buildCollabConfig sets 'consensus'.
+    const helper = new OrchestratorCollaborationHelper();
+    const results = [
+      makeTaskResult('e1', 'out1'),
+      makeTaskResult('e2', 'out2'),
+      makeTaskResult('e3', 'out3'),
+    ];
+
+    await helper.collaborativeSynthesis(results, makeAgentsMap(), makeTask());
+
+    expect(executeSelectorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ pattern: 'consensus' }),
+      expect.anything()
+    );
   });
 
   it('includes collaboration metadata', async () => {

--- a/packages/nexus-agents/src/agents/tech-lead-collaboration.ts
+++ b/packages/nexus-agents/src/agents/tech-lead-collaboration.ts
@@ -154,13 +154,21 @@ export class OrchestratorCollaborationHelper {
   ): Promise<Result<SynthesizedResult, AgentError>> {
     const recommendation = this.protocolSelector.getRecommendation(config);
     this.logger.info('Protocol recommendation', {
-      pattern: recommendation.recommendedPattern,
+      recommendedPattern: recommendation.recommendedPattern,
+      patternInUse: config.pattern,
       taskType: recommendation.taskType,
       confidence: recommendation.confidence,
     });
 
+    // Deliberately NOT `recommendation.recommendedPattern`. Until #4833,
+    // `getRecommendation` returned this call's own `config.pattern`, so
+    // passing it through was a no-op and adaptive selection never affected
+    // what ran. Now that the recommendation is the real adaptive choice,
+    // forwarding it would silently activate that selection in production —
+    // a behaviour change with nothing measuring whether it improves outcomes.
+    // Acting on the recommendation is the decision tracked in #4833.
     const collaborationResult = await this.protocolSelector.execute(
-      { ...config, pattern: recommendation.recommendedPattern },
+      { ...config, pattern: config.pattern },
       agents
     );
 


### PR DESCRIPTION
Fixes the misreporting half of #4833. Decided by `consensus_vote` (live 7-voter panel, `higher_order`): **Option C**, 6/6 approvers selecting it, threshold met. Full result and the dissent are on the issue.

## The tautology

```ts
const wasOverridden = explicitPattern !== selectedPattern;
return { pattern: wasOverridden ? explicitPattern : selectedPattern, … };
```

The false branch is reached only when the two are equal, so **the returned pattern is always `config.pattern`**. The class classifies the task and discards the result. `CollaborationPattern` has no `auto` member, so a caller has no way to defer to adaptation — the code's own comment anticipated that sentinel and it was never added.

`getRecommendation`, documented as a "preview of what protocol would be selected", returned the same value: the caller's own input, with reasoning like *"Voting/parallel protocols work better for reasoning tasks (+13.2%)"* attached to it.

## I gave the panel a premise that was wrong, and it changed the fix

I told the voters `selectProtocol` has **no production caller in-tree**. True of `selectProtocol` directly — and misleading, because `TechLeadCollaboration.executeCollaboration` calls `getRecommendation`, which calls it, and then does:

```ts
await this.protocolSelector.execute({ ...config, pattern: recommendation.recommendedPattern }, agents);
```

So there is a real consumer, and it **feeds the recommendation straight back into execution**. Harmless while the recommendation echoed the config — and it means that simply fixing `getRecommendation` would have silently switched production to adaptively-chosen protocols. That is Option A, which the panel explicitly rejected on the grounds that nothing measures whether adaptive selection improves outcomes.

So `executeCollaboration` now passes `config.pattern` explicitly, with a comment saying why. Behaviour is unchanged; the choice is visible instead of accidental. The panel's reasoning survives the corrected premise — it is *stronger* with a consumer present, since activating an unmeasured selection loop in production is exactly what it warned against.

Two consequences of the correction: the class is **not** marked `@deprecated` (it has a consumer), and #4833 now has the named consumer whose appearance the panel said should resolve add-a-sentinel vs remove-it.

## Changes

- `SelectionResult.adaptivePattern` — what adaptation would choose, previously computed and thrown away. `pattern` is unchanged and now documented as always the caller's.
- `getRecommendation` returns the adaptive choice.
- The log line `'Protocol selection'` with `wasOverridden` read as a live choice that had been reversed; it is now `'Protocol classification (advisory)'`, naming the pattern in use separately from the adaptive one. `wasOverridden` is kept (public API) and documented as a comparison, not evidence of an applied override.

## The tests pinned the bug, as the panel predicted

Both `getRecommendation` tests passed a config pattern that **already equalled the mapping's answer** — `'parallel'` for a reasoning task, `'consensus'` for a knowledge task — so caller-echo and adaptive-choice were the same value and neither could be distinguished. The same trap sat in the `tech-lead-collaboration` mock, which recommended `'consensus'` while `buildCollabConfig` sets `'consensus'`.

New tests use a config pattern that differs from the adaptive choice. The mock now recommends `'parallel'` against a `'consensus'` config, and its `execute` is hoisted so the call can be inspected.

## Verification

Full `src/agents` suite: **4133 tests, 161 files, green.** Every production hunk mutation-verified, including forwarding the recommendation again, which fails the new production-hold test. `api-surface.txt` regenerated for the additive field; minor, since `getRecommendation`'s return value changes for external callers.