### PR TITLE
fix(research): score recency on publication date, not discovery date

### DIFF
--- a/.changeset/recency-scores-publication-date.md
+++ b/.changeset/recency-scores-publication-date.md
@@ -1,0 +1,32 @@
+---
+'nexus-agents': minor
+---
+
+score research recency on the publication date, not the discovery date
+
+`scoreRecency` read `item.discoveredAt` — when _we_ found the source. Every one
+of the five producers stamps that with `getToday()`, so `daysSince` was always
+≈0, the documented 730-day decay was unreachable, and 20% of every composite
+score was the constant 1.0. A 2019 paper and a 2026 preprint scored identically.
+
+`DiscoveredSource` gains an optional `publishedAt`, and recency is scored from
+it. Three of the four producers already had the data and were discarding it:
+
+- **OpenAlex** — `publication_date` was in the zod schema and dropped at the mapper.
+- **Semantic Scholar** — `year` only; mapped to Jan 1, which never scores a paper
+  fresher than it is.
+- **arXiv** — `<published>` is on every entry and `extractTag` already existed;
+  it was simply never called for that tag.
+- **GitHub** — needed a schema field. Uses `pushed_at`, not `created_at`: for a
+  repository the recency signal is last activity, not project age.
+
+`QualityScore` gains `recencyMeasured`. When no publication date is available
+recency is the neutral 0.5 rather than 1.0 — an unknown age is not evidence of
+freshness, which is how this term became a constant in the first place.
+
+**Composite scores will move**, and downward for older items. That shifts which
+items clear the `>= 0.6` gate for `--create-issues` and the `>= 0.8` P1
+threshold. The previous uniform +0.2 was inflation, so this is the correction
+rather than a regression.
+
+Fixes #4841.

--- a/packages/nexus-agents/src/cli/research-helpers-review.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-review.test.ts
@@ -78,6 +78,7 @@ const mockQualityScore: QualityScore = {
   relevance: 0.9,
   impact: 0.8,
   recency: 0.7,
+  recencyMeasured: true,
   reproducibility: 0.6,
   composite: 0.75,
 };

--- a/packages/nexus-agents/src/cli/research-helpers-scoring.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-scoring.test.ts
@@ -18,6 +18,7 @@ function createItem(overrides: Partial<DiscoveredSource> = {}): DiscoveredSource
     description: 'A framework for multi-agent orchestration.',
     relevance: 'medium',
     discoveredAt: new Date().toISOString().split('T')[0] ?? '',
+    publishedAt: '2026-08-01',
     ...overrides,
   };
 }
@@ -80,11 +81,15 @@ describe('scoreDiscoveredItem', () => {
     expect(score.impact).toBe(0.2);
   });
 
