### PR TITLE
fix(routing): give the LinUCB bandit a real budget feature

### DIFF
--- a/.changeset/bandit-budget-feature-is-real.md
+++ b/.changeset/bandit-budget-feature-is-real.md
@@ -1,0 +1,33 @@
+---
+'nexus-agents': minor
+---
+
+give the LinUCB bandit a real budget feature
+
+`taskProfileToBanditContext` hardcoded `budgetUtilization: 0.5` on every call,
+so the bandit's budget dimension was a **constant**. A constant feature carries
+no information: whatever coefficient LinUCB learns for it is meaningless, and
+routing could never respond to budget pressure. This — not the prefix mismatch
+in #4834 — is what actually pinned the feature.
+
+It now takes the utilization the pipeline computes (#4869), falling back to the
+neutral `0.5` when no cost ceiling is configured. Neutral rather than zero:
+zero asserts "budget untouched", while `0.5` is the value `LinUCBBandit.warmStart`
+replays historical outcomes at, so an unknown budget matches the context the
+weights were reconstructed against.
+
+`LinUCBStage.extractBudgetUtilization` parsed a `budget:utilization-` signal
+(hyphen) that no producer emits. Rather than correcting the prefix, the parser
+is replaced by a validated metadata read, consistent with #4866's decision that
+cross-stage signals are not an input channel. An out-of-range value falls back
+to neutral instead of being clamped — an implausible number is more likely a
+wiring mistake than a measurement. The stage now states the value it used in
+its trace.
+
+**The `signal-contract` ratchet's `KNOWN_BROKEN` map is now empty.** Every
+consumed routing-signal prefix has a producer.
+
+`timePressure` is still hardcoded; no producer computes one anywhere in the
+tree, so there is nothing to thread. Tracked separately.
+
+Fixes #4834.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
@@ -1059,3 +1059,33 @@ describe('applyBudgetFilter task-class ceiling gating', () => {
     expect(result.eligible).toEqual(candidates);
   });
 });
