### PR TITLE
fix(orchestration): exclude an unmeasured step from reward scoring

### DIFF
--- a/.changeset/unmeasured-step-not-scored.md
+++ b/.changeset/unmeasured-step-not-scored.md
@@ -1,0 +1,31 @@
+---
+'nexus-agents': minor
+---
+
+stop rewarding a step for having no measured token usage
+
+`computeStepReward` penalises a step by `tokensUsed * rate`, so a step whose
+adapter reported no usage received **no cost penalty at all** and scored as more
+efficient than one that reported honestly. The reward preferred the step it knew
+least about, and the same zero under-accumulated into `totalCost` / `totalTokens`.
+
+Decided by a 7-voter `higher_order` panel (4/6): refuse to score an unmeasured
+step rather than impute a value for it. A per-step reward has no defensible
+substitute — a mean or a worst-case invents a number for _that_ step — so it is
+excluded from the trajectory the learner fits.
+
+- `AgentStepOutput` gains `tokensMeasured`; `buildStepOutput` carries it from
+  `result.metadata`.
+- `computeStepReward` returns `number | null`; `null` means unscorable.
+- `convertTrajectory` drops unscored steps — this is the exclusion itself.
+  `convertSingleStep` returns `null` so its caller decides.
+- `computeMetrics` averages over scored steps only and reports `scoredSteps`,
+  so the mean is not read as covering the whole trajectory.
+- `state-manager` sums measured steps only and counts the rest as
+  `unmeasuredSteps`, so the totals read as the lower bound they are.
+
+A **measured** zero is still scored: the check keys on `tokensMeasured === false`,
+never on `tokensUsed === 0`. Absent means measured, so no existing producer
+drops out of the trajectory.
+
+Fixes #4766.