-  it('should score recent items higher on recency', () => {
-    const today = new Date().toISOString().split('T')[0] ?? '';
-    const item = createItem({ discoveredAt: today });
-    const score = scoreDiscoveredItem(item, 'test');
-    expect(score.recency).toBeGreaterThan(0.9);
+  it('scores a recently PUBLISHED item higher than an old one (#4841)', () => {
+    // This replaces a test whose name promised a comparison and whose body
+    // scored a single item stamped today, asserting > 0.9. Every producer
+    // stamps `discoveredAt` with today's date, so it passed no matter what —
+    // including with the 730-day decay deleted entirely.
+    const fresh = scoreDiscoveredItem(createItem({ publishedAt: '2026-08-01' }), 'test');
+    const old = scoreDiscoveredItem(createItem({ publishedAt: '2019-03-01' }), 'test');
+
+    expect(fresh.recency).toBeGreaterThan(old.recency);
   });
 
   it('should handle empty topic gracefully', () => {
@@ -94,9 +99,50 @@ describe('scoreDiscoveredItem', () => {
   });
 
   it('should handle invalid date gracefully', () => {
-    const item = createItem({ discoveredAt: 'invalid' });
+    const item = createItem({ publishedAt: 'invalid' });
     const score = scoreDiscoveredItem(item, 'test');
     expect(score.recency).toBe(0.5);
+    expect(score.recencyMeasured).toBe(false);
+  });
+});
+
+// =============================================================================
+// Recency is scored on publication, not discovery (#4841)
+// =============================================================================
+
+describe('recency uses the publication date (#4841)', () => {
+  it('does not score recency from discoveredAt', () => {
+    // `discoveredAt` records when WE found the source, which every producer
+    // stamps as today. Scoring it made the 730-day decay unreachable and put
+    // a flat +0.2 on every composite: a 2019 paper and a 2026 preprint
+    // scored identically.
+    const old = createItem({ publishedAt: '2019-03-01', discoveredAt: '2026-08-25' });
+
+    expect(scoreDiscoveredItem(old, 'test').recency).toBeLessThan(0.5);
+  });
+
+  it('reports recency as unmeasured when no publication date is available', () => {
+    // Not every producer can supply one. Neutral rather than fresh, and said
+    // out loud — 1.0 would keep claiming the source is new.
+    const item = createItem();
+    delete (item as { publishedAt?: string }).publishedAt;
+
+    const score = scoreDiscoveredItem(item, 'test');
+
+    expect(score.recency).toBe(0.5);
+    expect(score.recencyMeasured).toBe(false);
+  });
+
+  it('marks recency measured when a publication date is present', () => {
+    // The pair: always-false would satisfy the test above.
+    expect(
+      scoreDiscoveredItem(createItem({ publishedAt: '2026-08-01' }), 'test').recencyMeasured
+    ).toBe(true);
+  });
+
+  it('still decays a genuinely old publication toward zero', () => {
+    // The decay the original code documented and could never reach.
+    expect(scoreDiscoveredItem(createItem({ publishedAt: '2015-01-01' }), 'test').recency).toBe(0);
   });
 });
 

--- a/packages/nexus-agents/src/cli/research-helpers-scoring.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-scoring.ts
@@ -22,6 +22,16 @@ export interface QualityScore {
   readonly impact: number;
   /** Recency decay (0-1) - newer items score higher. */
   readonly recency: number;
+  /**
+   * Whether {@link QualityScore.recency} is a measurement (#4841).
+   *
+   * `false` means the item carried no usable publication date, so `recency`
+   * is the neutral 0.5 and NOT a decay. It was previously scored from
+   * `discoveredAt` — when WE found the source, which every producer stamps as
+   * today — so the 730-day decay was unreachable and every composite carried
+   * a flat +0.2.
+   */
+  readonly recencyMeasured: boolean;
   /** Code availability (0-1) - items with repos score higher. */
   readonly reproducibility: number;
   /** Weighted composite score (0-1). */
@@ -66,14 +76,29 @@ function relevanceLabelToScore(relevance: string): number {
   }
 }
 
-/** Score recency based on discovered date. Decays over 2 years. */
-function scoreRecency(discoveredAt: string): number {
-  const discoveredDate = new Date(discoveredAt);
-  if (isNaN(discoveredDate.getTime())) return 0.5;
-  const now = new Date();
-  const daysSince = (now.getTime() - discoveredDate.getTime()) / (1000 * 60 * 60 * 24);
-  // Linear decay over 730 days (2 years)
-  return Math.max(0, 1 - daysSince / 730);
+/** Neutral recency for an item whose publication date is unknown. */
+const NEUTRAL_RECENCY = 0.5;
+/** Linear decay window: two years. */
+const RECENCY_DECAY_DAYS = 730;
+
+/**
+ * Score recency from the item's PUBLICATION date, decaying over two years.
+ *
+ * `undefined` or unparseable yields neutral with `measured: false`. Not 1.0:
+ * an unknown age is not evidence of freshness, and reporting it as fresh is
+ * what made this term a constant (#4841).
+ */
+function scoreRecency(publishedAt: string | undefined): {
+  value: number;
+  measured: boolean;
+} {
+  if (publishedAt === undefined || publishedAt === '') {
+    return { value: NEUTRAL_RECENCY, measured: false };
+  }
+  const published = new Date(publishedAt);
+  if (isNaN(published.getTime())) return { value: NEUTRAL_RECENCY, measured: false };
+  const daysSince = (Date.now() - published.getTime()) / (1000 * 60 * 60 * 24);
+  return { value: Math.max(0, 1 - daysSince / RECENCY_DECAY_DAYS), measured: true };
 }
 
 /** Score reproducibility based on source type. */
@@ -100,19 +125,20 @@ export function scoreDiscoveredItem(item: DiscoveredSource, topic: string): Qual
   const relevance =
     topic !== '' ? scoreRelevance(item.title, topic) : relevanceLabelToScore(item.relevance);
   const impact = relevanceLabelToScore(item.relevance);
-  const recency = scoreRecency(item.discoveredAt);
+  const recency = scoreRecency(item.publishedAt);
   const reproducibility = scoreReproducibility(item.source);
 
   const composite =
     WEIGHTS.relevance * relevance +
     WEIGHTS.impact * impact +
-    WEIGHTS.recency * recency +
+    WEIGHTS.recency * recency.value +
     WEIGHTS.reproducibility * reproducibility;
 
   return {
     relevance: Math.round(relevance * 100) / 100,
     impact: Math.round(impact * 100) / 100,
-    recency: Math.round(recency * 100) / 100,
+    recency: Math.round(recency.value * 100) / 100,
+    recencyMeasured: recency.measured,
     reproducibility: Math.round(reproducibility * 100) / 100,
     composite: Math.round(composite * 100) / 100,
   };

--- a/packages/nexus-agents/src/cli/research-helpers-sources-academic.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources-academic.ts
@@ -96,6 +96,9 @@ function mapSemanticScholarPaper(
     description: truncate(paper.abstract ?? ''),
     relevance: citationRelevance(paper.citationCount ?? 0),
     discoveredAt: getToday(),
+    // Year only — the API gives no finer granularity. Jan 1 of that year is
+    // the conservative reading: it never scores a paper fresher than it is.
+    ...(paper.year === undefined ? {} : { publishedAt: `${String(paper.year)}-01-01` }),
   };
 }
 
@@ -292,6 +295,10 @@ function mapOpenAlexWork(work: z.infer<typeof OpenAlexWorkSchema>): DiscoveredSo
     description: truncate(reconstructAbstract(work.abstract_inverted_index)),
     relevance: citationRelevance(work.cited_by_count ?? 0),
     discoveredAt: getToday(),
+    // Already parsed by the schema and previously discarded here (#4841).
+    ...(work.publication_date === null || work.publication_date === undefined
+      ? {}
+      : { publishedAt: work.publication_date }),
   };
 }
 

