### PR TITLE
fix(ci): give the pricing-drift check a verdict a failure can reach

### DIFF
--- a/.changeset/pricing-drift-verdict.md
+++ b/.changeset/pricing-drift-verdict.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+stop a litellm outage reading as clean pricing
+
+CI-only. The pricing-drift workflow had no failing path. `check-pricing-drift.ts`
+exits 0 on every route and says so, so the exit code carried no signal — and
+the workflow recovered its verdict by scraping `"N field"` out of the report
+prose with a `|| echo "0"` fallback. A catalog fetch failure prints no report,
+so it fell through to that fallback and rendered as zero drift. A provider
+outage and correct pricing produced the same green weekly run.
+
+The script now prints `PRICING_DRIFT_STATUS=clean|drift|skipped` and
+`PRICING_DRIFT_COUNT=<n>` on every terminating path, including the top-level
+error handler, and the workflow defaults the status to `skipped` rather than to
+a measurement. `check-parameter-drift.ts` already had exactly this shape; this
+is the same treatment applied to its sibling.
+
+Two reporting gaps close with it: a skip now emits a loud `::warning::` instead
+of passing silently, and drift of one to five fields — real drift that sat
+below the issue threshold and said nothing at all — is now reported without
+filing an issue.

--- a/.github/workflows/pricing-drift.yml
+++ b/.github/workflows/pricing-drift.yml
@@ -24,13 +24,29 @@ jobs:
         run: |
           OUTPUT=$(pnpm check:pricing-drift 2>&1)
           echo "$OUTPUT"
-          # Extract drift count from output
-          DRIFT=$(echo "$OUTPUT" | grep -oP '(\d+) field' | grep -oP '\d+' || echo "0")
-          echo "drift_count=$DRIFT" >> "$GITHUB_OUTPUT"
+          # Read the script's explicit verdict, not the prose. Scraping
+          # "N field" out of the report meant a fetch failure — which prints no
+          # report at all — fell through to `|| echo 0` and rendered as clean
+          # pricing (#4927). The default is now `skipped`, so an absent verdict
+          # is reported as absent.
+          STATUS=$(echo "$OUTPUT" | grep -oP 'PRICING_DRIFT_STATUS=\K\S+' | tail -1 || echo "skipped")
+          COUNT=$(echo "$OUTPUT" | grep -oP 'PRICING_DRIFT_COUNT=\K\d+' | tail -1 || echo "0")
+          echo "drift_status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "drift_count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "$OUTPUT" > drift-report.txt
 
+      - name: Note a loud skip (catalog fetch failure — NOT "no drift")
+        if: steps.drift.outputs.drift_status == 'skipped'
+        run: |
+          echo "::warning::Pricing-drift check SKIPPED — the litellm catalog fetch failed or the script errored. Not treated as 'no drift'; re-run when the catalog is reachable."
+
+      - name: Note drift below the issue threshold
+        if: steps.drift.outputs.drift_status == 'drift' && steps.drift.outputs.drift_count <= 5
+        run: |
+          echo "::warning::Pricing drift in ${{ steps.drift.outputs.drift_count }} field(s) — below the 5-field issue threshold, so no issue was filed. Real drift, reported rather than dropped."
+
       - name: Create issue if significant drift found
-        if: steps.drift.outputs.drift_count > 5
+        if: steps.drift.outputs.drift_status == 'drift' && steps.drift.outputs.drift_count > 5
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |

