### PR TITLE
fix(security): reject six reserved IP ranges the SSRF guard let through

### DIFF
--- a/.changeset/ssrf-reserved-ranges.md
+++ b/.changeset/ssrf-reserved-ranges.md
@@ -1,0 +1,31 @@
+---
+'nexus-agents': patch
+---
+
+close six more SSRF gaps in the custom-API address tables
+
+The IPv4 rule table listed the four blocks everyone remembers — 10/8,
+172.16/12, 192.168/16, 169.254/16 — and treated everything else as public.
+Verified against the real guard, all of these passed:
+
+- `100.64.0.0/10`, RFC6598 shared address space. Used for cloud NAT and
+  container fabrics, and `100.100.100.200` serves Alibaba Cloud instance
+  metadata, so this is a credential read on those providers.
+- `192.0.0.0/24`, which carries a legacy Oracle Cloud metadata endpoint at
+  `192.0.0.192`.
+- `198.18.0.0/15` benchmarking, `224.0.0.0/4` multicast, `240.0.0.0/4`
+  reserved, and `255.255.255.255` broadcast — local-segment reachable rather
+  than internet-routable.
+
+Because the IPv6 classifier delegates to the IPv4 table, each was reachable in
+mapped form too (`[::ffff:6464:64c8]`).
+
+Three IPv6 gaps alongside them. Link-local was matched as the string prefix
+`fe80:`, which is one 64th of `fe80::/10` — `febf::1` is equally link-local and
+was allowed. Site-local `fec0::/10` had no rule at all. And 6to4 `2002::/16`
+was the one IPv4-carrying prefix `embeddedIPv4` did not reach, despite its
+doc-comment claiming it covered every one, because 6to4 puts the payload in
+hextets 1–2 rather than 6–7.
+
+Prefix classification now reads the parsed first hextet instead of testing
+string prefixes, which is what made the `fe80:` gap possible.

--- a/packages/nexus-agents/src/adapters/sdk/custom-api-validation.test.ts
+++ b/packages/nexus-agents/src/adapters/sdk/custom-api-validation.test.ts
@@ -213,6 +213,88 @@ describe('validateCustomApiBaseUrl', () => {
     });
   });
 
