### PR TITLE
fix(doctor): check whether a CLI is installed before claiming it is

### DIFF
--- a/.changeset/doctor-live-checks-installed.md
+++ b/.changeset/doctor-live-checks-installed.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+make doctor --live actually check whether a CLI is installed
+
+The `installed` rung of the readiness ladder was the literal
+`{ status: 'verified' }` — the first level of a readiness report asserting
+itself. Nothing probed PATH.
+
+It now calls `detectCliBinary`, and a missing binary fails the ladder at
+`installed` with `authenticated` and `serves` reported `not-attempted`, per the
+ladder's own rule that a skipped level is never `failed`. That also fixes a
+misattributed reason: a CLI that was simply absent previously surfaced as
+"no usable credentials found", because the auth rung was consulted for a
+binary that does not exist.
+
+Narrower than #4840 claimed — the `authenticated` rung was not inventing a pass,
+and the base `doctor` output already printed a truthful "Not installed" line
+just above the ladder. Details on the issue.
+
+Fixes #4840.

--- a/packages/nexus-agents/src/cli/doctor-live-default-probe.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-live-default-probe.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The default `installed` probe is wired to the real binary detector (#4840).
+ *
+ * Separate file because it mocks `setup-cli-detection`, which the main
+ * doctor-live suite deliberately does not — every case there injects
+ * `isInstalled`, so none of them can see whether the DEFAULT reaches a real
+ * probe. That is the seam: with the injection point tested and the default
+ * untested, replacing the default with `() => true` passes the whole suite.
+ *
+ * @module cli/doctor-live-default-probe.test
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+const { detectCliBinaryMock } = vi.hoisted(() => ({
+  detectCliBinaryMock: vi.fn(() => ({ installed: false, version: undefined })),
+}));
+
+vi.mock('./setup-cli-detection.js', () => ({ detectCliBinary: detectCliBinaryMock }));
+
+import { runLiveReadiness } from './doctor-live.js';
+import type { ServesProbeTarget } from './cli-readiness.js';
+import type { CliName } from '../cli-adapters/types.js';
+
+describe('runLiveReadiness default installed probe (#4840)', () => {
+  it('consults the real binary detector when no override is supplied', async () => {
+    const adapters = new Map<CliName, ServesProbeTarget>([
+      ['claude', { execute: () => Promise.resolve({ ok: true as const, value: { text: 'ok' } }) }],
+    ]);
+
+    const report = await runLiveReadiness({
+      adapters,
+      authStates: new Map([['claude', 'authenticated']]),
+    });
+
+    expect(detectCliBinaryMock).toHaveBeenCalledWith('claude');
+    expect(report[0]?.levels.installed.status).toBe('failed');
+  });
+});

--- a/packages/nexus-agents/src/cli/doctor-live.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-live.test.ts
@@ -22,10 +22,19 @@ type AuthState = 'authenticated' | 'unknown' | 'not-ok';
 const auth = (m: Record<string, AuthState>): ReadonlyMap<CliName, AuthState> =>
   new Map(Object.entries(m)) as ReadonlyMap<CliName, AuthState>;
 
+/**
+ * These cases exercise the auth and serves rungs, so they declare the binary
+ * present. Before #4840 the `installed` rung was a literal, and every one of
+ * them depended on that constant without saying so — they broke the moment it
+ * became a real probe, which is how the dependency surfaced.
+ */
+const INSTALLED = { isInstalled: (): boolean => true };
+
 describe('runLiveReadiness', () => {
   it('reaches serves when the adapter returns content', async () => {
     const report = await runLiveReadiness({
       adapters: adapters({ claude: serving('ok') }),
+      ...INSTALLED,
       authStates: auth({ claude: 'authenticated' }),
     });
 
@@ -36,6 +45,7 @@ describe('runLiveReadiness', () => {
     // The whole point. Every prior check passes; the completion returns empty.
     const report = await runLiveReadiness({
       adapters: adapters({ claude: serving('') }),
+      ...INSTALLED,
       authStates: auth({ claude: 'authenticated' }),
     });
 
@@ -54,6 +64,7 @@ describe('runLiveReadiness', () => {
 
     const report = await runLiveReadiness({
       adapters: adapters({ claude: spy }),
+      ...INSTALLED,
       authStates: auth({ claude: 'not-ok' }),
     });
 
@@ -66,6 +77,7 @@ describe('runLiveReadiness', () => {
     // measurement just as much as claiming it passed.
     const report = await runLiveReadiness({
       adapters: adapters({ claude: serving('ok') }),
+      ...INSTALLED,
       authStates: auth({ claude: 'not-ok' }),
     });
 
@@ -80,6 +92,7 @@ describe('runLiveReadiness', () => {
     // `unknown`. The live probe is exactly what settles it.
     const report = await runLiveReadiness({
       adapters: adapters({ gemini: serving('ok') }),
+      ...INSTALLED,
       authStates: auth({ gemini: 'unknown' }),
     });
 
@@ -89,6 +102,7 @@ describe('runLiveReadiness', () => {
   it('reports each adapter independently', async () => {
     const report = await runLiveReadiness({
       adapters: adapters({ claude: serving('ok'), codex: serving('') }),
+      ...INSTALLED,
       authStates: auth({ claude: 'authenticated', codex: 'authenticated' }),
     });
 
@@ -104,9 +118,69 @@ describe('formatLiveReadiness', () => {
   it('names the failing level in the output', async () => {
     const report = await runLiveReadiness({
       adapters: adapters({ claude: serving('') }),
+      ...INSTALLED,
       authStates: auth({ claude: 'authenticated' }),
     });
 
     expect(formatLiveReadiness(report)).toContain('no content');
+  });
+});
+
+// ============================================================================
+// The installed rung is measured, not asserted (#4840)
+// ============================================================================
+
+describe('installed level reflects a real probe (#4840)', () => {
+  // `installed` was the literal `{ status: 'verified' }`. Nothing probed PATH,
+  // so a CLI that is not on the system still reported the first rung green —
+  // and every existing test above depends on that constant without saying so.
+
+  it('fails the ladder at installed when the binary is absent', async () => {
+    const report = await runLiveReadiness({
+      adapters: adapters({ claude: serving('ok') }),
+      authStates: auth({ claude: 'authenticated' }),
+      isInstalled: () => false,
+    });
+
+    expect(report[0]?.levels.installed.status).toBe('failed');
+    // `reached` is undefined, not a level name, when even installed failed.
+    expect(report[0]?.reached).toBeUndefined();
+  });
+
+  it('does not probe auth or serves for a CLI that is not installed', async () => {
+    // The ladder's own contract: a skipped level reports not-attempted, never
+    // failed — nothing was learned about it. Probing a missing binary for
+    // credentials is also how "not installed" became "no usable credentials
+    // found" in the reason string.
+    let served = false;
+    const report = await runLiveReadiness({
+      adapters: adapters({
+        claude: {
+          execute: () => {
+            served = true;
+            return Promise.resolve({ ok: true as const, value: { text: 'ok' } });
+          },
+        },
+      }),
+      authStates: auth({ claude: 'authenticated' }),
+      isInstalled: () => false,
+    });
+
+    expect(served).toBe(false);
+    expect(report[0]?.levels.authenticated.status).toBe('not-attempted');
+    expect(report[0]?.levels.serves.status).toBe('not-attempted');
+  });
+
+  it('still reaches serves when the binary is present', async () => {
+    // The pair. Without it, "always report not installed" satisfies both
+    // tests above and breaks every real run.
+    const report = await runLiveReadiness({
+      adapters: adapters({ claude: serving('ok') }),
+      authStates: auth({ claude: 'authenticated' }),
+      isInstalled: () => true,
+    });
+
+    expect(report[0]?.levels.installed.status).toBe('verified');
+    expect(report[0]?.reached).toBe('serves');
   });
 });

--- a/packages/nexus-agents/src/cli/doctor-live.ts
+++ b/packages/nexus-agents/src/cli/doctor-live.ts
@@ -14,6 +14,7 @@
 import { createAllAdapters } from '../cli-adapters/factory.js';
 import type { CliName } from '../cli-adapters/types.js';
 import { probeAllClis } from './cli-auth-probe.js';
+import { detectCliBinary } from './setup-cli-detection.js';
 import {
   buildReadiness,
   formatReadiness,
@@ -38,15 +39,22 @@ export async function runLiveReadiness(
   deps: {
     readonly adapters?: Map<CliName, ServesProbeTarget>;
     readonly authStates?: ReadonlyMap<CliName, 'authenticated' | 'unknown' | 'not-ok'>;
+    /**
+     * Whether a CLI's binary is on PATH. Defaults to a real `which` +
+     * `--version` probe (#4840); overridable so the ladder can be exercised
+     * without the host's actual toolchain.
+     */
+    readonly isInstalled?: (cli: CliName) => boolean;
   } = {}
 ): Promise<readonly CliReadiness[]> {
   const adapters =
     deps.adapters ?? (createAllAdapters() as unknown as Map<CliName, ServesProbeTarget>);
   const authStates = deps.authStates ?? (await readAuthStates());
+  const isInstalled = deps.isInstalled ?? ((cli: CliName) => detectCliBinary(cli).installed);
 
   const results: CliReadiness[] = [];
   for (const [cli, adapter] of adapters) {
-    results.push(await ladderFor(cli, adapter, authStates.get(cli)));
+    results.push(await ladderFor(cli, adapter, authStates.get(cli), isInstalled(cli)));
   }
   return results;
 }
@@ -54,8 +62,19 @@ export async function runLiveReadiness(
 async function ladderFor(
   cli: CliName,
   adapter: ServesProbeTarget,
-  auth: 'authenticated' | 'unknown' | 'not-ok' | undefined
+  auth: 'authenticated' | 'unknown' | 'not-ok' | undefined,
+  binaryPresent: boolean
 ): Promise<CliReadiness> {
+  // Was the literal `{ status: 'verified' }` — the first rung of a readiness
+  // ladder asserting itself (#4840). It also made the auth rung report "no
+  // usable credentials found" for a CLI that simply is not installed.
+  if (!binaryPresent) {
+    return buildReadiness(cli, {
+      installed: { status: 'failed', reason: 'binary not found on PATH' },
+      authenticated: { status: 'not-attempted', reason: NOT_REACHED },
+      serves: { status: 'not-attempted', reason: NOT_REACHED },
+    });
+  }
   const installed: LevelOutcome = { status: 'verified' };
 
   // `unknown` (#4391: a CLI exposing no readable auth signal) is admitted


### PR DESCRIPTION
Fixes #4840 — and corrects it. Half of what I filed was wrong; the correction is on the issue.

## What was real

`doctor-live.ts:59`:

```ts
const installed: LevelOutcome = { status: 'verified' };
```

The first rung of a readiness ladder asserting itself. No PATH probe, no version check, and `runLiveReadiness` falls back to `createAllAdapters()` unfiltered so nothing upstream narrows it.

It now calls `detectCliBinary`. A missing binary fails at `installed`, with `authenticated` and `serves` reported `not-attempted` — the ladder's own rule that a skipped level is never `failed`, since nothing was learned about it.

That also fixes a misattributed cause: a CLI that is simply absent previously surfaced as **"no usable credentials found"**, because the auth rung was consulted for a binary that does not exist.

## What I got wrong

The title said "reports every CLI as installed **and authenticated** without checking either." The second half is false. `probeAllClis` enumerates all four CLIs unconditionally and `probeCli` returns `not-installed` for gemini/codex/opencode, which `readAuthStates` collapses to `not-ok` → the rung reports **failed**. It was not inventing a pass.

Severity is also lower than implied: `handleDoctorCommand` runs the base `doctorCommand` first, which prints a genuine `Not installed` from a real probe. The ladder was contradicting a truthful line a few lines above it in the same output — self-inconsistent, not a blind spot.

## Every existing test in the file depended on the constant

All seven broke the moment `installed` became a real probe. They exercise the auth and serves rungs and had been relying on the first rung being free. They now declare `isInstalled: () => true` through a shared `INSTALLED` constant whose comment says why — the dependency is stated instead of assumed.

## The default wiring needed its own file

The mutation run caught this: with every test injecting `isInstalled`, replacing the **default** with `() => true` passes the entire suite. The injection point was tested and the wiring to the real detector was not — the same seam gap that has come up repeatedly this session.

`doctor-live-default-probe.test.ts` mocks `setup-cli-detection` and asserts the default reaches `detectCliBinary`. It is a separate file precisely because the main suite must *not* mock that module.

Three production hunks, each mutation-verified.

## Left for the issue

Two things I found while scoping and did not fix here, both recorded on #4840:

- `probeClaude` has no not-installed branch, so an uninstalled claude with a stale `~/.claude/.credentials.json` still reports authenticated. Now caught one rung earlier by this change, but the probe itself is still wrong.
- **`doctor --live` exits 0 for a CLI that cannot authenticate** — the exit code keys on `serves`, and an auth failure leaves `serves` at `not-attempted`. Possibly intended; I have not established that.

3634 tests across `src/cli`, green. `tsc`, eslint, and the producer/consumer ratchet clean.