### PR TITLE
fix(governance): write an audit record for votes run from the CLI

### DIFF
--- a/.changeset/cli-vote-audit-record.md
+++ b/.changeset/cli-vote-audit-record.md
@@ -1,0 +1,27 @@
+---
+'nexus-agents': patch
+---
+
+write an audit record for votes run from the CLI
+
+`persistVoteRecord` had exactly one caller — the MCP `consensus_vote` tool — so
+every decision made through `nexus-agents vote` was absent from the
+tamper-evident chain. `verify_audit_chain` reported the chain intact across
+those votes, and it was: contiguous sequence, no hash breaks. It simply did not
+contain them, and there was no field in which it could say so.
+
+Measured, not inferred: two live panels run at a terminal left no entry in any
+`vote-records.jsonl` on the machine. They also got none of the per-option
+instrumentation — no `optionTally`, no `optionCoverage`, no `proposalHash` —
+so a multi-option CLI vote was invisible to the machinery that records which
+option won.
+
+The CLI now calls the same `recordAuthenticVote` the MCP path uses rather than
+growing a second writer, and prints one line saying what reached the chain. A
+write failure is stated rather than swallowed: the vote must not fail because
+its record could not be written, but a decision that left no record must not
+look like one that did. Simulated runs are still skipped, and are reported as
+skipped rather than as a failure.
+
+The recorded strategy is the one that was applied, not the CLI's display
+`threshold` — the two can differ.

--- a/packages/nexus-agents/src/cli/vote-audit-line.ts
+++ b/packages/nexus-agents/src/cli/vote-audit-line.ts
@@ -1,0 +1,28 @@
+/**
+ * The operator-facing line describing what reached the audit chain.
+ *
+ * Its own module so the branch behaviour is testable without exporting it from
+ * `vote-command.ts` purely for a test — the producer/consumer ratchet is right
+ * that a test import is not a consumer.
+ *
+ * @module cli/vote-audit-line
+ */
+import { colors } from './ansi-output.js';
+import type { VoteRecordPersistOutcome } from '../mcp/tools/consensus-vote-recording.js';
+
+/**
+ * One operator-facing line describing what reached the audit chain.
+ *
+ * A persist failure is stated rather than swallowed: the vote itself must not
+ * fail because its record could not be written, but a decision that left no
+ * record must not look like one that did (#4924).
+ */
+export function auditLineFor(outcome: VoteRecordPersistOutcome): string {
+  if (outcome.persisted) {
+    return `${colors.dim}Audit record #${String(outcome.record.sequence)} written (${outcome.record.id})${colors.reset}\n`;
+  }
+  if (outcome.reason === 'all-simulated') {
+    return `${colors.dim}No audit record — votes were simulated${colors.reset}\n`;
+  }
+  return `${colors.yellow}Vote NOT recorded to the audit chain: ${outcome.detail}${colors.reset}\n`;
+}

--- a/packages/nexus-agents/src/cli/vote-command.test.ts
+++ b/packages/nexus-agents/src/cli/vote-command.test.ts
@@ -32,8 +32,8 @@ import {
   explainOutcome,
   recordVoteToGitHub,
   voteCommand,
-  auditLineFor,
 } from './vote-command.js';
