### PR TITLE
fix(research): stop the recency score saturating at two years

### DIFF
--- a/.changeset/research-recency-decay-saturation.md
+++ b/.changeset/research-recency-decay-saturation.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+stop the research recency score saturating at two years
+
+`scoreRecency` used `Math.max(0, 1 - daysSince / 730)`, so every source older
+than two years scored exactly `0.0`. A 2024 paper and a 2015 paper were
+indistinguishable, and `rankDiscoveredItems` sorts on the composite alone with
+no age tie-break — so with relevance and impact equal, `Array.prototype.sort`
+order decided which one entered the top-5 slice that `executeReview` files
+GitHub issues from, and which side of the `0.8` P1 boundary it landed on. The
+saturation was reachable in ordinary use: the review path never passes
+`sinceDate`, and Semantic Scholar stamps year-only dates as `${year}-01-01`, so
+anything from 2024 or earlier was already floored.
+
+Decay is now exponential with a one-year half-life, which approaches zero
+without reaching it. The half-life was picked so the curve still passes through
+`0.5` at one year, the point the old linear curve passed through — the `0.6`
+review gate and the `0.8` P1 boundary keep the calibration they were tuned
+against, and only the saturated tail moves.
+
+Also clamps the top. `Math.max(0, …)` bounded the floor and left the ceiling
+open, so a publication date one year in the future scored `1.5` and outranked
+anything actually published; year-only stamping makes that a real input, not a
+hypothetical.

--- a/packages/nexus-agents/src/cli/research-helpers-scoring.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-scoring.test.ts
@@ -23,6 +23,11 @@ function createItem(overrides: Partial<DiscoveredSource> = {}): DiscoveredSource
   };
 }
 