--- a/packages/nexus-agents/src/agents/orchestration/learning-integration.test.ts
+++ b/packages/nexus-agents/src/agents/orchestration/learning-integration.test.ts
@@ -52,6 +52,7 @@ function makeStep(overrides: Partial<PolicyTrajectoryStep> = {}) {
 
 const ZERO_METRICS = {
   avgReward: 0,
+  scoredSteps: 0,
   taskCompletionRate: 0,
   efficiencyScore: 0,
   compactionScore: 0,
@@ -118,6 +119,7 @@ function makeResult(overrides: Partial<PuppeteerResult> = {}) {
     emergentPatterns: { hubAgents: [], cycles: [], graphDensity: 0, cyclicalityScore: 0 },
     metrics: {
       avgReward: 0.8,
+      scoredSteps: 3,
       taskCompletionRate: 1.0,
       efficiencyScore: 0.5,
       compactionScore: 0.3,
@@ -200,6 +202,7 @@ describe('processOrchestrationForLearning', () => {
       totalSteps: 4,
       metrics: {
         avgReward: 0.5,
+        scoredSteps: 0,
         taskCompletionRate: 1.0,
         efficiencyScore: 0.5,
         compactionScore: 0.3,
@@ -402,6 +405,7 @@ describe('computeEpisodeReward', () => {
       totalSteps: 5,
       metrics: {
         avgReward: 0.6,
+        scoredSteps: 0,
         taskCompletionRate: 1.0,
         efficiencyScore: 0.5,
         compactionScore: 0.3,

--- a/packages/nexus-agents/src/agents/orchestration/puppeteer-events.test.ts
+++ b/packages/nexus-agents/src/agents/orchestration/puppeteer-events.test.ts
@@ -112,6 +112,7 @@ function createMockEmergentPatterns(): EmergentPatterns {
 function createMockMetrics(): PuppeteerMetrics {
   return {
     avgReward: 0.8,
+    scoredSteps: 0,
     taskCompletionRate: 0.9,
     efficiencyScore: 0.5,
     compactionScore: 0.6,

--- a/packages/nexus-agents/src/agents/orchestration/puppeteer-events.ts
+++ b/packages/nexus-agents/src/agents/orchestration/puppeteer-events.ts
@@ -87,7 +87,8 @@ export interface PuppeteerStepCompletedPayload {
   /** Tokens used */
   readonly tokensUsed: number;
   /** Reward for this step */
-  readonly reward: number;
+  /** Step reward, `null` when the step was excluded for unmeasured usage (#4766). */
+  readonly reward: number | null;
   /** Current progress */
   readonly progress: number;
   /** Whether this step terminates orchestration */

--- a/packages/nexus-agents/src/agents/orchestration/puppeteer-helpers.test.ts
+++ b/packages/nexus-agents/src/agents/orchestration/puppeteer-helpers.test.ts
@@ -50,33 +50,69 @@ describe('DEFAULT_REWARD_CONFIG', () => {
 // computeStepReward
 // ============================================================================
 
+/** Reward for a step that must be scorable — fails loudly if the step was excluded. */
+function scoreOf(
+  output: AgentStepOutput,
+  progressDelta: number,
+  config?: Parameters<typeof computeStepReward>[2]
+): number {
+  const reward = computeStepReward(output, progressDelta, config);
+  if (reward === null) throw new Error('expected a scorable step, got an excluded one');
+  return reward;
+}
+
 describe('computeStepReward', () => {
   it('computes positive reward for progress', () => {
     const output = makeStepOutput({ tokensUsed: 0, durationMs: 0 });
-    const reward = computeStepReward(output, 1.0);
+    const reward = scoreOf(output, 1.0);
     expect(reward).toBeGreaterThan(0);
+  });
+
+  it('refuses to score a step whose token usage was never measured (#4766)', () => {
+    // The cost penalty is `tokensUsed * rate`, so an unmeasured step paid
+    // ZERO and outscored a step that reported honestly — the reward preferred
+    // the step it knew least about. It is now excluded from the trajectory
+    // rather than scored on a number nobody measured.
+    const unmeasured = makeStepOutput({ tokensUsed: 0, tokensMeasured: false, durationMs: 1000 });
+
+    expect(computeStepReward(unmeasured, 1.0)).toBeNull();
+  });
+
+  it('still scores a step that genuinely used zero tokens (#4766)', () => {
+    // The distinction that has to survive: a MEASURED zero is a measurement.
+    // Excluding it as well would drop real data and make the fix look like
+    // it worked while quietly shrinking the trajectory.
+    const measuredZero = makeStepOutput({ tokensUsed: 0, tokensMeasured: true, durationMs: 1000 });
+
+    expect(computeStepReward(measuredZero, 1.0)).not.toBeNull();
+  });
+
+  it('treats an absent measured flag as measured (#4766)', () => {
+    // Absent means the producer predates the field, so no existing step
+    // silently drops out of the trajectory.
+    expect(computeStepReward(makeStepOutput({ tokensUsed: 100 }), 1.0)).not.toBeNull();
   });
 
   it('computes reward proportional to progress', () => {
     const output = makeStepOutput({ tokensUsed: 0, durationMs: 0 });
-    const rewardHigh = computeStepReward(output, 1.0);
-    const rewardLow = computeStepReward(output, 0.5);
+    const rewardHigh = scoreOf(output, 1.0);
+    const rewardLow = scoreOf(output, 0.5);
     expect(rewardHigh).toBeGreaterThan(rewardLow);
   });
 
   it('applies efficiency penalty for high cost', () => {
     const cheapOutput = makeStepOutput({ tokensUsed: 0, durationMs: 0 });
     const expensiveOutput = makeStepOutput({ tokensUsed: 100000, durationMs: 0 });
-    const cheapReward = computeStepReward(cheapOutput, 0.5);
-    const expensiveReward = computeStepReward(expensiveOutput, 0.5);
+    const cheapReward = scoreOf(cheapOutput, 0.5);
+    const expensiveReward = scoreOf(expensiveOutput, 0.5);
     expect(cheapReward).toBeGreaterThan(expensiveReward);
   });
 
   it('applies efficiency penalty for high time', () => {
     const fastOutput = makeStepOutput({ tokensUsed: 0, durationMs: 0 });
     const slowOutput = makeStepOutput({ tokensUsed: 0, durationMs: 300000 });
-    const fastReward = computeStepReward(fastOutput, 0.5);
-    const slowReward = computeStepReward(slowOutput, 0.5);
+    const fastReward = scoreOf(fastOutput, 0.5);
+    const slowReward = scoreOf(slowOutput, 0.5);
     expect(fastReward).toBeGreaterThan(slowReward);
   });
 
@@ -88,7 +124,7 @@ describe('computeStepReward', () => {
   it('uses custom config', () => {
     const output = makeStepOutput({ tokensUsed: 0, durationMs: 0 });
     const config = { ...DEFAULT_REWARD_CONFIG, progressWeight: 1.0 };
-    const reward = computeStepReward(output, 0.5, config);
+    const reward = scoreOf(output, 0.5, config);
     expect(reward).toBe(0.5);
   });
 });

--- a/packages/nexus-agents/src/agents/orchestration/puppeteer-helpers.ts
+++ b/packages/nexus-agents/src/agents/orchestration/puppeteer-helpers.ts
@@ -66,7 +66,17 @@ export function computeStepReward(
   output: AgentStepOutput,
   progressDelta: number,
   config: RewardConfig = DEFAULT_REWARD_CONFIG
-): number {
+): number | null {
+  // #4766: the cost penalty is `tokensUsed * rate`, so a step whose adapter
+  // reported nothing paid ZERO and outscored one that reported honestly — the
+  // reward preferred the step it knew least about. There is no defensible
+  // per-step substitute (a mean or a worst-case would invent a number for
+  // THIS step), so an unmeasured step is excluded from the trajectory the
+  // learner fits. Decided by a 7-voter panel, option B.
+  //
+  // A MEASURED zero is still scored: absence and a real zero are different.
+  if (output.tokensMeasured === false) return null;
+
   // Progress reward
   const progressReward = progressDelta * config.progressWeight;
 
@@ -186,6 +196,7 @@ export function computeMetrics(
   if (trajectory.length === 0) {
     return {
       avgReward: 0,
+      scoredSteps: 0,
       taskCompletionRate: success ? 1 : 0,
       efficiencyScore: 0,
       compactionScore: 0,
@@ -193,8 +204,15 @@ export function computeMetrics(
     };
   }
 
-  // Average reward
-  const avgReward = trajectory.reduce((sum, step) => sum + step.reward, 0) / trajectory.length;
+  // Average over SCORED steps only. A step excluded for unmeasured usage
+  // (#4766) has no reward to average, and counting it as 0 would reintroduce
+  // the same distortion at the trajectory level. `scoredSteps` reports the
+  // coverage so the mean is not read as covering the whole trajectory.
+  const scored = trajectory.filter(
+    (step): step is PuppeteerStepResult & { reward: number } => step.reward !== null
+  );
+  const avgReward =
+    scored.length > 0 ? scored.reduce((sum, step) => sum + step.reward, 0) / scored.length : 0;
 
   // Efficiency score (lower is better: fewer steps, less cost)
   const totalTokens = trajectory.reduce((sum, s) => sum + s.agentOutput.tokensUsed, 0);
@@ -206,6 +224,7 @@ export function computeMetrics(
 
   return {
     avgReward: Math.round(avgReward * 1000) / 1000,
+    scoredSteps: scored.length,
     taskCompletionRate: success ? 1 : 0,
     efficiencyScore: Math.round(efficiencyScore * 1000) / 1000,
     compactionScore: Math.round(compactionScore * 100) / 100,
@@ -274,6 +293,9 @@ export function buildAgentStepOutput(
     output: result.output,
     durationMs: result.metadata.durationMs,
     tokensUsed: result.metadata.tokensUsed,
+    ...(result.metadata.tokensMeasured === undefined
+      ? {}
+      : { tokensMeasured: result.metadata.tokensMeasured }),
     model: result.metadata.model,
   };
 }

--- a/packages/nexus-agents/src/agents/orchestration/puppeteer-result-types.ts
+++ b/packages/nexus-agents/src/agents/orchestration/puppeteer-result-types.ts
@@ -15,12 +15,7 @@ import type {
 
 /** Reasons for terminating orchestration. */
 export type PuppeteerTerminationReason =
-  | 'task_complete'
-  | 'max_steps'
-  | 'timeout'
-  | 'error'
-  | 'cancelled'
-  | 'convergence';
+  'task_complete' | 'max_steps' | 'timeout' | 'error' | 'cancelled' | 'convergence';
 
 /**
  * Result of one orchestration step.
@@ -35,7 +30,14 @@ export interface PuppeteerStepResult {
   /** Updated state after this step */
   readonly newState: PuppeteerState;
   /** Reward for this step */
-  readonly reward: number;
+  /**
+   * Step reward, or `null` when the step could not be scored (#4766).
+   *
+   * `null` means its token usage was never measured, so no defensible cost
+   * term existed — the step is excluded from the trajectory the learner fits
+   * rather than credited a zero cost and scored as maximally efficient.
+   */
+  readonly reward: number | null;
   /** Whether orchestration should terminate */
   readonly shouldTerminate: boolean;
   /** Reason for termination (if shouldTerminate) */
@@ -82,8 +84,16 @@ export interface EmergentPatterns {
  * Metrics from orchestration execution.
  */
 export interface PuppeteerMetrics {
-  /** Average reward across steps */
+  /** Average reward across SCORED steps. See {@link PuppeteerMetrics.scoredSteps}. */
   readonly avgReward: number;
+  /**
+   * Steps the average was actually taken over (#4766).
+   *
+   * Lower than the trajectory length when steps were excluded for unmeasured
+   * token usage. `0` means nothing was scored, so `avgReward` is `0` over
+   * nothing rather than a measured zero.
+   */
+  readonly scoredSteps: number;
   /** Task completion rate (0-1) */
   readonly taskCompletionRate: number;
   /** Efficiency score (lower is better) */

--- a/packages/nexus-agents/src/agents/orchestration/puppeteer-state-types.ts
+++ b/packages/nexus-agents/src/agents/orchestration/puppeteer-state-types.ts
@@ -21,8 +21,18 @@ export interface AgentStepOutput {
   readonly output: unknown;
   /** Execution duration in milliseconds */
   readonly durationMs: number;
-  /** Tokens consumed */
+  /** Tokens consumed. Meaningful only when {@link AgentStepOutput.tokensMeasured} is not `false`. */
   readonly tokensUsed: number;
+  /**
+   * Whether `tokensUsed` is a measurement (#4766).
+   *
+   * `false` means the adapter reported no usage, so `tokensUsed` is a
+   * placeholder `0` — and the step is EXCLUDED from reward scoring rather
+   * than credited a zero cost penalty, which made it outscore a step that
+   * reported honestly. Absent means measured, so no existing producer changes
+   * meaning.
+   */
+  readonly tokensMeasured?: boolean;
   /** Model used for execution */
   readonly model: string;
 }
@@ -35,8 +45,16 @@ export interface PuppeteerStateMetadata {
   readonly progress: number;
   /** Accumulated cost in dollars */
   readonly totalCost: number;
-  /** Accumulated tokens */
+  /** Accumulated tokens, over measured steps only. */
   readonly totalTokens: number;
+  /**
+   * Steps whose usage was never measured and so contributed nothing to
+   * `totalCost` / `totalTokens` (#4766).
+   *
+   * Without this the accumulators read as complete when they are a LOWER
+   * BOUND. Absent means the state predates the distinction.
+   */
+  readonly unmeasuredSteps?: number;
   /** Time elapsed in milliseconds */
   readonly elapsedMs: number;
   /** Start timestamp (ISO 8601) */

--- a/packages/nexus-agents/src/agents/orchestration/state-manager.test.ts
+++ b/packages/nexus-agents/src/agents/orchestration/state-manager.test.ts
@@ -197,6 +197,27 @@ describe('updateState', () => {
     expect(newState.metadata.totalTokens).toBe(50);
   });
 
+  it('does not add an unmeasured step to the totals, and counts it (#4766)', () => {
+    // `tokensUsed: 0` with `tokensMeasured: false` is a placeholder, not a
+    // measurement. Summing it is arithmetically a no-op today, but the count
+    // is what stops the totals reading as complete when they are a lower
+    // bound.
+    const output = { ...createTestOutput(0, 'agent-1'), tokensUsed: 0, tokensMeasured: false };
+
+    const newState = manager.updateState(initialState, output);
+
+    expect(newState.metadata.totalTokens).toBe(0);
+    expect(newState.metadata.unmeasuredSteps).toBe(1);
+  });
+
+  it('does not count a measured step as unmeasured (#4766)', () => {
+    // The pair: counting every step would make the disclosure meaningless.
+    const newState = manager.updateState(initialState, createTestOutput(0, 'agent-1'));
+
+    expect(newState.metadata.totalTokens).toBe(50);
+    expect(newState.metadata.unmeasuredSteps).toBe(0);
+  });
+
   it('updates total cost', () => {
     const output = createTestOutput(0, 'agent-1');
     const newState = manager.updateState(initialState, output);

--- a/packages/nexus-agents/src/agents/orchestration/state-manager.ts
+++ b/packages/nexus-agents/src/agents/orchestration/state-manager.ts
@@ -302,10 +302,16 @@ export class StateManager implements IStateManager {
     const elapsedMs = getTimeProvider().now() - startTime;
     const costPerToken = 0.00001; // $0.01 per 1K tokens
 
+    // #4766: a step whose usage was never measured contributes nothing, so
+    // these are sums over MEASURED steps. Counted rather than silently
+    // skipped — otherwise the totals read as complete when they are a lower
+    // bound.
+    const measured = output.tokensMeasured !== false;
     return {
       progress: current.progress,
-      totalCost: current.totalCost + output.tokensUsed * costPerToken,
-      totalTokens: current.totalTokens + output.tokensUsed,
+      totalCost: current.totalCost + (measured ? output.tokensUsed * costPerToken : 0),
+      totalTokens: current.totalTokens + (measured ? output.tokensUsed : 0),
+      unmeasuredSteps: (current.unmeasuredSteps ?? 0) + (measured ? 0 : 1),
       elapsedMs,
       startedAt: current.startedAt,
     };

--- a/packages/nexus-agents/src/agents/orchestration/trajectory-converter.test.ts
+++ b/packages/nexus-agents/src/agents/orchestration/trajectory-converter.test.ts
@@ -196,16 +196,25 @@ describe('convertSingleStep', () => {
     const step = createMockStepResult(0, 'agent-1', 1.5);
     const trajectoryStep = convertSingleStep(step);
 
-    expect(trajectoryStep.action).toBe('agent-1');
-    expect(trajectoryStep.reward).toBe(1.5);
-    expect(trajectoryStep.state).toBe(step.newState);
+    expect(trajectoryStep).not.toBeNull();
+    expect(trajectoryStep?.action).toBe('agent-1');
+    expect(trajectoryStep?.reward).toBe(1.5);
+    expect(trajectoryStep?.state).toBe(step.newState);
+  });
+
+  it('returns null for a step excluded for unmeasured usage (#4766)', () => {
+    // The caller must decide to drop it rather than receive a fabricated
+    // reward. Mirrors the batch converter, which filters these out.
+    const step = { ...createMockStepResult(0, 'agent-1', 1.5), reward: null };
+
+    expect(convertSingleStep(step)).toBeNull();
   });
 
   it('computes correct log probability', () => {
     const step = createMockStepResult(0, 'agent-1');
     const trajectoryStep = convertSingleStep(step);
 
-    expect(trajectoryStep.logProb).toBeCloseTo(Math.log(0.7), 5);
+    expect(trajectoryStep?.logProb).toBeCloseTo(Math.log(0.7), 5);
   });
 
   it('throws when agent not found', () => {
@@ -348,8 +357,8 @@ describe('log probability edge cases', () => {
     const trajectoryStep = convertSingleStep(step);
 
     // Should not be -Infinity due to MIN_PROBABILITY clamping
-    expect(Number.isFinite(trajectoryStep.logProb)).toBe(true);
-    expect(trajectoryStep.logProb).toBeLessThan(0);
+    expect(Number.isFinite(trajectoryStep?.logProb)).toBe(true);
+    expect(trajectoryStep?.logProb).toBeLessThan(0);
   });
 
   it('handles probability of 1.0', () => {
@@ -364,7 +373,7 @@ describe('log probability edge cases', () => {
     const trajectoryStep = convertSingleStep(step);
 
     // log(1) = 0
-    expect(trajectoryStep.logProb).toBeCloseTo(0, 5);
+    expect(trajectoryStep?.logProb).toBeCloseTo(0, 5);
   });
 });
 
@@ -395,9 +404,9 @@ describe('trajectory step properties', () => {
     expect(trajectoryStep).toHaveProperty('logProb');
 
     // Verify types
-    expect(typeof trajectoryStep.action).toBe('string');
-    expect(typeof trajectoryStep.reward).toBe('number');
-    expect(typeof trajectoryStep.logProb).toBe('number');
-    expect(typeof trajectoryStep.state).toBe('object');
+    expect(typeof trajectoryStep?.action).toBe('string');
+    expect(typeof trajectoryStep?.reward).toBe('number');
+    expect(typeof trajectoryStep?.logProb).toBe('number');
+    expect(typeof trajectoryStep?.state).toBe('object');
   });
 });

--- a/packages/nexus-agents/src/agents/orchestration/trajectory-converter.ts
+++ b/packages/nexus-agents/src/agents/orchestration/trajectory-converter.ts
@@ -77,16 +77,21 @@ function extractLogProbability(distribution: AgentDistribution, selectedAgent: s
  * ```
  */
 export function convertTrajectory(steps: readonly PuppeteerStepResult[]): PolicyTrajectoryStep[] {
-  return steps.map((step): PolicyTrajectoryStep => {
-    const logProb = extractLogProbability(step.distribution, step.selectedAgent);
+  // #4766: a step whose token usage was never measured carries `reward: null`
+  // and is dropped here rather than fitted at a fabricated value. This is the
+  // exclusion itself — everything else only propagates the flag.
+  return steps
+    .filter((step): step is (typeof steps)[number] & { reward: number } => step.reward !== null)
+    .map((step): PolicyTrajectoryStep => {
+      const logProb = extractLogProbability(step.distribution, step.selectedAgent);
 
-    return {
-      state: step.newState,
-      action: step.selectedAgent,
-      reward: step.reward,
-      logProb,
-    };
-  });
+      return {
+        state: step.newState,
+        action: step.selectedAgent,
+        reward: step.reward,
+        logProb,
+      };
+    });
 }
 
 /**
@@ -105,7 +110,10 @@ export function convertTrajectory(steps: readonly PuppeteerStepResult[]): Policy
  * const trajectoryStep = convertSingleStep(result);
  * ```
  */
-export function convertSingleStep(step: PuppeteerStepResult): PolicyTrajectoryStep {
+export function convertSingleStep(step: PuppeteerStepResult): PolicyTrajectoryStep | null {
+  // Null for an unscored step, mirroring the batch converter: the caller must
+  // decide to drop it rather than receive a fabricated reward (#4766).
+  if (step.reward === null) return null;
   const logProb = extractLogProbability(step.distribution, step.selectedAgent);
 
   return {


### PR DESCRIPTION
Fixes #4766. Decided by a live 7-voter `higher_order` panel — **Option B**, 4 of 6. Full result and the dissents are on the issue.

## The defect

`computeStepReward` penalises a step by `tokensUsed * rate`. Since #4744 an unmeasured step carries `tokensUsed: 0`, and only the number reached `AgentStepOutput` — so a step whose adapter reported nothing paid a cost penalty of **zero** and scored as more efficient than one that reported honestly.

**The reward systematically preferred the step it knew least about.** The same zero under-accumulated into `totalCost` / `totalTokens`.

## Why not impute

Both imputation options were rejected for inventing a number for *that specific step*. Mean substitution teaches the learner that unmeasured steps are exactly typical — a claim nobody measured. Pessimistic substitution is only incentive-compatible against a strategic under-reporter; against an honest telemetry gap it penalises a provider for its instrumentation.

The "flag it as partial" option lost on a point I had underweighted when filing: **the flag would ship as an unconsumed output.** Nothing downstream discounts a flagged reward, so the bias would be disclosed and unchanged — the same shape as the defect.

## The two conditions three approvers added independently

**Count the exclusions.** `PuppeteerMetrics` gains `scoredSteps`, and `avgReward` is taken over scored steps only. Counting an excluded step as `0` would have reintroduced the identical distortion one level up. `scoredSteps: 0` means the mean is zero over nothing.

**A measured zero is a measurement.** The check keys on `tokensMeasured === false`, never on `tokensUsed === 0`. That distinction is load-bearing and mutation-verified: excluding on the value instead fails four tests, because a genuinely-free step is real data.

## The dissent, recorded rather than dismissed

The contrarian rejected all four options, arguing we are tuning a signal whose utility is unproven — **the issue itself says nothing measures whether the reward improves outcomes** — and proposed removing the cost term entirely or fixing telemetry at the adapter level.

I adopted neither: removing the term is a larger change to the reward model, and the adapter gap is #4743's. But it is the honest framing of the residual risk and it is on the issue next to the fix.

## Changes

`AgentStepOutput.tokensMeasured` (additive) → `computeStepReward` returns `number | null` → `convertTrajectory` drops unscored steps, which **is** the exclusion → `convertSingleStep` returns `null` so its caller decides → `computeMetrics` and `state-manager` disclose coverage.

Absent `tokensMeasured` counts as measured, so no existing producer silently leaves the trajectory.

## Verification

Eight tests, red first. Four production hunks each mutation-verified, including the over-broad `tokensUsed === 0` variant and the converter no longer filtering.

**4139 tests across `src/agents`, green.** `tsc` and eslint clean; no api-surface change.