### PR TITLE
fix(security): stop logging a policy firewall the server never applies

### DIFF
--- a/.changeset/policy-firewall-not-claimed-enforcing.md
+++ b/.changeset/policy-firewall-not-claimed-enforcing.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+stop the server logging a policy firewall it never applies
+
+Startup logged `policyFirewallEnabled: true` and `policyMode: 'enforce'`, which
+reads as "policy enforcement is on". It is not. The firewall is constructed,
+passed to `registerMcpTools`, and used for nothing but that log line:
+`buildStandardDeps` never forwards it, no tool registration supplies it, and
+`createPolicyMiddleware` is therefore never reached for any tool.
+
+The two fields are removed and replaced by a warning naming the configured mode,
+so an operator who set a policy mode is told it is inert rather than handed a
+quieter boolean. A hardcoded `false` would have been the same constant with the
+sign flipped.
+
+A test asserted `policyFirewallEnabled: true, policyMode: 'enforce'`, pinning
+the claim as intended behaviour; it now asserts the fields are absent.
+
+The wiring itself is #4888 — a real behaviour change that wants staging, not a
+flip.

--- a/packages/nexus-agents/src/cli-server-tools.test.ts
+++ b/packages/nexus-agents/src/cli-server-tools.test.ts
@@ -727,13 +727,46 @@ describe('registerMcpTools - policy firewall', () => {
       (call: unknown[]) => call[0] === 'Tools registered with per-tool rate limiting'
     );
     expect(regCall).toBeDefined();
+    // No longer `policyFirewallEnabled: true` + `policyMode: 'enforce'`. The
+    // firewall is constructed and then dropped — `buildStandardDeps` does not
+    // forward it and no tool registration passes it, so `createPolicyMiddleware`
+    // is never reached for any tool. Logging it as enabled and enforcing
+    // claimed an enforcement that does not happen, and this assertion pinned
+    // that claim as intended behaviour.
     expect((regCall as unknown[])[1]).toEqual(
-      expect.objectContaining({
-        policyFirewallEnabled: true,
-        policyMode: 'enforce',
-        executionMode: 'read-write',
-      })
+      expect.objectContaining({ executionMode: 'read-write' })
     );
+    expect((regCall as unknown[])[1]).not.toHaveProperty('policyFirewallEnabled');
+    expect((regCall as unknown[])[1]).not.toHaveProperty('policyMode');
+  });
+
+  it('warns that a constructed policy firewall is not wired to any tool', () => {
+    const logger = makeMockLogger();
+    const mockFirewall = {
+      getMode: vi.fn().mockReturnValue('enforce'),
+    } as unknown as RegisterMcpToolsOptions['policyFirewall'];
+
+    registerMcpTools(makeDefaultOptions({ logger, policyFirewall: mockFirewall }));
+
+    const warn = logger.warn.mock.calls.find((call: unknown[]) =>
+      String(call[0]).includes('PolicyFirewall')
+    );
+    expect(warn).toBeDefined();
+    expect(String((warn as unknown[])[0])).toContain('not wired');
+    expect((warn as unknown[])[1]).toEqual(expect.objectContaining({ configuredMode: 'enforce' }));
+  });
+
+  it('does not warn when no policy firewall was constructed', () => {
+    // The pair: an unconditional warning would be noise on every start and
+    // would stop being read, which is how the original claim survived.
+    const logger = makeMockLogger();
+
+    registerMcpTools(makeDefaultOptions({ logger }));
+
+    const warn = logger.warn.mock.calls.find((call: unknown[]) =>
+      String(call[0]).includes('PolicyFirewall')
+    );
+    expect(warn).toBeUndefined();
   });
 
   it('should log executionMode as read-only when not provided', () => {

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -590,10 +590,25 @@ function logToolRegistration(
     builtInTemplateCount: info.builtInTemplates.size,
     realWorkflowExecution: info.modelAdapter !== undefined,
     realTechLead: info.modelAdapter !== undefined,
-    policyFirewallEnabled: info.policyFirewall !== undefined,
-    policyMode: info.policyFirewall?.getMode(),
     executionMode: info.executionMode ?? 'read-only',
   });
+
+  // The firewall is CONSTRUCTED by `logSecurityConfig` and then dropped:
+  // `buildStandardDeps` does not forward it, no tool registration passes it,
+  // and `createPolicyMiddleware` (middleware-chain.ts:327) is therefore never
+  // reached for any tool (#4888). This line used to report
+  // `policyFirewallEnabled: true` + `policyMode: 'enforce'`, which claimed an
+  // enforcement that does not happen — and a test pinned that claim.
+  //
+  // Warning rather than a `false` field: a hardcoded "not enforcing" is just
+  // the same constant with the sign flipped, and an operator who configured a
+  // policy mode needs to be told it is inert, not handed a quieter boolean.
+  if (info.policyFirewall !== undefined) {
+    logger.warn(
+      'PolicyFirewall is configured but not wired to any tool — no policy middleware runs',
+      { configuredMode: info.policyFirewall.getMode() }
+    );
+  }
 }
 
 /** Builds standard deps for a tool that needs only logger + rate limiter (+ optional security). */


### PR DESCRIPTION
MEDIUM finding from `.security-discoveries.jsonl`. Fixes the **false claim**; the wiring is #4888.

## What the server was saying

```
Tools registered with per-tool rate limiting
  policyFirewallEnabled: true
  policyMode: 'enforce'
```

That reads as "policy enforcement is on for these tools". It is not.

## What actually happens

`createConfiguredPolicyFirewall` builds it, `cli-server.ts:517` receives it, `registerMcpTools` destructures it — **and uses it for nothing but that log line.** `buildStandardDeps` returns `logger`, `rateLimiter`, `security`, `auditLogger`, never the firewall, and `grep -n policyFirewall src/mcp/tools/*.ts` returns zero non-test hits.

The support exists and is unreached: `middleware-chain.ts:324` attaches the policy middleware `if (config.policyFirewall !== undefined)`, and `createPolicyMiddleware` has exactly one caller — that line. Nothing supplies the field, so **no policy middleware runs for any tool.**

The rules are real, which makes it worse: `policyRuleCount` comes from `getRules().length`, so an operator sees rules loaded and a mode of `enforce`, and every call proceeds unchecked.

## A warning, not a `false`

The two fields are removed and replaced by a warning naming the configured mode.

A `policyFirewallEnforcing: false` field would have been the same constant with the sign flipped — and quieter, which is the wrong direction. Someone who deliberately set a policy mode should be told it is inert, not handed a boolean they have to notice.

The warning is conditional on a firewall existing. An unconditional one would fire on every start, and a warning that always fires stops being read — which is roughly how the original claim survived.

## The test pinned the claim

```ts
expect(...).toEqual(expect.objectContaining({
  policyFirewallEnabled: true,
  policyMode: 'enforce',
}));
```

An assertion that the server logs enforcement. It now asserts those fields are **absent**, with a comment saying why, and two new tests cover the warning and its negative case.

Three hunks mutation-verified. The unconditional-warning mutation is the interesting one — it fails 24 tests, because a warning on every start breaks every other assertion in the file. That is the noise cost made visible.

34 tests green; `tsc` and eslint clean.

## Not fixed here

Wiring the firewall into tool registration (#4888). It is a genuine behaviour change — rules that have never run would start denying — and this repo stages that kind of thing audit → soak → enforce rather than flipping it. Shipping the honest log now means the inert state is visible while that work is scheduled, instead of being masked by a `true`.