--- a/scripts/check-pricing-drift.test.ts
+++ b/scripts/check-pricing-drift.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the pricing-drift script's machine-readable verdict.
+ *
+ * @module scripts/check-pricing-drift.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+const ROOT = join(import.meta.dirname, '..');
+const SCRIPT = readFileSync(join(ROOT, 'scripts/check-pricing-drift.ts'), 'utf8');
+const WORKFLOW = readFileSync(join(ROOT, '.github/workflows/pricing-drift.yml'), 'utf8');
+
+describe('check-pricing-drift emits a verdict on every path (#4927)', () => {
+  // The script exits 0 unconditionally and says so, so the exit code carries
+  // no signal at all. Every terminating path therefore has to print a status,
+  // or the workflow's default fills it in — and the default used to be "0
+  // fields drifted", which is a measurement.
+  const terminatingPaths = [
+    ['catalog fetch failure', 'catalog fetch failed'],
+    ['no drift', 'No drift — our pricing matches litellm'],
+    ['top-level error handler', 'pricing-drift check errored'],
+  ] as const;
+
+  it.each(terminatingPaths)('prints a status on the %s path', (_name, marker) => {
+    const at = SCRIPT.indexOf(marker);
+    expect(at, `marker not found: ${marker}`).toBeGreaterThan(-1);
+    // The status line follows its marker within a few lines on each path.
+    expect(SCRIPT.slice(at, at + 400)).toContain('PRICING_DRIFT_STATUS=');
+  });
+
+  it('reports a fetch failure as skipped, never as clean', () => {
+    const at = SCRIPT.indexOf('catalog fetch failed');
+    expect(SCRIPT.slice(at, at + 400)).toContain('PRICING_DRIFT_STATUS=skipped');
+  });
+
+  it('reports an unexpected error as skipped, never as clean', () => {
+    const at = SCRIPT.indexOf('pricing-drift check errored');
+    expect(SCRIPT.slice(at, at + 400)).toContain('PRICING_DRIFT_STATUS=skipped');
+  });
+});
+
+describe('the pricing-drift workflow consumes the verdict (#4927)', () => {
+  interface Step {
+    readonly name?: string;
+    readonly if?: string;
+    readonly run?: string;
+  }
+  const parsed = parseYaml(WORKFLOW) as { jobs: Record<string, { steps: Step[] }> };
+  const steps: Step[] = parsed.jobs.check?.steps ?? [];
+
+  it('defaults the status to skipped when the script printed none', () => {
+    // The whole point: an absent verdict must not read as a clean one.
+    const check = steps.find((s) => s.name?.startsWith('Check pricing drift') === true);
+    expect(check?.run).toContain(`|| echo "skipped"`);
+  });
+
+  it('warns loudly on a skip', () => {
+    const skip = steps.find((s) => s.if?.includes("drift_status == 'skipped'") === true);
+    expect(skip).toBeDefined();
+    expect(skip?.run).toContain('::warning::');
+  });
+
+  it('files an issue only when drift was actually measured', () => {
+    // Without the status term, a `skipped` run with a defaulted count of 0
+    // and a `drift` run with a real count are the same input to this gate.
+    const create = steps.find((s) => s.name?.startsWith('Create issue') === true);
+    expect(create?.if).toContain("drift_status == 'drift'");
+  });
+
+  it('still reports drift that falls below the issue threshold', () => {
+    // 1-5 drifted fields filed no issue and said nothing at all.
+    const belowThreshold = steps.find((s) => s.if?.includes('drift_count <= 5') === true);
+    expect(belowThreshold?.run).toContain('::warning::');
+  });
+});

--- a/scripts/check-pricing-drift.ts
+++ b/scripts/check-pricing-drift.ts
@@ -3,7 +3,17 @@
  * Cross-check our in-tree-data.ts pricing and context windows against
  * litellm's community-maintained catalog.
  *
