### PR TITLE
fix(routing): scope distilled rules to the category they were learned for

### DIFF
--- a/.changeset/distilled-rules-scope-by-category.md
+++ b/.changeset/distilled-rules-scope-by-category.md
@@ -1,0 +1,32 @@
+---
+'nexus-agents': minor
+---
+
+scope distilled routing rules to the category they were learned for
+
+Increment 3 of #4866. Distilled rules are grouped and fingerprinted by
+`(cli, category)` — a rule means "penalize claude ON code_generation" — but the
+category filter never narrowed, so every CLI-matching rule applied to every
+task. Rules learned for `code_generation` were being applied to `documentation`.
+
+`DistilledRuleStage.extractCategory` read two signals. `task-category:` had no
+producer anywhere. `capability:type=` was assumed to be a typo for the existing
+`capability:task-` producer — it is not. That producer emits `reasoning | code |
+creative | general`, which shares **no values** with the `TASK_CATEGORIES` a rule
+carries. Renaming it would have matched no rule ever and taken the whole
+distillation loop dark while looking like a fix.
+
+The parser is deleted rather than corrected. The category now arrives as a typed
+argument from `detectTaskCategory` — the producer that speaks the right
+vocabulary, already used by `BudgetRouter` — validated at the boundary with
+`TaskCategorySchema`, so an off-vocabulary value is `unknown` rather than a
+category that silently matches nothing.
+
+When no category is detected, rules still apply unscoped as before, but the
+context now carries `distilled-rule:category-unknown` so an unscoped
+application is not mistaken for a scoped one.
+
+Removes the `task-category:` and `capability:type=` entries from the
+`signal-contract` ratchet's `KNOWN_BROKEN` map.
+
+Fixes #4832.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
@@ -9,6 +9,7 @@ import {
   CapacityFilterStage,
   CAPACITY_EXHAUSTED,
   ResourceStrategyStage,
+  DistilledRuleStage,
 } from './routing/stages/index.js';
 import type { CapacityStatus, ICliAdapter, RoutingArmId } from './types.js';
 
