### PR TITLE
fix(security): close two compounding SSRF bypasses in the custom-API guard

### DIFF
--- a/.changeset/ssrf-ipv4-mapped-ipv6.md
+++ b/.changeset/ssrf-ipv4-mapped-ipv6.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+close two compounding SSRF bypasses in the custom-API host guard
+
+**IPv4-mapped IPv6.** `isIPv6('::ffff:169.254.169.254')` is true and `isIPv4` is
+false, so mapped addresses were dispatched to the IPv6 classifier, which knew
+only `::1`, `fe80:` and `fc00::/7`. Every IPv4 rule — AWS IMDS, loopback,
+RFC1918 — was unreachable in mapped form. The URL parser normalises the dotted
+spelling to hex (`::ffff:a9fe:a9fe`), so the hex form is the one that actually
+arrives and a dotted-only fix would still have missed every real request.
+
+`classifyIPv6` now expands the literal and delegates any embedded IPv4 to the
+IPv4 rules, covering IPv4-mapped, IPv4-translated, the NAT64 well-known prefix
+`64:ff9b::/96`, and the deprecated IPv4-compatible form. The unspecified
+address `::`, which routes to localhost, is also rejected.
+
+**Mutual deference.** `assertCustomApiHostResolvesPublic` returned `ok` for any
+IP literal, on the stated grounds that the sync guard had classified it at
+construction. `discoverModels` never calls the sync guard — only this one — so
+on that path each guard deferred to the other and neither ran. It now
+classifies literals itself. That path matters because its base URL can come
+from a file (`opencode.json`), not only from operator intent.
+
+The two compound: a mapped IMDS literal passed both.

--- a/packages/nexus-agents/src/adapters/sdk/custom-api-validation.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/custom-api-validation.test.ts
@@ -160,6 +160,59 @@ describe('validateCustomApiBaseUrl', () => {
     });
   });
 
