### PR TITLE
fix(orchestration): reward the sum over scored steps, not an extrapolation

### DIFF
--- a/.changeset/reward-sum-over-scored-steps.md
+++ b/.changeset/reward-sum-over-scored-steps.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+stop the episode reward re-multiplying the steps it excluded
+
+Excluding unmeasured steps from the reward mean left both consumers of that
+mean multiplying it by `totalSteps`. That product was the reward sum while the
+mean covered every step; once it covered only scored steps it became an
+extrapolation, handing the policy back the contribution of exactly the steps
+exclusion removed. Three scored steps averaging 0.8 out of four reported a
+reward of 3.2 where the true sum is 2.4.
+
+Both now multiply by `scoredSteps`, which was already on the metrics object and
+unread.
+
+The empty case is handled rather than defaulted: with no step reporting a
+reward, the policy update is skipped instead of training on the zero that falls
+out of an empty mean — and in `computeEpisodeReward` that zero was followed by
+a completion bonus, so an episode with nothing measured produced a positive
+reward.
+
+The efficiency penalty stays on `totalSteps`. An unscored step was still
+executed and paid for, and scoping the penalty to scored steps would make it
+free — the same distortion in the other direction. A test pins that.

--- a/packages/nexus-agents/src/agents/orchestration/learning-integration.test.ts
+++ b/packages/nexus-agents/src/agents/orchestration/learning-integration.test.ts
@@ -117,17 +117,20 @@ function makeResult(overrides: Partial<PuppeteerResult> = {}) {
     totalTokens: 500,
     totalCost: 0.01,
     emergentPatterns: { hubAgents: [], cycles: [], graphDensity: 0, cyclicalityScore: 0 },
-    metrics: {
+    terminationReason: 'task_complete' as const,
+    sessionId: 'session-abc',
+    ...overrides,
+    // A fixture that varies `totalSteps` without saying otherwise means every
+    // step was scored. Leaving `scoredSteps` at its literal made the arithmetic
+    // in these tests inconsistent with itself once reward moved onto it.
+    metrics: overrides.metrics ?? {
       avgReward: 0.8,
-      scoredSteps: 3,
+      scoredSteps: overrides.totalSteps ?? 3,
       taskCompletionRate: 1.0,
       efficiencyScore: 0.5,
       compactionScore: 0.3,
       cyclicalityScore: 0.1,
     },
-    terminationReason: 'task_complete' as const,
-    sessionId: 'session-abc',
-    ...overrides,
   };
 }
 
@@ -197,11 +200,38 @@ describe('processOrchestrationForLearning', () => {
     expect(engine.updatePolicy).not.toHaveBeenCalled();
   });
 