- * Non-blocking advisory: prints a diff table and exits 0 regardless.
+ * Non-blocking advisory: prints a diff table and exits 0 regardless. Because
+ * the exit code carries no signal, the machine-readable verdict is on stdout:
+ *
+ *   PRICING_DRIFT_STATUS=clean|drift|skipped
+ *   PRICING_DRIFT_COUNT=<n>
+ *
+ * `skipped` is the load-bearing one. A catalog fetch failure previously exited
+ * 0 with no drift table, which the workflow's `grep … || echo "0"` read as
+ * zero drift — so a litellm outage was indistinguishable from clean pricing
+ * (#4927). Mirrors `check-parameter-drift.ts`, which already had this shape.
+ *
  * Run periodically (e.g. after a model provider price change) or as a
  * pre-release sanity check.
  *
@@ -135,7 +145,10 @@ async function main(): Promise<void> {
     catalog = await fetchLitellmCatalog();
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    console.error(`⚠️  Catalog fetch failed (non-blocking): ${msg}`);
+    console.error(`⚠️  SKIP: litellm catalog fetch failed (non-blocking): ${msg}`);
+    console.error('   A provider outage must not mask real pricing drift. Re-run when reachable.');
+    console.log('PRICING_DRIFT_STATUS=skipped');
+    console.log('PRICING_DRIFT_COUNT=0');
     process.exit(0);
   }
   console.log(`Catalog has ${String(Object.keys(catalog).length)} entries.\n`);
@@ -158,6 +171,8 @@ async function main(): Promise<void> {
 function printReports(allReports: DriftReport[], missing: string[]): void {
   if (allReports.length === 0 && missing.length === 0) {
     console.log('✅ No drift — our pricing matches litellm for all tracked models.');
+    console.log('PRICING_DRIFT_STATUS=clean');
+    console.log('PRICING_DRIFT_COUNT=0');
     return;
   }
 
@@ -180,11 +195,16 @@ function printReports(allReports: DriftReport[], missing: string[]): void {
   console.log(
     'Review and update packages/nexus-agents/src/config/in-tree-data.ts if drift is real.'
   );
-  console.log('Non-blocking: script always exits 0.');
+  console.log('Non-blocking: script always exits 0 — read PRICING_DRIFT_STATUS instead.');
+  console.log(`PRICING_DRIFT_STATUS=${allReports.length === 0 ? 'clean' : 'drift'}`);
+  console.log(`PRICING_DRIFT_COUNT=${String(allReports.length)}`);
 }
 
 main().catch((e: unknown) => {
   const msg = e instanceof Error ? e.message : String(e);
-  console.error(`Script error: ${msg}`);
+  // Even an unexpected error is a LOUD skip, never a silent "clean".
+  console.error(`⚠️  SKIP: pricing-drift check errored (non-blocking): ${msg}`);
+  console.log('PRICING_DRIFT_STATUS=skipped');
+  console.log('PRICING_DRIFT_COUNT=0');
   process.exit(0);
 });


### PR DESCRIPTION
Refs #4927 (finding 1). **`.github/workflows/` is CODEOWNERS-gated — owner ratification required.** Not self-merging.

## The workflow had no failing path

`check-pricing-drift.ts` exits 0 on every route and says so in its own output: `Non-blocking: script always exits 0`. So the exit code carries no signal, and the workflow recovered a verdict by scraping the report prose:

```bash
DRIFT=$(echo "$OUTPUT" | grep -oP '(\d+) field' | grep -oP '\d+' || echo "0")
```

A catalog fetch failure prints **no report**, so there is no `N field` text, so the grep fails, so `|| echo "0"` supplies zero — and the only consumer is `if: drift_count > 5`.

A litellm outage, a schema rename on their side, and genuinely correct pricing all produce the identical green weekly run. That is the reference shape: the failure text lands in the same variable the success signal is read from.

## The sibling already had the answer

`parameter-drift.yml` emits a `PARAM_DRIFT_STATUS` sentinel that **defaults to `skipped`**, and warns loudly when it fires. This is the same treatment applied to pricing:

- The script prints `PRICING_DRIFT_STATUS=clean|drift|skipped` and `PRICING_DRIFT_COUNT=<n>` on **every** terminating path — the fetch-failure branch, the no-drift return, the report path, and the top-level `.catch`.
- The workflow reads those, defaulting the status to `skipped` rather than to a measurement, so an absent verdict is reported as absent.
- The issue gate now requires `drift_status == 'drift'`. Without that term, a skipped run with a defaulted count and a real run with a real count are the same input.

## Two reporting gaps close with it

A skip now emits a `::warning::` instead of passing silently — the point of a sentinel is that someone sees it.

And drift of **1 to 5 fields** now gets a warning. That is real, measured drift which sat below the issue threshold and said nothing at all; the threshold governs whether an issue is filed, not whether the finding is mentioned.

## Tests and mutations

Nine tests: that every terminating path in the script prints a status, that both failure paths print `skipped` specifically (never `clean`), and that the workflow defaults to `skipped`, warns on it, gates the issue on a measured verdict, and reports sub-threshold drift.

| mutation | result |
| --- | --- |
| fetch-failure status line removed | 2 failed |
| catch-handler status line removed | 2 failed |
| workflow default flipped `skipped` → `clean` | 1 failed |
| status term dropped from the issue gate | 1 failed |
| loud-skip step disabled | 2 failed |

## Scope

Seven more findings from the same sweep are in #4927, each independently actionable. I picked this one first because it is the only one where the *entire workflow* has no failing path — the others have a reachable failure somewhere.
