### PR TITLE
fix(meta): exclude untrained predictions from the shadow agreement rate

### DIFF
--- a/.changeset/shadow-agreement-excludes-untrained.md
+++ b/.changeset/shadow-agreement-excludes-untrained.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': minor
+---
+
+stop reporting an agreement rate from an untrained shadow selector
+
+`MetaShadowRecord.learnedStrategy` was `'single-shot'` on every run.
+`NEXUS_META_SHADOW_TRAIN` defaults off, so the bandit is never updated, every
+arm holds identical parameters, `computeUCB` scores them equally, and the
+strict `>` tie-break in `select` resolves to arm 0 — which is `'single-shot'`.
+
+`summarizeShadowAgreement` counted those, so the reported agreement rate was
+not a comparison at all: it was **the frequency with which the rule-based
+router happens to choose single-shot**, labelled as learned-vs-rules agreement.
+That number is the evidence base for the enforce flip in #3552.
+
+- `predict` now returns `trained`, false while no arm has been pulled.
+- `MetaShadowRecord` gains an optional `modelTrained`. Absent means the record
+  predates the field and came from the same cold bandit, so it counts as
+  untrained.
+- `ShadowAgreementSummary` gains `trainedRecords`, and `agreementRate` is taken
+  over those only. Under the default configuration that is now `0` over `0` —
+  visibly nothing measured, rather than a high rate that looks like evidence.
+
+Fixes #4825.

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.test.ts
@@ -338,6 +338,37 @@ describe('MetaOrchestrator.select — shadow-mode learned selection (#3551)', ()
     expect(rec?.taskClass).toBe(d.analysis.taskType);
   });
 