@@ -1261,5 +1262,98 @@ describe('cross-stage routing signals (#4866)', () => {
     expect(routed.value.context.signals.some((s) => s.startsWith('resource-strategy:tier='))).toBe(
       true
     );
+  });
+});
+
+// ============================================================================
+// The distilled-rule runner supplies a category (#4832)
+// ============================================================================
+
+describe('runDistilledRuleStage supplies the task category (#4832)', () => {
+  const candidates: CliName[] = ['claude'];
+
+  function stageWithRule(): DistilledRuleStage {
+    const rule = {
+      id: 'failure-rate:claude:documentation',
+      patternType: 'failure-rate',
+      cli: 'claude' as CliName,
+      category: 'documentation',
+      action: 'penalize',
+      confidence: 0.8,
+      observationCount: 40,
+      metric: 0.7,
+      status: 'active',
+      createdAt: 0,
+      updatedAt: 0,
+      tainted: false,
+    };
+    const distiller = {
+      getRules: vi.fn(() => [rule]),
+      onOutcome: vi.fn(),
+      distill: vi.fn(),
+      getStats: vi.fn(),
+    };
+    return new DistilledRuleStage(distiller as never);
+  }
+
+  it('scopes rules by the category detected from the task', async () => {
+    // A documentation rule must not apply to a task detected as something
+    // else. Mocked-stage tests cannot see this — they assert on a result the
+    // mock already decided.
+    const deps = makeDeps({
+      config: { ...makeDeps().config, enableStrategyDistillation: true },
+      distilledRuleStage: stageWithRule(),
+    });
+
+    const result = await runDistilledRuleStage(
+      { content: 'design the service architecture and system boundaries' },
+      candidates,
+      [],
+      deps,
+      'architecture'
+    );
+
+    expect(result.rulesApplied).toBe(0);
+  });
+
+  it('detects the category from the task through the whole pipeline (#4832)', async () => {
+    // The last seam: runScoringStages calls detectTaskCategory itself, and
+    // neither the stage tests nor the runner tests reach that call.
+    //
+    // It has to be an EXCLUSION to be observable. With no category the rule
+    // applies unscoped — the designed fallback — so a matching task yields 1
+    // either way and proves nothing. A task detected as something OTHER than
+    // the rule's category yields 1 without detection and 0 with it.
+    const deps = makeDeps({
+      config: { ...makeDeps().config, enableStrategyDistillation: true },
+      distilledRuleStage: stageWithRule(),
+    });
+    const archTask: CliTask = { content: 'design the system architecture and service boundaries' };
+    const profile = analyzeTaskProfile(archTask, []);
+
+    const result = await runPipeline(archTask, profile, [], ['claude'], deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Omitted entirely when zero, so undefined is the scoped outcome.
+    expect(result.value.distilledRulesApplied).toBeUndefined();
+  });
+
+  it('applies the rule when the detected category matches', async () => {
+    // The pair: scoping to nothing would satisfy the test above.
+    const deps = makeDeps({
+      config: { ...makeDeps().config, enableStrategyDistillation: true },
+      distilledRuleStage: stageWithRule(),
+    });
+
+    const result = await runDistilledRuleStage(
+      { content: 'write the README' },
+      candidates,
+      [],
+      deps,
+      'documentation'
+    );
+
+    expect(result.rulesApplied).toBe(1);
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -507,13 +507,22 @@ export async function runDistilledRuleStage(
   task: CliTask,
   candidates: RoutingArmId[],
   stagesExecuted: string[],
-  deps: StageDependencies
+  deps: StageDependencies,
+  taskCategory?: string
 ): Promise<DistilledRuleStageResult> {
   if (!deps.config.enableStrategyDistillation || deps.distilledRuleStage === undefined) {
     return { scores: new Map(), rulesApplied: 0 };
   }
 
-  const ctx = createRoutingContext(task.content, armsToSlots(candidates));
+  // Typed argument rather than a cross-stage signal (#4866 option B). The
+  // vocabulary matters: rules carry a `TaskCategory`, and `detectTaskCategory`
+  // is the only producer that speaks it — `capability:task-` emits an
+  // unrelated four-value set (#4832).
+  const ctx = createRoutingContext(
+    task.content,
+    armsToSlots(candidates),
+    taskCategory === undefined ? undefined : { taskCategory }
+  );
   const result = await deps.distilledRuleStage.route(ctx);
   stagesExecuted.push('distilled-rule');
 
@@ -821,6 +830,17 @@ function mergeScoreMaps(
   return merged;
 }
 
+/**
+ * The task's category in the vocabulary a {@link DistilledRule} carries.
+ *
+ * `detectTaskCategory` is the only producer speaking `TASK_CATEGORIES`;
+ * `capability:task-` emits an unrelated four-value set (#4832). `undefined`
+ * when nothing scores, which leaves rules unscoped as before.
+ */
+function detectedCategory(task: CliTask): string | undefined {
+  return detectTaskCategory(task.content)?.category;
+}
+
 /** Runs scoring stages (priorities 10-55) and returns intermediate results. */
 async function runScoringStages(
   task: CliTask,
@@ -845,7 +865,8 @@ async function runScoringStages(
   const knnResult = await runKnnRoutingStage(task, candidates, stagesExecuted, deps);
   const zeroResult = runZeroRouterStage(task, candidates, stagesExecuted, deps);
   let filtered = zeroResult.filteredCandidates;
-  const distilledResult = await runDistilledRuleStage(task, filtered, stagesExecuted, deps);
+  const cat = detectedCategory(task);
+  const distilledResult = await runDistilledRuleStage(task, filtered, stagesExecuted, deps, cat);
   const prefResult = runPreferenceStage(task, filtered, stagesExecuted, deps);
   filtered = prefResult.preferredCandidates;
   const resourceResult = await runResourceStrategyStage(

--- a/packages/nexus-agents/src/cli-adapters/routing/signal-contract.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/signal-contract.test.ts
@@ -37,8 +37,6 @@ const ROUTING_DIR = join(process.cwd(), 'src', 'cli-adapters', 'routing');
  * something nobody sends.
  */
 const KNOWN_BROKEN: ReadonlyMap<string, string> = new Map([
-  ['task-category:', '#4832 — no producer; DistilledRuleStage category filter never narrows'],
-  ['capability:type=', '#4832 — CapabilityMatchStage emits `capability:task-`, not `type=`'],
   ['budget:utilization-', '#4834 — BudgetStage emits `budget:utilization=` (equals, not hyphen)'],
 ]);
 

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/distilled-rule-stage.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/distilled-rule-stage.test.ts
@@ -18,11 +18,12 @@ import type { DistilledRule, RuleStatus } from '../../../learning/strategy-disti
 function createContext(
   task: string,
   clis: CliName[] = ['claude', 'gemini', 'codex'],
-  signals: string[] = []
+  signals: string[] = [],
+  metadata?: Record<string, unknown>
 ): RoutingContext {
   return {
     task,
-    metadata: undefined,
+    metadata,
     availableClis: clis,
     scores: new Map(clis.map((c) => [c, 0])),
     filtered: new Map(),
@@ -263,5 +264,77 @@ describe('DistilledRuleStage', () => {
       const stage = createDistilledRuleStage(createMockDistiller());
       expect(stage).toBeInstanceOf(DistilledRuleStage);
     });
+  });
+});
+
+// ============================================================================
+// Category scoping (#4832 / #4866)
+// ============================================================================
+
+describe('rules are scoped to the category they were learned for (#4832)', () => {
+  // Rules are grouped and fingerprinted by `(cli, category)` in the distiller,
+  // so a rule means "penalize claude ON code_generation". Every rule was being
+  // applied to every task regardless, because the category was read from a
+  // `task-category:` signal nothing emits.
+
+  it('applies a rule whose category matches the task', async () => {
+    const stage = new DistilledRuleStage(createMockDistiller([makeRule()]));
+
+    const result = await stage.route(
+      createContext('write a function', ['claude'], [], { taskCategory: 'code_generation' })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(
+      result.value.context.signals.some((sig) => sig.startsWith('distilled-rule:applied='))
+    ).toBe(true);
+  });
+
+  it('does NOT apply a rule from a different category', async () => {
+    // The behaviour the whole issue is about. Nothing asserted this before.
+    const stage = new DistilledRuleStage(createMockDistiller([makeRule()]));
+
+    const result = await stage.route(
+      createContext('write the README', ['claude'], [], { taskCategory: 'documentation' })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(
+      result.value.context.signals.some((sig) => sig.startsWith('distilled-rule:applied='))
+    ).toBe(false);
+  });
+
+  it('rejects a category outside the TaskCategory vocabulary', async () => {
+    // The trap: `capability:task-` emits `code` / `reasoning` / `creative` /
+    // `general`, which share NO values with the `TASK_CATEGORIES` a rule
+    // carries. Wiring that producer in would match nothing and silently take
+    // the whole distillation loop dark. Anything off-vocabulary must be
+    // treated as unknown, not as a category that simply matches no rule.
+    const stage = new DistilledRuleStage(createMockDistiller([makeRule()]));
+
+    const result = await stage.route(
+      createContext('write a function', ['claude'], [], { taskCategory: 'code' })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.context.signals.includes('distilled-rule:category-unknown')).toBe(true);
+  });
+
+  it('applies every matching-CLI rule when the category is unknown, and says so', async () => {
+    // Preserves today's behaviour for undetectable tasks rather than silently
+    // dropping all rules — but the record now states that the check did not
+    // run, so an unscoped application is not mistaken for a scoped one.
+    const stage = new DistilledRuleStage(createMockDistiller([makeRule()]));
+
+    const result = await stage.route(createContext('zzz', ['claude'], []));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const { signals } = result.value.context;
+    expect(signals.some((sig) => sig.startsWith('distilled-rule:applied='))).toBe(true);
+    expect(signals).toContain('distilled-rule:category-unknown');
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/distilled-rule-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/distilled-rule-stage.ts
@@ -26,6 +26,7 @@ import type {
 import { addTrace, updateScore, getRemainingCandidates } from '../router-stage.js';
 import type { StrategyDistiller } from '../../../learning/strategy-distiller.js';
 import type { DistilledRule, StrategyAction } from '../../../learning/strategy-distiller-types.js';
+import { TaskCategorySchema } from '../../../config/task-specialization-types.js';
 
 /** Score deltas per action type. */
 const ACTION_DELTAS: Readonly<Record<StrategyAction, number>> = {
@@ -111,10 +112,15 @@ export class DistilledRuleStage implements IRouterStage {
       return ok({ context: updated, continuesPipeline: true });
     }
 
-    // Extract task category from signals
-    const category = this.extractCategory(ctx);
+    const category = readTaskCategory(ctx);
 
     let updated = ctx;
+    if (category === undefined) {
+      // An unscoped application is not the same as a scoped one, and the
+      // recorded `distilled-rule:applied=` cannot tell them apart on its own
+      // (#4832). Say which happened.
+      updated = { ...updated, signals: [...updated.signals, 'distilled-rule:category-unknown'] };
+    }
     let applied = 0;
 
     for (const cli of candidates) {
@@ -165,18 +171,25 @@ export class DistilledRuleStage implements IRouterStage {
           : this.config.avoidDelta;
     return baseDelta * rule.confidence;
   }
+}
 
-  private extractCategory(ctx: RoutingContext): string | undefined {
-    for (const signal of ctx.signals) {
-      if (signal.startsWith('task-category:')) {
-        return signal.slice('task-category:'.length);
-      }
-      if (signal.startsWith('capability:type=')) {
-        return signal.slice('capability:type='.length);
-      }
-    }
-    return undefined;
-  }
+/**
+ * Reads the task category the caller supplied, validated against the
+ * vocabulary a {@link DistilledRule} actually carries (#4832).
+ *
+ * This replaced a signal parser reading `task-category:` (which nothing
+ * emitted) and `capability:type=` (whose producer emits `capability:task-`
+ * over a DIFFERENT vocabulary — `reasoning|code|creative|general` — sharing no
+ * values with `TASK_CATEGORIES`). Renaming that prefix would have matched no
+ * rule ever and taken the whole distillation loop dark while looking like a
+ * fix, so the parser is gone rather than corrected.
+ *
+ * Anything off-vocabulary is `undefined`: unknown, not "a category that
+ * happens to match nothing".
+ */
+function readTaskCategory(ctx: RoutingContext): string | undefined {
+  const parsed = TaskCategorySchema.safeParse(ctx.metadata?.['taskCategory']);
+  return parsed.success ? parsed.data : undefined;
 }
 
 /** Factory function for creating DistilledRuleStage. */


### PR DESCRIPTION
Fixes #4832. Increment 3 of #4866, following the panel's Option B.

## What was broken

Distilled rules are grouped by `(cli, category)` and fingerprinted `patternType:cli:category`. A rule means **"penalize claude ON code_generation"**. The category filter never narrowed, so every CLI-matching rule applied to every task — rules learned for `code_generation` were being applied to `documentation`.

`findMatchingRules` short-circuits when the category is `undefined`, and it always was: `extractCategory` read two signals, `task-category:` (no producer anywhere) and `capability:type=`.

## The near-miss worth reading

`capability:type=` looks like a typo for the existing `capability:task-` producer, and my own issue text recommended renaming the consumer to match. **That would have been much worse than the bug.**

```
DistilledRule.category  →  architecture, code_generation, code_review, research,
                           security_review, planning, documentation, testing,
                           devops, exploration
capability:task-        →  reasoning, code, creative, general
```

**Zero values in common.** The rename would compare `'code'` against `'code_generation'`, match nothing, on every route — taking the entire strategy-distillation loop dark. And it would have presented as a fix: the signal ratchet goes green, `KNOWN_BROKEN` clears, and the only symptom is `distilledRulesApplied` quietly dropping to 0.

That is the general shape: **a fix that makes a counter go down looks like a filter working.**

So the parser is deleted rather than corrected. Both branches were wrong — one for having no producer, one for reading a different vocabulary — and neither is worth keeping.

## The fix

The category arrives as a typed argument from `detectTaskCategory`, the producer that speaks `TASK_CATEGORIES` (already used by `BudgetRouter`). It is validated at the boundary with `TaskCategorySchema`, so an off-vocabulary value reads as **unknown** rather than as a category that happens to match nothing — the distinction that makes the trap above impossible to fall into later.

Undetected category keeps today's unscoped behaviour rather than dropping all rules, but the context now carries `distilled-rule:category-unknown`, so `distilled-rule:applied=` can no longer be read as a scoped application when it wasn't.

Removes both `KNOWN_BROKEN` entries from the `signal-contract` ratchet.

## Testing, and two tests that needed inverting

Six tests, red first. Every existing test hand-supplied `['task-category:code_generation']` in the consumed form against a rule of the same category — same literal both sides, so none could see the missing producer, and **none asserted a different-category rule is excluded**, which is the actual behaviour.

Two of my own new tests were no better until the mutation run caught them:

- The runner-level test initially used a *matching* category. With no category the rule applies unscoped, so it yielded 1 either way. It has to be an **exclusion** to be observable.
- The pipeline-level test had the same flaw and passed with `detectTaskCategory` removed entirely. Now it routes an architecture task against a documentation rule and asserts the rule does **not** apply.

Four production hunks, each mutation-verified against a specific test — including removing the boundary validation, which is what re-opens the vocabulary trap.

Full `src/cli-adapters` suite: **2689 tests, 100 files, green.** `tsc` and eslint clean.

## Behaviour change

Deployments with accumulated distilled rules will see them apply to fewer tasks. That is the point: they were learned per-category and are currently applied everywhere. Rules on tasks whose category cannot be detected are unaffected.