--- a/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.test.ts
@@ -246,6 +246,32 @@ describe('discoverArxiv', () => {
     }
   });
 
+  it('carries the arXiv publication date through as publishedAt (#4841)', async () => {
+    // <published> is on every arXiv entry and `extractTag` already existed —
+    // it was simply never called for that tag, so recency was scored on the
+    // discovery date instead and the 730-day decay was unreachable.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () =>
+        Promise.resolve(`<?xml version="1.0" encoding="UTF-8"?>
+<feed>
+  <entry>
+    <id>http://arxiv.org/abs/1901.00001v1</id>
+    <title>An Older Paper</title>
+    <summary>Published years ago.</summary>
+    <published>2019-01-15T00:00:00Z</published>
+  </entry>
+</feed>`),
+    });
+
+    const result = await discoverArxiv('orchestration', 10);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value[0]?.publishedAt).toBe('2019-01-15T00:00:00Z');
+    }
+  });
+
   it('should use ti:/abs: query prefix', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -357,6 +383,32 @@ describe('arXiv-based providers', () => {
         const result = await fn('test', 5);
         expect(result.ok).toBe(false);
         if (!result.ok) expect(result.error.code).toBe('NETWORK');
+      });
+
+      it('carries the arXiv publication date through as publishedAt (#4841)', async () => {
+        // <published> is on every arXiv entry and `extractTag` already existed —
+        // it was simply never called for that tag, so recency was scored on the
+        // discovery date instead and the 730-day decay was unreachable.
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          text: () =>
+            Promise.resolve(`<?xml version="1.0" encoding="UTF-8"?>
+<feed>
+  <entry>
+    <id>http://arxiv.org/abs/1901.00001v1</id>
+    <title>An Older Paper</title>
+    <summary>Published years ago.</summary>
+    <published>2019-01-15T00:00:00Z</published>
+  </entry>
+</feed>`),
+        });
+
+        const result = await discoverArxiv('orchestration', 10);
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.value[0]?.publishedAt).toBe('2019-01-15T00:00:00Z');
+        }
       });
 
       it('should use ti:/abs: query prefix', async () => {

--- a/packages/nexus-agents/src/cli/research-helpers-sources.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-sources.ts
@@ -38,7 +38,13 @@ export interface DiscoveredSource {
   readonly url: string;
   readonly description: string;
   readonly relevance: 'high' | 'medium' | 'low';
+  /** When WE found this source — always the run date. NOT its age (#4841). */
   readonly discoveredAt: string;
+  /**
+   * When the source itself was published, ISO date, if the producer supplies
+   * one (#4841). Absent means unknown, which scores neutral rather than fresh.
+   */
+  readonly publishedAt?: string;
 }
 
 // =============================================================================
@@ -51,6 +57,14 @@ const GitHubRepoSchema = z.object({
   html_url: z.string().optional(),
   description: z.string().nullable().optional(),
   stargazers_count: z.number().optional(),
+  /**
+   * Last push, used as the recency signal for a repository (#4841).
+   *
+   * `created_at` would answer "how old is this project", which is the wrong
+   * question — an actively maintained 2019 repo is not stale. For a paper the
+   * publication date is the age; for a repo it is the last activity.
+   */
+  pushed_at: z.string().nullable().optional(),
 });
 
 const GitHubSearchResponseSchema = z.object({
@@ -150,6 +164,9 @@ function parseGitHubRepos(data: z.infer<typeof GitHubSearchResponseSchema>): Dis
           ? 'medium'
           : 'low',
     discoveredAt: getToday(),
+    ...(repo.pushed_at === null || repo.pushed_at === undefined
+      ? {}
+      : { publishedAt: repo.pushed_at }),
   }));
 }
 
