### PR TITLE
fix(cli): give threshold and period their own flags instead of colliding shorts

### DIFF
--- a/.changeset/cli-duplicate-short-flag.md
+++ b/.changeset/cli-duplicate-short-flag.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+stop `vote -t supermajority` silently running a simple-majority vote
+
+`parseArgs` takes one options object for the whole CLI, so a short letter is
+global even when the two long options belong to different commands. `-t` was
+claimed by both `task` and `threshold`; `task` is declared first and won, so
+`--threshold` was never set from the short form, `resolveStrategy` fell through
+to its `simple_majority` default, and the summary reported that default as the
+chosen threshold. No error — `strict: false` makes the misbinding silent.
+
+`-p` had the same collision between `proposal` and `period`, leaving
+`learning-metrics -p` unable to set its reporting window.
+
+Both losers drop their short form and keep the long one; neither was reachable,
+so nothing that worked before changes. The help entry and its example now show
+`--threshold`.
+
+The durable part is a test that walks the options table and asserts no letter
+is claimed twice — nothing in the type system or the parser objects to a
+duplicate, so the next one would recur silently.

--- a/packages/nexus-agents/src/cli-command-help.ts
+++ b/packages/nexus-agents/src/cli-command-help.ts
@@ -65,13 +65,13 @@ const VOTE_HELP: CommandHelpEntry = {
   command: 'vote',
   examples: [
     'nexus-agents vote --proposal "Add caching layer"',
-    'nexus-agents vote -p "Migrate to PostgreSQL" -t supermajority',
+    'nexus-agents vote -p "Migrate to PostgreSQL" --threshold supermajority',
     'nexus-agents vote -p "Quick decision" --quick',
     'nexus-agents vote -p "Test idea" --dry-run',
   ],
   flags: [
     { flag: '-p, --proposal <text>', description: 'Proposal text to vote on (required)' },
-    { flag: '-t, --threshold <t>', description: 'Threshold: majority, supermajority, unanimous' },
+    { flag: '--threshold <t>', description: 'Threshold: majority, supermajority, unanimous' },
     { flag: '--quick', description: 'Use 3 agents instead of the full 7 for faster votes' },
     { flag: '--dry-run', description: 'Simulate votes without agent execution' },
     { flag: '--timeout=<seconds>', description: 'Timeout per vote in seconds', defaultValue: '90' },

--- a/packages/nexus-agents/src/cli-types.test.ts
+++ b/packages/nexus-agents/src/cli-types.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for the CLI's parseArgs configuration.
+ *
+ * @module cli-types.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseArgs } from 'node:util';
+import { PARSE_ARGS_CONFIG } from './cli-types.js';
+
+describe('PARSE_ARGS_CONFIG short flags', () => {
+  it('assigns each short flag to exactly one option', () => {
+    // `parseArgs` takes ONE options object for every command, so a short flag
+    // is global even when the two long options belong to different commands.
+    // When two entries claim the same letter, one silently wins and the other
+    // is never settable — `vote -t supermajority` bound to `task` and ran a
+    // simple-majority vote while the help advertised `-t, --threshold`.
+    const byShort = new Map<string, string[]>();
+    for (const [name, spec] of Object.entries(PARSE_ARGS_CONFIG.options)) {
+      const short = (spec as { short?: string }).short;
+      if (short === undefined) continue;
+      byShort.set(short, [...(byShort.get(short) ?? []), name]);
+    }
+
+    const collisions = [...byShort.entries()]
+      .filter(([, names]) => names.length > 1)
+      .map(([short, names]) => `-${short} → ${names.join(', ')}`);
+
+    expect(collisions).toEqual([]);
+  });
+
+  it('finds the collisions it is looking for', () => {
+    // Guard the guard: the assertion above passes vacuously if the scan is
+    // broken, and an empty `byShort` would look identical to a clean config.
+    const shorts = Object.values(PARSE_ARGS_CONFIG.options).filter(
+      (spec) => (spec as { short?: string }).short !== undefined
+    );
+
+    expect(shorts.length).toBeGreaterThan(5);
+  });
+
+  it('binds --threshold, not --task, when the vote command is given a threshold', () => {
+    // The end-to-end shape of the bug, at the parser rather than the config.
+    const { values } = parseArgs({
+      args: ['vote', '--threshold', 'supermajority', '-p', 'x'],
+      options: PARSE_ARGS_CONFIG.options,
+      allowPositionals: true,
+      strict: false,
+    });
+
+    expect(values.threshold).toBe('supermajority');
+    expect(values.task).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -407,9 +407,12 @@ export const PARSE_ARGS_CONFIG = {
       type: 'string' as const,
       short: 'p',
     },
+    // No `short`. `parseArgs` takes one options object for every command, so
+    // a short letter is global: `-t` was already `task`, which won, and
+    // `vote -t supermajority` silently ran a simple-majority vote. Long form
+    // only — `cli-types.test.ts` pins that no two options share a letter.
     threshold: {
       type: 'string' as const,
-      short: 't',
     },
     quick: {
       type: 'boolean' as const,
@@ -484,9 +487,10 @@ export const PARSE_ARGS_CONFIG = {
       default: false,
     },
     // Learning-metrics command options
+    // No `short` — `-p` is `proposal`, which was declared first and won. See
+    // the note on `threshold`.
     period: {
       type: 'string' as const,
-      short: 'p',
     },
     export: {
       type: 'string' as const,


### PR DESCRIPTION
Closes #4922. Found by using the tool: I ran a 7-voter panel with `-t supermajority` and the output said `Threshold: simple_majority`.

## What happens

`nexus-agents vote -t supermajority` runs a **simple-majority** vote. No error, no warning — the printed threshold line looks like an echo of the flag and is in fact the default.

`parseArgs` takes one options object for the entire CLI, so a short letter is global even when the long options belong to different commands. `cli-types.ts` declared `short: 't'` twice — `task` (orchestrate, line 370) and `threshold` (vote, line 412) — and the first declaration wins. Reproduced against Node's parser directly:

```
parseArgs({args:['-t','supermajority','-p','x'], options:{task:{…short:'t'}, threshold:{…short:'t'}, …}})
→ {"task":"supermajority","proposal":"x"}
```

`values.threshold` is never set → `parseThreshold(undefined)` → the field is omitted from `ConsensusVoteInput` → `resolveStrategy` falls through to `simple_majority`. `strict: false` means nothing complains, and `vote` ignores the stray `task`.

`-p` had the same collision — `proposal` (vote) beats `period` (learning-metrics), so `learning-metrics -p 7d` sets `proposal` and leaves the reporting window undefined. Less serious, same defect.

## The fix that matters is the ratchet

Dropping `short` from the two losers is three lines, and neither was reachable, so nothing that worked before changes. But nothing in the type system or the parser objects to a duplicate — the next one recurs exactly as silently.

So there is now a test walking `PARSE_ARGS_CONFIG.options` and asserting no letter is claimed twice. It has a guard-the-guard assertion beside it, because an empty scan would produce an identical empty-collisions list to a clean config.

Reintroducing `short: 't'` on `threshold` fails it. Before this PR it reported both live collisions:

```
-t → task, threshold
-p → proposal, period
```

A third test drives the real parser end-to-end and asserts `--threshold` lands on `threshold` and not on `task`.

## Severity note

I would not normally call a CLI flag a governance issue, but this one decides the bar a consensus vote is tallied against. The panel still ran and the voters still reasoned; what was wrong is that the operator asked for the strictest threshold, got the loosest, and was shown the substituted value as though it had been chosen. That is the repo's own p1 shape — a default reported as a measurement.

Full CLI suite: 6807 passed.
