### PR TITLE
fix(routing): update the bandit with the feature vector it selected with

### DIFF
--- a/.changeset/bandit-train-score-symmetry.md
+++ b/.changeset/bandit-train-score-symmetry.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+update the LinUCB bandit with the feature vector it selected with
+
+A regression from the previous release. Giving the select path a real
+`budgetUtilization` left the outcome path on the `0.5` neutral default, so with
+a cost ceiling configured the bandit was fit against a constant column and then
+scored against a varying one — `θ_budget` biased every arm's estimate by a
+different amount depending on its observation count. Before that change both
+sides were `0.5`: the dimension carried no information, which was the thing
+being fixed; afterwards it carried misinformation.
+
+`checkBudget` is a pure function of the task and the constraint, so the outcome
+path now recomputes the selection-time value rather than caching a context
+across the request boundary. The formula lives in one place both paths call,
+because two call sites deriving the same feature independently is how this
+drifts again.
+
+Only reachable with a cost ceiling set (`--max-cost-usd`, or the `budget:`
+block that ships commented out) — with no ceiling both paths were already on
+the same default.

--- a/.changeset/bandit-train-score-symmetry.md
+++ b/.changeset/bandit-train-score-symmetry.md
@@ -1,5 +1,5 @@
 ---
-'nexus-agents': patch
+'nexus-agents': minor
 ---
 
 update the LinUCB bandit with the feature vector it selected with
@@ -21,3 +21,6 @@ drifts again.
 Only reachable with a cost ceiling set (`--max-cost-usd`, or the `budget:`
 block that ships commented out) — with no ceiling both paths were already on
 the same default.
+
+Minor rather than patch: `OutcomeDependencies` gains two optional fields, which
+is additive but a public-surface change.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -5865,6 +5865,8 @@ TypeAliasDeclaration OrchestratorType
 TypeAliasDeclaration OutcomeClass
   = 'success' | 'partial' | 'failure' | 'timeout' | 'error'
 InterfaceDeclaration OutcomeDependencies
+  budgetConstraints?: { maxCostUsd?: number | undefined; maxLatencyMs?: number | undefined; maxTokens?: number | undefined; taskClassMaxCostUsd?: Partial<Record<"research" | "architecture" | "documentation" | "testing" | "devops" | "planning" | "code_generation" | "code_review" | "security_review" | "exploration", number>> | undefined; } | undefined
+  budgetRouter?: BudgetRouter | undefined
   cliNames: RoutingArmId[]
   lastRoutedTask: LastRoutedTaskInfo | undefined
   linucbBandit: LinUCBBandit | undefined