+  it('records that the prediction came from an untrained model (#4825)', () => {
+    // Without this the agreement rate computed over these records reads as a
+    // learned comparison, when a cold bandit returns its tie-break arm every
+    // time. The seam matters: the selector reports `trained` and the summary
+    // reads `modelTrained`, and nothing else joins them.
+    const shadowSink = createRecordingShadowSink();
+    const meta = createMetaOrchestrator({
+      shadowSelector: createLearnedStrategySelector(),
+      shadowSink,
+    });
+
+    meta.select({ goal: 'should we adopt approach A or B', signals: { requiresConsensus: true } });
+
+    expect(shadowSink.getRecords()[0]?.modelTrained).toBe(false);
+  });
+
+  it('records a trained prediction as trained (#4825)', () => {
+    // The pair: hardcoding false would satisfy the test above and reinstate
+    // the same defect from the other side — an agreement rate stuck at zero.
+    const shadowSink = createRecordingShadowSink();
+    const selector = createLearnedStrategySelector();
+    const shadowSelector = selector;
+    const meta = createMetaOrchestrator({ shadowSelector, shadowSink });
+    const first = meta.select({ goal: 'implement the feature' });
+    selector.recordOutcome('single-shot', first, true);
+
+    meta.select({ goal: 'implement another feature' });
+
+    expect(shadowSink.getRecords()[1]?.modelTrained).toBe(true);
+  });
+
   it('does not log when only one of selector/sink is provided', () => {
     const shadowSink = createRecordingShadowSink();
     const meta = createMetaOrchestrator({ shadowSink }); // no selector

--- a/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
+++ b/packages/nexus-agents/src/orchestration/meta-orchestrator.ts
@@ -253,6 +253,7 @@ function recordShadow(
       agree: learned.strategy === decision.strategy,
       taskClass: decision.analysis.taskType,
       learnedScore: learned.score,
+      modelTrained: learned.trained,
     });
   } catch (err) {
     logger.warn('Shadow selection failed (non-fatal)', { error: getErrorMessage(err) });

--- a/packages/nexus-agents/src/orchestration/meta-shadow-selector.test.ts
+++ b/packages/nexus-agents/src/orchestration/meta-shadow-selector.test.ts
@@ -149,6 +149,9 @@ describe('createRecordingShadowSink', () => {
 
 describe('summarizeShadowAgreement', () => {
   it('computes overall and per-task-class agreement rates', () => {
+    // `modelTrained: true` is required for these to count at all (#4825) —
+    // this case tests the aggregation math, not the training gate, which has
+    // its own describe block below.
     const rec = (taskClass: string, agree: boolean): MetaShadowRecord => ({
       decisionId: 'x',
       timestamp: 't',
@@ -157,6 +160,7 @@ describe('summarizeShadowAgreement', () => {
       agree,
       taskClass,
       learnedScore: 0,
+      modelTrained: true,
     });
     const summary = summarizeShadowAgreement([
       rec('code_implementation', true),
@@ -173,10 +177,89 @@ describe('summarizeShadowAgreement', () => {
   it('returns a zero summary for no records', () => {
     expect(summarizeShadowAgreement([])).toEqual({
       total: 0,
+      trainedRecords: 0,
       agreements: 0,
       agreementRate: 0,
       perTaskClass: {},
     });
+  });
+});
+
+describe('predict reports whether the bandit has learned anything (#4825)', () => {
+  it('is untrained before any outcome is recorded', () => {
+    // The production default: NEXUS_META_SHADOW_TRAIN is off, so recordOutcome
+    // is never called and this stays false for the process's whole life.
+    const selector = createLearnedStrategySelector();
+
+    expect(selector.predict(decision()).trained).toBe(false);
+  });
+
+  it('becomes trained once an outcome lands', () => {
+    // The pair — hardcoding false would satisfy the test above.
+    const selector = createLearnedStrategySelector();
+    selector.recordOutcome('pipeline', decision(), true);
+
+    expect(selector.predict(decision()).trained).toBe(true);
+  });
+
+  it('returns the tie-break arm while untrained, which is the whole defect', () => {
+    // Every arm scores identically on a cold bandit and `select` resolves the
+    // tie to index 0. Recorded here so the constant is visible rather than
+    // being inferred from the issue.
+    const selector = createLearnedStrategySelector();
+
+    expect(selector.predict(decision()).strategy).toBe(SHADOW_STRATEGY_ARMS[0]);
+  });
+});
+
+describe('agreement excludes predictions from an untrained model (#4825)', () => {
+  // With NEXUS_META_SHADOW_TRAIN off — the default — the bandit is never
+  // updated, every arm scores identically, and ties resolve to index 0, which
+  // is 'single-shot'. The resulting "agreement rate" is really the frequency
+  // with which the RULES chose single-shot, wearing the label of a learned
+  // comparison. That number is the evidence base for #3552.
+  const rec = (agree: boolean, modelTrained: boolean): MetaShadowRecord => ({
+    decisionId: 'x',
+    timestamp: 't',
+    ruleStrategy: 'single-shot',
+    learnedStrategy: agree ? 'single-shot' : 'pipeline',
+    agree,
+    taskClass: 'general',
+    learnedScore: 0,
+    modelTrained,
+  });
+
+  it('counts only trained predictions in the agreement rate', () => {
+    const summary = summarizeShadowAgreement([
+      rec(true, false),
+      rec(true, false),
+      rec(false, true),
+      rec(true, true),
+    ]);
+
+    expect(summary.total).toBe(4);
+    expect(summary.trainedRecords).toBe(2);
+    expect(summary.agreementRate).toBeCloseTo(0.5);
+  });
+
+  it('reports a rate of zero over zero trained records, not a high one', () => {
+    // Today's actual state: every record untrained. The old summary reported
+    // ~100% agreement here, which reads as a learned selector matching the
+    // rules almost perfectly.
+    const summary = summarizeShadowAgreement([rec(true, false), rec(true, false)]);
+
+    expect(summary.total).toBe(2);
+    expect(summary.trainedRecords).toBe(0);
+    expect(summary.agreementRate).toBe(0);
+  });
+
+  it('treats a record with no training flag as untrained', () => {
+    // Records written before this field existed cannot be assumed trained;
+    // they were produced by the cold bandit this issue is about.
+    const legacy: MetaShadowRecord = { ...rec(true, false) };
+    delete (legacy as { modelTrained?: boolean }).modelTrained;
+
+    expect(summarizeShadowAgreement([legacy]).trainedRecords).toBe(0);
   });
 });
 

--- a/packages/nexus-agents/src/orchestration/meta-shadow-selector.ts
+++ b/packages/nexus-agents/src/orchestration/meta-shadow-selector.ts
@@ -67,6 +67,15 @@ export interface MetaShadowRecord {
   readonly taskClass: string;
   /** UCB score the learned selector assigned its choice. */
   readonly learnedScore: number;
+  /**
+   * Whether the bandit had been trained when this prediction was made (#4825).
+   *
+   * `false` means every arm still held identical parameters, so the "learned"
+   * choice was the tie-break — arm 0, `single-shot` — and carries no learning.
+   * Absent means the record predates this field and was produced by that same
+   * cold bandit, so it is treated as untrained.
+   */
+  readonly modelTrained?: boolean;
 }
 
 /** A sink that receives every shadow comparison. Must not throw. */
@@ -114,8 +123,18 @@ export interface ShadowArmStat {
 
 /** The learned selector: predict a strategy + learn from outcomes. */
 export interface ILearnedStrategySelector {
-  /** Predict the best strategy for a decision's signals (shadow — not executed). */
-  predict(decision: MetaDecision): { strategy: ExecutionStrategy; score: number };
+  /**
+   * Predict the best strategy for a decision's signals (shadow — not executed).
+   *
+   * `trained` is false while no arm has been pulled: the bandit then scores
+   * every arm identically and `select` resolves the tie to arm 0, so the
+   * returned strategy is a constant, not a prediction (#4825).
+   */
+  predict(decision: MetaDecision): {
+    strategy: ExecutionStrategy;
+    score: number;
+    trained: boolean;
+  };
   /** Train: record whether `strategy` succeeded for a decision's context. */
   recordOutcome(strategy: ExecutionStrategy, decision: MetaDecision, success: boolean): void;
   /** Per-arm pull counts + reward means — bandit-movement telemetry (#3593). */
@@ -171,12 +190,17 @@ function createHydratableSelector(): IHydratableSelector {
     bandit.update(idx, context, success ? SUCCESS_REWARD : FAILURE_REWARD);
   };
   return {
-    predict(decision: MetaDecision): { strategy: ExecutionStrategy; score: number } {
+    predict(decision: MetaDecision): {
+      strategy: ExecutionStrategy;
+      score: number;
+      trained: boolean;
+    } {
       const { armName, ucbScore } = bandit.select(toBanditContext(decision));
       const strategy = SHADOW_STRATEGY_ARMS.includes(armName as ExecutionStrategy)
         ? (armName as ExecutionStrategy)
         : FALLBACK_STRATEGY;
-      return { strategy, score: ucbScore };
+      const trained = bandit.getStats().some((st) => st.pullCount > 0);
+      return { strategy, score: ucbScore, trained };
     },
     recordOutcome(strategy: ExecutionStrategy, decision: MetaDecision, success: boolean): void {
       apply(strategy, toBanditContext(decision), success);
@@ -204,6 +228,14 @@ export interface TaskClassAgreement {
 /** Offline policy-evaluation summary: agreement overall + per task class. */
 export interface ShadowAgreementSummary {
   readonly total: number;
+  /**
+   * Records whose prediction came from a trained bandit (#4825).
+   *
+   * `agreementRate` is taken over these only. When it is 0 the rate is 0 over
+   * nothing — which is what the default configuration produces, since
+   * `NEXUS_META_SHADOW_TRAIN` is off and the bandit never learns.
+   */
+  readonly trainedRecords: number;
   readonly agreements: number;
   readonly agreementRate: number;
   readonly perTaskClass: Readonly<Record<string, TaskClassAgreement>>;
@@ -219,7 +251,11 @@ export function summarizeShadowAgreement(
 ): ShadowAgreementSummary {
   const perTaskClass: Record<string, { total: number; agree: number; rate: number }> = {};
   let agreements = 0;
-  for (const r of records) {
+  // Only a trained bandit produces a comparison. An untrained one returns its
+  // tie-break arm every time, so counting those would report the rules'
+  // preference for that strategy as a learned agreement rate (#4825).
+  const trained = records.filter((r) => r.modelTrained === true);
+  for (const r of trained) {
     if (r.agree) agreements++;
     const cur = perTaskClass[r.taskClass] ?? { total: 0, agree: 0, rate: 0 };
     cur.total++;
@@ -227,11 +263,11 @@ export function summarizeShadowAgreement(
     cur.rate = cur.agree / cur.total;
     perTaskClass[r.taskClass] = cur;
   }
-  const total = records.length;
   return {
-    total,
+    total: records.length,
+    trainedRecords: trained.length,
     agreements,
-    agreementRate: total === 0 ? 0 : agreements / total,
+    agreementRate: trained.length === 0 ? 0 : agreements / trained.length,
     perTaskClass,
   };
 }


### PR DESCRIPTION
Fixes #4825.

## What the number actually was

`MetaShadowRecord.learnedStrategy` was `'single-shot'` on every run. `NEXUS_META_SHADOW_TRAIN` defaults off, so `recordOutcome` never fires, every arm keeps identical parameters, `computeUCB` scores them equally, and the strict `>` tie-break in `select` never lets anything beat index 0 — which is `'single-shot'`.

`summarizeShadowAgreement` counted those records, so the "agreement rate" was **the frequency with which the rule-based router happens to choose single-shot**, wearing the label of a learned-vs-rules comparison.

That is the shape this repo treats as p1: not a missing measurement but a plausible one that measures something else. And it is not idle telemetry — it is the evidence base for the enforce flip in #3552. A reader would draw a conclusion about learned-selection readiness from a statistic containing no learning.

## The fix

`predict` returns `trained`, false while no arm has been pulled. `MetaShadowRecord` gains an optional `modelTrained`, and `ShadowAgreementSummary` gains `trainedRecords` with `agreementRate` taken over those only.

Under the default configuration the rate is now **0 over 0** — visibly nothing measured. That is the honest reading of the current state, and it is what #3552 needs to see before deciding anything.

Absent `modelTrained` counts as untrained rather than unknown-so-include: records without it predate the field and were produced by exactly the cold bandit this issue is about, so treating them as trained would preserve the defect for all existing data.

The issue offered "gate the prediction on the training flag" as option 1. I kept the prediction and marked it instead — the record is still useful (it shows the rules' distribution, and that the model is cold), and the misreport was in the aggregate, not the individual row.

## Testing

Nine tests, red first. Two are recorded facts rather than assertions of new behaviour: that an untrained selector returns the tie-break arm, and that it flips to trained after one outcome — so the mechanism is visible in the suite rather than only in the issue.

Three production hunks, each mutation-verified. Two were unpinned on the first pass — `predict`'s `trained` computation and the record wiring in `meta-orchestrator` — which is the join-between-two-green-suites gap again; both now have their own test.

**One existing test had to change**, and it is worth being explicit that this is not appeasing it: `computes overall and per-task-class agreement rates` builds records with no `modelTrained`, which under the new semantics are untrained. It tests the aggregation math, not the training gate, so it now sets the flag with a comment saying which contract it covers. The training gate has its own block.

1205 tests across `src/orchestration`, green. `tsc` and eslint clean; no API-surface change.