### PR TITLE
fix(orchestration): disclose that orchestrate's token count is unmeasured

### DIFF
--- a/.changeset/orchestrate-discloses-unmeasured-tokens.md
+++ b/.changeset/orchestrate-discloses-unmeasured-tokens.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': minor
+---
+
+stop orchestrate reporting tokensUsed: 0 as if it were a count
+
+`createStep` and `createResult` in `orchestrator-adapters.ts` both hardcode
+`0`, and `orchestrate` publishes the total straight through — so the live MCP
+tool reported `tokensUsed: 0` on every run, with nothing saying whether tokens
+were measured.
+
+Threading a real count is not available here: `OrchestratorAgentLike.execute`
+returns `Result<unknown, unknown>`, so no usage metadata reaches this seam at
+all. The honest fix is disclosure.
+
+`OrchestratorStep` and `OrchestratorResult` gain an optional
+`tokensMeasured`, following `ResultMetadata.tokensMeasured` (#4734) and
+`AggregationMetadata.confidenceMeasured` (#4831). Both are set `false` here,
+the result derives its flag from its steps, and the `orchestrate` output schema
+carries it so a client can tell "spent nothing" from "nobody counted".
+
+Fixes #4829.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -5766,7 +5766,7 @@ FunctionDeclaration orchestrateInputToTaskContract
 TypeAliasDeclaration OrchestrateOutput
   = z.infer<typeof OrchestrateOutputSchema>
 VariableDeclaration OrchestrateOutputSchema
-  : z.ZodObject<{ analysis: z.ZodObject<{ approach: z.ZodString; complexity: z.ZodNumber; estimatedEffort: z.ZodNumber; needsDecomposition: z.ZodBoolean; requirements: z.ZodArray<z.ZodString>; risks: z.ZodArray<z.ZodString>; taskId: z.ZodString; taskType: z.ZodString; }, z.core.$strip>; metadata: z.ZodObject<{ durationMs: z.ZodNumber; expertsUsed: z.ZodArray<z.ZodString>; timeoutReason: z.ZodOptional<z.ZodString>; tokensUsed: z.ZodNumber; }, z.core.$strip>; result: z.ZodUnknown; routing: z.ZodOptional<z.ZodObject<{ confidence: z.ZodNumber; orchestratorType: z.ZodString; pattern: z.ZodString; reasoning: z.ZodString; }, z.core.$strip>>; stepsCompleted: z.ZodNumber; taskId: z.ZodString; workerDispatchStatus: z.ZodOptional<z.ZodEnum<{ failed: "failed"; partial: "partial"; success: "success"; }>>; }, z.core.$strip>
+  : z.ZodObject<{ analysis: z.ZodObject<{ approach: z.ZodString; complexity: z.ZodNumber; estimatedEffort: z.ZodNumber; needsDecomposition: z.ZodBoolean; requirements: z.ZodArray<z.ZodString>; risks: z.ZodArray<z.ZodString>; taskId: z.ZodString; taskType: z.ZodString; }, z.core.$strip>; metadata: z.ZodObject<{ durationMs: z.ZodNumber; expertsUsed: z.ZodArray<z.ZodString>; timeoutReason: z.ZodOptional<z.ZodString>; tokensMeasured: z.ZodOptional<z.ZodBoolean>; tokensUsed: z.ZodNumber; }, z.core.$strip>; result: z.ZodUnknown; routing: z.ZodOptional<z.ZodObject<{ confidence: z.ZodNumber; orchestratorType: z.ZodString; pattern: z.ZodString; reasoning: z.ZodString; }, z.core.$strip>>; stepsCompleted: z.ZodNumber; taskId: z.ZodString; workerDispatchStatus: z.ZodOptional<z.ZodEnum<{ failed: "failed"; partial: "partial"; success: "success"; }>>; }, z.core.$strip>
 ClassDeclaration OrchestrationError
 TypeAliasDeclaration OrchestrationObserverEvent
   = | { agentId: string; previousState: AgentState; state: AgentState; type: 'agent_state_changed'; } | { decision: RoutingDecision; type: 'routing_decision'; } | { pattern: string; sessionId: string; type: 'session_started'; } | { durationMs: number; sessionId: string; success: boolean; type: 'session_completed'; } | { metrics: OrchestrationStats; type: 'metrics_updated'; } | { error: string; source: string; type: 'error'; }
@@ -5846,6 +5846,7 @@ InterfaceDeclaration OrchestratorResult
   orchestratorType: OrchestratorType
   output: unknown
   steps: OrchestratorStep[]
+  tokensMeasured?: boolean | undefined
   totalDurationMs: number
   totalTokensUsed: number
 InterfaceDeclaration OrchestratorStep
@@ -5857,6 +5858,7 @@ InterfaceDeclaration OrchestratorStep
   output: unknown
   role: AgentRole
   status: "success" | "failed" | "skipped"
+  tokensMeasured?: boolean | undefined
   tokensUsed: number
 TypeAliasDeclaration OrchestratorType
   = 'orchestrator' | 'puppeteer' | 'workflow' | 'custom'

--- a/packages/nexus-agents/src/core/types/orchestrator.ts
+++ b/packages/nexus-agents/src/core/types/orchestrator.ts
@@ -64,8 +64,17 @@ export interface OrchestratorStep {
   output: unknown;
   /** Duration in ms */
   durationMs: number;
-  /** Tokens used in this step */
+  /** Tokens used in this step. Meaningful only when {@link OrchestratorStep.tokensMeasured} is not `false`. */
   tokensUsed: number;
+  /**
+   * Whether `tokensUsed` is a measurement (#4829).
+   *
+   * `false` means no usage was reported for this step, so `tokensUsed` is a
+   * placeholder `0` and NOT a count. Absent means the producer predates the
+   * distinction — unknown, not measured. Mirrors `ResultMetadata.tokensMeasured`
+   * (#4734).
+   */
+  tokensMeasured?: boolean;
   /** Status */
   status: 'success' | 'failed' | 'skipped';
   /** Error if failed */
@@ -86,8 +95,16 @@ export interface OrchestratorResult {
   output: unknown;
   /** Total execution time in ms */
   totalDurationMs: number;
-  /** Total tokens consumed */
+  /** Total tokens consumed. Meaningful only when {@link OrchestratorResult.tokensMeasured} is not `false`. */
   totalTokensUsed: number;
+  /**
+   * Whether `totalTokensUsed` is a measurement (#4829).
+   *
+   * `false` means no step reported usage, so the total is a placeholder `0`
+   * and NOT a count — for anything cap-shaped, reading it as a count
+   * under-counts in the dangerous direction.
+   */
+  tokensMeasured?: boolean;
   /** Agents involved */
   agentsUsed: string[];
 }

--- a/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate-types.ts
@@ -99,6 +99,14 @@ export const OrchestrateOutputSchema = z.object({
   metadata: z.object({
     durationMs: z.number(),
     tokensUsed: z.number(),
+    /**
+     * Whether `tokensUsed` is a measurement (#4829).
+     *
+     * `false` means no usage was reported, so `tokensUsed` is a placeholder
+     * `0` and not a count. Without it a caller cannot tell a run that spent
+     * nothing from a run nobody counted.
+     */
+    tokensMeasured: z.boolean().optional(),
     expertsUsed: z.array(z.string()),
     /**
      * Populated only when the outer wall-clock deadline fires before

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.test.ts
@@ -311,6 +311,36 @@ describe('OrchestrateOutputSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts tokensMeasured so an uncounted run is distinguishable (#4829)', () => {
+    // The orchestrator adapters hardcode 0 because no usage metadata reaches
+    // that seam. Without this field a client cannot tell "spent nothing" from
+    // "nobody counted", and 0 under-counts in the dangerous direction for
+    // anything cap-shaped.
+    const output = {
+      taskId: 'orch-abc123',
+      analysis: {
+        taskId: 'orch-abc123',
+        complexity: 5,
+        taskType: 'implementation',
+        requirements: [],
+        risks: [],
+        needsDecomposition: false,
+        approach: 'Direct',
+        estimatedEffort: 1,
+      },
+      result: null,
+      stepsCompleted: 1,
+      metadata: { durationMs: 100, tokensUsed: 0, tokensMeasured: false, expertsUsed: [] },
+    };
+
+    const parsed = OrchestrateOutputSchema.safeParse(output);
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.metadata.tokensMeasured).toBe(false);
+    }
+  });
+
   it('should reject invalid complexity range', () => {
     const output = {
       taskId: 'orch-abc123',

--- a/packages/nexus-agents/src/mcp/tools/orchestrate.ts
+++ b/packages/nexus-agents/src/mcp/tools/orchestrate.ts
@@ -265,6 +265,9 @@ function buildOutputFromOrchestratorResult(
     metadata: {
       durationMs,
       tokensUsed: orchResult.totalTokensUsed,
+      ...(orchResult.tokensMeasured === undefined
+        ? {}
+        : { tokensMeasured: orchResult.tokensMeasured }),
       expertsUsed: orchResult.agentsUsed,
     },
   };

--- a/packages/nexus-agents/src/orchestration/orchestrator-adapters.test.ts
+++ b/packages/nexus-agents/src/orchestration/orchestrator-adapters.test.ts
@@ -358,3 +358,43 @@ describe('WorkflowAdapter', () => {
     expect(adapter.getHistory()).toHaveLength(2);
   });
 });
+
+// ============================================================================
+// Token counts are placeholders and say so (#4829)
+// ============================================================================
+
+describe('unmeasured token counts are disclosed (#4829)', () => {
+  // `OrchestratorAgentLike.execute` returns `Result<unknown, unknown>` — no
+  // usage metadata reaches this seam at all, so both `createStep` and
+  // `createResult` hardcode 0. A consumer could not tell "used no tokens"
+  // from "nobody counted", and the live `orchestrate` MCP tool published the
+  // zero straight through.
+  it('marks the result and its steps as unmeasured rather than zero-cost', async () => {
+    const adapter = new OrchestratorAdapter(makeMockLogger());
+
+    const result = await adapter.execute(makeTaskDef(), {});
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.tokensMeasured).toBe(false);
+    expect(result.value.steps.every((s) => s.tokensMeasured === false)).toBe(true);
+  });
+
+  it('applies to every adapter in this file, not just the first', async () => {
+    // createStep/createResult are shared by all three, so a fix reaching only
+    // one would be worse than none — the flag would then imply the others HAD
+    // measured. Each adapter needs the definition kind it accepts; passing a
+    // task definition to all three made an earlier version of this test pass
+    // vacuously, because the two that rejected it never reached the assertion.
+    const cases: ReadonlyArray<[string, Promise<unknown>]> = [
+      ['puppeteer', new PuppeteerAdapter().execute(makePolicyDef(), {})],
+      ['workflow', new WorkflowAdapter().execute(makeWorkflowDef(), {})],
+    ];
+
+    for (const [name, pending] of cases) {
+      const result = (await pending) as { ok: boolean; value?: { tokensMeasured?: boolean } };
+      expect(result.ok, `${name} should execute`).toBe(true);
+      expect(result.value?.tokensMeasured, name).toBe(false);
+    }
+  });
+});

--- a/packages/nexus-agents/src/orchestration/orchestrator-adapters.ts
+++ b/packages/nexus-agents/src/orchestration/orchestrator-adapters.ts
@@ -55,7 +55,11 @@ function createStep(
     action,
     output,
     durationMs,
+    // `OrchestratorAgentLike.execute` returns `Result<unknown, unknown>` — no
+    // usage metadata reaches this seam, so there is nothing to count. Say so
+    // rather than reporting a zero that reads as a measurement (#4829).
     tokensUsed: 0,
+    tokensMeasured: false,
     status: 'success',
     error: undefined,
   };
@@ -74,7 +78,9 @@ function createResult(
     steps,
     output,
     totalDurationMs: durationMs,
+    // Every step is unmeasured (see createStep), so the total is too (#4829).
     totalTokensUsed: 0,
+    tokensMeasured: steps.every((s) => s.tokensMeasured !== false),
     agentsUsed: steps.map((s) => s.agentId),
   };
 }


### PR DESCRIPTION
Fixes #4829.

## The defect

`orchestrator-adapters.ts` hardcodes zero in **two** places, not the one the issue named:

```ts
function createStep(…)   { return { …, tokensUsed: 0, … }; }        // :58
function createResult(…) { return { …, totalTokensUsed: 0, … }; }   // :77
```

`orchestrate.ts:267` publishes the total straight through, so the live MCP tool reported `tokensUsed: 0` on **every** run with nothing indicating whether tokens were counted. A consumer could not tell "used no tokens" from "nobody counted", and zero under-counts in the dangerous direction for anything cap-shaped.

## Threading a real count is not possible at this seam

The issue offered two shapes and said to pick whichever #4743 settles on. Tracing the inputs rules out the first: `OrchestratorAgentLike.execute` returns `Result<unknown, unknown>`. **No usage metadata reaches this file at all** — which is also why summing the steps would not help; they are hardcoded too. Option 1 would require widening the agent interface, which is a different and larger change.

## Disclosure, following the pattern this repo already has three of

`OrchestratorStep` and `OrchestratorResult` gain an optional `tokensMeasured`, matching `ResultMetadata.tokensMeasured` (#4734), `AggregationMetadata.unmeasuredResults` (#4743) and `confidenceMeasured` (#4831, landed today). Optional, so nothing existing breaks; the result derives its flag from its steps rather than restating it; the `orchestrate` output schema carries it to the client.

This does **not** wait on #4743. That issue's blocker is widening `TrinityPhaseResult.tokensUsed`, a breaking public-API change needing a unanimous vote and a major. The additive-companion approach sidesteps that entirely and is the convention #4743's own analysis recommends for the "sums" shape.

## Coverage, stated honestly

Three production hunks, each mutation-verified against a specific test.

**The publisher's pass-through in `orchestrate.ts` is not directly unit-pinned.** `buildOutputFromOrchestratorResult` is private, and exporting it for the test would trip the producer/consumer ratchet — a test-only export with no production consumer. What is pinned instead: the source flag (adapter tests) and the schema accepting and preserving the field (`OrchestrateOutputSchema` test). The three lines between them are a conditional spread. Saying so rather than implying full coverage.

## One test I had to fix before it counted

The "applies to every adapter" case originally passed a task definition to all three adapters and asserted inside `if (result.ok)`. Two of them reject a task definition, so the assertion never ran for them and the test passed **vacuously**. It now gives each adapter the definition kind it accepts and asserts `ok` first.

73 tests green across the two suites; `tsc`, eslint clean; `api-surface.txt` regenerated (additive optional fields → minor).