--- a/packages/nexus-agents/src/cli-adapters/composite-router-budget-feature.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-budget-feature.ts
@@ -1,0 +1,68 @@
+/**
+ * Budget constraint construction and the budget feature the LinUCB bandit uses.
+ *
+ * Its own module because the routing path and the outcome path must derive the
+ * feature identically, and a shared formula living in either caller's file
+ * reads as belonging to that caller (#4910).
+ *
+ * @module cli-adapters/composite-router-budget-feature
+ */
+import type { BudgetRouter } from './budget-router.js';
+import type { CliTask, BudgetConstraint } from './types.js';
+import type { CompositeRouterConfig } from './composite-router-types.js';
+
+/** Narrows the router config's budget constraints to a {@link BudgetConstraint}. */
+export function toBudgetConstraint(
+  raw: CompositeRouterConfig['budgetConstraints']
+): BudgetConstraint {
+  const constraint: BudgetConstraint = {};
+  if (raw?.maxTokens !== undefined) {
+    (constraint as { maxTokens: number }).maxTokens = raw.maxTokens;
+  }
+  if (raw?.maxCostUsd !== undefined) {
+    (constraint as { maxCostUsd: number }).maxCostUsd = raw.maxCostUsd;
+  }
+  if (raw?.maxLatencyMs !== undefined) {
+    (constraint as { maxLatencyMs: number }).maxLatencyMs = raw.maxLatencyMs;
+  }
+  return constraint;
+}
+
+/**
+ * The share of the cost ceiling a projected spend consumes, or undefined when
+ * no ceiling is configured.
+ *
+ * Mirrors BudgetFilterStage's formula (budget-stage.ts:233), over the selected
+ * adapter's projected cost rather than an average across candidates — this is
+ * the spend actually being contemplated.
+ *
+ * Extracted so the routing path and the outcome path cannot drift: LinUCB fits
+ * its weights against the feature vector handed to `update` and scores with the
+ * one handed to `selectArm`, so the two computing this differently biases every
+ * arm's estimate (#4910).
+ */
+export function budgetUtilizationOf(
+  estimatedCostUsd: number,
+  maxCostUsd: number | undefined
+): number | undefined {
+  if (maxCostUsd === undefined || maxCostUsd <= 0) return undefined;
+  return Math.min(1, estimatedCostUsd / maxCostUsd);
+}
+
+/**
+ * Recompute the routing-time budget utilization for a task after the fact.
+ *
+ * `checkBudget` is a pure function of the task and the constraint, so the
+ * outcome path can reproduce the selection-time value exactly rather than
+ * caching it across the request boundary.
+ */
+export function budgetUtilizationForTask(
+  task: CliTask,
+  budgetRouter: BudgetRouter | undefined,
+  rawConstraints: CompositeRouterConfig['budgetConstraints']
+): number | undefined {
+  if (budgetRouter === undefined) return undefined;
+  const constraint = toBudgetConstraint(rawConstraints);
+  const result = budgetRouter.checkBudget(task, constraint);
+  return budgetUtilizationOf(result.estimatedCostUsd, constraint.maxCostUsd);
+}

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
@@ -9,7 +9,7 @@
 
 import type { Task } from '../core/types/agent.js';
 import { getTimeProvider, type TaskProfile } from '../core/index.js';
-import type { CliName, RoutingArmId, CliTask, BudgetConstraint } from './types.js';
+import type { CliName, RoutingArmId, CliTask } from './types.js';
 import { routingArmDisplaySlot } from './types.js';
 import type { BanditContext } from './budget-router-types.js';
 import type { TopsisModelProfile, TopsisResult } from './topsis-types.js';
