### PR TITLE
fix(routing): give ResourceStrategyStage the budget data it reads

### DIFF
--- a/.changeset/thread-budget-utilization.md
+++ b/.changeset/thread-budget-utilization.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': minor
+---
+
+give ResourceStrategyStage the budget data it reads
+
+Increment 2 of #4866, following the panel's Option B: pass each stage what it
+needs as a typed argument rather than reviving the cross-stage signal channel.
+
+`ResourceStrategyStage` runs on every route (`enableResourceStrategy` defaults
+to `true`) and skipped every time with trace reason "no budget data". It looked
+for a `budget:utilization=` signal emitted by `BudgetFilterStage` — which has no
+production instantiation — and was handed a fresh context with `signals: []`
+regardless.
+
+- `applyBudgetFilter` computes utilization from the projected spend and the
+  configured `maxCostUsd`, mirroring the formula in `budget-stage.ts`.
+- `runBudgetStage` returns it; `runPipeline` threads it into
+  `runResourceStrategyStage` as a typed argument.
+- `ResourceStrategyStageResult` gains `tierMeasured`. `buildOptionalFields`
+  recorded `resourceTier` only when the tier differed from `'balanced'`, so a
+  measured balanced tier was indistinguishable from a stage that never ran.
+  It now keys on whether a tier was selected.
+
+**Scope of the behaviour change:** utilization is `undefined` unless
+`maxCostUsd` is configured, and the stage keeps skipping in that case. Only
+deployments that set a cost ceiling — an explicit opt-in to budget-aware
+routing — see tier adjustments begin to apply.
+
+Fixes the `it.fails` proof added in #4867. Refs #4834.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
@@ -349,6 +349,59 @@ describe('applyBudgetFilter', () => {
     expect(result.eligible).toEqual(candidates);
     expect(result.withinBudget).toBe(true);
   });
