### PR TITLE
fix(adapters): stop streaming paths zero-filling the prompt token count

### DIFF
--- a/.changeset/streaming-does-not-zero-fill-tokens.md
+++ b/.changeset/streaming-does-not-zero-fill-tokens.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': minor
+---
+
+stop streaming paths reporting a zero prompt count as a measurement
+
+Four streaming paths zero-filled `inputTokens`, against the omit-rather-than-
+zero-fill policy the repo states at `gemini-adapter.ts:362` (#4439). A stream
+consumer billing on those numbers prices a large-context call at zero prompt
+cost, and `inputTokens: 0` is byte-identical whether the prompt was empty or
+simply unreported.
+
+- **Claude** — the prompt count arrives on `message_start`, not on
+  `message_delta`. The adapter already received that event and read only
+  `model`, dropping a number it had in hand. It now carries the real usage,
+  read defensively and omitted when a vendor sends none rather than crashing a
+  stream over a telemetry field.
+- **Gemini** and **the SDK adapter** reported `{0, 0, 0}` where nothing is
+  known. They now omit `usage`, which the chunk type already allows — the
+  policy applied literally, no type change needed.
+- **openai-mappers** keeps the real `outputTokens` and flags the input.
+
+`TokenUsage` gains an optional `inputTokensMeasured`. `false` means the vendor
+reported no prompt count, so `inputTokens` is a placeholder and `totalTokens`
+is a LOWER BOUND. Absent means measured, so no existing producer changes
+meaning. `StreamChunk`'s `message_start` variant gains an optional `usage`.
+
+Fixes #4835.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -8499,7 +8499,7 @@ ClassDeclaration StrategyDistiller
   promote(routingMemory: IRoutingMemory) => number
 ClassDeclaration StreamCancelledError
 TypeAliasDeclaration StreamChunk
-  = | { contentBlock: ContentBlock; index: number; type: 'content_block_start'; } | { delta: { text: string; type: 'text_delta'; }; index: number; type: 'content_block_delta'; } | { index: number; type: 'content_block_stop'; } | { message: { model: string; }; type: 'message_start'; } | { delta: { stop_reason: StopReason; }; type: 'message_delta'; usage?: TokenUsage; } | { type: 'message_stop'; }
+  = | { contentBlock: ContentBlock; index: number; type: 'content_block_start'; } | { delta: { text: string; type: 'text_delta'; }; index: number; type: 'content_block_delta'; } | { index: number; type: 'content_block_stop'; } | { message: { model: string; }; type: 'message_start'; usage?: TokenUsage; } | { delta: { stop_reason: StopReason; }; type: 'message_delta'; usage?: TokenUsage; } | { type: 'message_stop'; }
 ClassDeclaration StreamController
   cancel(reason?: string) => void
   complete() => void
@@ -9050,6 +9050,7 @@ InterfaceDeclaration TokenUsage
   cacheCreationInputTokens?: number | undefined
   cachedInputTokens?: number | undefined
   inputTokens: number
+  inputTokensMeasured?: boolean | undefined
   outputTokens: number
   readonly cacheCreationInputTokens?: number | undefined
   readonly cachedInputTokens?: number | undefined

--- a/packages/nexus-agents/src/adapters/claude-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.test.ts
@@ -784,6 +784,56 @@ describe('ClaudeAdapter', () => {
       });
     });
 
