### PR TITLE
fix(routing-audit): label the simulated budget stage and drop the duplicate bandit builder

### DIFF
--- a/.changeset/routing-audit-labels-simulated.md
+++ b/.changeset/routing-audit-labels-simulated.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+label routing-audit's simulated budget stage, and stop duplicating the bandit builder
+
+`routing-audit` rendered a green `Budget Filter (4/4 pass)` identically to the
+TOPSIS and LinUCB stages beside it — and those two construct real routers,
+while `simulateBudgetFilter` passes every CLI unconditionally with no cost
+estimate, token count or config read.
+
+The source was candid about it (the function name, its JSDoc, and the call-site
+comment all say "simulated"), but none of that reached the terminal. Someone
+debugging a selection saw budget filtering apparently evaluated and ruled it out
+as a cause. The stage now renders as
+`[simulated — not evaluated against real cost or config]`.
+
+Separately, the audit kept a byte-equivalent copy of `taskProfileToBanditContext`.
+The two agreed only by coincidence: #4874 gave the production builder an
+optional real budget figure whose default is the same neutral `0.5` the copy
+hardcoded, so their outputs matched while the definitions had already parted.
+The audit now delegates, with a test pinning that the two agree — an audit that
+can drift from the router it audits reports a decision the router would not make.
+
+Fixes #4843.

--- a/packages/nexus-agents/src/cli/routing-audit-format.test.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-format.test.ts
@@ -144,6 +144,26 @@ describe('routing-audit-format', () => {
       expect(output).toContain('codex');
     });
 