+/** ISO date `n` days before now; negative `n` yields a future date. */
+function daysAgo(n: number): string {
+  return new Date(Date.now() - n * 86_400_000).toISOString().split('T')[0] ?? '';
+}
+
 describe('scoreDiscoveredItem', () => {
   it('should return scores between 0 and 1', () => {
     const item = createItem();
@@ -141,8 +146,57 @@ describe('recency uses the publication date (#4841)', () => {
   });
 
   it('still decays a genuinely old publication toward zero', () => {
-    // The decay the original code documented and could never reach.
-    expect(scoreDiscoveredItem(createItem({ publishedAt: '2015-01-01' }), 'test').recency).toBe(0);
+    // The decay the original code documented and could never reach. Asserted
+    // as a bound, not `=== 0`: the exact-zero form pinned the saturation that
+    // #4882 removes, and a decay that never reaches zero is the point.
+    expect(
+      scoreDiscoveredItem(createItem({ publishedAt: daysAgo(11 * 365) }), 'test').recency
+    ).toBeLessThan(0.05);
+  });
+});
+
+// =============================================================================
+// The decay must not saturate (#4882)
+// =============================================================================
+
+describe('recency decay does not saturate (#4882)', () => {
+  it('ranks a 3-year-old publication above an 11-year-old one', () => {
+    // The linear `max(0, 1 - days/730)` floored both at exactly 0.0, so a 2024
+    // paper and a 2015 paper were indistinguishable. `rankDiscoveredItems`
+    // sorts on composite alone with no age tie-break, so which of the two
+    // entered the top-5 issue-filing slice was decided by sort order.
+    const old = scoreDiscoveredItem(createItem({ publishedAt: daysAgo(3 * 365) }), 'test');
+    const ancient = scoreDiscoveredItem(createItem({ publishedAt: daysAgo(11 * 365) }), 'test');
+
+    expect(old.recency).toBeGreaterThan(ancient.recency);
+  });
+
+  it('separates two publications that are both past the old 730-day floor', () => {
+    // The boundary case specifically: both of these scored 0.0 before.
+    const justPast = scoreDiscoveredItem(createItem({ publishedAt: daysAgo(800) }), 'test');
+    const wellPast = scoreDiscoveredItem(createItem({ publishedAt: daysAgo(2000) }), 'test');
+
+    expect(justPast.recency).toBeGreaterThan(wellPast.recency);
+    expect(wellPast.recency).toBeGreaterThan(0);
+  });
+
+  it('holds the one-year half-life the previous curve was calibrated on', () => {
+    // The 0.6 review gate and the 0.8 P1 boundary in `executeReview` were tuned
+    // against the old curve, which passed through 0.5 at one year. Keeping that
+    // point fixed is what makes this a tail fix rather than a recalibration.
+    const oneYear = scoreDiscoveredItem(createItem({ publishedAt: daysAgo(365) }), 'test');
+
+    expect(oneYear.recency).toBeCloseTo(0.5, 2);
+  });
+
+  it('never scores above 1.0 for a future publication date', () => {
+    // `Math.max(0, 1 - days/730)` clamped the floor and left the ceiling open:
+    // a date one year ahead scored 1.5. Semantic Scholar stamps year-only dates
+    // as `${year}-01-01`, so a paper carrying next year's volume year produces
+    // exactly this.
+    const future = scoreDiscoveredItem(createItem({ publishedAt: daysAgo(-365) }), 'test');
+
+    expect(future.recency).toBeLessThanOrEqual(1);
   });
 });
 

--- a/packages/nexus-agents/src/cli/research-helpers-scoring.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-scoring.ts
@@ -78,11 +78,22 @@ function relevanceLabelToScore(relevance: string): number {
 
 /** Neutral recency for an item whose publication date is unknown. */
 const NEUTRAL_RECENCY = 0.5;
-/** Linear decay window: two years. */
-const RECENCY_DECAY_DAYS = 730;
+/**
+ * Age at which recency halves. Chosen to match the point the previous linear
+ * curve passed through 0.5, so the 0.6 review gate and the 0.8 P1 boundary in
+ * `executeReview` keep the calibration they were tuned against (#4882).
+ */
+const RECENCY_HALF_LIFE_DAYS = 365;
 
 /**
- * Score recency from the item's PUBLICATION date, decaying over two years.
+ * Score recency from the item's PUBLICATION date, halving each year.
+ *
+ * Exponential rather than linear because a linear decay has to bottom out
+ * somewhere, and the old `max(0, 1 - days/730)` bottomed out at two years:
+ * every source older than that scored exactly 0.0, so a 2024 paper and a 2015
+ * paper were indistinguishable to a ranking that sorts on composite alone
+ * (#4882). Halving approaches zero without ever reaching it, so age keeps
+ * separating sources however old they get.
  *
  * `undefined` or unparseable yields neutral with `measured: false`. Not 1.0:
  * an unknown age is not evidence of freshness, and reporting it as fresh is
@@ -98,7 +109,10 @@ function scoreRecency(publishedAt: string | undefined): {
   const published = new Date(publishedAt);
   if (isNaN(published.getTime())) return { value: NEUTRAL_RECENCY, measured: false };
   const daysSince = (Date.now() - published.getTime()) / (1000 * 60 * 60 * 24);
-  return { value: Math.max(0, 1 - daysSince / RECENCY_DECAY_DAYS), measured: true };
+  // Clamped at the top, not just the bottom: a future publication date is a
+  // real input — Semantic Scholar stamps year-only dates as `${year}-01-01` —
+  // and it used to score above 1.0, outscoring anything actually published.
+  return { value: Math.min(1, 0.5 ** (daysSince / RECENCY_HALF_LIFE_DAYS)), measured: true };
 }
 
 /** Score reproducibility based on source type. */


### PR DESCRIPTION
Closes #4882.

## The defect

`scoreRecency` decayed linearly and clamped at the bottom:

```ts
Math.max(0, 1 - daysSince / 730)
```

Every source older than two years scored **exactly `0.0`**. A 2024 paper and a 2015 paper were indistinguishable.

## Why that changes an outcome rather than just a number

`rankDiscoveredItems` sorts on `composite` alone — no secondary age key, and `publishedAt` is never consulted again after scoring. `executeReview` then takes `composite >= 0.6`, slices the **top 5**, and files a GitHub issue for each with `priority: composite >= 0.8 ? 'P1' : 'P2'`.

So for two saturated sources with equal relevance and impact, the composites are identical and `Array.prototype.sort` order decides which one gets an issue filed and which is dropped. Same for the P1 boundary.

And the saturated region is not an edge case. The review path never passes `sinceDate`; it is optional, applies only to the arXiv-family URL builders, and GitHub / Semantic Scholar / OpenAlex have no date filter at all. Semantic Scholar also stamps year-only dates as `${year}-01-01`, so **every result from 2024 or earlier arrives pre-floored**.

## The fix, and why this half-life

Exponential decay with a one-year half-life: it approaches zero without reaching it, so age keeps separating sources however old they get.

The constant is the interesting choice. `0.6` and `0.8` in `executeReview` were tuned against the old curve, so I picked the half-life that keeps that curve's anchor point — the old linear decay passed through `0.5` at one year, and so does this one:

| age | old | new |
| --- | --- | --- |
| 0 | 1.000 | 1.000 |
| 6mo | 0.750 | 0.707 |
| **1y** | **0.500** | **0.500** |
| 18mo | 0.250 | 0.354 |
| 2y | 0.000 | 0.250 |
| 3y | 0.000 | 0.125 |
| 11y | 0.000 | 0.0005 |

Under one year the two agree within 0.043, which is 0.009 on the composite at the term's 0.2 weight. That makes this a tail fix rather than a recalibration — the sources whose scores move are the ones that had no score to speak of.

## An adjacent bug in the same expression

`Math.max(0, …)` bounded the floor and left the ceiling open. A publication date one year in the future scored **1.5** — above the 0..1 range the function's own contract test asserts — and outranked anything actually published. Given the year-only stamping above, a paper carrying next year's volume year produces exactly this. Now clamped with `Math.min(1, …)`.

## Tests

Four new, plus one retargeted. Each production hunk was mutation-tested individually:

| mutation | result |
| --- | --- |
| drop the `Math.min(1, …)` ceiling | 1 failed |
| half-life 365 → 730 | 1 failed |
| restore the old linear clamp | 3 failed |

The retargeted one matters: `'still decays a genuinely old publication toward zero'` asserted `recency === 0` for a 2015 date. That assertion **pinned the defect** — it was the exact-zero saturation, written as if it were the decay working. It now asserts a bound (`< 0.05`) at a computed age, which is what "decays toward zero" actually means and which the old code fails.

New tests use dates computed from `Date.now()` rather than hardcoded ISO strings, so they do not rot as the fixed dates elsewhere in the file will.

Full research suite: 470 passed.
