### PR TITLE
fix(doctor): report the fix it made, and a count that matches the verdict

### DIFF
--- a/.changeset/doctor-honest-fix-count.md
+++ b/.changeset/doctor-honest-fix-count.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': patch
+---
+
+stop doctor reporting a fix it did not make and a count that contradicts its verdict
+
+Two defects in `doctor`, both reporting success it had not achieved.
+
+**`--fix` claimed to create directories when it created none.** The fix runs when
+a data subdirectory is missing **or not writable**, but `ensureDir` returns early
+for a path that already exists and never checks writability. An
+existing-but-unwritable directory therefore lands in `alreadyExisted`, `failures`
+stays empty, and `success` is true — so doctor printed
+"✓ Created missing data directories" and incremented the fix count for precisely
+the condition that triggered it. `created.length` was already on the result and
+was not consulted; a new `describeDataDirFix` now reads it and says plainly that
+setup cannot repair permissions.
+
+**The summary count contradicted the verdict.** `totalIssues` enumerated CLIs,
+node version and `mcpServerReady`, while `isAllHealthy` additionally fails on an
+unacceptable scratch severity. A critical scratch filesystem with everything else
+healthy printed `Summary: 0 issue(s) found` — a summary shown only because
+something is wrong, saying nothing is wrong. The count now includes the same
+term the verdict reads, and `scratchSeverityIsAcceptable` moved next to
+`worstSeverity` so both callers share one definition rather than the count
+drifting from the verdict again.
+
+Fixes #4851.

--- a/packages/nexus-agents/src/cli/doctor-formatting.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.test.ts
@@ -66,6 +66,27 @@ vi.mock('../cli-adapters/types.js', () => ({
   },
 }));
 
