### PR TITLE
fix(config): recognize four documented env vars, and isolate the suite's data dir

### DIFF
--- a/.changeset/test-data-dir-isolation.md
+++ b/.changeset/test-data-dir-isolation.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+recognize NEXUS_DATA_DIR, NEXUS_REPO_PREFERRED, NEXUS_ACCESS_POLICY_MODE and NEXUS_SANDBOX in the env schema
+
+All four are documented in CLAUDE.md's environment table and none were in
+`env-schema.ts`, so `validateNexusEnv` reported them as **unknown** `NEXUS_*`
+variables — offering a typo suggestion for a name spelled correctly. Anyone
+following the documentation to set a runtime data root was told the variable
+did not exist.
+
+Found while stopping the test suite writing to `~/.nexus-agents/`, the real
+cross-repo store holding capability gaps, memory and learning outcomes: test
+runs were putting synthetic tool names and fabricated gaps into the data the
+routing and improvement loops read. The suite now runs against a per-run data
+dir set in `vitest.config.ts`, beside the `TMPDIR` redirect that was already
+there.
+
+A test now cross-checks the documented list against the schema, so the two
+cannot drift apart again, and another asserts the suite's data dir is not the
+real one — the isolation is a single config line, and nothing else would notice
+it being dropped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ Most-used env vars:
 
 Full list in [docs/getting-started/CONFIGURATION.md](./docs/getting-started/CONFIGURATION.md). Install: [INSTALLATION.md](./docs/getting-started/INSTALLATION.md). Sandboxed: [SANDBOXED-USAGE.md](./docs/guides/SANDBOXED-USAGE.md).
 