+import { auditLineFor } from './vote-audit-line.js';
 
 function createMockConsensusResult(overrides: Partial<ConsensusResult> = {}): ConsensusResult {
   return {

--- a/packages/nexus-agents/src/cli/vote-command.test.ts
+++ b/packages/nexus-agents/src/cli/vote-command.test.ts
@@ -8,14 +8,23 @@ import type { VotingResult } from './vote-types.js';
 import type { ConsensusResult, Vote } from '../consensus/types.js';
 import type { AgentVoteResult } from './voter-agents.js';
 
-const { safeExecSandboxedMock, executeVotingMock } = vi.hoisted(() => ({
+const { safeExecSandboxedMock, executeVotingMock, recordAuthenticVoteMock } = vi.hoisted(() => ({
   safeExecSandboxedMock: vi.fn(),
   executeVotingMock: vi.fn(),
+  // Default impl so every describe that does not care about persistence still
+  // gets a well-formed outcome back.
+  recordAuthenticVoteMock: vi.fn(() => ({
+    persisted: true,
+    record: { id: 'vote-1', sequence: 7 },
+  })),
 }));
 vi.mock('./sandbox-exec.js', () => ({ safeExecSandboxed: safeExecSandboxedMock }));
 // #4135: stub executeVoting so voteCommand exit-code mapping can be driven by a
 // fixed response-layer decision (approved / rejected / no_quorum).
 vi.mock('../mcp/tools/consensus-vote.js', () => ({ executeVoting: executeVotingMock }));
+vi.mock('../mcp/tools/consensus-vote-recording.js', () => ({
+  recordAuthenticVote: recordAuthenticVoteMock,
+}));
 
 import {
   formatVoteComment,
@@ -23,6 +32,7 @@ import {
   explainOutcome,
   recordVoteToGitHub,
   voteCommand,
+  auditLineFor,
 } from './vote-command.js';
 
 function createMockConsensusResult(overrides: Partial<ConsensusResult> = {}): ConsensusResult {
@@ -390,5 +400,120 @@ describe('voteCommand — exit-code mapping for no_quorum (#4135)', () => {
   it('a rejected decision → exit 1 (unchanged)', async () => {
     executeVotingMock.mockResolvedValue(extendedResult('rejected'));
     expect(await voteCommand({ proposal: 'p', onNoQuorum: 'exit2' })).toBe(1);
+  });
+});
+
+// =============================================================================
+// The CLI writes its own audit record (#4924)
+// =============================================================================
+
+/** A minimal `persisted: true` outcome; only `id` and `sequence` are read. */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function persistedOutcome() {
+  return { persisted: true, record: { id: 'vote-1', sequence: 7 } } as unknown as Parameters<
+    typeof auditLineFor
+  >[0];
+}
+
+describe('voteCommand persists to the audit chain (#4924)', () => {
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  function extendedResult(decision: string) {
+    return {
+      proposal: 'p',
+      threshold: 'supermajority',
+      result: createMockConsensusResult({ outcome: 'approved' }),
+      votes: [],
+      totalTimeMs: 5,
+      simulateVotes: false,
+      strategy: 'higher_order',
+      decision,
+    };
+  }
+
+  beforeEach(() => {
+    executeVotingMock.mockReset();
+    recordAuthenticVoteMock.mockReset();
+    recordAuthenticVoteMock.mockReturnValue(
+      persistedOutcome() as unknown as {
+        persisted: boolean;
+        record: { id: string; sequence: number };
+      }
+    );
+  });
+
+  it('records the vote', () => {
+    // `persistVoteRecord` had exactly one caller — the MCP tool — so every
+    // decision made at a terminal was absent from the tamper-evident chain
+    // while `verify_audit_chain` reported it intact.
+    executeVotingMock.mockResolvedValue(extendedResult('approved'));
+
+    return voteCommand({ proposal: 'p' }).then(() => {
+      expect(recordAuthenticVoteMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('records the strategy that was actually applied, not the CLI display value', async () => {
+    // The CLI narrows `ExtendedVotingResult` to the base view for printing,
+    // which drops `strategy`. Recording the printed `threshold` instead would
+    // put `supermajority` in the chain for a `higher_order` run.
+    executeVotingMock.mockResolvedValue(extendedResult('approved'));
+
+    await voteCommand({ proposal: 'p' });
+
+    const firstCall = recordAuthenticVoteMock.mock.calls[0] as unknown[] | undefined;
+    expect(firstCall?.[0]).toMatchObject({ strategy: 'higher_order' });
+  });
+
+  it('records a rejection too', async () => {
+    // A rejected vote is a decision. Recording only approvals would make the
+    // chain a record of what passed rather than of what was decided.
+    executeVotingMock.mockResolvedValue(extendedResult('rejected'));
+
+    await voteCommand({ proposal: 'p' });
+
+    expect(recordAuthenticVoteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not record a dry run', async () => {
+    // Simulated votes must never seed governance (#2319). The recorder skips
+    // them on its own; not calling it at all keeps the CLI from printing a
+    // persistence line for a vote that never happened.
+    executeVotingMock.mockResolvedValue({ ...extendedResult('approved'), simulateVotes: true });
+
+    await voteCommand({ proposal: 'p', dryRun: true });
+
+    expect(recordAuthenticVoteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('auditLineFor (#4924)', () => {
+  it('names the sequence when the record was written', () => {
+    expect(auditLineFor(persistedOutcome())).toContain('7');
+  });
+
+  it('says a write failure out loud rather than staying silent', () => {
+    const line = auditLineFor({
+      persisted: false,
+      reason: 'write-failed',
+      detail: 'data dir unwritable at /x',
+    });
+
+    expect(line).toMatch(/not recorded/i);
+    expect(line).toContain('/x');
+  });
+
+  it('distinguishes a skipped simulation from a failure', () => {
+    // Both are `persisted: false`. Collapsing them would report a deliberate
+    // skip in the same alarming words as an unwritable data dir — the
+    // `not.toMatch` is what catches that, and a weaker one on /failed/ did
+    // not, since the failure line says "NOT recorded" rather than "failed".
+    const line = auditLineFor({
+      persisted: false,
+      reason: 'all-simulated',
+      detail: 'simulated',
+    });
+
+    expect(line).toMatch(/simulat/i);
+    expect(line).not.toMatch(/NOT recorded/i);
   });
 });

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -34,10 +34,8 @@ import { executeVoting } from '../mcp/tools/consensus-vote.js';
 import type { ConsensusVoteInput, VoteDecisionStatus } from '../mcp/tools/consensus-vote-types.js';
 import { mapOutcomeToDecision } from '../mcp/tools/consensus-vote-types.js';
 import { colors, symbols, writeLine } from './ansi-output.js';
-import {
-  recordAuthenticVote,
-  type VoteRecordPersistOutcome,
-} from '../mcp/tools/consensus-vote-recording.js';
+import { recordAuthenticVote } from '../mcp/tools/consensus-vote-recording.js';
+import { auditLineFor } from './vote-audit-line.js';
 
 function generateVoteHash(role: VoterRole, vote: Vote): VoteHash {
   const data = JSON.stringify({ role, decision: vote.decision, reasoning: vote.reasoning });
@@ -387,23 +385,6 @@ function exitCodeForDecision(decision: VoteDecisionStatus, policy: NoQuorumPolic
   if (decision === 'approved') return 0;
   if (decision === 'no_quorum') return policy === 'exit2' ? 2 : 1;
   return 1;
-}
-
-/**
- * One operator-facing line describing what reached the audit chain.
- *
- * A persist failure is stated rather than swallowed: the vote itself must not
- * fail because its record could not be written, but a decision that left no
- * record must not look like one that did (#4924).
- */
-export function auditLineFor(outcome: VoteRecordPersistOutcome): string {
-  if (outcome.persisted) {
-    return `${colors.dim}Audit record #${String(outcome.record.sequence)} written (${outcome.record.id})${colors.reset}\n`;
-  }
-  if (outcome.reason === 'all-simulated') {
-    return `${colors.dim}No audit record — votes were simulated${colors.reset}\n`;
-  }
-  return `${colors.yellow}Vote NOT recorded to the audit chain: ${outcome.detail}${colors.reset}\n`;
 }
 
 /**

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -34,6 +34,10 @@ import { executeVoting } from '../mcp/tools/consensus-vote.js';
 import type { ConsensusVoteInput, VoteDecisionStatus } from '../mcp/tools/consensus-vote-types.js';
 import { mapOutcomeToDecision } from '../mcp/tools/consensus-vote-types.js';
 import { colors, symbols, writeLine } from './ansi-output.js';
+import {
+  recordAuthenticVote,
+  type VoteRecordPersistOutcome,
+} from '../mcp/tools/consensus-vote-recording.js';
 
 function generateVoteHash(role: VoterRole, vote: Vote): VoteHash {
   const data = JSON.stringify({ role, decision: vote.decision, reasoning: vote.reasoning });
@@ -279,7 +283,7 @@ export function recordVoteToGitHub(
  */
 async function runVote(
   options: VoteCommandOptions
-): Promise<VotingResult & { readonly decision: VoteDecisionStatus }> {
+): Promise<VotingResult & { readonly decision: VoteDecisionStatus; readonly strategy: string }> {
   // Validate and constrain timeout to allowed range (Issue #607). Done at
   // the CLI boundary so the operator sees the adjustment immediately.
   const requestedTimeoutMs = options.timeoutMs ?? DEFAULT_VOTE_TIMEOUT_MS;
@@ -322,6 +326,9 @@ async function runVote(
     totalTimeMs: result.totalTimeMs,
     simulateVotes: result.simulateVotes,
     decision: result.decision ?? mapOutcomeToDecision(result.result.outcome),
+    // Carried past the narrowing above so the audit record states the strategy
+    // that was applied. `threshold` is the display value and can differ (#4924).
+    strategy: result.strategy,
   };
 }
 
@@ -383,6 +390,48 @@ function exitCodeForDecision(decision: VoteDecisionStatus, policy: NoQuorumPolic
 }
 
 /**
+ * One operator-facing line describing what reached the audit chain.
+ *
+ * A persist failure is stated rather than swallowed: the vote itself must not
+ * fail because its record could not be written, but a decision that left no
+ * record must not look like one that did (#4924).
+ */
+export function auditLineFor(outcome: VoteRecordPersistOutcome): string {
+  if (outcome.persisted) {
+    return `${colors.dim}Audit record #${String(outcome.record.sequence)} written (${outcome.record.id})${colors.reset}\n`;
+  }
+  if (outcome.reason === 'all-simulated') {
+    return `${colors.dim}No audit record — votes were simulated${colors.reset}\n`;
+  }
+  return `${colors.yellow}Vote NOT recorded to the audit chain: ${outcome.detail}${colors.reset}\n`;
+}
+
+/**
+ * Write the vote to the tamper-evident chain, sharing the MCP path's recorder
+ * rather than growing a second one.
+ *
+ * Skipped for a dry run: `recordAuthenticVote` would decline it anyway, and
+ * printing a persistence line for a vote that never happened is its own small
+ * misreport.
+ */
+function persistToAuditChain(
+  options: VoteCommandOptions,
+  result: VotingResult & { readonly strategy: string }
+): void {
+  if (options.dryRun === true) return;
+  writeLine(
+    auditLineFor(
+      recordAuthenticVote({
+        proposal: result.proposal,
+        strategy: result.strategy,
+        result: result.result,
+        votes: result.votes,
+      })
+    )
+  );
+}
+
+/**
  * Run the vote command.
  */
 export async function voteCommand(options: VoteCommandOptions): Promise<number> {
@@ -411,6 +460,7 @@ export async function voteCommand(options: VoteCommandOptions): Promise<number> 
     if (options.verbose === true) printHashes(result.votes);
     writeLine(`${colors.dim}Completed in ${String(result.totalTimeMs)}ms${colors.reset}\n`);
 
+    persistToAuditChain(options, result);
     handleRecording(options, result, result.decision);
 
     return exitCodeForDecision(result.decision, onNoQuorum);


### PR DESCRIPTION
Closes #4924.

## The gap

`persistVoteRecord` had exactly **one** non-test call site — `src/mcp/tools/consensus-vote-recording.ts:178`. `src/cli/vote-command.ts` never imported it, and its only recording path was `recordVoteToGitHub`, which posts a comment when `--issue-number` is supplied: a different artifact, opt-in, and not the chain.

So every decision made through `nexus-agents vote` was absent from the tamper-evident record.

**Measured rather than inferred.** I ran two live panels at a terminal today. Every `vote-records.jsonl` on this machine — the repo-local `.nexus-agents/governance/` store and the cross-repo `~/.nexus-agents/` one — has a last-modified time hours earlier, and a filesystem-wide `find -newermt` for the window returns nothing.

## Why this is the p1 shape and not a missing feature

`verify_audit_chain` reports the chain **intact** across those votes, and it is: contiguous sequence, no `previousHash` breaks. It just does not contain them, and there is no field in which the record could say "some decisions were made outside this chain." Absence renders as completeness — worse than an empty chain, which announces itself.

The gap also silently dropped the per-option instrumentation added in #4472. CLI votes got no `optionTally`, no `optionCoverage`, no `proposalHash` — so a multi-option vote run at a terminal was invisible to the machinery built to record *which option won*.

Not hypothetical: two decisions I acted on today went through this path, and I cited one of them while proposing work.

## Approach

Call the existing `recordAuthenticVote`, not a new writer. It already assembles the record, hashes the proposal, tallies options, skips all-simulated runs, and returns a structured outcome. A second implementation of the audit writer is precisely how the two would drift.

One operator-facing line reports what reached the chain, and a **write failure is stated rather than swallowed**:

```
Audit record #68 written (vote-1756…)
Vote NOT recorded to the audit chain: <actionable detail with the resolved path>
No audit record — votes were simulated
```

The vote must not fail because its record could not be written — that is the store's existing posture — but a decision that left no record must not look like one that did.

**The recorded strategy is the one that was applied.** The CLI narrows `ExtendedVotingResult` to the base view for printing, which drops `strategy`; recording the printed `threshold` instead would have put `supermajority` in the chain for a `higher_order` run. Carried through explicitly, with a test.

## Mutations

| mutation | result |
| --- | --- |
| remove the persist call | 3 failed |
| record the display `threshold` instead of `strategy` | 1 failed |
| drop the dry-run skip | 1 failed |
| collapse `all-simulated` into the failure branch | 1 failed |

The last one is worth a note: it initially **survived**. My assertion was `not.toMatch(/failed/i)`, and the failure line says "NOT recorded to the audit chain" — no "failed" in it. A skipped simulation would have been reported in the same alarming words as an unwritable data dir and the test would not have noticed. Retargeted to `/NOT recorded/i`, which fails.

Full CLI suite: 6814 passed.
