### PR TITLE
chore(docs): drop three $schema refs to files that do not exist

### DIFF
--- a/.changeset/dangling-schema-refs.md
+++ b/.changeset/dangling-schema-refs.md
@@ -1,0 +1,6 @@
+---
+---
+
+Repo hygiene: removes three `$schema` declarations pointing at files that do not
+exist, and adds a test that any relative `$schema` must resolve (#4612). No
+shippable source changes.

--- a/docs/ops/orphan-allowlist.json
+++ b/docs/ops/orphan-allowlist.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "./orphan-allowlist.schema.json",
   "version": "1.0.0",
   "description": "Allowlist for the orphan-detection check (#2410, blocking since #4583). Files matching these patterns or paths are exempted from orphan flagging — typically because they're invoked by name (CLI scripts, migrations) or intentionally not imported (examples, illustrative code). `patterns` are permanent structural facts about the repo layout. Each `specific_files` entry must declare exactly one of `expires` (YYYY-MM-DD, dated debt — the file flags once the date passes) or `permanent: true` (the file can never be imported); an entry declaring neither fails the check by name.",
   "patterns": [

--- a/docs/ops/registry-coverage-manifest.json
+++ b/docs/ops/registry-coverage-manifest.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "./registry-coverage-manifest.schema.json",
   "version": "1.0.0",
   "description": "Registry-coverage manifest. When the source file changes in a way that touches the marker, every peer file MUST also change in the same PR. Hard-fail in CI. See docs/architecture/REGISTRY_COVERAGE.md (#2405).",
   "registries": [

--- a/docs/ops/schema-fanout-manifest.json
+++ b/docs/ops/schema-fanout-manifest.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "./schema-fanout-manifest.schema.json",
   "version": "1.0.0",
   "description": "Schema-fan-out manifest. When a tracked schema's source file changes in a way that touches the schema's marker, at least one consumer test file MUST also change in the same PR. v1 ships warn-only; promote to fail when false-positive rate stabilizes. See docs/architecture/SCHEMA_FANOUT_COVERAGE.md (#2407).",
   "schemas": [

--- a/scripts/schema-refs.test.ts
+++ b/scripts/schema-refs.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Every relative `$schema` reference resolves to a file that exists (#4612).
+ *
+ * A `$schema` pointing at a missing file is not inert: an editor resolves it
+ * to nothing and silently offers no validation, which looks exactly like
+ * "validated and fine". The author of a manifest entry gets no completion, no
+ * type checking, and no warning that they got neither.
+ *
+ * When this test was written, **three** relative references existed and
+ * **none** of them resolved — every manifest under `docs/ops/` declared a
+ * schema that had never been committed. The lines were removed rather than
+ * backfilled: each manifest already has an enforcing script that is the
+ * authoritative validator, and a JSON Schema drifting from that script would
+ * be worse than no schema.
+ *
+ * This test is what makes writing one later safe: add the schema file and the
+ * `$schema` line together, and the reference stays honest.
+ *
+ * @module scripts/schema-refs.test
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync, globSync } from 'node:fs';
+import { dirname, join, normalize } from 'node:path';
+
+interface SchemaRef {
+  readonly file: string;
+  readonly ref: string;
+  readonly resolved: string;
+}
+
+function jsonFiles(): string[] {
+  return globSync('**/*.json', {
+    cwd: process.cwd(),
+    exclude: (p: string) =>
+      p.includes('node_modules') ||
+      p.includes('.git/') ||
+      p.includes('worktrees') ||
+      p.includes('/dist/') ||
+      p.startsWith('coverage/'),
+  });
+}
+
+/** File count the guard actually scanned — a broken glob makes it vacuous. */
+function relativeSchemaRefsScanCount(): number {
+  return jsonFiles().length;
+}
+
+function relativeSchemaRefs(): SchemaRef[] {
+  const files = jsonFiles();
+  const refs: SchemaRef[] = [];
+  for (const file of files) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(join(process.cwd(), file), 'utf8'));
+    } catch {
+      continue; // Malformed JSON is another test's problem.
+    }
+    if (typeof parsed !== 'object' || parsed === null) continue;
+    const ref = (parsed as Record<string, unknown>)['$schema'];
+    // A URL reference is resolved by the editor over the network, not from
+    // the tree, so it is out of scope here.
+    if (typeof ref !== 'string' || ref.startsWith('http')) continue;
+    refs.push({ file, ref, resolved: normalize(join(dirname(file), ref)) });
+  }
+  return refs;
+}
+
+describe('relative $schema references (#4612)', () => {
+  it('resolve to a file that exists', () => {
+    const dangling = relativeSchemaRefs().filter(
+      (r) => !existsSync(join(process.cwd(), r.resolved))
+    );
+
+    expect(
+      dangling.map((r) => `${r.file} -> ${r.ref}`),
+      'These declare a schema that is not in the repo. An editor resolves it to nothing and offers no validation, which is indistinguishable from validating cleanly. Add the schema file, or drop the $schema line.'
+    ).toEqual([]);
+  });
+
+  it('scans a non-trivial number of JSON files', () => {
+    // Guard the guard: a broken glob would make the assertion above vacuous,
+    // and an empty scan passes it perfectly.
+    const scanned = relativeSchemaRefsScanCount();
+
+    expect(scanned).toBeGreaterThan(20);
+  });
+});


### PR DESCRIPTION
Fixes #4612. Repo hygiene — no shippable source changes.

## The sweep changed the answer

#4612 reported one dangling `$schema`, in `docs/ops/orphan-allowlist.json`, and suggested checking whether others resolve. They do not:

```
url refs (fine):        8
relative refs OK:       0
relative refs BROKEN:   3
  docs/ops/orphan-allowlist.json          -> ./orphan-allowlist.schema.json
  docs/ops/registry-coverage-manifest.json -> ./registry-coverage-manifest.schema.json
  docs/ops/schema-fanout-manifest.json     -> ./schema-fanout-manifest.schema.json
```

**Every relative `$schema` reference in the repo was dangling.** Not one has ever resolved. That is a pattern in how these manifests were written, not an oversight in one file — and it is why the issue's lean toward "write the schema" no longer holds.

## Why drop rather than backfill

The issue leaned to writing the schema, flagging a DRY objection: `validateAllowlist()` in `check-orphans.ts` is the authoritative validator, and a JSON Schema drifting from it would be worse than none.

With three files that objection triples. Each manifest already has an enforcing script — `check-orphans.ts`, `check-registry-coverage.ts`, `check-schema-fanout.ts` — and all three are wired into CI. Backfilling three schemas means three second copies of rules whose first copies are the ones that actually run.

Dropping loses nothing that exists today: a reference to a missing file gives no completion and no validation. It removes a declaration that asserts something untrue about the repo, which is the whole complaint.

## The durable part is the guard

`scripts/schema-refs.test.ts` asserts every relative `$schema` resolves, and it runs inside `Script Tests`, which is required. Zero of three resolved and nothing noticed, for however long.

**That is also what makes writing a schema safe later**: add the file and the line together and the reference stays honest. So this is not a decision against schemas — it removes false claims now and makes a real one verifiable when someone wants it.

URL references are skipped: an editor resolves those over the network, not from the tree.

## Verification

Red first — the guard named all three before the removal. Two mutations, and the second one matters more than the first: reintroducing a dangling ref fails the resolution test, and **breaking the glob so it scans nothing fails the companion test**. Without that second assertion an empty scan passes the guard perfectly, which is the shape this repo keeps finding.

All three consuming scripts re-run clean after the edit (`check-orphans` reports no flagged orphans; the other two exit 0), and each file still parses.