+    it('carries the real prompt count on message_start (#4835)', async () => {
+      // The Anthropic protocol puts the input count on `message_start`, not
+      // on `message_delta` — the adapter already received this event and read
+      // only `model`, dropping a number it had in hand.
+      async function* gen() {
+        yield {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4-6', usage: { input_tokens: 1234, output_tokens: 1 } },
+        };
+        yield { type: 'message_stop' };
+      }
+      mockStream.mockReturnValue(gen());
+
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of new ClaudeAdapter(validConfig).stream({
+        messages: [{ role: 'user', content: 'Hi!' }],
+      })) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toContainEqual({
+        type: 'message_start',
+        message: { model: 'claude-sonnet-4-6' },
+        usage: { inputTokens: 1234, outputTokens: 1, totalTokens: 1235 },
+      });
+    });
+
+    it('omits usage on message_start when the vendor sent none (#4835)', async () => {
+      // The SDK types `usage` as required, but an Anthropic-compatible proxy
+      // may omit it. Omit rather than zero-fill or throw — crashing a stream
+      // over a telemetry field would be worse than the defect being fixed.
+      async function* gen() {
+        yield { type: 'message_start', message: { model: 'claude-sonnet-4-6' } };
+        yield { type: 'message_stop' };
+      }
+      mockStream.mockReturnValue(gen());
+
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of new ClaudeAdapter(validConfig).stream({
+        messages: [{ role: 'user', content: 'Hi!' }],
+      })) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toContainEqual({
+        type: 'message_start',
+        message: { model: 'claude-sonnet-4-6' },
+      });
+    });
+
     it('should map message_delta events with usage', async () => {
       async function* mockStreamGenerator() {
         yield {
@@ -805,10 +855,14 @@ describe('ClaudeAdapter', () => {
         chunks.push(chunk);
       }
 
+      // `inputTokens: 0` is retained — the field is required — but flagged
+      // unmeasured, because the prompt count is not on this event. Asserting
+      // the bare zero (as this did) pinned a placeholder as a measurement,
+      // and a consumer billing on it priced the prompt at nothing (#4835).
       expect(chunks).toContainEqual({
         type: 'message_delta',
         delta: { stop_reason: 'end_turn' },
-        usage: { inputTokens: 0, outputTokens: 10, totalTokens: 10 },
+        usage: { inputTokens: 0, inputTokensMeasured: false, outputTokens: 10, totalTokens: 10 },
       });
     });
 

--- a/packages/nexus-agents/src/adapters/claude-adapter.ts
+++ b/packages/nexus-agents/src/adapters/claude-adapter.ts
@@ -356,15 +356,37 @@ export class ClaudeAdapter extends BaseAdapter {
     };
   }
 
+  /** Usage for a `message_start` chunk, omitted when the vendor sent none (#4835). */
+  private static usageFrom(raw: { input_tokens?: number; output_tokens?: number } | undefined): {
+    usage?: TokenUsage;
+  } {
+    const inputTokens = raw?.input_tokens;
+    if (typeof inputTokens !== 'number') return {};
+    const outputTokens = typeof raw?.output_tokens === 'number' ? raw.output_tokens : 0;
+    return {
+      usage: { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens },
+    };
+  }
+
   /**
    * Maps Anthropic stream events to our StreamChunk format.
    */
   private mapStreamEvent(event: MessageStreamEvent): StreamChunk | null {
     switch (event.type) {
       case 'message_start':
+        // #4835: the prompt count arrives HERE, not on message_delta — the
+        // Anthropic protocol puts it on `message.usage`. The delta comment
+        // ("Not available in delta") was correct about the wrong event, and
+        // the value was being dropped rather than being unavailable.
+        //
+        // Read defensively and OMIT when absent rather than zero-fill: the
+        // SDK types it as required, but an Anthropic-compatible proxy may not
+        // send it, and crashing a stream over a telemetry field would be a
+        // worse failure than the one being fixed.
         return {
           type: 'message_start',
           message: { model: event.message.model },
+          ...ClaudeAdapter.usageFrom(event.message.usage),
         };
 
       case 'content_block_start':
@@ -395,7 +417,11 @@ export class ClaudeAdapter extends BaseAdapter {
           type: 'message_delta',
           delta: { stop_reason: mapStopReason(event.delta.stop_reason ?? null) },
           usage: {
-            inputTokens: 0, // Not available in delta
+            // Genuinely absent on this event; the real count was emitted on
+            // message_start above. Flagged so `totalTokens` reads as the
+            // lower bound it is rather than as a total (#4835).
+            inputTokens: 0,
+            inputTokensMeasured: false,
             outputTokens: event.usage.output_tokens,
             totalTokens: event.usage.output_tokens,
           },

--- a/packages/nexus-agents/src/adapters/gemini-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter.test.ts
@@ -533,6 +533,28 @@ describe('GeminiAdapter', () => {
       });
     });
 
+    it('emits no usage when the stream reports none (#4835)', async () => {
+      // This path used to emit `{inputTokens: 0, outputTokens: 0,
+      // totalTokens: 0}` — byte-identical to a call that consumed nothing, in
+      // the same file whose NON-streaming path already documents the
+      // omit-rather-than-zero-fill policy (#4439).
+      async function* mockStreamGenerator() {
+        yield { text: 'Hello' };
+      }
+      mockGenerateContentStream.mockResolvedValueOnce(mockStreamGenerator());
+
+      const chunks: StreamChunk[] = [];
+      for await (const chunk of new GeminiAdapter(validConfig).stream({
+        messages: [{ role: 'user', content: 'Hi!' }],
+      })) {
+        chunks.push(chunk);
+      }
+
+      const delta = chunks.find((c) => c.type === 'message_delta');
+      expect(delta).toBeDefined();
+      expect(delta).not.toHaveProperty('usage');
+    });
+
     it('should map content_block_start events correctly', async () => {
       async function* mockStreamGenerator() {
         yield { text: 'Initial' };

--- a/packages/nexus-agents/src/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/adapters/gemini-adapter.ts
@@ -232,7 +232,9 @@ export class GeminiAdapter extends BaseAdapter {
     controller.push({
       type: 'message_delta',
       delta: { stop_reason: 'end_turn' },
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      // #4835: no usage is reported on this path, so none is emitted —
+      // zero-filling all three made an unmeasured stream indistinguishable
+      // from one that consumed nothing. `usage` is optional on the chunk.
     });
     controller.push({ type: 'message_stop' });
     controller.complete();

--- a/packages/nexus-agents/src/adapters/openai-mappers.test.ts
+++ b/packages/nexus-agents/src/adapters/openai-mappers.test.ts
@@ -289,6 +289,25 @@ describe('mapStreamChunk', () => {
     expect(result.some((c) => c.type === 'message_start')).toBe(false);
   });
 
+  it('marks the streamed prompt count as unmeasured (#4835)', () => {
+    // OpenAI streaming does not report prompt_tokens on the final chunk, so
+    // `inputTokens: 0` is a placeholder. Unflagged it is byte-identical to an
+    // empty prompt, and a consumer billing on it prices a large-context call
+    // at zero.
+    const chunk = {
+      model: 'gpt-4',
+      choices: [{ delta: {}, index: 0, finish_reason: 'stop' }],
+      usage: { completion_tokens: 42, total_tokens: 42 },
+    } as unknown as ChatCompletionChunk;
+
+    const delta = mapStreamChunk(chunk, 0, true).find((c) => c.type === 'message_delta');
+
+    expect(delta).toBeDefined();
+    expect(delta?.type === 'message_delta' ? delta.usage : undefined).toEqual(
+      expect.objectContaining({ inputTokens: 0, inputTokensMeasured: false, outputTokens: 42 })
+    );
+  });
+
   it('handles empty choices', () => {
     const chunk = { model: 'gpt-4', choices: [] } as unknown as ChatCompletionChunk;
     const result = mapStreamChunk(chunk, 0, true);

--- a/packages/nexus-agents/src/adapters/openai-mappers.ts
+++ b/packages/nexus-agents/src/adapters/openai-mappers.ts
@@ -306,7 +306,9 @@ function mapFinishChunks(
       type: 'message_delta',
       delta: { stop_reason: mapStopReason(choice.finish_reason) },
       usage: {
+        // OpenAI streaming omits prompt_tokens on the final chunk (#4835).
         inputTokens: 0,
+        inputTokensMeasured: false,
         outputTokens: chunk.usage?.completion_tokens ?? 0,
         totalTokens: chunk.usage?.total_tokens ?? 0,
       },

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.test.ts
@@ -422,6 +422,14 @@ describe('SdkAdapter', () => {
         delta: { type: 'text_delta', text: 'Hello' },
       });
       expect(chunks[7]).toEqual({ type: 'message_stop' });
+      // #4835: this path reports no usage, so it emits none. It used to emit
+      // `{inputTokens: 0, outputTokens: 0, totalTokens: 0}`, which is
+      // byte-identical to a stream that genuinely consumed nothing — a
+      // consumer billing on it priced the whole call at zero.
+      expect(chunks[6]).toEqual({
+        type: 'message_delta',
+        delta: { stop_reason: 'end_turn' },
+      });
     });
 
     it('skips empty-string deltas (#3317 #8)', async () => {

--- a/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
+++ b/packages/nexus-agents/src/adapters/sdk/sdk-adapter.ts
@@ -556,7 +556,9 @@ export class SdkAdapter extends BaseAdapter {
     yield {
       type: 'message_delta',
       delta: { stop_reason: 'end_turn' },
-      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      // #4835: no usage is reported on this path, so none is emitted —
+      // zero-filling all three made an unmeasured stream indistinguishable
+      // from one that consumed nothing. `usage` is optional on the chunk.
     };
     yield { type: 'message_stop' };
   }

--- a/packages/nexus-agents/src/core/types/model.ts
+++ b/packages/nexus-agents/src/core/types/model.ts
@@ -126,6 +126,20 @@ export interface TokenUsage {
   outputTokens: number;
   totalTokens: number;
   /**
+   * Whether `inputTokens` is a measurement (#4835).
+   *
+   * `false` means the vendor did not report a prompt count on this event, so
+   * `inputTokens` is a placeholder `0` — and `totalTokens` is therefore a
+   * LOWER BOUND, not a total. A stream consumer that bills on these numbers
+   * otherwise prices a large-context call at zero prompt cost, which
+   * under-counts in the dangerous direction.
+   *
+   * Absent means measured, so no existing producer changes meaning. Where
+   * NOTHING is known, prefer omitting `usage` entirely — that is the #4439
+   * policy, and the field is already optional on the chunk.
+   */
+  inputTokensMeasured?: boolean;
+  /**
    * Input tokens READ from an existing prompt cache, when the vendor reports
    * them separately. Billed at roughly a tenth of the uncached input rate, so
    * kept out of `inputTokens` rather than summed into it (#4435).
@@ -187,7 +201,7 @@ export type StreamChunk =
   | { type: 'content_block_start'; index: number; contentBlock: ContentBlock }
   | { type: 'content_block_delta'; index: number; delta: { type: 'text_delta'; text: string } }
   | { type: 'content_block_stop'; index: number }
-  | { type: 'message_start'; message: { model: string } }
+  | { type: 'message_start'; message: { model: string }; usage?: TokenUsage }
   | { type: 'message_delta'; delta: { stop_reason: StopReason }; usage?: TokenUsage }
   | { type: 'message_stop' };
 


### PR DESCRIPTION
Fixes #4835.

## The policy and the violations

The repo states the convention at `gemini-adapter.ts:362`: *"omit rather than zero-fill when Gemini sent no usageMetadata"* (#4439). Four streaming paths did the opposite. A consumer billing on those numbers prices a large-context call at **zero prompt cost**, and `inputTokens: 0` is byte-identical whether the prompt was empty or simply unreported.

## The Claude case was recoverable, and I verified the caveat first

The issue flagged one claim it could not confirm: whether the count is on `message_start`. Checked against the installed SDK — `RawMessageStartEvent.message: Message` and `Message.usage` is **required**, so `event.message.usage.input_tokens` exists.

So the `// Not available in delta` comment was correct about the wrong event. **The adapter already received `message_start` and read only `model`**, discarding a number it had in hand. It now carries the real usage.

Read defensively and omitted when absent: the SDK types it as required, but an Anthropic-compatible proxy may not send it, and crashing a stream over a telemetry field would be a worse failure than the one being fixed. The test suite proved that immediately — the existing mock has no `usage` and threw on the first attempt.

## Two sites needed no type change at all

Gemini and the SDK adapter reported `{0, 0, 0}` where **nothing** is known. `usage` is already optional on the chunk, so they now omit it — #4439 applied literally.

## The issue's site list was wrong on one entry

It listed `openai-compat-adapter.ts:232` as a fifth violation. That is a **failure-path telemetry event** carrying `success: false` and an `errorCode` — different semantics (the call errored), and disclosed by the adjacent flag. Not touched, and the issue is corrected.

So: four sites, not five.

## The flag

`TokenUsage` gains an optional `inputTokensMeasured`. `false` means no prompt count was reported, so `inputTokens` is a placeholder and `totalTokens` is a **lower bound**. Absent means measured, so no existing producer changes meaning. Same pattern as `ResultMetadata.tokensMeasured` (#4744) and `confidenceMeasured` (#4831).

## Testing

A test asserted `usage: { inputTokens: 0, outputTokens: 10, totalTokens: 10 }` — pinning the placeholder as a measurement. Updated, with a comment saying why.

Six mutation checks, one per site plus the defensive read and the omit-vs-zero choice. Three sites had **no coverage at all** — the suite passed with `usage` removed from Gemini and the SDK adapter, so those changes were unpinned until I added tests. That is the seam gap again: the type allowed the field to vanish and nothing noticed.

2206 tests across `src/adapters` and `src/core`, green. `tsc` and eslint clean. `api-surface.txt` regenerated — two additive optional fields, so minor.