### PR TITLE
fix(routing-audit): keep the budget line in its box and make the drift guard failable

### DIFF
--- a/.changeset/routing-audit-box-and-drift-guard.md
+++ b/.changeset/routing-audit-box-and-drift-guard.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+fix the routing-audit budget line spilling out of its box, and a drift guard that could not fail
+
+Two defects from the previous release, both mine.
+
+The `[simulated — not evaluated against real cost or config]` label was appended
+to the "Budget Filter" heading, giving an 82-character line inside a
+63-character content area. `padEnd` silently no-ops past its target, so the
+right border was pushed off every line of that section. Split across two lines.
+The test that shipped with it asserted `toContain('simulated')`, which passes on
+a broken render; it is now joined by one that measures the rendered width.
+
+The accompanying anti-drift test was vacuous. It called the audit's context
+builder and the production one and compared the outputs — but the audit side had
+just become `return taskProfileToBanditContext(profile)`, so it compared a
+one-line delegation to its own callee: true for every input, forever. The
+wrapper is now a re-export of the production symbol, and the test asserts
+function identity, which fails the moment anyone reintroduces a body. Divergence
+is impossible rather than merely untested.
+
+Also removes an orphaned doc comment left behind by a deleted constant.

--- a/packages/nexus-agents/src/cli/routing-audit-format.test.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-format.test.ts
@@ -17,6 +17,7 @@ import {
   formatAsciiOutput,
   formatJsonOutput,
 } from './routing-audit-format.js';