-  it('computes finalReward as avgReward * totalSteps', async () => {
+  it('rewards the sum over scored steps, not an extrapolation across all of them', async () => {
+    // `avgReward` became the mean over SCORED steps in #4766. Multiplying it
+    // by `totalSteps` hands the policy back the contribution of exactly the
+    // steps that exclusion removed: 3 scored steps averaging 0.8 out of 4
+    // total is a reward sum of 2.4, and the old form reported 3.2.
     const result = makeResult({
       totalSteps: 4,
       metrics: {
-        avgReward: 0.5,
+        avgReward: 0.8,
+        scoredSteps: 3,
+        taskCompletionRate: 1.0,
+        efficiencyScore: 0.5,
+        compactionScore: 0.3,
+        cyclicalityScore: 0.1,
+      },
+    });
+    const buffer = makeBuffer();
+    const engine = makeEngine();
+
+    await processOrchestrationForLearning(result, buffer, engine);
+
+    expect(engine.updatePolicy).toHaveBeenCalledWith(steps, 2.4000000000000004);
+  });
+
+  it('skips the policy update when no step reported a reward', async () => {
+    // The empty case. With every step unmeasured there is no reward to learn
+    // from; updating on the 0 that falls out of an empty mean trains the
+    // policy on the absence of data as though it were a measurement.
+    const result = makeResult({
+      totalSteps: 4,
+      metrics: {
+        avgReward: 0,
         scoredSteps: 0,
         taskCompletionRate: 1.0,
         efficiencyScore: 0.5,
@@ -211,8 +241,11 @@ describe('processOrchestrationForLearning', () => {
     });
     const buffer = makeBuffer();
     const engine = makeEngine();
+
     await processOrchestrationForLearning(result, buffer, engine);
-    expect(engine.updatePolicy).toHaveBeenCalledWith(steps, 2.0);
+
+    expect(buffer.addEpisode).toHaveBeenCalled();
+    expect(engine.updatePolicy).not.toHaveBeenCalled();
   });
 
   it('handles policy update returning error result', async () => {
@@ -360,13 +393,37 @@ describe('createLearningHandler', () => {
 });
 
 describe('computeEpisodeReward', () => {
-  it('computes base reward as avgReward * totalSteps', () => {
+  it('computes base reward over scored steps, not total steps', () => {
+    // The old assertion used `totalSteps: 0`, where every multiplier yields 0
+    // — it passed whichever factor the code used. These differ.
     const result = makeResult({
       success: false,
-      totalSteps: 0,
-      metrics: { ...ZERO_METRICS, avgReward: 0.5 },
+      totalSteps: 10,
+      metrics: { ...ZERO_METRICS, avgReward: 0.5, scoredSteps: 2 },
     });
-    expect(computeEpisodeReward(result, 0, 0)).toBe(0);
+
+    expect(computeEpisodeReward(result, 0, 0)).toBe(1.0);
+  });
+
+  it('still charges the efficiency penalty for unscored steps', () => {
+    // The pair: a step that reported no reward was still executed and paid
+    // for, so the penalty is over `totalSteps`. Scoping it to scored steps
+    // would make an unmeasured step free, which is the distortion #4766 set
+    // out to remove.
+    const scoredOnly = makeResult({
+      success: false,
+      totalSteps: 2,
+      metrics: { ...ZERO_METRICS, avgReward: 0, scoredSteps: 2 },
+    });
+    const withUnscored = makeResult({
+      success: false,
+      totalSteps: 10,
+      metrics: { ...ZERO_METRICS, avgReward: 0, scoredSteps: 2 },
+    });
+
+    expect(computeEpisodeReward(withUnscored, 0, 1)).toBeLessThan(
+      computeEpisodeReward(scoredOnly, 0, 1)
+    );
   });
 
   it('adds completion bonus on success', () => {
@@ -405,7 +462,7 @@ describe('computeEpisodeReward', () => {
       totalSteps: 5,
       metrics: {
         avgReward: 0.6,
-        scoredSteps: 0,
+        scoredSteps: 5,
         taskCompletionRate: 1.0,
         efficiencyScore: 0.5,
         compactionScore: 0.3,
@@ -426,7 +483,7 @@ describe('computeEpisodeReward', () => {
     const result = makeResult({
       success: false,
       totalSteps: 2,
-      metrics: { ...ZERO_METRICS, avgReward: -1.0 },
+      metrics: { ...ZERO_METRICS, avgReward: -1.0, scoredSteps: 2 },
     });
     expect(computeEpisodeReward(result, 0, 0)).toBe(-2.0);
   });

--- a/packages/nexus-agents/src/agents/orchestration/learning-integration.ts
+++ b/packages/nexus-agents/src/agents/orchestration/learning-integration.ts
@@ -190,8 +190,26 @@ export async function processOrchestrationForLearning(
       return;
     }
 
-    const finalReward = result.metrics.avgReward * result.totalSteps;
-    await tryUpdatePolicy(policyEngine, trajectory, finalReward, result.sessionId, episodeId);
+    // `avgReward` is the mean over SCORED steps (#4766), so multiplying by
+    // `totalSteps` extrapolates it across the very steps that exclusion
+    // removed — handing the policy back the contribution of steps that
+    // reported no usage. Multiplying by `scoredSteps` recovers the actual
+    // reward total (#4916).
+    const { avgReward, scoredSteps } = result.metrics;
+    if (scoredSteps === 0) {
+      logger.debug('No step reported a measurable reward; skipping policy update', {
+        sessionId: result.sessionId,
+        totalSteps: result.totalSteps,
+      });
+      return;
+    }
+    await tryUpdatePolicy(
+      policyEngine,
+      trajectory,
+      avgReward * scoredSteps,
+      result.sessionId,
+      episodeId
+    );
   } catch (error) {
     // Top-level error handler to ensure we never propagate
     const err = error instanceof Error ? error : new Error(String(error));
@@ -254,7 +272,7 @@ export function createLearningHandler(
  * Computes the final reward for an episode from orchestration metrics.
  *
  * Combines multiple reward signals into a single scalar value for learning:
- * - Average step reward (weighted by trajectory length)
+ * - Average step reward (weighted by the number of SCORED steps)
  * - Task completion bonus
  * - Efficiency penalty (lower steps is better)
  *
@@ -274,7 +292,10 @@ export function computeEpisodeReward(
   completionBonus: number = 1.0,
   efficiencyWeight: number = 0.1
 ): number {
-  let reward = result.metrics.avgReward * result.totalSteps;
+  // Over scored steps: `avgReward` is their mean, so this is the reward total.
+  // The efficiency penalty below stays on `totalSteps` — every step was paid
+  // for, whether or not it reported a reward (#4916).
+  let reward = result.metrics.avgReward * result.metrics.scoredSteps;
 
   // Add completion bonus
   if (result.success) {


### PR DESCRIPTION
Closes #4916. A defect in my own #4895, found by an adversarial review of that commit.

## What #4895 did, and what it missed

It excluded unmeasured steps from the reward mean, so a step reporting no usage stopped outscoring one that reported honestly. `avgReward` became the mean over **scored** steps, with `scoredSteps` published alongside it as coverage.

Both consumers kept multiplying by `totalSteps`:

```ts
const finalReward = result.metrics.avgReward * result.totalSteps;   // :193
let reward       = result.metrics.avgReward * result.totalSteps;    // :277
```

That product *was* the reward sum, back when the mean covered every step. It no longer is. The scored mean now gets extrapolated across the very steps exclusion removed — the policy is handed back the reward contribution of steps that reported nothing, which is the distortion #4766 deleted, reassembled one layer up.

3 scored steps averaging 0.8 out of 4 total: true sum **2.4**, reported **3.2**.

`scoredSteps` was sitting on the same object, unread — recorded but not consumed.

## The empty case was the worse half

Every step unmeasured gives `scored.length === 0`, so `avgReward` falls to `0` and the reward is `0 × totalSteps = 0` — training the policy on a zero presented as a measurement, when the honest statement is that nothing was measured. In `computeEpisodeReward` the completion bonus is added *after*, so an episode with **zero measured rewards produced a positive reward**.

Now the update is skipped when `scoredSteps === 0`, with a debug line naming it.

## What deliberately did not change

The efficiency penalty still uses `totalSteps`. An unscored step was executed and paid for; scoping the penalty to scored steps would make an unmeasured step free, which is the original distortion facing the other way. There is a test pinning that direction so the fix cannot over-apply — mutating the penalty onto `scoredSteps` fails 3 tests.

## The fixtures pinned the bug

Two tests were named for the defect: `computes finalReward as avgReward * totalSteps`, `computes base reward as avgReward * totalSteps`. Retargeted.

Several fixtures also carried `scoredSteps: 0` beside a nonzero `avgReward` — an impossible state, a nonzero mean over zero scored steps — added mechanically when #4895 introduced the field. One used `totalSteps: 0`, where every multiplier yields 0, so it passed whichever factor the code used. `makeResult` now derives `scoredSteps` from `totalSteps` by default, so a fixture that varies step count stays internally consistent.

## Mutations

| mutation | result |
| --- | --- |
| `finalReward` back to `totalSteps` | 1 failed |
| `computeEpisodeReward` back to `totalSteps` | 1 failed |
| empty-case guard removed | 1 failed |
| penalty scoped to `scoredSteps` | 3 failed |

Full orchestration suite: 532 passed.