+/** Applies a scratchSpace override outside the fixture literal (keeps its complexity under the cap). */
+function withScratch(
+  override: DoctorResult['scratchSpace'] | undefined,
+  base: DoctorResult
+): DoctorResult {
+  return override === undefined ? base : { ...base, scratchSpace: override };
+}
+
+const DEFAULT_SCRATCH_SPACE: DoctorResult['scratchSpace'] = [
+  {
+    label: 'nexus' as const,
+    root: '/tmp/nexus-test',
+    available: true,
+    freeBytes: 20 * 1024 ** 3,
+    totalBytes: 32 * 1024 ** 3,
+    percentUsed: 38,
+    severity: 'ok' as const,
+    message: '20.0 GiB free of 32.0 GiB (38% used)',
+  },
+];
+
 describe('doctor-formatting', () => {
   let writeLineMock: MockedFunction<typeof ansiOutput.writeLine>;
 
@@ -131,84 +152,75 @@ describe('doctor-formatting', () => {
       mcpServerReady?: boolean;
       mcpClientReady?: boolean;
       voterTransport?: { configured: boolean };
+      scratchSpace?: DoctorResult['scratchSpace'];
     } = {}
-  ): DoctorResult => ({
-    allHealthy: options.allHealthy ?? true,
-    nodeVersion: options.nodeVersion ?? createNodeVersionCheck(true, 'v22.0.0'),
-    apiKeys: options.apiKeys ?? [],
-    configFile: options.configFile ?? createConfigFileCheck(true, './nexus-agents.yaml'),
-    clis: options.clis ?? [],
-    mcpServerReady: options.mcpServerReady ?? true,
-    mcpClientReady: options.mcpClientReady ?? true,
-    registryAdvisory: {
-      totalModels: 10,
-      availableModels: 10,
-      unavailableModels: 0,
-      models: [],
-      registryAgeDays: 1,
-      registryStale: false,
-    },
-    learningPersistence: {
-      enabled: false,
-      dirExists: false,
-      dirWritable: false,
-      outcomeCount: 0,
-      ruleCount: 0,
-      rulesLastSaved: null,
-      error: null,
-    },
-    sqliteCheck: {
-      available: true,
-      error: null,
-    },
-    dataDirectory: {
-      rootExists: true,
-      rootPath: '/home/test/.nexus-agents',
-      repoRoot: null,
-      // A real doctor run always resolves the standard subdirectory set, and
-      // since #4581 the printer no longer calls an unmeasured layout healthy —
-      // an empty list here would emit a remediation line the test does not
-      // expect, and would be an unrealistic fixture besides.
-      subdirectories: [
-        {
-          name: 'memory',
-          path: '/home/test/.nexus-agents/memory',
-          scope: 'cross-repo' as const,
-          exists: true,
-          writable: true,
-        },
-      ],
-    },
-    sandbox: {
-      active: false,
-      flavor: undefined,
-      root: undefined,
-      heuristicMatch: 'unknown' as const,
-      mismatch: false,
-      dataDirInsideRepo: false,
-    },
-    harnessAlignment: {
-      agentsMdExists: true,
-      files: [],
-      alignedCount: 0,
-      driftCount: 0,
-      missingCount: 0,
-    },
-    voterTransport: options.voterTransport ?? { configured: false },
-    scratchSpace: [
-      {
-        label: 'nexus' as const,
-        root: '/tmp/nexus-test',
-        available: true,
-        freeBytes: 20 * 1024 ** 3,
-        totalBytes: 32 * 1024 ** 3,
-        percentUsed: 38,
-        severity: 'ok' as const,
-        message: '20.0 GiB free of 32.0 GiB (38% used)',
+  ): DoctorResult =>
+    withScratch(options.scratchSpace, {
+      allHealthy: options.allHealthy ?? true,
+      nodeVersion: options.nodeVersion ?? createNodeVersionCheck(true, 'v22.0.0'),
+      apiKeys: options.apiKeys ?? [],
+      configFile: options.configFile ?? createConfigFileCheck(true, './nexus-agents.yaml'),
+      clis: options.clis ?? [],
+      mcpServerReady: options.mcpServerReady ?? true,
+      mcpClientReady: options.mcpClientReady ?? true,
+      registryAdvisory: {
+        totalModels: 10,
+        availableModels: 10,
+        unavailableModels: 0,
+        models: [],
+        registryAgeDays: 1,
+        registryStale: false,
       },
-    ],
-    timestamp: new Date('2024-01-01T00:00:00Z'),
-  });
+      learningPersistence: {
+        enabled: false,
+        dirExists: false,
+        dirWritable: false,
+        outcomeCount: 0,
+        ruleCount: 0,
+        rulesLastSaved: null,
+        error: null,
+      },
+      sqliteCheck: {
+        available: true,
+        error: null,
+      },
+      dataDirectory: {
+        rootExists: true,
+        rootPath: '/home/test/.nexus-agents',
+        repoRoot: null,
+        // A real doctor run always resolves the standard subdirectory set, and
+        // since #4581 the printer no longer calls an unmeasured layout healthy —
+        // an empty list here would emit a remediation line the test does not
+        // expect, and would be an unrealistic fixture besides.
+        subdirectories: [
+          {
+            name: 'memory',
+            path: '/home/test/.nexus-agents/memory',
+            scope: 'cross-repo' as const,
+            exists: true,
+            writable: true,
+          },
+        ],
+      },
+      sandbox: {
+        active: false,
+        flavor: undefined,
+        root: undefined,
+        heuristicMatch: 'unknown' as const,
+        mismatch: false,
+        dataDirInsideRepo: false,
+      },
+      harnessAlignment: {
+        agentsMdExists: true,
+        files: [],
+        alignedCount: 0,
+        driftCount: 0,
+        missingCount: 0,
+      },
+      voterTransport: options.voterTransport ?? { configured: false },
+      scratchSpace: DEFAULT_SCRATCH_SPACE,
+      timestamp: new Date('2024-01-01T00:00:00Z'),
+    });
 
   describe('printDoctorResults', () => {
     it('should print header and section titles', () => {
@@ -635,6 +647,54 @@ describe('doctor-formatting', () => {
       const calls = getCalls();
       // 2 unhealthy CLIs + 1 Node issue + 1 MCP issue = 4 total
       expect(calls.some((call) => call.includes('4 issue(s) found'))).toBe(true);
+    });
+  });
+
+  describe('the summary count agrees with the verdict (#4851)', () => {
+    it('does not report zero issues when the verdict is unhealthy', () => {
+      // `totalIssues` counted CLIs, node version and mcpServerReady;
+      // `isAllHealthy` ALSO fails on an unacceptable scratch severity. So a
+      // critical scratch filesystem with everything else fine printed
+      // "Summary: 0 issue(s) found" — a summary shown only because something
+      // is wrong, saying nothing is wrong.
+      const result = createDoctorResult({
+        allHealthy: false,
+        scratchSpace: [
+          {
+            label: 'system' as const,
+            root: '/tmp',
+            available: true,
+            freeBytes: 0,
+            totalBytes: 34_359_738_368,
+            percentUsed: 100,
+            severity: 'critical' as const,
+            message: '/tmp is full',
+          },
+        ],
+      });
+
+      printDoctorResults(result);
+
+      const calls = getCalls();
+      expect(calls.some((call) => call.includes('0 issue(s) found'))).toBe(false);
+      expect(calls.some((call) => call.includes('1 issue(s) found'))).toBe(true);
+    });
+
+    it('still counts the CLI, node and MCP issues it always did', () => {
+      // The pair: the scratch term must add to the count, not replace it.
+      const result = createDoctorResult({
+        allHealthy: false,
+        nodeVersion: createNodeVersionCheck(false, 'v18.0.0'),
+        clis: [
+          createCliCheckResult('claude', false, false, 'unsupported'),
+          createCliCheckResult('codex', true, false, 'supported', { version: '0.1.0' }),
+        ],
+        mcpServerReady: false,
+      });
+
+      printDoctorResults(result);
+
+      expect(getCalls().some((call) => call.includes('4 issue(s) found'))).toBe(true);
     });
   });
 

--- a/packages/nexus-agents/src/cli/doctor-formatting.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.ts
@@ -8,7 +8,11 @@
  */
 
 import { DEFAULT_CAPABILITIES } from '../cli-adapters/types.js';
-import { formatScratchFilesystems } from './doctor-scratch-space.js';
+import {
+  formatScratchFilesystems,
+  scratchSeverityIsAcceptable,
+  worstSeverity,
+} from './doctor-scratch-space.js';
 import type { CapacityStatus } from '../cli-adapters/types.js';
 import type {
   CliCheckResult,
@@ -384,7 +388,13 @@ function printSandbox(check: DoctorResult['sandbox']): void {
 function printDoctorSummary(result: DoctorResult): void {
   const unhealthyCount = result.clis.filter((c) => !c.installed || !c.authenticated).length;
   const nodeIssue = result.nodeVersion.supported ? 0 : 1;
-  const totalIssues = unhealthyCount + nodeIssue + (result.mcpServerReady ? 0 : 1);
+  // #4851: the count enumerated CLIs, node and MCP while `isAllHealthy` ALSO
+  // fails on an unacceptable scratch severity — so a critical scratch
+  // filesystem with everything else fine printed "Summary: 0 issue(s) found",
+  // a summary shown only because something is wrong, saying nothing is wrong.
+  // Every term the verdict reads must be a term the count reads.
+  const scratchIssue = scratchSeverityIsAcceptable(worstSeverity(result.scratchSpace)) ? 0 : 1;
+  const totalIssues = unhealthyCount + nodeIssue + (result.mcpServerReady ? 0 : 1) + scratchIssue;
   const summary = result.allHealthy
     ? `${colors.green}${colors.bold}Status: Ready${colors.reset}`
     : `${colors.yellow}${colors.bold}Summary: ${String(totalIssues)} issue(s) found${colors.reset}`;

--- a/packages/nexus-agents/src/cli/doctor-scratch-space.ts
+++ b/packages/nexus-agents/src/cli/doctor-scratch-space.ts
@@ -257,3 +257,26 @@ export function formatScratchSpace(check: ScratchSpaceCheck): string {
     '    Free space, or point NEXUS_TMPDIR at a roomier filesystem.',
   ].join('\n');
 }
+
+/**
+ * Whether a scratch severity permits a healthy verdict (#4563).
+ *
+ * Exhaustive rather than `!== 'critical'`: a severity added later — say
+ * `fatal` — would silently satisfy a negative test and let the verdict pass,
+ * which is the same shape as the `skip`-reaching-`!== 'fail'` regression on
+ * the ship gate. Each level must be classified deliberately.
+ */
+export function scratchSeverityIsAcceptable(severity: ScratchSpaceSeverity): boolean {
+  switch (severity) {
+    case 'ok':
+    case 'warn':
+      // warn still leaves room for the current run.
+      return true;
+    case 'critical':
+      return false;
+    default: {
+      const exhaustive: never = severity;
+      throw new Error(`Unhandled scratch severity: ${String(exhaustive)}`);
+    }
+  }
+}

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -28,7 +28,7 @@ import {
   checkScratchFilesystems,
   worstSeverity,
   type ScratchSpaceCheck,
-  type ScratchSpaceSeverity,
+  scratchSeverityIsAcceptable,
 } from './doctor-scratch-space.js';
 import { getTimeProvider, getErrorMessage } from '../core/index.js';
 import {
@@ -775,28 +775,6 @@ export interface HealthVerdictInput {
  * current run, and failing the whole command on it would collapse the
  * distinction between the two thresholds into one.
  */
-/**
- * Whether a scratch severity permits a healthy verdict (#4563).
- *
- * Exhaustive rather than `!== 'critical'`: a severity added later — say
- * `fatal` — would silently satisfy a negative test and let the verdict pass,
- * which is the same shape as the `skip`-reaching-`!== 'fail'` regression on
- * the ship gate. Each level must be classified deliberately.
- */
-function scratchSeverityIsAcceptable(severity: ScratchSpaceSeverity): boolean {
-  switch (severity) {
-    case 'ok':
-    case 'warn':
-      // warn still leaves room for the current run.
-      return true;
-    case 'critical':
-      return false;
-    default: {
-      const exhaustive: never = severity;
-      throw new Error(`Unhandled scratch severity: ${String(exhaustive)}`);
-    }
-  }
-}
 
 export function isAllHealthy(input: HealthVerdictInput): boolean {
   return (
@@ -911,18 +889,19 @@ async function runDoctorFix(result: DoctorResult): Promise<void> {
     !result.dataDirectory.rootExists ||
     result.dataDirectory.subdirectories.some((d) => !d.exists || !d.writable)
   ) {
-    const { runSetup } = await import('./setup-command.js');
-    const setupResult = runSetup({
-      skipMcp: true,
-      skipRules: true,
-      skipHooks: true,
-      skipConfig: true,
-      skipOpencode: true,
-    });
-    if (setupResult.success) {
-      writeLine('✓ Created missing data directories');
-      fixCount++;
-    }
+    // Calls the data-dir initializer directly rather than `runSetup` with
+    // every other step skipped: the result carries `created`, and that is the
+    // only thing distinguishing a real fix from a no-op.
+    //
+    // #4851: this reported on `setupResult.success` alone and so claimed
+    // "✓ Created missing data directories" for the unwritable case — which
+    // setup cannot repair. `ensureDir` returns early for a path that already
+    // exists and never checks writability, so nothing is created and success
+    // is still true, for precisely the condition that triggered the fix.
+    const { initDataDirectories, describeDataDirFix } = await import('./setup-data-dir.js');
+    const outcome = describeDataDirFix(initDataDirectories());
+    writeLine(outcome.line);
+    if (outcome.counted) fixCount++;
   }
 
   // Fix: config file

--- a/packages/nexus-agents/src/cli/setup-data-dir.test.ts
+++ b/packages/nexus-agents/src/cli/setup-data-dir.test.ts
@@ -120,3 +120,46 @@ describe('initDataDirectories (#1249)', () => {
     }
   });
 });
+
+// ============================================================================
+// doctor --fix reporting (#4851)
+// ============================================================================
+
+describe('describeDataDirFix (#4851)', () => {
+  const base = { rootPath: '/tmp/x', alreadyExisted: [], error: null };
+
+  it('does not claim a fix when nothing was created', async () => {
+    const { describeDataDirFix } = await import('./setup-data-dir.js');
+    // The exact case that triggers the fix: `doctor --fix` runs when a
+    // subdirectory is missing OR not writable, but `ensureDir` returns early
+    // for an existing path and never checks writability — so an unwritable
+    // directory yields success with an empty `created`. Doctor printed
+    // "✓ Created missing data directories" and counted it.
+    const outcome = describeDataDirFix({ ...base, success: true, created: [] });
+
+    expect(outcome.counted).toBe(false);
+    expect(outcome.line).toContain('not writable');
+  });
+
+  it('claims a fix when directories were actually created', async () => {
+    const { describeDataDirFix } = await import('./setup-data-dir.js');
+    // The pair: never counting would make --fix report nothing it does.
+    const outcome = describeDataDirFix({ ...base, success: true, created: ['/tmp/x/memory'] });
+
+    expect(outcome.counted).toBe(true);
+    expect(outcome.line).toContain('Created 1');
+  });
+
+  it('reports an outright failure as a failure, not a fix', async () => {
+    const { describeDataDirFix } = await import('./setup-data-dir.js');
+    const outcome = describeDataDirFix({
+      ...base,
+      success: false,
+      created: [],
+      error: 'EACCES',
+    });
+
+    expect(outcome.counted).toBe(false);
+    expect(outcome.line).toContain('EACCES');
+  });
+});

--- a/packages/nexus-agents/src/cli/setup-data-dir.ts
+++ b/packages/nexus-agents/src/cli/setup-data-dir.ts
@@ -109,3 +109,46 @@ function ensureDir(
   }
   created.push(dirPath);
 }
+
+/** What `doctor --fix` should report after asking setup to create data dirs. */
+export interface DataDirFixOutcome {
+  /** Operator-facing line. */
+  readonly line: string;
+  /** Whether this counts toward "N issue(s) fixed". */
+  readonly counted: boolean;
+}
+
+/**
+ * Turn a data-directory init result into an honest `doctor --fix` report (#4851).
+ *
+ * `doctor --fix` runs this step when a subdirectory is missing OR not writable,
+ * then printed "✓ Created missing data directories" and incremented the fix
+ * count on `success` alone. But `ensureDir` returns early for a path that
+ * already exists and never checks writability, so an existing-but-unwritable
+ * directory lands in `alreadyExisted`, `failures` stays empty, and `success` is
+ * true — doctor claimed a fix for precisely the condition that triggered it,
+ * having created nothing.
+ *
+ * `created.length` is the only thing that distinguishes the two, and it was
+ * already on the result.
+ */
+export function describeDataDirFix(result: DataDirInitResult): DataDirFixOutcome {
+  if (!result.success) {
+    return {
+      line: `✗ Could not create data directories: ${result.error ?? 'unknown error'}`,
+      counted: false,
+    };
+  }
+  if (result.created.length === 0) {
+    return {
+      line:
+        '✗ Data directories already exist but are not writable — setup creates missing ' +
+        'directories and cannot repair permissions. Fix them manually (chmod u+w).',
+      counted: false,
+    };
+  }
+  return {
+    line: `✓ Created ${String(result.created.length)} missing data director${result.created.length === 1 ? 'y' : 'ies'}`,
+    counted: true,
+  };
+}

--- a/packages/nexus-agents/src/cli/setup-data-dir.ts
+++ b/packages/nexus-agents/src/cli/setup-data-dir.ts
@@ -111,7 +111,7 @@ function ensureDir(
 }
 
 /** What `doctor --fix` should report after asking setup to create data dirs. */
-export interface DataDirFixOutcome {
+interface DataDirFixOutcome {
   /** Operator-facing line. */
   readonly line: string;
   /** Whether this counts toward "N issue(s) fixed". */


### PR DESCRIPTION
Fixes #4851. Two defects in `doctor`, both reporting success it had not achieved.

## 1. `--fix` claimed to create directories when it created none

The fix runs when a data subdirectory is missing **or not writable**:

```ts
result.dataDirectory.subdirectories.some((d) => !d.exists || !d.writable)
```

But `ensureDir` returns early for a path that already exists and never checks writability. So an existing-but-unwritable directory lands in `alreadyExisted`, `failures` stays empty, `success` is true — and doctor printed **"✓ Created missing data directories"** and incremented the fix count, for precisely the condition that triggered it.

`created.length` was already on the result and simply not consulted. A new `describeDataDirFix` reads it and says plainly that setup creates missing directories and cannot repair permissions.

**I nearly shipped an inverted version of this.** My first attempt called `initDataDirectories(true)` as a dry run *after* `runSetup` — by which point setup had created the directories, so the dry run would report zero created and the honest branch would fire on the case it was meant to exclude. It now calls the initializer directly, which is also simpler: `runSetup` was being invoked with every other step skipped anyway.

## 2. The summary count contradicted the verdict

`totalIssues` enumerated CLIs, node version and `mcpServerReady`. `isAllHealthy` additionally fails on an unacceptable scratch severity. So a critical scratch filesystem with everything else healthy printed:

```
Summary: 0 issue(s) found
```

A summary shown *only because something is wrong*, saying nothing is wrong.

The count now includes the same term the verdict reads. `scratchSeverityIsAcceptable` moved from `doctor.ts` to sit beside `worstSeverity` in `doctor-scratch-space.ts`, so the count and the verdict share one definition — the duplication is what let them drift, and two copies would drift again.

## Testing

Five tests, red first, each with its pair: a fix that *is* real must still be counted, and the CLI/node/MCP terms must still be counted rather than replaced by the scratch term.

Three production hunks mutation-verified — dropping the scratch term, counting a no-op as a fix, and counting every outcome each fail a specific test.

**3651 tests across `src/cli`, green.** `tsc`, eslint and the export ratchet clean.

## One thing I did not fix, and it is worth knowing

`#4851` also noted a suspected `versionStatus === 'unsupported'` divergence between the same two functions. It is **not reachable**: `createHealthyResult` sets `authenticated = versionOk && …`, so an unsupported-version CLI is already counted in `unhealthyCount`. Dropped rather than "fixed", so nobody re-derives it later.