### PR TITLE
test(routing): prove stage signals do not reach cross-stage consumers

### DIFF
--- a/.changeset/routing-signal-gap-proof.md
+++ b/.changeset/routing-signal-gap-proof.md
@@ -1,0 +1,5 @@
+---
+---
+
+Test-only: adds executable proof that the composite router's stage signals do
+not cross stage boundaries (#4866). No shippable source changes.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
@@ -5,12 +5,17 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { CapacityFilterStage, CAPACITY_EXHAUSTED } from './routing/stages/index.js';
+import {
+  CapacityFilterStage,
+  CAPACITY_EXHAUSTED,
+  ResourceStrategyStage,
+} from './routing/stages/index.js';
 import type { CapacityStatus, ICliAdapter, RoutingArmId } from './types.js';
 
 import { ok } from '../core/index.js';
 import type { CliName, CliTask } from './types.js';
 import { CompositeRoutingError } from './composite-router-types.js';
+import { createRoutingContext } from './routing/router-stage.js';
 import { CATEGORY_CHAIN_OVERRIDES } from './fallback-chains.js';
 
 import {
@@ -1178,5 +1183,58 @@ describe('runCapacityStage', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value).toEqual(['claude']);
+  });
+});
+
+// ============================================================================
+// The signal channel does not cross stage boundaries (#4866)
+// ============================================================================
+
+describe('cross-stage routing signals (#4866)', () => {
+  const candidates: CliName[] = ['claude', 'gemini', 'codex'];
+
+  // Every other test in this file hands `runResourceStrategyStage` a MOCKED
+  // stage whose result already contains `resource-strategy:tier=…`. That
+  // pre-seeds the answer, so none of them can see that a real stage is given
+  // an empty context and skips. These drive the real stage instead.
+
+  it.fails('KNOWN BROKEN (#4866): a real ResourceStrategyStage receives budget data', async () => {
+    // `createRoutingContext` (router-stage.ts:253-261) hard-sets
+    // `signals: []` and the runner passes no metadata, so
+    // `extractResourceLevel` finds neither the `budget:utilization=` signal
+    // nor a `resourceLevel` in metadata. The stage skips with trace reason
+    // "no budget data" on every production call, and no resource tier is
+    // ever selected.
+    //
+    // `it.fails` rather than a pinned assertion of the broken behaviour:
+    // this is executable proof of the defect that turns RED the moment the
+    // plumbing lands, at which point it becomes a plain `it`.
+    const deps = makeDeps({
+      config: { ...makeDeps().config, enableResourceStrategy: true },
+      resourceStrategyStage: new ResourceStrategyStage(),
+    });
+
+    const result = await runResourceStrategyStage(mockTask, candidates, [], deps);
+
+    expect(result.resourceLevel).toBeDefined();
+  });
+
+  it('a real ResourceStrategyStage does reach a tier when given the data directly', async () => {
+    // The control: the stage itself works. It reads `resourceLevel` from
+    // context metadata (resource-strategy-stage.ts:238-244) — a channel
+    // `createRoutingContext` accepts as its third argument and the runner
+    // never supplies. So the defect is the plumbing, not the stage, and
+    // deleting the stage would be the wrong reading of #4866.
+    const stage = new ResourceStrategyStage();
+
+    const routed = await stage.route(
+      createRoutingContext(mockTask.content, candidates, { resourceLevel: 0.9 })
+    );
+
+    expect(routed.ok).toBe(true);
+    if (!routed.ok) return;
+    expect(routed.value.context.signals.some((s) => s.startsWith('resource-strategy:tier='))).toBe(
+      true
+    );
   });
 });


### PR DESCRIPTION
Step 1 of #4866, which a `consensus_vote` panel resolved to **Option B** (6/6 approvers). Test-only — no shippable source changes.

## Why a test-only PR

The panel's dissenting voter rejected all three options with one concrete demand, and three approvers independently asked for the same thing:

> *"first introduce an integration test that fails under the current broken state."*

That is right, and it is the deliverable here. The refactor is worthless without it, because **CI is currently reporting false confidence**: every existing test of `runResourceStrategyStage` hands it a *mocked* stage whose result already contains `resource-strategy:tier=…`. The answer is pre-seeded, so none of them can observe that a real stage is handed an empty context and skips.

## The two tests

**`it.fails` — executable proof of the defect.** A real `ResourceStrategyStage` driven through the real runner. `createRoutingContext` hard-sets `signals: []` and the runner passes no metadata, so `extractResourceLevel` finds neither the `budget:utilization=` signal nor a `resourceLevel` in metadata. The stage skips with trace reason `"no budget data"` on every production call.

`it.fails` rather than asserting the broken behaviour as expected: pinning it would make the bug the contract, and this repo has been bitten by exactly that. This version turns **red the moment the plumbing lands**, at which point it becomes a plain `it`. Vitest reports it as `1 expected fail`, so CI is green and the defect is visible in the run output rather than only in an issue.

**A control that the stage itself works.** Given `resourceLevel` in context metadata — a channel `createRoutingContext` accepts as its third argument and the runner never supplies — the stage computes a tier and emits its signal. This matters for the decision: it rules out Option C's reading that the stage is dead code. **The plumbing is broken, not the stage.** Mutation-verified: making `extractResourceLevel` always return undefined fails it.

## What is deliberately not in this PR

Threading the budget figure through, which activates resource-tier score adjustments in live routing. The panel was explicit that each dormant behaviour is activated in its own change **with outcome instrumentation before it counts** — the whole reason Option A lost. A budget utilization figure is computable in the pipeline (`BudgetRouter.checkBudget` produces the inputs `BudgetFilterStage` uses at `budget-stage.ts:233`) but is not computed there today, so that increment is real work, not a one-liner.

Sequence recorded on #4866: this → typed budget input to `ResourceStrategyStage` → typed category input to `DistilledRuleStage` (which also carries #4832's product question) → follow-up for the unreachable `RoutingStage` half.

## Verification

65 tests in the file: 64 pass, 1 expected fail. `tsc` and eslint clean. Empty changeset — no shippable source touched.