+  describe('IPv4-mapped IPv6 reaches the IPv4 rules', () => {
+    // `isIPv6('::ffff:169.254.169.254')` is true and `isIPv4` is false, so
+    // these were dispatched to the IPv6 classifier, which only knew `::1`,
+    // `fe80:` and `fc00::/7`. Every IPv4 rule — IMDS, loopback, RFC1918 —
+    // was unreachable in mapped form.
+    //
+    // The URL parser NORMALISES the dotted form to hex
+    // (`::ffff:169.254.169.254` → `::ffff:a9fe:a9fe`), so a fix matching only
+    // the dotted spelling would still miss every real request. Both are
+    // asserted for that reason.
+
+    it('rejects the AWS IMDS address in mapped dotted form', () => {
+      const result = validateCustomApiBaseUrl('http://[::ffff:169.254.169.254]/latest/meta-data/');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/link-local|169\.254/);
+    });
+
+    it('rejects the AWS IMDS address in mapped hex form', () => {
+      expect(validateCustomApiBaseUrl('http://[::ffff:a9fe:a9fe]/').ok).toBe(false);
+    });
+
+    it('rejects mapped loopback and RFC1918', () => {
+      expect(validateCustomApiBaseUrl('http://[::ffff:127.0.0.1]/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://[::ffff:10.0.0.1]/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://[::ffff:192.168.1.1]/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://[::ffff:172.16.0.1]/').ok).toBe(false);
+    });
+
+    it('rejects the NAT64 well-known prefix carrying a private IPv4', () => {
+      // 64:ff9b::/96 is how an IPv6-only network reaches IPv4 — the same
+      // address by another spelling.
+      expect(validateCustomApiBaseUrl('http://[64:ff9b::169.254.169.254]/').ok).toBe(false);
+    });
+
+    it('rejects the unspecified address', () => {
+      // `::` routes to localhost on most stacks, the IPv6 analogue of 0.0.0.0.
+      expect(validateCustomApiBaseUrl('http://[::]/').ok).toBe(false);
+    });
+
+    it('still allows a genuinely public IPv6 address', () => {
+      // The pair. Rejecting all IPv6 would satisfy every test above and break
+      // every legitimate v6 gateway.
+      expect(validateCustomApiBaseUrl('http://[2606:4700:4700::1111]/v1').ok).toBe(true);
+    });
+
+    it('still allows a public IPv4 address in mapped form', () => {
+      // Mapped is a spelling, not a verdict — it must not become a blanket
+      // rejection.
+      expect(validateCustomApiBaseUrl('http://[::ffff:1.1.1.1]/v1').ok).toBe(true);
+    });
+  });
+
   describe('SSRF guard escape hatch (NEXUS_CUSTOM_API_ALLOW_PRIVATE)', () => {
     it('allows localhost when allowPrivate=true is passed explicitly', () => {
       const result = validateCustomApiBaseUrl('http://localhost:8080/v1', {
@@ -256,17 +309,49 @@ describe('assertCustomApiHostResolvesPublic (DNS-resolve-time SSRF guard, #3426)
     });
   });
 
-  describe('IP literals skip DNS (handled by the sync guard at construction)', () => {
-    it('does not call dns.lookup for an IPv4 literal', async () => {
-      const result = await assertCustomApiHostResolvesPublic('93.184.216.34');
-      expect(result.ok).toBe(true);
-      expect(lookupMock).not.toHaveBeenCalled();
+  describe('IP literals need no DNS, but are still classified here', () => {
+    // This used to return ok for ANY literal, on the stated grounds that the
+    // sync guard classified it at construction. `discoverModels` never calls
+    // the sync guard — it calls only this one — so on that path each guard
+    // deferred to the other and neither ran. A base URL of
+    // `http://169.254.169.254/` reached IMDS, and that URL can come from a
+    // FILE (opencode.json), not only from operator intent.
+
+    it('does not call dns.lookup for a public IPv4 literal', () => {
+      const result = assertCustomApiHostResolvesPublic('93.184.216.34');
+      return result.then((r) => {
+        expect(r.ok).toBe(true);
+        expect(lookupMock).not.toHaveBeenCalled();
+      });
     });
 
     it('does not call dns.lookup for a bracket-stripped IPv6 literal', async () => {
       const result = await assertCustomApiHostResolvesPublic('[2606:2800:220:1::1]');
       expect(result.ok).toBe(true);
       expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a private IPv4 literal instead of deferring', async () => {
+      const result = await assertCustomApiHostResolvesPublic('169.254.169.254');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error.message).toMatch(/link-local|169\.254/);
+      expect(lookupMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a loopback literal instead of deferring', async () => {
+      expect((await assertCustomApiHostResolvesPublic('127.0.0.1')).ok).toBe(false);
+    });
+
+    it('rejects an IPv4-mapped IPv6 literal — both halves of the same bypass', async () => {
+      // Needs BOTH fixes: the literal must be classified here at all, and the
+      // classifier must see through the mapped form.
+      expect((await assertCustomApiHostResolvesPublic('[::ffff:a9fe:a9fe]')).ok).toBe(false);
+    });
+
+    it('still honours allowPrivate for a private literal', async () => {
+      const result = await assertCustomApiHostResolvesPublic('127.0.0.1', { allowPrivate: true });
+      expect(result.ok).toBe(true);
     });
   });
 

--- a/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
+++ b/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
@@ -163,6 +163,17 @@ function classifyIpAddress(normalized: string): RejectionDetail | null | 'not_an
   return 'not_an_ip';
 }
 
+/** Verdict for a host that is already an IP literal — no DNS required. */
+function classifyLiteral(hostname: string, normalized: string): Result<void, ConfigError> {
+  const literal = classifyIpAddress(normalized);
+  if (literal === null || literal === 'not_an_ip') return ok(undefined);
+  return err(
+    new ConfigError(
+      `Custom API host '${hostname}' is a ${literal.reason} address: ${literal.message}`
+    )
+  );
+}
+
 /**
  * DNS-resolve-time SSRF guard for the custom-openai gateway.
  *
@@ -202,9 +213,15 @@ export async function assertCustomApiHostResolvesPublic(
 
   const normalized = normalizeHost(hostname);
 
-  // IP literals are already handled by the sync guard at construction; no DNS.
+  // A literal needs no DNS, but it is still classified HERE rather than
+  // assumed handled elsewhere. This used to return ok for any literal on the
+  // grounds that the sync guard had classified it at construction — but
+  // `discoverModels` calls only this guard, never the sync one, so on that
+  // path each deferred to the other and neither ran. `http://169.254.169.254/`
+  // reached IMDS, from a base URL that can come from a file rather than from
+  // operator intent.
   if (isIPv4(normalized) || isIPv6(normalized)) {
-    return ok(undefined);
+    return classifyLiteral(hostname, normalized);
   }
 
   // Only `address` is read; the resolver's `family` is intentionally NOT
@@ -292,6 +309,65 @@ function classifyIPv4(ip: string): RejectionDetail | null {
   return null;
 }
 
+/**
+ * Expand an IPv6 literal to its eight 16-bit groups, or null if unparseable.
+ *
+ * A trailing dotted quad (`::ffff:1.2.3.4`) is folded into two groups first,
+ * so callers see one representation regardless of spelling.
+ */
+function foldTrailingQuad(s: string): string | null {
+  const dotted = /(?:^|:)((?:\d{1,3}\.){3}\d{1,3})$/.exec(s);
+  if (dotted?.[1] === undefined) return s;
+  const q = dotted[1].split('.').map((n) => Number.parseInt(n, 10));
+  if (q.length !== 4 || q.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return null;
+  const hi = (((q[0] ?? 0) << 8) | (q[1] ?? 0)).toString(16);
+  const lo = (((q[2] ?? 0) << 8) | (q[3] ?? 0)).toString(16);
+  return `${s.slice(0, s.length - dotted[1].length)}${hi}:${lo}`;
+}
+
+function toHextets(ip: string): number[] | null {
+  const s = foldTrailingQuad(ip.toLowerCase());
+  if (s === null) return null;
+  const halves = s.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] === '' || halves[0] === undefined ? [] : halves[0].split(':');
+  const tail = halves[1] === '' || halves[1] === undefined ? [] : halves[1].split(':');
+  const groups =
+    halves.length === 1
+      ? head
+      : [...head, ...Array<string>(8 - head.length - tail.length).fill('0'), ...tail];
+  if (groups.length !== 8) return null;
+  const out = groups.map((g) => Number.parseInt(g === '' ? '0' : g, 16));
+  return out.some((n) => Number.isNaN(n) || n < 0 || n > 0xffff) ? null : out;
+}
+
+/**
+ * The IPv4 address embedded in an IPv6 literal, in dotted form, or null.
+ *
+ * Covers every prefix that carries a routable IPv4 payload: IPv4-mapped
+ * (`::ffff:0:0/96`), IPv4-translated (`::ffff:0:0:0/96`), the NAT64
+ * well-known prefix (`64:ff9b::/96`), and the deprecated IPv4-compatible
+ * form (`::a.b.c.d`). Each is the same destination under a different
+ * spelling, and the IPv4 rules must apply to all of them.
+ */
+function embeddedIPv4(g: readonly number[]): string | null {
+  const top = g.slice(0, 6);
+  const prefixes: ReadonlyArray<readonly number[]> = [
+    [0, 0, 0, 0, 0, 0xffff], // ::ffff:0:0/96    — IPv4-mapped
+    [0, 0, 0, 0, 0xffff, 0], // ::ffff:0:0:0/96  — IPv4-translated
+    [0x64, 0xff9b, 0, 0, 0, 0], // 64:ff9b::/96  — NAT64 well-known
+    [0, 0, 0, 0, 0, 0], // ::a.b.c.d           — deprecated IPv4-compatible
+  ];
+  const matched = prefixes.some((p) => p.every((v, i) => top[i] === v));
+  if (!matched) return null;
+  const g6 = g[6] ?? 0;
+  const g7 = g[7] ?? 0;
+  // `::` and `::1` are their own addresses, not embedded IPv4.
+  if (top.every((v) => v === 0) && g6 === 0 && g7 <= 1) return null;
+  const octets = [(g6 >> 8) & 255, g6 & 255, (g7 >> 8) & 255, g7 & 255];
+  return octets.join('.');
+}
+
 function classifyIPv6(ip: string): RejectionDetail | null {
   const lower = ip.toLowerCase();
   if (lower === '::1') return { reason: 'loopback', message: `IPv6 loopback (${ip})` };
@@ -301,5 +377,23 @@ function classifyIPv6(ip: string): RejectionDetail | null {
   if (/^fc|^fd/.test(lower)) {
     return { reason: 'private_range', message: `IPv6 unique-local (${ip}, fc00::/7)` };
   }
-  return null;
+
+  const groups = toHextets(lower);
+  if (groups === null) return null;
+
+  if (groups.every((n) => n === 0)) {
+    return { reason: 'reserved', message: `IPv6 unspecified (${ip}) — routes to localhost` };
+  }
+
+  // An IPv4 address written in IPv6 form is still that IPv4 address, and
+  // `isIPv6` is true for it so it never reached the IPv4 rules — IMDS,
+  // loopback and RFC1918 were all reachable this way. Note the URL parser
+  // normalises the dotted spelling to hex, so the hex form is the one that
+  // actually arrives.
+  const v4 = embeddedIPv4(groups);
+  if (v4 === null) return null;
+  const detail = classifyIPv4(v4);
+  return detail === null
+    ? null
+    : { reason: detail.reason, message: `${detail.message} via IPv6 (${ip})` };
 }


### PR DESCRIPTION
Two HIGH findings from `.security-discoveries.jsonl`, fixed together because a single request exploited both.

## 1. IPv4-mapped IPv6 never reached the IPv4 rules

`isIPv6('::ffff:169.254.169.254')` is **true** and `isIPv4` is **false**, so `classifyIpAddress` dispatched mapped addresses to the IPv6 classifier — which knew only `::1`, `fe80:` and `fc00::/7`. AWS IMDS, loopback and every RFC1918 range were reachable in mapped form.

Reproduced before fixing, and the reproduction changed the fix:

```
::ffff:169.254.169.254   isIPv4=false  isIPv6=true
new URL('http://[::ffff:169.254.169.254]/').hostname  →  [::ffff:a9fe:a9fe]
```

**The URL parser normalises the dotted spelling to hex.** A fix matching only `::ffff:` plus a dotted quad would pass its own tests and still miss every real request. Both spellings are asserted, and the mutation run confirms it: restricting the parser to the dotted form fails all five rejection tests.

`classifyIPv6` now expands the literal and delegates any embedded IPv4 to the existing IPv4 rules, covering IPv4-mapped, IPv4-translated, the NAT64 well-known prefix `64:ff9b::/96`, and the deprecated IPv4-compatible form — the same destination under four spellings. The unspecified address `::`, which routes to localhost, is rejected too.

## 2. Two guards, each deferring to the other

`assertCustomApiHostResolvesPublic` returned `ok` for **any** IP literal:

```ts
// IP literals are already handled by the sync guard at construction; no DNS.
if (isIPv4(normalized) || isIPv6(normalized)) return ok(undefined);
```

That comment is false on the path that matters. `discoverModels` calls **only** this guard — never `validateCustomApiBaseUrl` — so each guard deferred to the other and neither ran. `http://169.254.169.254/` went straight through.

It matters more than a config-level SSRF usually would, because that base URL can come from a **file** (`opencode.json` via `NEXUS_OPENCODE_CONFIG`), which the code's own comment notes is "not always direct operator intent".

It now classifies literals itself. `allowPrivate` still bypasses, so the documented escape hatch is unchanged.

## They compound

A mapped IMDS literal passed both: skipped by guard 2 for being a literal, and invisible to guard 1 for being IPv6-shaped. End-to-end after the fix:

```
http://[::ffff:169.254.169.254]/latest/meta-data/   blocked
http://[::ffff:a9fe:a9fe]/                          blocked
http://169.254.169.254/                             blocked
```

## Testing

13 tests, red first, including two positive controls — a genuinely public IPv6 address and a public IPv4 in mapped form must still pass, or the fix becomes a blanket rejection of IPv6.

Every hunk mutation-verified. **One mutation initially reported a false negative**: an index-sliced edit silently produced a file that still worked, so the test looked unpinned when it wasn't. Redone with an exact-match anchor, it fails as expected — the second time today a no-op mutation has looked identical to a test that pins nothing.

940 tests across `src/adapters`, green. `tsc` and eslint clean; complexity ceilings required extracting `foldTrailingQuad` and `classifyLiteral`.

## Not fixed here

The TOCTOU gap the module already documents — this is resolve-time, not socket-connect-time, so DNS rebinding after the check still connects. Closing it needs a custom `fetch` lookup hook validating the peer at the socket layer. Out of scope, unchanged by this PR, and still recorded in the module comment.