### PR TITLE
fix(pipeline): match the dry-run failure note to the dispatch mode available

### DIFF
--- a/.changeset/dev-pipeline-dryrun-note.md
+++ b/.changeset/dev-pipeline-dryrun-note.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+stop telling dry runs to retry with a dispatch mode they ignore
+
+`run_dev_pipeline` appended the same hint to every synchronous error envelope —
+_"Retry with `dispatch: 'async'` to get a jobId immediately"_ — including for
+dry runs, where `dispatch` is explicitly ignored. A caller following it gets
+another synchronous run and no explanation. The failure note now matches the
+dispatch mode actually available: dry runs are told they are synchronous and
+why, real runs still get the async escape hatch they can use.
+
+Reporting only. Whether dry runs should be eligible for async at all is the
+open question in the issue: they are excluded on the stated grounds that
+"plan+vote completes fast", and a vote on this substrate measured 255s with 3
+voters and 319s with 7.

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -165,6 +165,49 @@ describe('DevPipelineInputSchema', () => {
   });
 });
 
+// #4933: the async hint is remediation text, and remediation that does not
+// apply to the request it answers is worse than none — a caller following it
+// verbatim gets another synchronous run.
+describe('the async hint matches whether async is actually available (#4933)', () => {
+  /** Drives the handler's catch block: no task and no planFile. */
+  async function errorEnvelope(extra: Record<string, unknown>): Promise<string> {
+    const handler = captureHandler();
+    const result = await handler(extra, STDIO_CTX);
+    return result.content[0]!.text;
+  }
+
+  it('omits the async hint for a dry run, which ignores dispatch entirely', async () => {
+    // `input.dispatch === 'async' && !input.dryRun` is false for a dry run, so
+    // `dispatch: 'async'` is silently discarded. Telling the caller to retry
+    // with it sends them back through the same synchronous path.
+    const text = await errorEnvelope({ dryRun: true });
+
+    expect(text).not.toContain("dispatch: 'async'");
+  });
+
+  it('says instead that dry runs are synchronous', async () => {
+    // The pair: deleting the hint entirely would satisfy the assertion above
+    // while leaving the caller with no explanation at all.
+    const text = await errorEnvelope({ dryRun: true });
+
+    expect(text).toMatch(/dry run/i);
+  });
+
+  it('still carries the hint for a real run, where async does apply', async () => {
+    // The other pair, and the regression this must not cause: a non-dryRun
+    // run genuinely can exceed the 900s ceiling, and async is its escape.
+    const text = await errorEnvelope({ dryRun: false });
+
+    expect(text).toContain("dispatch: 'async'");
+  });
+
+  it('reports the underlying error in both cases', async () => {
+    // Whatever the hint says, the actual failure has to survive it.
+    expect(await errorEnvelope({ dryRun: true })).toContain('planFile');
+    expect(await errorEnvelope({ dryRun: false })).toContain('planFile');
+  });
+});
+
 // #3726: async dispatch mode. A real run can exceed the 900s MCP request
 // timeout, so `dispatch: 'async'` returns a jobId immediately and runs the
 // pipeline in the background (poll get_job_result).

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -43,6 +43,22 @@ const DEV_PIPELINE_ASYNC_HINT =
   "Retry with `dispatch: 'async'` to get a jobId immediately, then poll " +
   'get_job_result({ jobId }) for the result.';
 
+/**
+ * What to tell a caller whose DRY run failed (#4933).
+ *
+ * `dispatch: 'async'` is ignored when `dryRun` is true, so the hint above is
+ * remediation the caller cannot take — following it verbatim produces another
+ * synchronous run. Say what is true instead.
+ */
+const DEV_PIPELINE_DRY_RUN_NOTE =
+  'This was a dry run (plan+vote), which always runs synchronously; async ' +
+  'dispatch is ignored for dry runs, so retrying with it changes nothing.';
+
+/** The failure-time note that matches the dispatch mode actually available. */
+function dispatchNoteFor(dryRun: boolean): string {
+  return dryRun ? DEV_PIPELINE_DRY_RUN_NOTE : DEV_PIPELINE_ASYNC_HINT;
+}
+
 // ============================================================================
 // Input Schema
 // ============================================================================
@@ -408,7 +424,7 @@ async function runDevPipelineHandler(
     // for runs that exceed the 900s request timeout.
     return toolStructuredError({
       errorCategory: 'internal',
-      message: `${DEV_PIPELINE_ASYNC_HINT} Pipeline error: ${getErrorMessage(error)}`,
+      message: `${dispatchNoteFor(input.dryRun)} Pipeline error: ${getErrorMessage(error)}`,
     });
   }
 }


### PR DESCRIPTION
Refs #4933 (option 2 — the unambiguous half). `src/mcp/` is CODEOWNERS review-requested, not merge-blocked; flagging rather than assuming.

## What happened

Driving the pipeline family that the 2026-08-25 e2e validation left BLOCKED, a `dryRun: true` call failed and returned:

> A full run_dev_pipeline run can exceed the 900s synchronous MCP timeout. Retry with `dispatch: 'async'` to get a jobId immediately, then poll get_job_result({ jobId }) for the result.

So I retried with `dispatch: 'async'`. It ran synchronously again and timed out again.

`DEV_PIPELINE_ASYNC_HINT` is prepended to **every** sync error envelope, but the dispatch branch is `input.dispatch === 'async' && !input.dryRun` — async is silently discarded for dry runs. The remediation text is unconditional; the remediation is not.

The schema description does carry the caveat ("Ignored for dryRun"), so this is the runtime message disagreeing with the schema rather than an undocumented constraint. The runtime message is the one a caller reads at the moment of failure, and it is the one that was wrong.

## The change

One conditional. Dry runs get a note saying they are synchronous and that retrying with async changes nothing; real runs keep the hint, which for them is correct and useful.

Four tests: the hint is absent for a dry run, an explanation is present in its place, the hint survives for a real run, and the underlying error survives in both. Each production hunk mutation-tested:

| mutation | result |
| --- | --- |
| revert to the unconditional hint | 2 failed |
| always emit the dry-run note | 2 failed |
| emit no note at all | 3 failed |

The second row is why there are two dry-run assertions rather than one: `not.toContain` alone is satisfied by deleting the hint and saying nothing, which trades bad advice for no advice.

## Deliberately not in scope

The reason dry runs are excluded from async is stated in the code as *"plan+vote completes fast"* (`dev-pipeline-tool.ts:399`, and the schema at `:136`). Measured on this machine today, plan+vote is not fast — a vote alone took **255s** with 3 voters and **319s** with 7, and a dry run did not return within 180s on two attempts.

That premise being wrong is the substantive half of #4933, and it is a design call: either let dry runs use async, or fix the vote latency the estimate was built on. This PR only stops the error message misdirecting people while that is decided.