+
+  it('reports budget utilization against a configured cost ceiling (#4866)', () => {
+    // ResourceStrategyStage's only input. Nothing on this path produced it —
+    // it looked for a `budget:utilization=` signal emitted by BudgetFilterStage,
+    // which has no production instantiation.
+    const mockRouter = {
+      checkBudget: vi.fn(() => ({ withinBudget: true, estimatedCostUsd: 0.25 })),
+    };
+
+    const result = applyBudgetFilter(
+      makeCliTask(),
+      candidates,
+      mockRouter as never,
+      {
+        budgetConstraints: { maxCostUsd: 1 },
+      } as never
+    );
+
+    expect(result.budgetUtilization).toBeCloseTo(0.25);
+  });
+
+  it('reports no utilization when no cost ceiling is configured (#4866)', () => {
+    // The empty case, named: with no ceiling there is nothing to be a
+    // fraction of. Returning 0 would read as "budget untouched" and push
+    // ResourceStrategyStage to its most aggressive tier.
+    const mockRouter = {
+      checkBudget: vi.fn(() => ({ withinBudget: true, estimatedCostUsd: 0.25 })),
+    };
+
+    const result = applyBudgetFilter(
+      makeCliTask(),
+      candidates,
+      mockRouter as never,
+      config as never
+    );
+
+    expect(result.budgetUtilization).toBeUndefined();
+  });
+
+  it('caps utilization at 1 when the estimate exceeds the ceiling (#4866)', () => {
+    const mockRouter = { checkBudget: vi.fn(() => ({ withinBudget: true, estimatedCostUsd: 5 })) };
+
+    const result = applyBudgetFilter(
+      makeCliTask(),
+      candidates,
+      mockRouter as never,
+      {
+        budgetConstraints: { maxCostUsd: 1 },
+      } as never
+    );
+
+    expect(result.budgetUtilization).toBe(1);
+  });
 });
 
 // ============================================================================

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
@@ -156,6 +156,30 @@ export function cliTaskToTask(cliTask: CliTask): Task {
 export interface BudgetFilterResult {
   eligible: RoutingArmId[];
   withinBudget: boolean;
+  /**
+   * Projected spend as a fraction of the configured cost ceiling (#4866).
+   *
+   * `undefined` when no `maxCostUsd` is configured — there is then no ceiling
+   * to be a fraction of, and an unknown budget must not be rendered as a
+   * known one. `ResourceStrategyStage` consumes this; it previously looked
+   * for a `budget:utilization=` signal that nothing on this path emitted.
+   */
+  budgetUtilization?: number;
+}
+
+/** Narrows the router config's budget constraints to a {@link BudgetConstraint}. */
+function toBudgetConstraint(raw: CompositeRouterConfig['budgetConstraints']): BudgetConstraint {
+  const constraint: BudgetConstraint = {};
+  if (raw?.maxTokens !== undefined) {
+    (constraint as { maxTokens: number }).maxTokens = raw.maxTokens;
+  }
+  if (raw?.maxCostUsd !== undefined) {
+    (constraint as { maxCostUsd: number }).maxCostUsd = raw.maxCostUsd;
+  }
+  if (raw?.maxLatencyMs !== undefined) {
+    (constraint as { maxLatencyMs: number }).maxLatencyMs = raw.maxLatencyMs;
+  }
+  return constraint;
 }
 
 /**
@@ -169,26 +193,27 @@ export function applyBudgetFilter(
 ): BudgetFilterResult {
   if (budgetRouter === undefined) return { eligible: candidates, withinBudget: true };
 
-  const rawConstraints = config.budgetConstraints;
-  const constraint: BudgetConstraint = {};
-  if (rawConstraints?.maxTokens !== undefined) {
-    (constraint as { maxTokens: number }).maxTokens = rawConstraints.maxTokens;
-  }
-  if (rawConstraints?.maxCostUsd !== undefined) {
-    (constraint as { maxCostUsd: number }).maxCostUsd = rawConstraints.maxCostUsd;
-  }
-  if (rawConstraints?.maxLatencyMs !== undefined) {
-    (constraint as { maxLatencyMs: number }).maxLatencyMs = rawConstraints.maxLatencyMs;
-  }
+  const constraint = toBudgetConstraint(config.budgetConstraints);
 
   const result = budgetRouter.checkBudget(task, constraint);
   if (!result.withinBudget) return { eligible: [], withinBudget: false };
-  // #4196: per-task-class cost ceiling — enforced ONLY under api billing.
-  // Plan mode is a no-op here; the decision carries PLAN_MODE_COST_ANNOTATION
-  // instead of silently skipping. A candidate with missing registry pricing
-  // FAILS the ceiling (fail-closed) — see BudgetRouter.filterByTaskClassCeiling.
-  if (config.billingMode !== 'api') return { eligible: candidates, withinBudget: true };
-  return { eligible: budgetRouter.filterByTaskClassCeiling(task, candidates), withinBudget: true };
+
+  // Mirrors BudgetFilterStage's formula (budget-stage.ts:233), over the
+  // selected adapter's projected cost rather than an average across
+  // candidates — this is the spend actually being contemplated.
+  const maxCostUsd = constraint.maxCostUsd;
+  const utilization =
+    maxCostUsd !== undefined && maxCostUsd > 0
+      ? { budgetUtilization: Math.min(1, result.estimatedCostUsd / maxCostUsd) }
+      : {};
+
+  if (config.billingMode !== 'api')
+    return { eligible: candidates, withinBudget: true, ...utilization };
+  return {
+    eligible: budgetRouter.filterByTaskClassCeiling(task, candidates),
+    withinBudget: true,
+    ...utilization,
+  };
 }
 
 /**

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
@@ -1198,25 +1198,50 @@ describe('cross-stage routing signals (#4866)', () => {
   // pre-seeds the answer, so none of them can see that a real stage is given
   // an empty context and skips. These drive the real stage instead.
 
-  it.fails('KNOWN BROKEN (#4866): a real ResourceStrategyStage receives budget data', async () => {
-    // `createRoutingContext` (router-stage.ts:253-261) hard-sets
-    // `signals: []` and the runner passes no metadata, so
-    // `extractResourceLevel` finds neither the `budget:utilization=` signal
-    // nor a `resourceLevel` in metadata. The stage skips with trace reason
-    // "no budget data" on every production call, and no resource tier is
-    // ever selected.
-    //
-    // `it.fails` rather than a pinned assertion of the broken behaviour:
-    // this is executable proof of the defect that turns RED the moment the
-    // plumbing lands, at which point it becomes a plain `it`.
+  it('a real ResourceStrategyStage receives budget data through the runner (#4866)', async () => {
+    // Was `it.fails`: the runner built a fresh empty context and passed no
+    // metadata, so `extractResourceLevel` found neither the
+    // `budget:utilization=` signal nor a `resourceLevel`, and the stage
+    // skipped with trace reason "no budget data" on every production call.
     const deps = makeDeps({
       config: { ...makeDeps().config, enableResourceStrategy: true },
       resourceStrategyStage: new ResourceStrategyStage(),
     });
 
-    const result = await runResourceStrategyStage(mockTask, candidates, [], deps);
+    const result = await runResourceStrategyStage(mockTask, candidates, [], deps, 0.25);
 
-    expect(result.resourceLevel).toBeDefined();
+    // Utilization is the SPENT ratio; resource level is what remains.
+    expect(result.resourceLevel).toBeCloseTo(0.75);
+  });
+
+  it('leaves the stage skipped when no budget ceiling is configured (#4866)', async () => {
+    // The benign majority. Without `maxCostUsd` there is no utilization to
+    // compute, and an unknown budget must not be rendered as a known one —
+    // defaulting here would activate tier adjustments for every user who
+    // never asked for budget-aware routing.
+    const deps = makeDeps({
+      config: { ...makeDeps().config, enableResourceStrategy: true },
+      resourceStrategyStage: new ResourceStrategyStage(),
+    });
+
+    const result = await runResourceStrategyStage(mockTask, candidates, [], deps, undefined);
+
+    expect(result.resourceLevel).toBeUndefined();
+    expect(result.tierMeasured).toBe(false);
+  });
+
+  it('marks the tier as measured even when it comes out balanced (#4866)', async () => {
+    // `buildOptionalFields` omitted `resourceTier` whenever the tier equalled
+    // 'balanced', so a tier that WAS selected and happened to be balanced was
+    // indistinguishable in the recorded decision from a stage that never ran.
+    const deps = makeDeps({
+      config: { ...makeDeps().config, enableResourceStrategy: true },
+      resourceStrategyStage: new ResourceStrategyStage(),
+    });
+
+    const result = await runResourceStrategyStage(mockTask, candidates, [], deps, 0.5);
+
+    expect(result.tierMeasured).toBe(true);
   });
 
   it('a real ResourceStrategyStage does reach a tier when given the data directly', async () => {

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -133,7 +133,12 @@ export function runBudgetStage(
   stagesExecuted: string[],
   deps: StageDependencies
 ): Result<
-  { candidates: RoutingArmId[]; withinBudget: boolean | undefined },
+  {
+    candidates: RoutingArmId[];
+    withinBudget: boolean | undefined;
+    /** Projected spend / cost ceiling; undefined when no ceiling is set (#4866). */
+    budgetUtilization?: number;
+  },
   CompositeRoutingError
 > {
   if (!deps.config.enableBudgetFilter || deps.budgetRouter === undefined) {
@@ -144,7 +149,13 @@ export function runBudgetStage(
   if (result.eligible.length === 0) {
     return err(new CompositeRoutingError('No CLIs within budget', 'budget-filter'));
   }
-  return ok({ candidates: result.eligible, withinBudget: result.withinBudget });
+  return ok({
+    candidates: result.eligible,
+    withinBudget: result.withinBudget,
+    ...(result.budgetUtilization === undefined
+      ? {}
+      : { budgetUtilization: result.budgetUtilization }),
+  });
 }
 
 /**
@@ -409,6 +420,14 @@ export interface ResourceStrategyStageResult {
   scores: Map<CliName, number>;
   tier: string;
   resourceLevel: number | undefined;
+  /**
+   * Whether a tier was actually selected (#4866).
+   *
+   * `false` means the stage skipped for want of budget data, so `tier` is the
+   * `'balanced'` default and NOT a decision. Without this, a genuinely
+   * selected balanced tier and a stage that never ran are the same value.
+   */
+  tierMeasured: boolean;
 }
 
 /** Default resource strategy result. */
@@ -416,6 +435,7 @@ const DEFAULT_RESOURCE_RESULT: ResourceStrategyStageResult = {
   scores: new Map(),
   tier: 'balanced',
   resourceLevel: undefined,
+  tierMeasured: false,
 };
 
 /** Runs resource strategy stage. (Issue #998, #1350) */
@@ -423,13 +443,29 @@ export async function runResourceStrategyStage(
   task: CliTask,
   candidates: RoutingArmId[],
   stagesExecuted: string[],
-  deps: StageDependencies
+  deps: StageDependencies,
+  budgetUtilization?: number
 ): Promise<ResourceStrategyStageResult> {
   if (!deps.config.enableResourceStrategy || deps.resourceStrategyStage === undefined) {
     return DEFAULT_RESOURCE_RESULT;
   }
 
-  const ctx = createRoutingContext(task.content, armsToSlots(candidates));
+  // The stage reads its input from context metadata. It used to be given a
+  // fresh context with no metadata and no signals, so it skipped with "no
+  // budget data" on every production call and no tier was ever selected
+  // (#4866). Passed as a typed argument rather than revived as a cross-stage
+  // signal channel — the string-prefix channel is what produced #4832/#4834.
+  //
+  // Undefined stays undefined: with no cost ceiling configured there is no
+  // utilization, and substituting a default would activate tier adjustments
+  // for users who never asked for budget-aware routing.
+  const resourceLevel =
+    budgetUtilization === undefined ? undefined : Math.max(0, Math.min(1, 1 - budgetUtilization));
+  const ctx = createRoutingContext(
+    task.content,
+    armsToSlots(candidates),
+    resourceLevel === undefined ? undefined : { resourceLevel }
+  );
   const result = await deps.resourceStrategyStage.route(ctx);
   stagesExecuted.push('resource-strategy');
 
@@ -440,10 +476,24 @@ export async function runResourceStrategyStage(
 
   const { signals, scores } = result.value.context;
   const tier = extractTierFromSignals(signals);
+  const tierMeasured = signals.some((sig) => sig.startsWith('resource-strategy:tier='));
 
-  deps.logger.debug('Resource strategy completed', { tier, scoreCount: scores.size });
+  deps.logger.debug('Resource strategy completed', {
+    tier,
+    tierMeasured,
+    resourceLevel,
+    scoreCount: scores.size,
+  });
 
-  return { scores: new Map(scores), tier, resourceLevel: undefined };
+  // Only report the level the stage actually ACTED on. Returning the input
+  // regardless would claim a level was applied when the stage had skipped —
+  // the same "reported but not used" shape this change exists to remove.
+  return {
+    scores: new Map(scores),
+    tier,
+    resourceLevel: tierMeasured ? resourceLevel : undefined,
+    tierMeasured,
+  };
 }
 
 /** Distilled rule stage result. (Issue #999) */
@@ -776,7 +826,8 @@ async function runScoringStages(
   task: CliTask,
   candidates: RoutingArmId[],
   stagesExecuted: string[],
-  deps: StageDependencies
+  deps: StageDependencies,
+  budgetUtilization?: number
 ): Promise<{
   cascadeResult: ConfidenceCascadeStageResult;
   memoryResult: RoutingMemoryStageResult;
@@ -797,7 +848,13 @@ async function runScoringStages(
   const distilledResult = await runDistilledRuleStage(task, filtered, stagesExecuted, deps);
   const prefResult = runPreferenceStage(task, filtered, stagesExecuted, deps);
   filtered = prefResult.preferredCandidates;
-  const resourceResult = await runResourceStrategyStage(task, filtered, stagesExecuted, deps);
+  const resourceResult = await runResourceStrategyStage(
+    task,
+    filtered,
+    stagesExecuted,
+    deps,
+    budgetUtilization
+  );
   return {
     cascadeResult,
     memoryResult,
@@ -1005,7 +1062,13 @@ export async function runPipeline(
   if (!capacityResult.ok) return capacityResult;
   candidates = capacityResult.value;
 
-  const scoring = await runScoringStages(task, candidates, stagesExecuted, deps);
+  const scoring = await runScoringStages(
+    task,
+    candidates,
+    stagesExecuted,
+    deps,
+    budgetResult.value.budgetUtilization
+  );
   candidates = scoring.candidates;
 
   // Constraint-first: quality constraints filter BEFORE TOPSIS/LinUCB (#1686)
@@ -1106,7 +1169,10 @@ function buildPipelineResult(p: PipelineResultParams): PipelineResult {
       : {}),
     ...(p.capResult.taskType !== 'general' ? { capabilityTaskType: p.capResult.taskType } : {}),
     ...(p.qualityResult.filtered.size > 0 ? { qualityFiltered: p.qualityResult.filtered } : {}),
-    ...(p.resourceResult.tier !== 'balanced' ? { resourceTier: p.resourceResult.tier } : {}),
+    // Keyed on whether a tier was SELECTED, not on whether it differs from
+    // the default — a measured 'balanced' is a decision and must be recorded
+    // as one (#4866).
+    ...(p.resourceResult.tierMeasured ? { resourceTier: p.resourceResult.tier } : {}),
     ...(p.distilledResult.rulesApplied > 0
       ? { distilledRulesApplied: p.distilledResult.rulesApplied }
       : {}),


### PR DESCRIPTION
Increment 2 of #4866, following the panel's **Option B** (typed argument, not a revived signal channel). Flips the `it.fails` proof from #4867 to a passing test.

## What was broken

`ResourceStrategyStage` runs on **every** route — `enableResourceStrategy` defaults to `true` — and skipped every single time with trace reason `"no budget data"`. Two independent reasons:

- It reads a `budget:utilization=` signal emitted by `BudgetFilterStage`, which has **no production instantiation**. `runBudgetStage` calls `applyBudgetFilter` directly.
- `createRoutingContext` hard-sets `signals: []` and the runner passed no metadata, so even a real producer would not have reached it.

So a stage that is on by default has never once selected a resource tier.

## The fix

`applyBudgetFilter` computes utilization from the projected spend against the configured `maxCostUsd`, mirroring the formula in `budget-stage.ts:233`. `runBudgetStage` returns it, `runPipeline` threads it into `runResourceStrategyStage` as a typed parameter, and the runner passes it through the metadata channel the stage already reads.

**Blast radius is genuinely narrow, and deliberately so.** Utilization is `undefined` unless `maxCostUsd` is configured, and the stage keeps skipping in that case. Only deployments that set a cost ceiling — an explicit opt-in to budget-aware routing — begin to see tier adjustments. That is what let this land without the shadow-flag apparatus Option A would have needed: the opt-in already exists in the config.

## Instrumentation, which the panel required before activation

`ResourceStrategyStageResult` gains `tierMeasured`. `buildOptionalFields` recorded `resourceTier` only when the tier **differed from `'balanced'`** — so a measured balanced tier was indistinguishable in the recorded decision from a stage that never ran. It now keys on whether a tier was selected, so the audit trail can tell you the stage acted.

## A defect the mutation run found in my own fix

The first version returned the computed `resourceLevel` unconditionally. Reverting the metadata plumbing left the stage skipping while the runner still reported `resourceLevel: 0.75` — **claiming a level had been applied when nothing consumed it**. Precisely the shape this change exists to remove, shipped inside the change removing it.

It now reports the level only when `tierMeasured`. Caught because the mutation failed one test instead of the two I expected; the count being wrong was the signal, not the failure itself.

## Verification

Six tests across producer and consumer, red first. Four production hunks each mutation-verified against a specific test, including "undefined utilization defaults to 0", which would silently activate tier adjustments for every user who never configured a budget.

Full `src/cli-adapters` suite: **2682 tests, 100 files, green.** `tsc` and eslint clean — `applyBudgetFilter` crossed the complexity ceiling, so the constraint-narrowing block moved to `toBudgetConstraint`.

## Next

Increment 3 is the typed category input to `DistilledRuleStage`, which also carries #4832's product question: turning category scoping on means existing distilled rules **start narrowing** where they currently apply to every task regardless of category. That wants its own vote.