+Every `NEXUS_*` variable is validated at startup against `config/env-schema.ts`; an unrecognized name is reported as unknown with a typo suggestion. A variable named in this table but missing from that schema is therefore reported as a typo despite being spelled correctly (#4722), so the two lists are cross-checked by a test.
+
 Note: `NEXUS_WORKERS_*` / `NEXUS_WORKFLOW_MAX_PARALLEL` / `NEXUS_TEST_PARALLELISM` / `NEXUS_EVALUATION_MAX_WORKERS` / `NEXUS_EVENTBUS_MAX_HISTORY` / `NEXUS_SWARM_OBSERVER_MAX_EVENTS` were removed in 2.82.0 (#2977 — silent no-ops; consumer wiring never landed); `NEXUS_TEST_TIMEOUT_MS` / `NEXUS_TIMEOUT_CLISIMPLE` / `NEXUS_TIMEOUT_CLICOMPLEX` were removed for the same reason in #4180 (per-complexity CLI timeouts flow through `TIMEOUT_PROFILES`, not env vars).
 
 ---

--- a/docs/getting-started/CONFIGURATION.md
+++ b/docs/getting-started/CONFIGURATION.md
@@ -168,6 +168,14 @@ logging:
 
 All configuration can be overridden with environment variables:
 
+**Every `NEXUS_*` variable is validated at startup** against
+`packages/nexus-agents/src/config/env-schema.ts`. A name the schema does not
+recognize is reported as unknown, with a typo suggestion — including a name
+that is correct and documented here but absent from the schema, which is how
+`NEXUS_DATA_DIR` came to be flagged (#4722). A variable added to this document
+must be added to the schema in the same change, and a test now cross-checks the
+two lists so they cannot drift apart again.
+
 ### Core Variables
 
 | Variable                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                     | Default                   |

--- a/packages/nexus-agents/src/cli/hooks/handlers/handler-utils.test.ts
+++ b/packages/nexus-agents/src/cli/hooks/handlers/handler-utils.test.ts
@@ -41,10 +41,28 @@ describe('handler-utils', () => {
   });
 
   describe('getNexusDataDir', () => {
-    it('should return nexus-agents data directory', () => {
-      const result = getNexusDataDir();
+    it('falls back to the homedir when NEXUS_DATA_DIR is unset', () => {
+      // Asserted with the override explicitly cleared. Without that the test
+      // states the homedir branch while measuring whatever the environment
+      // happens to hold — it failed the moment the suite set NEXUS_DATA_DIR
+      // to isolate itself (#4722).
+      vi.stubEnv('NEXUS_DATA_DIR', undefined);
+      try {
+        expect(getNexusDataDir()).toBe(join(homedir(), '.nexus-agents'));
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    });
 
-      expect(result).toBe(join(homedir(), '.nexus-agents'));
+    it('honors NEXUS_DATA_DIR when it is set', () => {
+      // The pair, and a branch that had no test at all: the override is
+      // documented in CLAUDE.md and nothing pinned that it is read here.
+      vi.stubEnv('NEXUS_DATA_DIR', '/tmp/nexus-override-probe');
+      try {
+        expect(getNexusDataDir()).toBe('/tmp/nexus-override-probe');
+      } finally {
+        vi.unstubAllEnvs();
+      }
     });
   });
 

--- a/packages/nexus-agents/src/cli/setup-data-dir.test.ts
+++ b/packages/nexus-agents/src/cli/setup-data-dir.test.ts
@@ -17,6 +17,7 @@ describe('initDataDirectories (#1249)', () => {
   let dataDirPath: string;
   let originalRepoPreferred: string | undefined;
   let originalGitignoreAuto: string | undefined;
+  let originalDataDir: string | undefined;
 
   beforeEach(async () => {
     // Import after mock is in place
@@ -32,6 +33,12 @@ describe('initDataDirectories (#1249)', () => {
     originalGitignoreAuto = process.env['NEXUS_GITIGNORE_AUTO'];
     process.env['NEXUS_REPO_PREFERRED'] = '0';
     process.env['NEXUS_GITIGNORE_AUTO'] = '0';
+    // These tests exercise the HOMEDIR branch of the resolver, and reach it by
+    // mocking `homedir()`. `NEXUS_DATA_DIR` outranks that branch, so leaving it
+    // set sends every assertion to a directory the mock does not control —
+    // which is why the suite could not isolate itself without this (#4722).
+    originalDataDir = process.env['NEXUS_DATA_DIR'];
+    delete process.env['NEXUS_DATA_DIR'];
   });
 
   afterEach(() => {
@@ -39,6 +46,8 @@ describe('initDataDirectories (#1249)', () => {
     else process.env['NEXUS_REPO_PREFERRED'] = originalRepoPreferred;
     if (originalGitignoreAuto === undefined) delete process.env['NEXUS_GITIGNORE_AUTO'];
     else process.env['NEXUS_GITIGNORE_AUTO'] = originalGitignoreAuto;
+    if (originalDataDir === undefined) delete process.env['NEXUS_DATA_DIR'];
+    else process.env['NEXUS_DATA_DIR'] = originalDataDir;
     if (existsSync(dataDirPath)) {
       rmSync(dataDirPath, { recursive: true, force: true });
     }

--- a/packages/nexus-agents/src/config/config-loader.test.ts
+++ b/packages/nexus-agents/src/config/config-loader.test.ts
@@ -160,6 +160,11 @@ describe('config-loader', () => {
     });
 
     it('falls back to global config in ~/.nexus-agents/ (#1265)', () => {
+      // The homedir branch specifically, so the `NEXUS_DATA_DIR` override has
+      // to be cleared — it outranks homedir, and the test would otherwise
+      // assert one branch while measuring whichever the environment picked
+      // (#4722).
+      vi.stubEnv('NEXUS_DATA_DIR', undefined);
       const home = process.env['HOME'] ?? '/home/test';
       const globalPath = `${home}/.nexus-agents/nexus-agents.yaml`;
       mockExistsSync.mockImplementation((p) => {
@@ -178,6 +183,7 @@ describe('config-loader', () => {
         expect(result.value.configPath).toContain('.nexus-agents');
         expect(result.value.config.models.default).toBe('global-model');
       }
+      vi.unstubAllEnvs();
     });
   });
 

--- a/packages/nexus-agents/src/config/env-schema.test.ts
+++ b/packages/nexus-agents/src/config/env-schema.test.ts
@@ -6,6 +6,12 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { validateNexusEnv, getKnownNexusVarNames } from './env-schema.js';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** Repo root, from `<root>/packages/nexus-agents/src/config/`. */
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
 
 describe('env-schema', () => {
   beforeEach(() => {
@@ -258,5 +264,48 @@ describe('env-schema', () => {
         expect(name).toMatch(/^NEXUS_/);
       }
     });
+  });
+});
+
+// =============================================================================
+// The schema must know every variable the docs tell people to set (#4722)
+// =============================================================================
+
+describe('documented NEXUS_* vars are all in the schema (#4722)', () => {
+  // `NEXUS_DATA_DIR` sat in CLAUDE.md's most-used table and not in this schema,
+  // so setting the documented variable made `validateNexusEnv` report it as an
+  // UNKNOWN var — with a typo suggestion for a name spelled correctly. Three
+  // siblings were missing the same way. Nothing connected the two lists.
+  const CLAUDE_MD = readFileSync(join(REPO_ROOT, 'CLAUDE.md'), 'utf8');
+
+  /** Every `NEXUS_*` name appearing in backticks in CLAUDE.md. */
+  function documentedVars(): string[] {
+    const found = new Set<string>();
+    for (const m of CLAUDE_MD.matchAll(/`(NEXUS_[A-Z0-9_]+)`/g)) {
+      const name = m[1];
+      if (name !== undefined) found.add(name);
+    }
+    return [...found].sort();
+  }
+
+  it('finds the documented list it is checking against', () => {
+    // Guard the guard: a regex that matched nothing would make the assertion
+    // below pass over an empty set, which is the failure this file is about.
+    expect(documentedVars().length).toBeGreaterThan(10);
+  });
+
+  it('recognizes every documented variable', () => {
+    // CLAUDE.md also names variables that were REMOVED (#2977, #4180) and
+    // documents them as removed; those must stay out of the schema.
+    const removed = new Set(
+      documentedVars().filter((v) =>
+        new RegExp(`\`${v}\`[^\\n]*(?:removed|were removed)`, 'i').test(CLAUDE_MD)
+      )
+    );
+    const schemaKeys = new Set(getKnownNexusVarNames());
+
+    const missing = documentedVars().filter((v) => !schemaKeys.has(v) && !removed.has(v));
+
+    expect(missing).toEqual([]);
   });
 });

--- a/packages/nexus-agents/src/config/env-schema.ts
+++ b/packages/nexus-agents/src/config/env-schema.ts
@@ -117,9 +117,21 @@ const NexusEnvSchema = z.object({
   // NEXUS_EVENTBUS_MAX_HISTORY removed in #2977 — silent no-op (no production reader).
   NEXUS_BILLING_MODE: z.enum(['plan', 'api']).optional(),
   NEXUS_CONFIG_PATH: z.string().optional(),
+  // Explicit runtime data root; overrides the per-repo/cross-repo split. In
+  // CLAUDE.md's most-used table since it shipped, and absent from this schema
+  // until #4722 — so setting the documented variable made `validateNexusEnv`
+  // report it as an UNKNOWN NEXUS_* var, typo suggestion and all.
+  NEXUS_DATA_DIR: z.string().optional(),
+  // `0` opts out of the per-repo data dir (epic #2872; default ON).
+  NEXUS_REPO_PREFERRED: z.enum(['0', '1']).optional(),
   // Scratch root for short-lived working files (#4412, getNexusTmpDir). Unset
   // resolves to `<dataDir>/tmp`; set it to relocate scratch off the repo.
   NEXUS_TMPDIR: z.string().optional(),
+  // ClawGuard access-policy mode.
+  NEXUS_ACCESS_POLICY_MODE: z.enum(['off', 'audit', 'confirm_risky', 'enforce']).optional(),
+  // Sandbox mode (epic #2500).
+  NEXUS_SANDBOX: boolStr.optional(),
+  NEXUS_SANDBOX_ROOT: z.string().optional(),
   NEXUS_ALLOW_MOCK_ORCHESTRATION: boolStr.optional(),
   // Explicit opt-in for simulateVotes outside test runners (#4170) — read by
   // checkSimulationAllowed (mcp/tools/simulation-guard.ts). Unset = fail closed.

--- a/packages/nexus-agents/src/consensus/correlation-persistence.test.ts
+++ b/packages/nexus-agents/src/consensus/correlation-persistence.test.ts
@@ -156,9 +156,14 @@ describe('saveCorrelationData and loadCorrelationData', () => {
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join('/tmp', 'nexus-corr-test-'));
     mocks.setTestHomedir(testDir);
+    // Isolation cannot rest on the homedir mock alone: `NEXUS_DATA_DIR`
+    // outranks the homedir branch, so with it set every test in this file
+    // shared one directory and state accumulated across them (#4722).
+    vi.stubEnv('NEXUS_DATA_DIR', path.join(testDir, '.nexus-agents'));
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     if (fs.existsSync(testDir)) {
       fs.rmSync(testDir, { recursive: true });
     }
@@ -353,10 +358,12 @@ describe('createPersistentCorrelationTracker', () => {
 
   beforeEach(() => {
     testDir = fs.mkdtempSync(path.join('/tmp', 'nexus-tracker-test-'));
+    vi.stubEnv('NEXUS_DATA_DIR', path.join(testDir, '.nexus-agents'));
     mocks.setTestHomedir(testDir);
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     if (fs.existsSync(testDir)) {
       fs.rmSync(testDir, { recursive: true });
     }

--- a/packages/nexus-agents/src/mcp/tools/research-auto-catalog-persistence.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-auto-catalog-persistence.test.ts
@@ -53,11 +53,16 @@ let testDir: string;
 beforeEach(() => {
   testDir = fs.mkdtempSync(path.join('/tmp', 'nexus-catalog-test-'));
   mocks.setTestHomedir(testDir);
+  // The homedir mock is not enough on its own: `NEXUS_DATA_DIR` outranks the
+  // homedir branch of the resolver, so with it set every test here shared one
+  // catalog file and entries accumulated across them (#4722).
+  vi.stubEnv('NEXUS_DATA_DIR', path.join(testDir, '.nexus-agents'));
   resetAutoCatalog();
 });
 
 afterEach(() => {
   resetAutoCatalog();
+  vi.unstubAllEnvs();
   if (fs.existsSync(testDir)) {
     fs.rmSync(testDir, { recursive: true });
   }

--- a/packages/nexus-agents/src/testing/data-dir-isolation.test.ts
+++ b/packages/nexus-agents/src/testing/data-dir-isolation.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Asserts the suite is not writing to the developer's real data dir (#4722).
+ *
+ * @module testing/data-dir-isolation.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
+describe('the test run is isolated from the real data dir (#4722)', () => {
+  // Before this, `npx vitest run` wrote to `~/.nexus-agents/` — the real,
+  // homedir-scoped, cross-repo store holding capability gaps, memory and
+  // learning outcomes. Synthetic tool names and fabricated gaps from test runs
+  // landed in the same data the routing and improvement loops read, silently,
+  // outside the repo where `git status` never shows it.
+  //
+  // The isolation lives in `vitest.config.ts` rather than in each module, for
+  // the same reason the CLI spawn guard is a setup file and not a convention:
+  // code reaching a singleton through middleware cannot opt in. Which means
+  // nothing but this test notices if that config line is dropped.
+
+  it('sets NEXUS_DATA_DIR for every worker', () => {
+    expect(process.env['NEXUS_DATA_DIR']).toBeDefined();
+  });
+
+  it('points it somewhere other than the real store', () => {
+    // The assertion that matters. A `NEXUS_DATA_DIR` that happened to resolve
+    // to `~/.nexus-agents` would satisfy the check above and isolate nothing.
+    const dataDir = resolve(process.env['NEXUS_DATA_DIR'] ?? '');
+
+    expect(dataDir).not.toBe(resolve(homedir(), '.nexus-agents'));
+    expect(dataDir.startsWith(resolve(homedir(), '.nexus-agents'))).toBe(false);
+  });
+});

--- a/packages/nexus-agents/src/testing/test-scratch-root.ts
+++ b/packages/nexus-agents/src/testing/test-scratch-root.ts
@@ -30,3 +30,22 @@ export function ensureTestScratchRoot(): string {
   mkdirSync(TEST_SCRATCH_ROOT, { recursive: true });
   return TEST_SCRATCH_ROOT;
 }
+
+/**
+ * A per-run `NEXUS_DATA_DIR` for the suite (#4722).
+ *
+ * Without it the suite writes to `~/.nexus-agents/` — the real, homedir-scoped,
+ * cross-repo store holding capability gaps, memory and learning outcomes. Test
+ * runs put synthetic tool names and fabricated gaps into the same data the
+ * routing and improvement loops read, silently, outside the repo where
+ * `git status` never shows it.
+ *
+ * Per run rather than a fixed path, so state cannot leak between runs — a
+ * shared directory would be the same hazard as the homedir, only narrower.
+ * Lives under the scratch root so the existing reaper (#4413) collects it.
+ */
+export function ensureTestDataDir(): string {
+  const dir = join(TEST_SCRATCH_ROOT, 'data', `run-${String(process.pid)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}

--- a/packages/nexus-agents/vitest.config.ts
+++ b/packages/nexus-agents/vitest.config.ts
@@ -10,7 +10,7 @@
 import { tmpdir } from 'node:os';
 import { defineConfig } from 'vitest/config';
 
-import { ensureTestScratchRoot } from './src/testing/test-scratch-root.js';
+import { ensureTestDataDir, ensureTestScratchRoot } from './src/testing/test-scratch-root.js';
 
 /**
  * Scratch root for the test run (#4412).
@@ -31,6 +31,17 @@ import { ensureTestScratchRoot } from './src/testing/test-scratch-root.js';
  */
 const TEST_TMP = ensureTestScratchRoot();
 
+/**
+ * Runtime data root for the test run (#4722).
+ *
+ * `NEXUS_DATA_DIR` overrides the per-repo/cross-repo split, so setting it here
+ * keeps the suite out of `~/.nexus-agents/` — the real cross-repo governance
+ * and learning store. Isolation belongs in the config rather than in each
+ * module, for the same reason the CLI spawn guard is a setup file rather than
+ * a convention: code reaching a singleton through middleware cannot opt in.
+ */
+const TEST_DATA_DIR = ensureTestDataDir();
+
 export default defineConfig({
   test: {
     // Reap scratch older than a day before the run — see testing/global-setup.ts.
@@ -44,7 +55,12 @@ export default defineConfig({
     // Tests asserting repo-*detection* need a dir with no `.git` ancestor,
     // which TEST_TMP cannot provide. Hand them the real system temp dir; see
     // src/testing/non-repo-temp-dir.ts.
-    env: { TMPDIR: TEST_TMP, NEXUS_TMPDIR: TEST_TMP, VITEST_SYSTEM_TMPDIR: tmpdir() },
+    env: {
+      TMPDIR: TEST_TMP,
+      NEXUS_TMPDIR: TEST_TMP,
+      NEXUS_DATA_DIR: TEST_DATA_DIR,
+      VITEST_SYSTEM_TMPDIR: tmpdir(),
+    },
 
     // Test file patterns
     include: ['src/**/*.test.ts'],


### PR DESCRIPTION
Closes #4722.

## The reported problem

`npx vitest run` wrote to `~/.nexus-agents/` — the real, homedir-scoped, cross-repo store holding capability gaps, memory and learning outcomes. Test runs put synthetic tool names and fabricated gaps into the same data the routing and improvement loops read. Silently, and outside the repo, so `git status` never showed it.

The fix is one line in `vitest.config.ts`, beside the `TMPDIR` redirect that was already there. Config-level for the same reason the CLI spawn guard is a setup file and not a convention: code reaching a singleton through middleware cannot opt in. Per-run rather than a fixed path, since a shared directory is the same state-leaking hazard as the homedir, only narrower; it sits under the scratch root so the existing reaper collects it.

## The issue asked me to measure first, and the measurement was the interesting part

Its own suggested first step was *"measure how many tests change behaviour under an isolated dir before committing to the approach — if the answer is many, that is itself a finding about hidden coupling to developer-local state."*

**Thirteen tests across four files.** All the same shape: they isolate by mocking `homedir()`, which only works while the data dir is homedir-derived. `NEXUS_DATA_DIR` outranks that branch.

Which means — and this is the part that outlives the test-hygiene fix — **those tests already fail on `main` today for anyone who sets `NEXUS_DATA_DIR`.** Verified directly, no changes of mine:

```
main, no env:                    63 passed
main, NEXUS_DATA_DIR=/tmp/probe: 13 failed | 43 passed
```

A documented, first-class environment variable breaks the suite. They now isolate via `NEXUS_DATA_DIR` itself, so they no longer depend on which branch the resolver takes.

## And the variable was not in the schema at all

The full-suite run surfaced `env-schema.test.ts` failing with `expected [ { name: 'NEXUS_DATA_DIR' } ] to have length 0`. `validateNexusEnv` classified it as an **unknown** `NEXUS_*` var — a typo suggestion, for a name spelled correctly, taken from CLAUDE.md's own table.

Checking the rest of that table found four missing: `NEXUS_DATA_DIR`, `NEXUS_REPO_PREFERRED`, `NEXUS_ACCESS_POLICY_MODE`, `NEXUS_SANDBOX`. Its sibling `NEXUS_TMPDIR` was there, which is what makes the omission look accidental rather than deliberate.

## Three ratchets, because each fix is one deletable line

| test | catches |
| --- | --- |
| documented vars ⊆ schema | the docs and the schema drifting apart again |
| `NEXUS_DATA_DIR` is set for every worker | the config line being dropped |
| …and does not resolve under `~/.nexus-agents` | a value that satisfies the above and isolates nothing |

The first excludes variables CLAUDE.md documents *as removed* (#2977, #4180) and carries a guard-the-guard assertion, since a scan matching nothing would pass over an empty set — the exact failure this file is about.

## Verification

| | |
| --- | --- |
| full suite | **28,475 passed**, 1 failed → 0 after the last fix |
| writes to `~/.nexus-agents/` during the run | **none** (`find -newer` over the window) |
| drop `NEXUS_DATA_DIR` from the config | isolation test fails |
| drop `NEXUS_DATA_DIR` from the schema | 8 tests fail |
| make the docs scan match nothing | guard-the-guard fails |

One process note: I lost the ratchet test once to a `git checkout -- <file>` used to undo a mutation, which reverted the real work alongside it. Restored from the same source; recording it because it is a trap I have hit before.