+import { BOX_WIDTH } from './box-drawing.js';
 import type {
   RoutingAuditResult,
   BudgetFilterResult,
@@ -154,6 +155,25 @@ describe('routing-audit-format', () => {
       const output = formatBudgetFilter(mockResult).join('\n');
 
       expect(output).toContain('simulated');
+    });
+
+    it('keeps every rendered line inside the box (#4891 regression)', () => {
+      // `toContain('simulated')` above passes on a broken render, so it could
+      // not catch what the label actually did: at 82 characters it overflowed
+      // the 63-character content area, `padEnd` no-opped, and the right border
+      // was pushed off every line of the budget section.
+      //
+      // Scoped to this stage. Widening it to the whole report fails on five
+      // pre-existing overflows with a different root cause — `boxLine` pads on
+      // `.length`, which counts ANSI escapes — filed separately as #4913
+      // rather than folded into a regression fix.
+      const output = formatBudgetFilter(mockResult);
+      const visible = (line: string): string => line.replace(/\u001b\[[0-9;]*m/g, '');
+      const overflowing = output
+        .filter((line) => visible(line).startsWith('│'))
+        .filter((line) => visible(line).length > BOX_WIDTH);
+
+      expect(overflowing).toEqual([]);
     });
 
     it('does not mark the other stages as simulated', () => {

--- a/packages/nexus-agents/src/cli/routing-audit-format.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-format.ts
@@ -61,12 +61,13 @@ export function formatBudgetFilter(result: RoutingAuditResult): string[] {
   // reached the terminal, so this stage rendered identically to the TOPSIS and
   // LinUCB stages beside it, which construct real routers. Say it here, where
   // the reader is.
+  // Two lines, not one: `boxLine` pads to BOX_WIDTH - 2 = 63 and `padEnd`
+  // silently no-ops past that, so the 82-character single line this started as
+  // pushed the right border off the box on every render.
   lines.push(
-    boxLine(
-      color(` Budget Filter (${String(passCount)}/${String(total)} pass):`, ANSI.bold) +
-        color(' [simulated — not evaluated against real cost or config]', ANSI.dim)
-    )
+    boxLine(color(` Budget Filter (${String(passCount)}/${String(total)} pass):`, ANSI.bold))
   );
+  lines.push(boxLine(color('   [simulated — not evaluated against cost or config]', ANSI.dim)));
   for (const br of result.budgetResults) {
     const status = br.withinBudget ? color('✓', ANSI.green) : color('✗', ANSI.red);
     lines.push(boxLine(`   ${status} ${br.cliName.padEnd(8)} - ${br.reason}`));

--- a/packages/nexus-agents/src/cli/routing-audit-logic.test.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-logic.test.ts
@@ -81,19 +81,22 @@ describe('routing-audit-logic', () => {
   });
 
   describe('bandit context matches the production builder (#4843)', () => {
-    it('produces the same context the composite router would', async () => {
+    it('is the production builder, not a copy that agrees with it today', async () => {
       // The audit kept its own copy of the builder. #4874 gave the production
       // one an optional real budget figure, and the copy did not follow — so
       // the audit reported a bandit context the router no longer uses. An
       // audit that silently diverges from the thing it audits is worse than
       // no audit.
+      //
+      // This asserts function IDENTITY. The first version of this test called
+      // both and compared outputs, which was vacuous once the audit side
+      // became a one-line delegation: `f(x)` equalling `g(x)` where `f` is
+      // `return g(x)` is true for every input, forever. Identity fails the
+      // moment anyone reintroduces a body here, which is the actual risk.
       const { taskProfileToBanditContext } =
         await import('../cli-adapters/composite-router-helpers.js');
-      const profile = analyzeTaskString('Write a function to sort an array');
 
-      expect(taskProfileToBanditContextFromProfile(profile)).toEqual(
-        taskProfileToBanditContext(profile)
-      );
+      expect(taskProfileToBanditContextFromProfile).toBe(taskProfileToBanditContext);
     });
   });
 

--- a/packages/nexus-agents/src/cli/routing-audit-logic.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-logic.ts
@@ -43,8 +43,6 @@ const sharedAnalyzer = createSharedTaskAnalyzer();
 
 const CLI_NAMES: readonly CliName[] = ['claude', 'gemini', 'codex', 'opencode'];
 
-/** Normalization ceiling for context length (tokens). */
-
 // =============================================================================
 // Helper Functions
 // =============================================================================
@@ -63,7 +61,7 @@ export function analyzeTaskString(taskStr: string): TaskProfile {
 }
 
 /**
- * Converts task profile to bandit context, delegating to the production builder.
+ * The production bandit-context builder, re-exported under the audit's name.
  *
  * This was a byte-equivalent copy of `taskProfileToBanditContext`. The two
  * agreed only by coincidence: #4874 gave the production one an optional real
@@ -74,10 +72,13 @@ export function analyzeTaskString(taskStr: string): TaskProfile {
  * No utilization is passed, which yields that neutral default — correct here,
  * because the audit's budget stage is simulated (#4843) and there is no real
  * figure to supply.
+ *
+ * A re-export rather than a delegating wrapper: with a wrapper, the only test
+ * that could guard the drift compared the wrapper's output to its own callee,
+ * which is true by construction and can never fail. Aliasing the symbol makes
+ * divergence impossible instead of merely untested.
  */
-export function taskProfileToBanditContextFromProfile(profile: TaskProfile): BanditContext {
-  return taskProfileToBanditContext(profile);
-}
+export { taskProfileToBanditContext as taskProfileToBanditContextFromProfile };
 
 /**
  * Analyzes a task string and returns its bandit context directly.
@@ -232,7 +233,7 @@ export function auditRouting(options: RoutingAuditOptions): RoutingAuditResult {
 
   // Step 4: LinUCB selection
   const bandit = new LinUCBBandit(eligibleClis);
-  const context = taskProfileToBanditContextFromProfile(taskProfile);
+  const context = taskProfileToBanditContext(taskProfile);
   const linucbDetails = computeLinUCBDetails(bandit, context);
   const selection = bandit.select(context);
 


### PR DESCRIPTION
Two defects from my own #4891, found by an adversarial review of that commit.

## 1. The label I added broke the box

`[simulated — not evaluated against real cost or config]` was appended to the "Budget Filter" heading. `boxLine` pads to `BOX_WIDTH - 2 = 63`; the combined line is **82 characters**. `padEnd` no-ops past its target, so the right border was pushed off every line of that section:

```
│ Budget Filter (4/4 pass): [simulated — not evaluated against real cost or config]│
│   ✓ claude   - within budget                                  │
```

Split across two lines. The information the label carries is the point of #4891, so shortening it to fit was the wrong trade.

**The test that shipped with it could not catch this.** `expect(output).toContain('simulated')` passes on the render above. There is now a companion that measures the rendered width after stripping ANSI, which fails on the old single-line form.

That new test, widened from this stage to the whole report, fails on five more lines with a different root cause — `boxLine` pads on `.length`, which counts ANSI escapes, and three call sites carry hand-tuned `BOX_WIDTH + 8` / `+ 11` / `+ 7` fudge factors compensating for exactly that. Filed as #4913 rather than folded in here; the test is scoped to this stage with a pointer, and widening it is a one-line change once #4913 lands.

## 2. The anti-drift test was tautological

#4891 also removed the audit's duplicate bandit-context builder, leaving `taskProfileToBanditContextFromProfile` as `return taskProfileToBanditContext(profile)` — and added a test comparing the two:

```ts
expect(taskProfileToBanditContextFromProfile(profile)).toEqual(
  taskProfileToBanditContext(profile)
);
```

`f(x)` equals `g(x)` where `f` is defined as `return g(x)`. True for every input, forever. Its changeset described it as "a test pinning that the two agree", which is precisely the check-that-cannot-fail the doctrine names — and it sat in CI reading as a passing guard against drift it did not provide.

The wrapper is now a **re-export** of the production symbol, and the test asserts function identity:

```ts
expect(taskProfileToBanditContextFromProfile).toBe(taskProfileToBanditContext);
```

That fails the moment anyone reintroduces a body, which is the actual risk the original was reaching for. Better still, it makes divergence impossible rather than merely detected — one fewer indirection, and the internal caller now uses the canonical name directly.

## 3. Orphan

`/** Normalization ceiling for context length (tokens). */` was left behind by a constant #4891 deleted, documenting nothing.

## Mutation results

| mutation | before | after |
| --- | --- | --- |
| restore the one-line budget label | green | **1 failed** |
| reintroduce the delegating wrapper | green | **1 failed** |

The second row is the whole point: that mutation is exactly what the old test claimed to guard against, and it passed.