@@ -23,6 +23,11 @@ import {
 import type { BillingMode } from '../mcp/tools/delegate-to-model-types.js';
 import type { BudgetRouter } from './budget-router.js';
 import { TopsisRouter } from './topsis-router.js';
+import {
+  toBudgetConstraint,
+  budgetUtilizationOf,
+  budgetUtilizationForTask,
+} from './composite-router-budget-feature.js';
 import type { CompositeRouterConfig } from './composite-router-types.js';
 import type { IZeroRouter } from './zero-router.js';
 import type { DifficultyEstimate, DifficultyOutcome, ModelTier } from './zero-router-types.js';
@@ -187,21 +192,6 @@ export interface BudgetFilterResult {
   budgetUtilization?: number;
 }
 
-/** Narrows the router config's budget constraints to a {@link BudgetConstraint}. */
-function toBudgetConstraint(raw: CompositeRouterConfig['budgetConstraints']): BudgetConstraint {
-  const constraint: BudgetConstraint = {};
-  if (raw?.maxTokens !== undefined) {
-    (constraint as { maxTokens: number }).maxTokens = raw.maxTokens;
-  }
-  if (raw?.maxCostUsd !== undefined) {
-    (constraint as { maxCostUsd: number }).maxCostUsd = raw.maxCostUsd;
-  }
-  if (raw?.maxLatencyMs !== undefined) {
-    (constraint as { maxLatencyMs: number }).maxLatencyMs = raw.maxLatencyMs;
-  }
-  return constraint;
-}
-
 /**
  * Applies budget filtering to candidate CLIs.
  */
@@ -218,14 +208,8 @@ export function applyBudgetFilter(
   const result = budgetRouter.checkBudget(task, constraint);
   if (!result.withinBudget) return { eligible: [], withinBudget: false };
 
-  // Mirrors BudgetFilterStage's formula (budget-stage.ts:233), over the
-  // selected adapter's projected cost rather than an average across
-  // candidates — this is the spend actually being contemplated.
-  const maxCostUsd = constraint.maxCostUsd;
-  const utilization =
-    maxCostUsd !== undefined && maxCostUsd > 0
-      ? { budgetUtilization: Math.min(1, result.estimatedCostUsd / maxCostUsd) }
-      : {};
+  const share = budgetUtilizationOf(result.estimatedCostUsd, constraint.maxCostUsd);
+  const utilization = share === undefined ? {} : { budgetUtilization: share };
 
   if (config.billingMode !== 'api')
     return { eligible: candidates, withinBudget: true, ...utilization };
@@ -642,3 +626,5 @@ export function buildPreferenceStats(
 // #4373 will reintroduce capacity reads as a routing *exclusion predicate*
 // inside the stage chain — a decision input, not a dashboard. Adapter capacity
 // is still available directly via `ICliAdapter.getCapacity()`.
+
+export { budgetUtilizationOf, budgetUtilizationForTask };

--- a/packages/nexus-agents/src/cli-adapters/composite-router-outcome.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-outcome.test.ts
@@ -20,6 +20,10 @@ import {
   type OutcomeDependencies,
 } from './composite-router-outcome.js';
 import { getOutcomeStore, resetOutcomeStore } from '../orchestration/outcomes/index.js';
+import { applyBudgetFilter } from './composite-router-helpers.js';
+import type { BudgetRouter } from './budget-router.js';
+import type { CompositeRouterConfig } from './composite-router-types.js';
+import type { BanditContext } from '../core/index.js';
 
 vi.mock('../config/learning-persistence.js', () => ({
   isPersistenceEnabled: vi.fn(() => false),
@@ -76,12 +80,23 @@ function createBaseDeps(overrides: Partial<OutcomeDependencies> = {}) {
     preferenceRouter: undefined,
     zeroRouter: undefined,
     lastRoutedTask: undefined,
+    budgetRouter: undefined,
+    budgetConstraints: undefined,
     ...overrides,
   };
 }
 
 function createCliTask(content = 'test task'): CliTask {
   return { content, maxTokens: 1000 };
+}
+
+/** A BudgetRouter stub whose `checkBudget` reports a fixed projected spend. */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function createMockBudgetRouter(estimatedCostUsd: number) {
+  return {
+    checkBudget: vi.fn(() => ({ withinBudget: true, estimatedCostUsd })),
+    filterByTaskClassCeiling: vi.fn((_t: unknown, c: unknown) => c),
+  } as unknown as BudgetRouter;
 }
 
 describe('composite-router-outcome', () => {
@@ -96,6 +111,43 @@ describe('composite-router-outcome', () => {
         cliName: 'claude',
         reward: 0.85,
       });
+    });
+
+    it('updates with the same budgetUtilization the select path scored with', () => {
+      // LinUCB's invariant: the feature vector passed to `update` must be the
+      // one `selectArm` scored. #4874 gave the select path a real
+      // `budgetUtilization` and left this path on the 0.5 default, so with a
+      // cost budget configured the bandit was fit against a constant column
+      // and then scored against a varying one.
+      const bandit = createMockLinUCBBandit();
+      const budgetRouter = createMockBudgetRouter(0.03);
+      const budgetConstraints = { maxCostUsd: 0.05 };
+      const config = { budgetConstraints } as CompositeRouterConfig;
+      const task = createCliTask();
+      const deps = createBaseDeps({ linucbBandit: bandit, budgetRouter, budgetConstraints });
+
+      recordBanditOutcome('claude', task, 0.85, deps);
+
+      // Derived from the select path itself rather than restated: a hardcoded
+      // 0.6 here would keep passing if both sides drifted together.
+      const atSelect = applyBudgetFilter(task, ['claude'], budgetRouter, config);
+      const atUpdate = vi.mocked(bandit.update).mock.calls[0]?.[1] as BanditContext;
+
+      expect(atSelect.budgetUtilization).toBeDefined();
+      expect(atUpdate.budgetUtilization).toBe(atSelect.budgetUtilization);
+    });
+
+    it('falls back to the neutral feature when no cost budget is configured', () => {
+      // The pair. Symmetry is the requirement, not a particular number: with
+      // no budget the select path also yields nothing and both sides sit at
+      // the neutral 0.5.
+      const bandit = createMockLinUCBBandit();
+      const deps = createBaseDeps({ linucbBandit: bandit });
+
+      recordBanditOutcome('claude', createCliTask(), 0.85, deps);
+
+      const ctx = vi.mocked(bandit.update).mock.calls[0]?.[1] as BanditContext;
+      expect(ctx.budgetUtilization).toBe(0.5);
     });
 
     it('should return early when linucbBandit is undefined', () => {

--- a/packages/nexus-agents/src/cli-adapters/composite-router-outcome.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-outcome.ts
@@ -15,7 +15,13 @@ import { routingArmDisplaySlot } from './types.js';
 import type { LinUCBBandit } from './linucb-bandit.js';
 import type { PreferenceRouter } from './preference-router.js';
 import type { IZeroRouter } from './zero-router.js';
-import { cliTaskToTask, buildDifficultyOutcome } from './composite-router-helpers.js';
+import {
+  cliTaskToTask,
+  buildDifficultyOutcome,
+  budgetUtilizationForTask,
+} from './composite-router-helpers.js';
+import type { BudgetRouter } from './budget-router.js';
+import type { CompositeRouterConfig } from './composite-router-types.js';
 import { getOutcomeStore } from '../orchestration/outcomes/outcome-store.js';
 import { clamp01 } from '../utils/math-utils.js';
 
@@ -37,6 +43,13 @@ export interface OutcomeDependencies {
   preferenceRouter: PreferenceRouter | undefined;
   zeroRouter: IZeroRouter | undefined;
   lastRoutedTask: LastRoutedTaskInfo | undefined;
+  /**
+   * Present so the outcome path can reproduce the budget feature the routing
+   * path scored with. Undefined when budget routing is off, which puts both
+   * paths on the same neutral default (#4910).
+   */
+  budgetRouter?: BudgetRouter | undefined;
+  budgetConstraints?: CompositeRouterConfig['budgetConstraints'];
 }
 
 /** Records a bandit outcome for the given routing arm (CLI slot or api:* arm). */
@@ -54,7 +67,18 @@ export function recordBanditOutcome(
   }
   const internalTask = cliTaskToTask(task);
   const analysis = sharedAnalyzer.analyze(internalTask);
-  const context = taskAnalysisResultToBanditContext(analysis);
+  // Recomputed rather than defaulted: `selectArm` scored this task with the
+  // real utilization, and LinUCB is only consistent if `update` sees the same
+  // feature vector (#4910).
+  const budgetUtilization = budgetUtilizationForTask(
+    task,
+    deps.budgetRouter,
+    deps.budgetConstraints
+  );
+  const context = taskAnalysisResultToBanditContext(
+    analysis,
+    budgetUtilization === undefined ? {} : { budgetUtilization }
+  );
   deps.linucbBandit.update(armIndex, context, reward);
   deps.logger.debug('Recorded outcome', { cliName, reward });
 }

--- a/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.test.ts
@@ -30,6 +30,7 @@ import {
   resetModelSelectionShadowFailureCount,
 } from './model-selection-shadow.js';
 import { resetModelSelectionReadinessLogging } from './model-selection-readiness.js';
+import type { LinUCBBandit } from './linucb-bandit.js';
 import { getModelSelectionShadowFile } from '../config/learning-persistence.js';
 import { getDefaultModelForCli } from '../config/model-config-helpers.js';
 import type { CliNameLiteral } from '../config/model-capabilities-types.js';
@@ -426,6 +427,29 @@ describe('CompositeRouter', () => {
       expect(() => {
         router.recordOutcome('unknown' as CliName, task, 0.5);
       }).not.toThrow();
+    });
+
+    it('hands the bandit the budget feature it selected with (#4910)', () => {
+      // A wiring test, reaching past `private`, because the seam it guards is
+      // exactly the one that survived mutation: deleting the two lines that
+      // forward `budgetRouter`/`budgetConstraints` into the outcome deps left
+      // all 316 router tests green. Both halves of the fix were correct in
+      // isolation and the join between them was untested.
+      const budgeted = new CompositeRouter(adapters, {
+        budgetConstraints: { maxCostUsd: 0.05 },
+      });
+      const bandit = (budgeted as unknown as { linucbBandit?: LinUCBBandit }).linucbBandit;
+      expect(bandit).toBeDefined();
+      if (bandit === undefined) return;
+      const update = vi.spyOn(bandit, 'update');
+
+      budgeted.recordOutcome('claude', { content: 'Test task' }, 0.8);
+
+      const context = update.mock.calls[0]?.[1];
+      expect(context).toBeDefined();
+      // 0.5 is the neutral default the outcome path used before the fix; any
+      // measured value is a different number.
+      expect(context?.budgetUtilization).not.toBe(0.5);
     });
 
     it('should not record when LinUCB disabled', () => {

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -995,6 +995,8 @@ export class CompositeRouter implements ICompositeRouter {
       preferenceRouter: this.preferenceRouter,
       zeroRouter: this.zeroRouter,
       lastRoutedTask: this.lastRoutedTask,
+      budgetRouter: this.budgetRouter,
+      budgetConstraints: this.config.budgetConstraints,
     };
   }
 


### PR DESCRIPTION
Closes #4910. A regression I introduced in #4874, found by an adversarial review of my own same-day merges.

## The invariant that broke

LinUCB is only consistent if the feature vector handed to `update` is the one `selectArm` scored. `budgetUtilization` sits at index 4 of the six-element vector (`linucb-math.ts:41-49`).

#4874 gave the **select** path a real value. The **update** path kept calling `taskAnalysisResultToBanditContext(analysis)` with no options, so it fell to the `0.5` neutral default.

Before #4874 both sides were `0.5`: the dimension was inert, which is exactly what that issue set out to fix. Afterwards the column was constant during training and varying at score time, so `θ_budget` was fit against a constant and then multiplied by a value in `[0,1]` — biasing each arm's estimate by a different amount depending on its observation count. **The dimension went from carrying no information to carrying misinformation.** That is a worse state than the one I was fixing.

## Reachability, stated precisely

Narrower than it looks. `applyBudgetFilter` emits a utilization only when `maxCostUsd` is set, and `nexus-agents.yaml` ships the `budget:` block commented out. On a default install both paths are still `0.5` and symmetric. It bites when a cost ceiling is configured — `--max-cost-usd`, or uncommenting the YAML.

That is also why #4874's tests could not have caught it: both hand-feed `0.87` to the select path, and nothing exercised the pair.

## Approach

`checkBudget` is a pure function of the task and the constraint, so the outcome path **recomputes** the selection-time value rather than caching a context across the request boundary — no new lifetime to get wrong, and no stale-context class of bug.

The formula and `toBudgetConstraint` moved into `composite-router-budget-feature.ts`, which both paths call. Two call sites deriving the same feature independently is precisely how this drifts again, and a shared helper parked in either caller's file reads as belonging to that caller. (The move also brought `composite-router-helpers.ts` back under the 400-line cap it had crossed.)

## The seam test is the point of this PR

The first version of this fix was correct at both ends and I nearly shipped it. Deleting the two lines that forward `budgetRouter`/`budgetConstraints` into the outcome deps left **all 316 router tests green** — the mutation was invisible, because each half was tested in isolation and the join between them was not.

So there are now three tests, and the third is the one that matters:

| test | pins |
| --- | --- |
| outcome path matches select path | the formula |
| no budget → both at `0.5` | the empty case, as symmetry rather than a magic number |
| **router hands the bandit a measured value** | **the wiring** |

The third reaches past `private` to spy on the bandit. That is deliberate: the seam it guards is the one that silently survived mutation, and a test that cannot observe the join cannot pin it.

The first test derives its expectation by calling `applyBudgetFilter` rather than restating `0.6` — a hardcoded expectation would keep passing if both sides drifted together, which is the failure mode being fixed.

Verified: `M1` (outcome ignores the budget) → 1 failure. `M2` (router stops forwarding) → 1 failure, where it previously produced none. Full `cli-adapters` suite: 2697 passed.