@@ -425,6 +442,11 @@ function parseArxivEntries(xml: string, source: string, topic = ''): DiscoveredS
       description: truncate(extractTag(entry, 'summary')),
       relevance: topic !== '' ? scoreRelevance(title, topic) : 'medium',
       discoveredAt: getToday(),
+      // arXiv returns <published> on every entry; extractTag already existed
+      // and was simply never called for it (#4841).
+      ...(extractTag(entry, 'published') === ''
+        ? {}
+        : { publishedAt: extractTag(entry, 'published') }),
     });
   }
   return items;


### PR DESCRIPTION
Fixes #4841.

## The defect

`scoreRecency` read `item.discoveredAt` — when **we** found the source. All five producers stamp that with `getToday()`, so `daysSince` was always ≈0, the documented 730-day decay was unreachable, and 20% of every composite was the constant `1.0`.

The confusion is semantic: `discoveredAt` records our discovery, and the score used it as though it recorded the source's age. **A 2019 paper and a 2026 preprint scored identically.**

Verified against main before changing anything — all five `getToday()` producers traced, since two of my recent issues had a load-bearing claim that turned out to be wrong.

## Three of four producers already had the data and threw it away

- **OpenAlex** — `publication_date` was already in the zod schema and dropped at the mapper.
- **Semantic Scholar** — `year` only, mapped to Jan 1 of that year: the conservative reading, never scoring a paper fresher than it is.
- **arXiv** — `<published>` is on every entry, and `extractTag` already existed. It was simply never called for that tag.
- **GitHub** — the only one needing a schema field. It uses `pushed_at`, not `created_at`: for a repository the recency signal is last activity, not project age. An actively maintained 2019 repo is not stale.

## Unknown is neutral, not fresh

`QualityScore` gains `recencyMeasured`. With no publication date, recency is `0.5` rather than `1.0` — an unknown age is not evidence of freshness, and treating it as such is exactly how this term became a constant.

## The test that hid it, and what replaced it

`should score recent items higher on recency` promised a comparison and scored **one** item stamped today, asserting `> 0.9`. It passed with the decay deleted entirely. And `createItem` defaulted `discoveredAt` to today, so the surrounding range and ordering tests wrote and read the same literal.

It now compares a 2026 publication against a 2019 one. Three production hunks mutation-verified, including "unknown publication treated as fresh", which is the specific regression that would restore the constant.

## Behaviour change, measured

```
published 2026-08  recency=0.97  composite=0.83   clears 0.6 ✓   P1 ✓
published 2024     recency=0     composite=0.64   clears 0.6 ✓   P1 ✗
published 2019     recency=0     composite=0.64   clears 0.6 ✓   P1 ✗
no date            recency=0.50  composite=0.73   clears 0.6 ✓   P1 ✗
```

Composites drop for older items, which shifts what clears the `>= 0.6` gate for `--create-issues` and the `>= 0.8` P1 threshold. The previous uniform +0.2 was inflation, so this is the correction.

## One thing the measurement now exposes

**A 2024 paper scores 0, the same as a 2015 one** — the 730-day window saturates, so beyond two years the term is effectively binary. That was always the design (`// Linear decay over 730 days`), but it never mattered while recency was pinned at 1.0. Whether two years is the right window for this field is a judgement I have not made unilaterally; filing it separately now that it is reachable.

3741 tests across `src/cli` and the research MCP tools, green. `tsc`, eslint clean; no API-surface change.