+  describe('reserved ranges beyond RFC1918', () => {
+    // The first pass listed the four ranges everyone remembers — 10/8,
+    // 172.16/12, 192.168/16, 169.254/16 — and stopped. Cloud metadata does
+    // not live only at 169.254.169.254, and "not RFC1918" is not the same
+    // as "public".
+
+    it('rejects the CGNAT range that carries Alibaba Cloud metadata', () => {
+      // 100.64/10 is RFC6598 shared address space: cloud NAT, container
+      // fabrics, and 100.100.100.200, which serves instance credentials.
+      expect(validateCustomApiBaseUrl('http://100.100.100.200/latest/meta-data/').ok).toBe(false);
+    });
+
+    it('rejects CGNAT written as mapped IPv6', () => {
+      // The pair for the fix above: the v6 classifier delegates to the v4
+      // rules, so a gap in that table is reachable by both spellings.
+      expect(validateCustomApiBaseUrl('http://[::ffff:6464:64c8]/').ok).toBe(false);
+    });
+
+    it('rejects 192.0.0.0/24, which carries legacy Oracle Cloud metadata', () => {
+      expect(validateCustomApiBaseUrl('http://192.0.0.192/').ok).toBe(false);
+    });
+
+    it('rejects the 198.18.0.0/15 benchmarking range', () => {
+      // Both halves. A /15 spans two second octets, and asserting only 198.18
+      // passes against a rule narrowed to it — checked by mutation.
+      expect(validateCustomApiBaseUrl('http://198.18.0.1/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://198.19.255.254/').ok).toBe(false);
+    });
+
+    it('rejects multicast and the reserved 240/4 block', () => {
+      expect(validateCustomApiBaseUrl('http://224.0.0.1/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://240.0.0.1/').ok).toBe(false);
+    });
+
+    it('rejects the limited broadcast address', () => {
+      expect(validateCustomApiBaseUrl('http://255.255.255.255/').ok).toBe(false);
+    });
+
+    it('keeps the neighbours of each new range allowed', () => {
+      // Every rule above is an inequality, and an off-by-one turns a /10 into
+      // a /8. These are the addresses immediately outside each block.
+      expect(validateCustomApiBaseUrl('http://100.63.255.255/v1').ok).toBe(true);
+      expect(validateCustomApiBaseUrl('http://100.128.0.1/v1').ok).toBe(true);
+      expect(validateCustomApiBaseUrl('http://192.0.1.1/v1').ok).toBe(true);
+      expect(validateCustomApiBaseUrl('http://198.17.255.255/v1').ok).toBe(true);
+      expect(validateCustomApiBaseUrl('http://198.20.0.1/v1').ok).toBe(true);
+      expect(validateCustomApiBaseUrl('http://223.255.255.255/v1').ok).toBe(true);
+    });
+  });
+
+  describe('IPv6 link-local and site-local cover their whole prefix', () => {
+    it('rejects link-local above fe80:', () => {
+      // The check was `startsWith('fe80:')`, but link-local is fe80::/10 —
+      // fe80 through febf. Only the first 1/64th of the block was covered.
+      expect(validateCustomApiBaseUrl('http://[febf::1]/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://[fe90::1]/').ok).toBe(false);
+    });
+
+    it('rejects deprecated site-local addresses', () => {
+      expect(validateCustomApiBaseUrl('http://[fec0::1]/').ok).toBe(false);
+    });
+
+    it('rejects a 6to4 address carrying a private IPv4', () => {
+      // 2002::/16 embeds the IPv4 in hextets 1-2, not 6-7, so it was the one
+      // IPv4-carrying prefix `embeddedIPv4` did not reach despite the
+      // doc-comment claiming it covered every one.
+      expect(validateCustomApiBaseUrl('http://[2002:a9fe:a9fe::]/').ok).toBe(false);
+      expect(validateCustomApiBaseUrl('http://[2002:7f00:1::]/').ok).toBe(false);
+    });
+
+    it('still allows 6to4 wrapping a public IPv4', () => {
+      // The pair: 2002::/16 must not become a blanket rejection.
+      expect(validateCustomApiBaseUrl('http://[2002:101:101::]/v1').ok).toBe(true);
+    });
+
+    it('still allows public IPv6 that merely starts with fe', () => {
+      // fe00::/9 below fe80 is not link-local; a prefix test widened to `fe`
+      // would swallow it.
+      expect(validateCustomApiBaseUrl('http://[fe00::1]/v1').ok).toBe(true);
+    });
+  });
+
   describe('SSRF guard escape hatch (NEXUS_CUSTOM_API_ALLOW_PRIVATE)', () => {
     it('allows localhost when allowPrivate=true is passed explicitly', () => {
       const result = validateCustomApiBaseUrl('http://localhost:8080/v1', {

--- a/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
+++ b/packages/nexus-agents/src/adapters/sdk/custom-api-validation.ts
@@ -271,9 +271,17 @@ function firstPrivateAddress(
   return null;
 }
 
-/** IPv4 ranges the SSRF guard rejects, in order of specificity. */
+/**
+ * IPv4 ranges the SSRF guard rejects, in order of specificity.
+ *
+ * "Not RFC1918" is not the same as "public". The blocks below RFC1918 are
+ * here because each is reachable from a host and serves something: 100.64/10
+ * carries Alibaba Cloud's metadata endpoint, 192.0.0/24 carries a legacy
+ * Oracle Cloud one, and multicast/reserved/broadcast reach the local segment
+ * rather than the internet (second pass over #4884).
+ */
 const IPV4_RULES: ReadonlyArray<{
-  readonly match: (a: number, b: number) => boolean;
+  readonly match: (a: number, b: number, c: number) => boolean;
   readonly reason: BaseUrlRejectionReason;
   readonly label: string;
 }> = [
@@ -295,14 +303,35 @@ const IPV4_RULES: ReadonlyArray<{
     label: 'IPv4 link-local (169.254/16 — AWS IMDS)',
   },
   { match: (a) => a === 0, reason: 'reserved', label: 'IPv4 reserved (0/8)' },
+  {
+    match: (a, b) => a === 100 && b >= 64 && b <= 127,
+    reason: 'private_range',
+    label: 'IPv4 shared address space (100.64/10 — CGNAT, Alibaba metadata)',
+  },
+  {
+    match: (a, b, c) => a === 192 && b === 0 && c === 0,
+    reason: 'reserved',
+    label: 'IPv4 IETF protocol assignments (192.0.0/24 — legacy Oracle metadata)',
+  },
+  {
+    match: (a, b) => a === 198 && (b === 18 || b === 19),
+    reason: 'reserved',
+    label: 'IPv4 benchmarking (198.18/15)',
+  },
+  { match: (a) => a >= 224 && a <= 239, reason: 'reserved', label: 'IPv4 multicast (224/4)' },
+  {
+    match: (a) => a >= 240,
+    reason: 'reserved',
+    label: 'IPv4 reserved (240/4, includes 255.255.255.255 broadcast)',
+  },
 ];
 
 function classifyIPv4(ip: string): RejectionDetail | null {
   const parts = ip.split('.').map((p) => Number.parseInt(p, 10));
   if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return null;
-  const [a, b] = parts as [number, number, number, number];
+  const [a, b, c] = parts as [number, number, number, number];
   for (const rule of IPV4_RULES) {
-    if (rule.match(a, b)) {
+    if (rule.match(a, b, c)) {
       return { reason: rule.reason, message: `${rule.label} (${ip})` };
     }
   }
@@ -346,11 +375,14 @@ function toHextets(ip: string): number[] | null {
  *
  * Covers every prefix that carries a routable IPv4 payload: IPv4-mapped
  * (`::ffff:0:0/96`), IPv4-translated (`::ffff:0:0:0/96`), the NAT64
- * well-known prefix (`64:ff9b::/96`), and the deprecated IPv4-compatible
- * form (`::a.b.c.d`). Each is the same destination under a different
- * spelling, and the IPv4 rules must apply to all of them.
+ * well-known prefix (`64:ff9b::/96`), 6to4 (`2002::/16`), and the deprecated
+ * IPv4-compatible form (`::a.b.c.d`). Each is the same destination under a
+ * different spelling, and the IPv4 rules must apply to all of them.
  */
 function embeddedIPv4(g: readonly number[]): string | null {
+  // 6to4 is the odd one out: the payload sits in hextets 1-2, not 6-7, so it
+  // cannot share the trailing-quad extraction below.
+  if (g[0] === 0x2002) return hextetPairToDotted(g[1] ?? 0, g[2] ?? 0);
   const top = g.slice(0, 6);
   const prefixes: ReadonlyArray<readonly number[]> = [
     [0, 0, 0, 0, 0, 0xffff], // ::ffff:0:0/96    — IPv4-mapped
@@ -364,22 +396,44 @@ function embeddedIPv4(g: readonly number[]): string | null {
   const g7 = g[7] ?? 0;
   // `::` and `::1` are their own addresses, not embedded IPv4.
   if (top.every((v) => v === 0) && g6 === 0 && g7 <= 1) return null;
-  const octets = [(g6 >> 8) & 255, g6 & 255, (g7 >> 8) & 255, g7 & 255];
-  return octets.join('.');
+  return hextetPairToDotted(g6, g7);
+}
+
+/** The dotted IPv4 address carried by two consecutive 16-bit hextets. */
+function hextetPairToDotted(hi: number, lo: number): string {
+  return [(hi >> 8) & 255, hi & 255, (lo >> 8) & 255, lo & 255].join('.');
+}
+
+/**
+ * Classify an IPv6 address by its first hextet, or null if it is not in a
+ * non-global prefix.
+ *
+ * Numeric rather than a string prefix test. The previous `startsWith('fe80:')`
+ * covered 1/64th of fe80::/10 — `febf::1` is equally link-local and was
+ * allowed — and site-local fec0::/10 had no check at all (second pass over #4884).
+ */
+function classifyIPv6Prefix(first: number, ip: string): RejectionDetail | null {
+  if (first >= 0xfc00 && first <= 0xfdff) {
+    return { reason: 'private_range', message: `IPv6 unique-local (${ip}, fc00::/7)` };
+  }
+  if (first >= 0xfe80 && first <= 0xfebf) {
+    return { reason: 'link_local', message: `IPv6 link-local (${ip}, fe80::/10)` };
+  }
+  if (first >= 0xfec0 && first <= 0xfeff) {
+    return { reason: 'private_range', message: `IPv6 site-local (${ip}, fec0::/10)` };
+  }
+  return null;
 }
 
 function classifyIPv6(ip: string): RejectionDetail | null {
   const lower = ip.toLowerCase();
   if (lower === '::1') return { reason: 'loopback', message: `IPv6 loopback (${ip})` };
-  if (lower.startsWith('fe80:'))
-    return { reason: 'link_local', message: `IPv6 link-local (${ip})` };
-  // Unique-local: fc00::/7 → first byte has high bit set and second-high bit set
-  if (/^fc|^fd/.test(lower)) {
-    return { reason: 'private_range', message: `IPv6 unique-local (${ip}, fc00::/7)` };
-  }
 
   const groups = toHextets(lower);
   if (groups === null) return null;
+
+  const prefixDetail = classifyIPv6Prefix(groups[0] ?? 0, ip);
+  if (prefixDetail !== null) return prefixDetail;
 
   if (groups.every((n) => n === 0)) {
     return { reason: 'reserved', message: `IPv6 unspecified (${ip}) — routes to localhost` };


### PR DESCRIPTION
A second pass over the address tables from #4884, prompted by an adversarial review of that commit. Findings are in the security ledger rather than a public issue, per the discovered-issues protocol.

## What was reachable

The IPv4 rule table listed the four blocks everyone remembers — `10/8`, `172.16/12`, `192.168/16`, `169.254/16` — and treated everything else as public. Every address below was **verified against the real guard**, not inferred from reading it:

| address | block | what lives there |
| --- | --- | --- |
| `100.100.100.200` | `100.64/10` (RFC6598) | Alibaba Cloud instance metadata |
| `192.0.0.192` | `192.0.0/24` | legacy Oracle Cloud metadata |
| `198.18.0.1` | `198.18/15` | benchmarking |
| `224.0.0.1` | `224/4` | multicast |
| `240.0.0.1` | `240/4` | reserved |
| `255.255.255.255` | — | limited broadcast |

`100.64/10` is the one that matters most: it is not obscure, it is what cloud NAT and container fabrics use, and the metadata endpoint in it serves instance credentials. `192.0.0.192` was PASS on both guards too.

Because the IPv6 classifier delegates to the IPv4 table — the delegation #4884 added — each was also reachable in mapped form. `http://[::ffff:6464:64c8]/` is `100.100.100.200`, and it passed.

## Three IPv6 gaps alongside them

**Link-local was a string prefix.** `lower.startsWith('fe80:')` covers `fe80` and nothing else, but link-local is `fe80::/10` — `fe80` through `febf`. One sixty-fourth of the block was checked. `[febf::1]` passed.

**Site-local `fec0::/10` had no rule at all.** Deprecated, still routable on networks that deployed it.

**6to4 `2002::/16` was the one IPv4-carrying prefix `embeddedIPv4` did not reach**, despite the doc-comment on it claiming to cover "every prefix that carries a routable IPv4 payload". 6to4 puts the payload in hextets 1–2 rather than 6–7, so it could not share the trailing-quad extraction — a special case, not an oversight in the list.

Prefix classification now reads the parsed first hextet rather than testing string prefixes. That is the change that makes the `fe80:` class of gap structurally hard to reintroduce: an inequality on a number cannot silently cover 1/64th of its intended range.

## Tests

14 new. Every one of the 9 production hunks was mutation-tested individually, and one gap in my own tests turned up doing it: narrowing `198.18/15` to `198.18/16` left the suite **green**, because I had asserted only `198.18.0.1`. A `/15` spans two second octets. Test extended to `198.19.255.254`; the mutation now fails.

Includes the negative cases, since every new rule is an inequality and an off-by-one turns a `/10` into a `/8`: `100.63.255.255`, `100.128.0.1`, `192.0.1.1`, `198.17.255.255`, `198.20.0.1`, `223.255.255.255`, `[fe00::1]`, and 6to4 wrapping a public IPv4 all still resolve as allowed.

## Deliberately not in scope

Three findings from the same review are architectural and are recorded in the ledger rather than patched here: the `discoverModels` path skips the sync guard entirely (so scheme and `.local` rules never apply on it, and DNS failure is fail-open), redirects are unconstrained on every path, and the TOCTOU window is wider than the doc-comment describes — both paths guard once for the process lifetime, not once per request. Fixing the last properly needs a pinned-IP dispatcher, not a bigger table.
