### PR TITLE
fix(governance): require an approving verdict at the governor review gate

### DIFF
--- a/.changeset/governor-gate-requires-approval.md
+++ b/.changeset/governor-gate-requires-approval.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+require an approving verdict at the governor review gate
+
+`matchedRecordOutcome` returned `pass` whenever a diff-bound `pr_review` record
+existed for the PR, without ever reading `match.verdict` — and interpolated the
+verdict into the pass reason, so the gate could emit
+`pass ... verdict=request_changes`. A reviewer who explicitly refused a
+governor-path change satisfied the gate that exists to require review.
+
+- `request_changes` now **fails**, closed regardless of warn-first: warn-first
+  covers a review that has not happened yet, not one that happened and said no.
+- `abstain` **warns** — nothing affirmed, nothing refused, so it sits with
+  absence pending the enforce flip (#4058).
+- `approve` passes, unchanged.
+
+Verdicts are also aggregated across every matching record, with
+`request_changes` winning. The gate took `records.find(...)` — the first match
+in an append-only ledger — so the _earliest_ review for a diff decided the
+outcome and an early approve shadowed a later refusal on the identical diff.
+
+A refusal does not block indefinitely: records are bound to
+`reviewedDiffHash`, so pushing a fix changes the hash and the gate falls back
+to warn-on-absence until a new review lands.

--- a/scripts/check-governor-review.test.ts
+++ b/scripts/check-governor-review.test.ts
@@ -225,6 +225,63 @@ describe('analyzeGovernorReview — binding conditions', () => {
     if (outcome.kind === 'fail') expect(outcome.message).toContain('sequence_gap');
   });
 
+  it('(v1) FAILS when the diff-bound record REQUESTED CHANGES', () => {
+    // The gate returned pass on record EXISTENCE and never read the verdict —
+    // it even interpolated `verdict=request_changes` into the pass reason. A
+    // reviewer who explicitly refused a governor-path change satisfied the
+    // gate that exists to require review.
+    const outcome = analyzeGovernorReview(
+      inputs({ records: [record({ verdict: 'request_changes' })] })
+    );
+
+    expect(outcome.kind).toBe('fail');
+    if (outcome.kind === 'fail') expect(outcome.message).toContain('request_changes');
+  });
+
+  it('(v2) WARNS on an abstain record — nothing affirmed, nothing refused', () => {
+    // Abstain carries no signal either way, so it sits with absence under the
+    // warn-first posture rather than blocking ahead of the #4058 flip.
+    const outcome = analyzeGovernorReview(inputs({ records: [record({ verdict: 'abstain' })] }));
+
+    expect(outcome.kind).toBe('warn');
+  });
+
+  it('(v3) still PASSES an approve record', () => {
+    // The pair. Failing every verdict would satisfy v1 and v2 and block all
+    // governor-path work.
+    expect(analyzeGovernorReview(inputs({ records: [record()] })).kind).toBe('pass');
+  });
+
+  it('(v4) a request_changes is not shadowed by an earlier approve on the same diff', () => {
+    // `records.find(...)` returned the FIRST match in an append-only ledger,
+    // so the EARLIEST review for a diff won and every later one was ignored.
+    // Two reviewers on the identical diff — one approves, one then refuses —
+    // and the gate reported pass. Verdicts are now aggregated, refusal wins.
+    const approved = record({ sequence: 0 });
+    const refused = record({ sequence: 1, verdict: 'request_changes' });
+
+    const outcome = analyzeGovernorReview(inputs({ records: [approved, refused] }));
+
+    expect(outcome.kind).toBe('fail');
+  });
+
+  it('(v5) order does not decide the outcome', () => {
+    // The same two records the other way round must give the same verdict, or
+    // the gate is deciding on ledger position rather than on review content.
+    const refused = record({ sequence: 0, verdict: 'request_changes' });
+    const approved = record({ sequence: 1 });
+
+    expect(analyzeGovernorReview(inputs({ records: [refused, approved] })).kind).toBe('fail');
+  });
+
+  it('(v6) an abstain alongside an approve still passes', () => {
+    // Aggregation must not turn a non-signal into a blocker.
+    const approved = record({ sequence: 0 });
+    const abstained = record({ sequence: 1, verdict: 'abstain' });
+
+    expect(analyzeGovernorReview(inputs({ records: [approved, abstained] })).kind).toBe('pass');
+  });
+
   it('(e) PASSES a genesis-exempt PR even with no record', () => {
     const outcome = analyzeGovernorReview(
       inputs({ records: [], genesisExemptPrs: new Set([5000]) })

--- a/scripts/check-governor-review.ts
+++ b/scripts/check-governor-review.ts
@@ -268,10 +268,58 @@ export interface GovernorReviewInputs {
  * a mismatch when the base is directly comparable to the record's pinned
  * `^[0-9a-f]{40}$` format — otherwise we PASS rather than risk a spurious warn.
  */
+/**
+ * Verdict of a set of diff-bound records, aggregated (#4058 follow-up).
+ *
+ * `request_changes` wins over `approve`. The gate used to take
+ * `records.find(...)` — the FIRST match in an append-only ledger — so the
+ * EARLIEST review for a diff decided the outcome and every later one was
+ * ignored: an early approve shadowed a subsequent refusal on the identical
+ * diff. Aggregating removes ledger position from the decision.
+ *
+ * A refusal does not block forever: the record is bound to
+ * `reviewedDiffHash`, so pushing a fix changes the hash, the old record stops
+ * matching, and the gate falls back to warn-on-absence until a new review
+ * lands.
+ */
+function aggregateVerdict(
+  matches: readonly PrReviewRecord[]
+): 'approve' | 'request_changes' | 'abstain' {
+  if (matches.some((r) => r.verdict === 'request_changes')) return 'request_changes';
+  if (matches.some((r) => r.verdict === 'approve')) return 'approve';
+  return 'abstain';
+}
+
 function matchedRecordOutcome(
+  matches: readonly PrReviewRecord[],
   match: PrReviewRecord,
   inputs: GovernorReviewInputs
 ): GovernorReviewOutcome {
+  // A review that HAPPENED is not a review that APPROVED. This returned pass
+  // on record existence alone, and interpolated the verdict into the pass
+  // reason — so it could emit "pass ... verdict=request_changes" (#4058).
+  const verdict = aggregateVerdict(matches);
+  if (verdict === 'request_changes') {
+    return {
+      kind: 'fail',
+      message:
+        `PR #${String(inputs.prNumber)} touches governor paths and its diff-bound ` +
+        `pr_review verdict is request_changes — the review ran and REFUSED. ` +
+        `This is fail-closed regardless of warn-first: warn-first covers a review ` +
+        `that has not happened yet, not one that happened and said no. ` +
+        `Address the review and re-run pr_review at the current head.`,
+    };
+  }
+  if (verdict === 'abstain') {
+    return {
+      kind: 'warn',
+      message:
+        `PR #${String(inputs.prNumber)} touches governor paths and its diff-bound ` +
+        `pr_review verdict is abstain — nothing was affirmed and nothing refused. ` +
+        `An abstention is not an approval; it is treated as absence, which is ` +
+        `warn-first pending the enforce flip (#4058). Re-run pr_review for a verdict.`,
+    };
+  }
   const ciBase = inputs.baseSha.toLowerCase();
   const comparable = /^[0-9a-f]{40}$/.test(ciBase);
   if (comparable && match.baseSha.toLowerCase() !== ciBase) {
@@ -322,11 +370,12 @@ export function analyzeGovernorReview(inputs: GovernorReviewInputs): GovernorRev
   }
 
   // (4) Diff-bound record present? (Option-C — number AND reviewedDiffHash match.)
-  const match = inputs.records.find(
+  const matches = inputs.records.filter(
     (r) => r.prNumber === inputs.prNumber && r.reviewedDiffHash === inputs.reviewedDiffHash
   );
+  const match = matches[0];
   if (match !== undefined) {
-    return matchedRecordOutcome(match, inputs);
+    return matchedRecordOutcome(matches, match, inputs);
   }
 
   // (5) Absence → WARN-FIRST (condition 2): actionable, non-blocking this stage.


### PR DESCRIPTION
HIGH finding from `.security-discoveries.jsonl`. **Do not merge without owner ratification** — `scripts/check-governor-review.ts` is CODEOWNERS-gated to @williamzujkowski, and it is the governor gate itself. I have not self-merged it.

## The defect

`matchedRecordOutcome` returned `pass` whenever a diff-bound `pr_review` record existed for the PR. It never read `match.verdict`. It did, however, interpolate it into the pass reason — so the gate could literally emit:

```
pass — diff-bound pr_review record found for PR #N (…, verdict=request_changes)
```

**A reviewer who explicitly refused a governor-path change satisfied the gate that exists to require review.** Verdicts are `approve | request_changes | abstain`; all three passed.

No test covered it. The only `request_changes` in the suite uses that value to *break a record hash* for a tamper-evidence case, so every valid-record test is an `approve` and the gap was invisible.

## Decided by vote, because the severity is a real fork

Live 7-voter panel, `higher_order`: **Option A**, 5 of 6 approvers (`request_changes` fails, `abstain` warns).

Nobody argued `request_changes` should pass. The question was whether failing moves ahead of the #4058 enforce flip. The majority reasoning: warn-first is a posture about *review has not happened yet*; a review that happened and refused is the opposite, and the gate already fails closed "regardless of warn-first" for tamper evidence — the other case where it holds affirmative adverse evidence rather than an absence.

The security voter argued Option C (abstain should also fail, since an abstain record is otherwise a bypass). The counter that carried: while absence still only warns, emitting an abstain gains an attacker nothing over emitting no record at all. That bypass becomes real at the #4058 flip, and abstain must harden in the same change — **noted on #4058 rather than left implicit.**

## The dissent found something the majority missed

The contrarian rejected all options over multi-record conflict, and it was right that the case was undefined — though the exposure runs the other way from its guess.

`records.find(...)` returns the **first** match in an append-only ledger, so the *earliest* review for a given diff decided the outcome and every later one was ignored. Two reviewers on the identical diff — one approves, one then refuses — and the gate reported pass.

Verdicts are now aggregated across all matching records with `request_changes` winning, and two tests pin that the result does not depend on ledger order.

## A refusal does not block forever

Worth stating, since a permanently-red gate would be its own defect: records are bound to `reviewedDiffHash`. Pushing a fix changes the diff, the old `request_changes` stops matching, and the gate falls back to warn-on-absence until a new review lands.

## Verification

Six tests, red first, including a positive control that `approve` still passes — failing every verdict would satisfy the others and block all governor-path work.

Three production hunks, each mutation-verified: ignoring the verdict, reverting to first-match-wins, and treating abstain as approval each fail a specific test.

26 tests green. eslint clean. The two `tsc` errors in the repo-root project (`check-harness-alignment.ts`, `website/src/content.config.ts`) are pre-existing on main — confirmed by stashing this branch — and unrelated to these files.