+
+// ============================================================================
+// The bandit's budget feature is real (#4834)
+// ============================================================================
+
+describe('taskProfileToBanditContext budget feature (#4834)', () => {
+  // It returned 0.5 unconditionally, so the bandit's budget dimension was a
+  // constant. A constant feature carries no information: whatever coefficient
+  // LinUCB learns for it is meaningless, and the routing decision could never
+  // respond to budget pressure.
+
+  it('uses the supplied utilization', () => {
+    expect(taskProfileToBanditContext(makeTaskProfile(), 0.9).budgetUtilization).toBe(0.9);
+  });
+
+  it('falls back to neutral when no utilization is available', () => {
+    // Neutral, not zero: zero asserts "budget untouched", and 0.5 matches the
+    // context `warmStart` replays historical outcomes at.
+    expect(taskProfileToBanditContext(makeTaskProfile()).budgetUtilization).toBe(0.5);
+  });
+
+  it('does not make the feature constant across different budgets', () => {
+    // The property that actually matters — the whole defect was that these
+    // two were equal.
+    const low = taskProfileToBanditContext(makeTaskProfile(), 0.1).budgetUtilization;
+    const high = taskProfileToBanditContext(makeTaskProfile(), 0.95).budgetUtilization;
+
+    expect(low).not.toBe(high);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
@@ -45,16 +45,36 @@ export function adjustProfileForTask(
   return profile;
 }
 
+/** Neutral feature value — what {@link LinUCBBandit.warmStart} replays. */
+const NEUTRAL_FEATURE = 0.5;
+
 /**
  * Converts a task profile to LinUCB bandit context.
+ *
+ * `budgetUtilization` was hardcoded to 0.5 on every call, so the bandit's
+ * budget feature was constant and carried no information — a dead input to a
+ * learned model, and the actual reason the feature never varied (#4834). It
+ * now takes the figure the pipeline computes, falling back to neutral when no
+ * cost ceiling is configured and there is nothing to measure.
+ *
+ * Neutral rather than zero: zero would read as "budget untouched" and is a
+ * claim; 0.5 is the same value `warmStart` replays historical outcomes at, so
+ * an unknown budget matches the context the weights were reconstructed
+ * against.
+ *
+ * `timePressure` remains hardcoded — no producer computes one anywhere in the
+ * tree, so there is nothing to thread. Tracked separately.
  */
-export function taskProfileToBanditContext(profile: TaskProfile): BanditContext {
+export function taskProfileToBanditContext(
+  profile: TaskProfile,
+  budgetUtilization?: number
+): BanditContext {
   return {
     taskComplexity: profile.reasoningComplexity / 10,
     contextLengthNormalized: Math.min(profile.contextRequired / 100000, 1),
     isCodeTask: profile.codeGeneration ? 1 : 0,
     isReasoningTask: profile.taskType === 'architecture' || profile.reasoningComplexity > 5 ? 1 : 0,
-    budgetUtilization: 0.5,
+    budgetUtilization: budgetUtilization ?? NEUTRAL_FEATURE,
     timePressure: 0.3,
   };
 }

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.test.ts
@@ -534,6 +534,33 @@ describe('runLinUCBStage', () => {
     expect(stages).not.toContain('linucb-selection');
   });
 
+  it('passes the real budget utilization into the bandit context (#4834)', () => {
+    // The seam. The stage tests cover the builder and the pipeline covers the
+    // producer; without this, dropping the argument here leaves both green
+    // and the bandit's budget feature silently constant again.
+    const selectMock = vi.fn(() => ({ armName: 'claude', ucbScore: 0.5 }));
+    const deps = makeDeps({
+      config: { ...makeDeps().config, enableLinUCBSelection: true },
+      linucbBandit: { select: selectMock } as never,
+    });
+
+    runLinUCBStage(analyzeTaskProfile(mockTask, []), ranking, [], deps, 0.87);
+
+    expect(selectMock).toHaveBeenCalledWith(expect.objectContaining({ budgetUtilization: 0.87 }));
+  });
+
+  it('falls back to the neutral feature value when no ceiling is configured (#4834)', () => {
+    const selectMock = vi.fn(() => ({ armName: 'claude', ucbScore: 0.5 }));
+    const deps = makeDeps({
+      config: { ...makeDeps().config, enableLinUCBSelection: true },
+      linucbBandit: { select: selectMock } as never,
+    });
+
+    runLinUCBStage(analyzeTaskProfile(mockTask, []), ranking, [], deps, undefined);
+
+    expect(selectMock).toHaveBeenCalledWith(expect.objectContaining({ budgetUtilization: 0.5 }));
+  });
+
   it('returns first candidate when bandit undefined', () => {
     const stages: string[] = [];
     const profile = analyzeTaskProfile(mockTask, []);

--- a/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-stages.ts
@@ -657,12 +657,13 @@ export function runLinUCBStage(
   taskProfile: TaskProfile,
   topsisRanking: RoutingArmId[],
   stagesExecuted: string[],
-  deps: StageDependencies
+  deps: StageDependencies,
+  budgetUtilization?: number
 ): { selectedCli: RoutingArmId | undefined; ucbScore: number | undefined } {
   if (!deps.config.enableLinUCBSelection || deps.linucbBandit === undefined) {
     return { selectedCli: topsisRanking[0], ucbScore: undefined };
   }
-  const banditContext = taskProfileToBanditContext(taskProfile);
+  const banditContext = taskProfileToBanditContext(taskProfile, budgetUtilization);
   const selection = deps.linucbBandit.select(banditContext);
   stagesExecuted.push('linucb-selection');
   // armName is the routing arm id — a CLI slot or a distinct api:* arm (#3422).
@@ -1110,7 +1111,13 @@ export async function runPipeline(
   if (stageScores.size > 0) topsisOpts.stageScores = stageScores;
   const topsisResult = runTopsisStage(taskProfile, candidates, stagesExecuted, deps, topsisOpts);
 
-  const linucbResult = runLinUCBStage(taskProfile, topsisResult.ranking, stagesExecuted, deps);
+  const linucbResult = runLinUCBStage(
+    taskProfile,
+    topsisResult.ranking,
+    stagesExecuted,
+    deps,
+    budgetResult.value.budgetUtilization
+  );
   if (linucbResult.selectedCli === undefined) {
     return err(new CompositeRoutingError('No candidates available', 'selection'));
   }

--- a/packages/nexus-agents/src/cli-adapters/routing/signal-contract.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/signal-contract.test.ts
@@ -36,9 +36,7 @@ const ROUTING_DIR = join(process.cwd(), 'src', 'cli-adapters', 'routing');
  * a red test green — an unmatched prefix means the consumer is reading
  * something nobody sends.
  */
-const KNOWN_BROKEN: ReadonlyMap<string, string> = new Map([
-  ['budget:utilization-', '#4834 — BudgetStage emits `budget:utilization=` (equals, not hyphen)'],
-]);
+const KNOWN_BROKEN: ReadonlyMap<string, string> = new Map([]);
 
 function routingSources(): string[] {
   return globSync('**/*.ts', { cwd: ROUTING_DIR }).filter(

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/linucb-stage.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/linucb-stage.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LinUCBStage, createLinUCBStage } from './linucb-stage.js';
 import type { RoutingOutcome } from '../router-stage.js';
+import type { RoutingContext } from '../router-stage.js';
 import { createRoutingContext } from '../router-stage.js';
 import { FixedTimeProvider, setTimeProvider, resetTimeProvider } from '../../../core/index.js';
 
@@ -23,8 +24,8 @@ beforeEach(() => {
 });
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-function makeCtx(task = 'test task', signals: string[] = []) {
-  const ctx = createRoutingContext(task);
+function makeCtx(task = 'test task', signals: string[] = [], metadata?: Record<string, unknown>) {
+  const ctx = createRoutingContext(task, undefined, metadata);
   return { ...ctx, signals: [...ctx.signals, ...signals] };
 }
 
@@ -207,21 +208,41 @@ describe('LinUCBStage.route task detection', () => {
   });
 });
 
-describe('LinUCBStage.route budget signals', () => {
-  it('extracts budget utilization from signals', async () => {
-    expect((await new LinUCBStage().route(makeCtx('task', ['budget:utilization-0.8']))).ok).toBe(
-      true
-    );
+describe('LinUCBStage budget utilization (#4834)', () => {
+  // These three tests were named for extraction and asserted only `.ok`, so
+  // they passed against a consumer reading `budget:utilization-` (hyphen)
+  // that no producer ever emitted. The signal channel is gone (#4866 option
+  // B); the value now arrives as validated context metadata, and the stage
+  // states which value it used so the choice is observable.
+
+  function utilizationFromTrace(ctx: RoutingContext): string {
+    return ctx.trace.map((t) => t.details ?? '').join(' ');
+  }
+
+  it('uses the utilization supplied in metadata', async () => {
+    const result = await new LinUCBStage().route(makeCtx('task', [], { budgetUtilization: 0.8 }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(utilizationFromTrace(result.value.context)).toContain('budget=0.80');
   });
 
-  it('uses default utilization when no signal present', async () => {
-    expect((await new LinUCBStage().route(makeCtx('task', ['other-signal']))).ok).toBe(true);
+  it('falls back to the neutral 0.5 when metadata carries none', async () => {
+    // Neutral matches what `warmStart` replays, so an unknown budget is the
+    // same value the learned weights were reconstructed against.
+    const result = await new LinUCBStage().route(makeCtx('task', ['other-signal']));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(utilizationFromTrace(result.value.context)).toContain('budget=0.50');
   });
 
-  it('handles malformed budget signal gracefully', async () => {
-    expect(
-      (await new LinUCBStage().route(makeCtx('task', ['budget:utilization-notanumber']))).ok
-    ).toBe(true);
+  it('falls back to neutral for an out-of-range value', async () => {
+    const result = await new LinUCBStage().route(makeCtx('task', [], { budgetUtilization: 42 }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(utilizationFromTrace(result.value.context)).toContain('budget=0.50');
   });
 });
 

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/linucb-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/linucb-stage.ts
@@ -52,6 +52,27 @@ const CLI_ARMS: readonly CliName[] = ['claude', 'gemini', 'codex', 'opencode'];
 // Stage Implementation
 // ============================================================================
 
+/** Neutral budget utilization — the value {@link LinUCBBandit.warmStart} replays. */
+const NEUTRAL_BUDGET_UTILIZATION = 0.5;
+
+/**
+ * Budget utilization for the bandit feature vector, from context metadata.
+ *
+ * Replaces a parser looking for a `budget:utilization-` signal (hyphen) that
+ * no producer emitted — `BudgetFilterStage` writes `budget:utilization=`, and
+ * is not instantiated in production anyway (#4834). Cross-stage signals are
+ * not an input channel (#4866), so this reads the value the caller supplied.
+ *
+ * Out-of-range or absent values fall back to neutral rather than being
+ * clamped: an implausible number is more likely a wiring mistake than a real
+ * measurement, and neutral is what the learned weights were reconstructed
+ * against.
+ */
+function readBudgetUtilization(ctx: RoutingContext): number {
+  const raw = ctx.metadata?.['budgetUtilization'];
+  return typeof raw === 'number' && raw >= 0 && raw <= 1 ? raw : NEUTRAL_BUDGET_UTILIZATION;
+}
+
 /**
  * LinUCB Stage for bandit-based adaptive model selection.
  */
@@ -113,7 +134,7 @@ export class LinUCBStage implements IRouterStage {
       this.name,
       durationMs,
       'score',
-      `Selected: ${selectedCli}, UCB: ${selection.ucbScore.toFixed(3)}`
+      `Selected: ${selectedCli}, UCB: ${selection.ucbScore.toFixed(3)}, budget=${readBudgetUtilization(ctx).toFixed(2)}`
     );
 
     this.logger.debug('LinUCB scoring complete', {
@@ -186,7 +207,7 @@ export class LinUCBStage implements IRouterStage {
       contextLengthNormalized: Math.min(1, ctx.task.length / 10000),
       isCodeTask,
       isReasoningTask,
-      budgetUtilization: this.extractBudgetUtilization(ctx.signals),
+      budgetUtilization: readBudgetUtilization(ctx),
       timePressure: 0.5, // Default medium pressure
     };
   }
@@ -232,18 +253,6 @@ export class LinUCBStage implements IRouterStage {
   private isReasoningRelated(task: string): boolean {
     const reasoningPatterns = /explain|why|how|analyze|compare|evaluate|reason|think|consider/i;
     return reasoningPatterns.test(task);
-  }
-
-  /**
-   * Extract budget utilization from signals.
-   */
-  private extractBudgetUtilization(signals: string[]): number {
-    const budgetSignal = signals.find((s) => s.startsWith('budget:utilization-'));
-    if (budgetSignal !== undefined) {
-      const value = parseFloat(budgetSignal.replace('budget:utilization-', ''));
-      if (!isNaN(value)) return value;
-    }
-    return 0.5; // Default
   }
 
   /**


### PR DESCRIPTION
Fixes #4834. Completes the signal-contract work from #4866.

## The real cause, which the issue got wrong

#4834 was filed as a prefix mismatch: `LinUCBStage` reads `budget:utilization-` (hyphen) while the producer emits `budget:utilization=`. True, and **fixing it would have changed nothing observable**, because `LinUCBStage` is not wired into the composite pipeline at all.

What actually pinned the feature is a hardcode one layer over:

```ts
export function taskProfileToBanditContext(profile: TaskProfile): BanditContext {
  return { …, budgetUtilization: 0.5, timePressure: 0.3 };
}
```

Called on every route by `runLinUCBStage`. **The bandit's budget dimension was a constant.** A constant feature carries no information — whatever coefficient LinUCB learns for it is meaningless, and routing could never respond to budget pressure.

It now takes the figure `applyBudgetFilter` computes (added in #4869).

## Why the distribution-shift worry does not bite

Feeding real values into a previously-constant feature would normally invalidate an already-trained model's coefficient for that dimension. It does not here: `LinUCBBandit` is constructed fresh per process and warm-started by replaying outcomes through a **neutral context** — the original task context isn't stored in `TaskOutcome`, so every feature is already constant during warm-start and varying at selection time. This change makes `budgetUtilization` behave like every other feature rather than introducing a new inconsistency.

That is also why the fallback is `0.5` and not `0`: neutral is the exact value `warmStart` replays against, so an unknown budget matches the context the weights were reconstructed from. Zero would assert "budget untouched" — a claim, not an absence.

## LinUCBStage: parser removed, not corrected

Rather than fixing the hyphen, `extractBudgetUtilization` is replaced by a validated metadata read, consistent with #4866's decision that cross-stage signals are not an input channel. Out-of-range values fall back to neutral instead of being clamped — an implausible number is more likely a wiring mistake than a measurement, and clamping would launder it into a plausible one.

The stage now reports the value it used in its trace, which is also what made the tests assertable.

## The ratchet's KNOWN_BROKEN map is now empty

Every consumed routing-signal prefix has a producer. Pleasingly, the mutation run confirms the ratchet earns its keep with an empty map: restoring the dead prefix read fails **the ratchet itself**, not just the unit test.

## Testing

Eight tests. The three existing LinUCB "budget signal" tests were named for extraction and asserted only `.ok === true` — they passed against a consumer reading a prefix nobody emitted, and would have passed after a fix too. Rewritten to assert the value actually used.

Four production hunks, each mutation-verified. The runner seam — `runLinUCBStage` passing the argument through — was initially unpinned and needed its own test; that is the third time this session two green suites have hidden a broken join, so I now check for it deliberately.

**2801 tests across `src/cli-adapters` and the routing audit, green.** `tsc` and eslint clean.

## Left alone

`timePressure: 0.3` is still hardcoded. No producer computes one anywhere in the tree, so unlike budget there is nothing to thread — filing rather than inventing a source.