+    it('marks the stage as simulated (#4843)', () => {
+      // `simulateBudgetFilter` passes every CLI unconditionally — no cost
+      // estimate, no config read. The source says so (the function name, its
+      // JSDoc, and the call-site comment), but NONE of that reached the
+      // terminal: the stage rendered identically to the TOPSIS and LinUCB
+      // stages beside it, which construct real routers. Someone debugging a
+      // selection saw budget filtering apparently evaluated and ruled it out.
+      const output = formatBudgetFilter(mockResult).join('\n');
+
+      expect(output).toContain('simulated');
+    });
+
+    it('does not mark the other stages as simulated', () => {
+      // The pair: the label must identify THIS stage, not decorate the whole
+      // report — TOPSIS and LinUCB really do run.
+      const topsis = formatTopsisRanking(mockResult).join('\n');
+
+      expect(topsis).not.toContain('simulated');
+    });
+
     it('should show failed budget checks', () => {
       const failedBudgetResult: RoutingAuditResult = {
         ...mockResult,

--- a/packages/nexus-agents/src/cli/routing-audit-format.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-format.ts
@@ -55,8 +55,17 @@ export function formatBudgetFilter(result: RoutingAuditResult): string[] {
   const lines: string[] = [];
   const passCount = result.budgetResults.filter((r) => r.withinBudget).length;
   const total = result.budgetResults.length;
+  // #4843: `simulateBudgetFilter` passes every CLI unconditionally — no cost
+  // estimate, no token count, no config read. The source is candid about that
+  // (the function name, its JSDoc, the call-site comment), but none of it
+  // reached the terminal, so this stage rendered identically to the TOPSIS and
+  // LinUCB stages beside it, which construct real routers. Say it here, where
+  // the reader is.
   lines.push(
-    boxLine(color(` Budget Filter (${String(passCount)}/${String(total)} pass):`, ANSI.bold))
+    boxLine(
+      color(` Budget Filter (${String(passCount)}/${String(total)} pass):`, ANSI.bold) +
+        color(' [simulated — not evaluated against real cost or config]', ANSI.dim)
+    )
   );
   for (const br of result.budgetResults) {
     const status = br.withinBudget ? color('✓', ANSI.green) : color('✗', ANSI.red);

--- a/packages/nexus-agents/src/cli/routing-audit-logic.test.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-logic.test.ts
@@ -80,6 +80,23 @@ describe('routing-audit-logic', () => {
     });
   });
 
+  describe('bandit context matches the production builder (#4843)', () => {
+    it('produces the same context the composite router would', async () => {
+      // The audit kept its own copy of the builder. #4874 gave the production
+      // one an optional real budget figure, and the copy did not follow — so
+      // the audit reported a bandit context the router no longer uses. An
+      // audit that silently diverges from the thing it audits is worse than
+      // no audit.
+      const { taskProfileToBanditContext } =
+        await import('../cli-adapters/composite-router-helpers.js');
+      const profile = analyzeTaskString('Write a function to sort an array');
+
+      expect(taskProfileToBanditContextFromProfile(profile)).toEqual(
+        taskProfileToBanditContext(profile)
+      );
+    });
+  });
+
   describe('taskProfileToBanditContextFromProfile', () => {
     it('should convert task profile to bandit context', () => {
       const profile = analyzeTaskString('Write a complex algorithm with optimization');

--- a/packages/nexus-agents/src/cli/routing-audit-logic.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-logic.ts
@@ -21,6 +21,7 @@ import { TopsisRouter } from '../cli-adapters/topsis-router.js';
 import type { TopsisResult } from '../cli-adapters/topsis-types.js';
 import { DEFAULT_MODEL_PROFILES } from '../cli-adapters/topsis-types.js';
 import { LinUCBBandit } from '../cli-adapters/linucb-bandit.js';
+import { taskProfileToBanditContext } from '../cli-adapters/composite-router-helpers.js';
 import type { Task } from '../core/types/agent.js';
 import type {
   RoutingAuditOptions,
@@ -43,7 +44,6 @@ const sharedAnalyzer = createSharedTaskAnalyzer();
 const CLI_NAMES: readonly CliName[] = ['claude', 'gemini', 'codex', 'opencode'];
 
 /** Normalization ceiling for context length (tokens). */
-const CONTEXT_NORMALIZATION_TOKENS = 100_000;
 
 // =============================================================================
 // Helper Functions
@@ -63,18 +63,20 @@ export function analyzeTaskString(taskStr: string): TaskProfile {
 }
 
 /**
- * Converts task profile to bandit context using core adapter.
+ * Converts task profile to bandit context, delegating to the production builder.
+ *
+ * This was a byte-equivalent copy of `taskProfileToBanditContext`. The two
+ * agreed only by coincidence: #4874 gave the production one an optional real
+ * budget figure whose default is the same neutral 0.5 this copy hardcoded, so
+ * outputs matched while the definitions had already parted. An audit that can
+ * drift from the router it audits reports a decision the router would not make.
+ *
+ * No utilization is passed, which yields that neutral default — correct here,
+ * because the audit's budget stage is simulated (#4843) and there is no real
+ * figure to supply.
  */
 export function taskProfileToBanditContextFromProfile(profile: TaskProfile): BanditContext {
-  // For backward compatibility, convert profile back to context using original formula
-  return {
-    taskComplexity: profile.reasoningComplexity / 10,
-    contextLengthNormalized: Math.min(profile.contextRequired / CONTEXT_NORMALIZATION_TOKENS, 1),
-    isCodeTask: profile.codeGeneration ? 1 : 0,
-    isReasoningTask: profile.taskType === 'architecture' || profile.reasoningComplexity > 5 ? 1 : 0,
-    budgetUtilization: 0.5,
-    timePressure: 0.3,
-  };
+  return taskProfileToBanditContext(profile);
 }
 
 /**


### PR DESCRIPTION
Fixes #4843.

## One simulated stage rendered as three real ones

`simulateBudgetFilter` passes every CLI unconditionally — no cost estimate, no token count, no config read. The output was:

```
 Budget Filter (4/4 pass):
   ✓ claude   - within budget
```

identical in shape to the TOPSIS and LinUCB stages beside it, **which construct real routers** (`new TopsisRouter(...)`, `new LinUCBBandit(...)`).

The source is candid — the function is called `simulateBudgetFilter`, its JSDoc says so, and the call site is commented `// Step 2: Budget filtering (simulated)`. **None of that reaches the terminal**, and the command is documented as showing "the routing decision for a task without executing it". Someone debugging a selection sees budget filtering apparently evaluated and rules it out as a cause.

Now: `Budget Filter (4/4 pass) [simulated — not evaluated against real cost or config]`, with a paired test asserting the *other* stages are not labelled, so it identifies this stage rather than decorating the report.

## My own issue recommended the wrong fix

#4843 offered "use the real stage — `BudgetStage` exists" and preferred it. Today's work makes that wrong: `BudgetFilterStage` has **no production instantiation**, its `budget:utilization=` signal is now redundant against the typed argument added in #4869, and #4872 is open on whether that whole half should be deleted. Wiring the audit to it would resurrect code that may be removed.

The right version of that option is `applyBudgetFilter` — the path that actually runs — but `auditRouting` takes only `{task, deterministic, banditStats}` with no config or `BudgetRouter`, so it needs a design decision about whether a debugging tool should depend on local config. Not made here.

## A duplicate that agreed by coincidence

The audit kept a byte-equivalent copy of `taskProfileToBanditContext`. #4874 gave the production builder an optional real budget figure — and its default is the same neutral `0.5` the copy hardcoded, so **outputs matched while the definitions had already parted**. The audit now delegates.

Stated precisely because I nearly overstated it: there is no current output divergence. This is a structural fix plus a guard, not a live bug.

## The guard needed a correct mutation to be worth anything

The test asserts audit-context equals production-context. After delegation that is `f(x) === f(x)` — so my first mutation (changing the shared builder) could not fail it, and passing told me nothing.

The real failure mode is someone re-inlining a divergent copy. Mutating *that* fails the test, and also fails `should set default budget utilization`. The guard is trivially satisfied while delegation holds and fails exactly when it stops — the same shape as the signal-contract ratchet.

The now-unused `CONTEXT_NORMALIZATION_TOKENS` is removed with the copy.

110 tests across the routing-audit suite, green. `tsc` and eslint clean.