### PR TITLE
fix(routing): separate the expected warm-start skip from a regressed one

### DIFF
--- a/.changeset/warmstart-skip-partition.md
+++ b/.changeset/warmstart-skip-partition.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+stop the warm-start skip warning burying real regressions under an expected one
+
+`skippedByArm` was added so an arm that should have warm-started and did not
+would be visible — `api:*` arms had been discarding their entire history
+silently. It then also reported `'unknown'`, the deliberate sentinel for
+outcomes whose executing CLI cannot be resolved, which can never warm-start by
+design and appears on every run. A live run logged
+`skippedByArm: {"unknown": 210}` against 3,488 replayed.
+
+So a genuinely regressed arm would have rendered exactly like a warning
+operators had been trained by repetition to skip past. The two are now
+separated: an unmatched arm-shaped id still warns, the unattributed bucket is
+counted and logged at debug. An empty `skippedByArm` again means what the field
+was built to mean — every arm with history warm-started.
+
+The count is kept rather than filtered away; its volume says how much execution
+cannot be attributed to a CLI, which is worth seeing somewhere.
+
+Which bucket warrants which level is now a pure function, so the level is
+assertable without mocking the module logger.

--- a/packages/nexus-agents/src/cli-adapters/linucb-bandit.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/linucb-bandit.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { LinUCBBandit, createLinUCBBandit } from './linucb-bandit.js';
+import { partitionWarmStartSkips, warmStartSkipLogs } from './warm-start-skips.js';
 import type { BanditContext } from './budget-router-types.js';
 
 describe('LinUCBBandit', () => {
@@ -378,6 +379,81 @@ describe('LinUCBBandit', () => {
     it('should return 0 for empty outcomes', () => {
       const bandit = new LinUCBBandit(armNames);
       expect(bandit.warmStart([])).toBe(0);
+    });
+  });
+
+  describe('warm-start skip partitioning (#4904)', () => {
+    // `skippedByArm` was added by #4400 to surface an arm that SHOULD have
+    // warm-started and did not — `api:*` arms were discarding their whole
+    // history silently. It then also reported `'unknown'`, which can never
+    // warm-start by design and appears on every run, so a real regression
+    // rendered identically to a line printed 210 times in a live run.
+
+    it('keeps an unmatched arm-shaped id in byArm, where the warning reads it', () => {
+      const skips = partitionWarmStartSkips(new Map([['api:anthropic', 12]]));
+
+      expect(skips.byArm).toEqual({ 'api:anthropic': 12 });
+      expect(skips.unattributed).toBe(0);
+    });
+
+    it('moves the unattributed bucket out of byArm', () => {
+      const skips = partitionWarmStartSkips(new Map([['unknown', 210]]));
+
+      expect(skips.byArm).toEqual({});
+      expect(skips.unattributed).toBe(210);
+    });
+
+    it('separates the two when both are present', () => {
+      // The case that matters: a regression arriving alongside the permanent
+      // bucket must still leave byArm non-empty.
+      const skips = partitionWarmStartSkips(
+        new Map([
+          ['unknown', 210],
+          ['api:openai', 3],
+        ])
+      );
+
+      expect(skips.byArm).toEqual({ 'api:openai': 3 });
+      expect(skips.unattributed).toBe(210);
+    });
+
+    it('does not discard the unattributed count', () => {
+      // Filtering `'unknown'` away entirely would also make byArm empty and
+      // pass every assertion above. Its volume is a real signal about how much
+      // execution cannot be attributed to a CLI.
+      expect(partitionWarmStartSkips(new Map([['unknown', 7]])).unattributed).toBe(7);
+    });
+
+    it('warns for an unmatched arm and only debugs the unattributed bucket', () => {
+      // The level is the fix. Both buckets logged at `warn` is what made a
+      // real regression indistinguishable from the line printed every run.
+      const lines = warmStartSkipLogs({ byArm: { 'api:openai': 3 }, unattributed: 210 }, 3488, [
+        'claude',
+      ]);
+
+      expect(lines.map((l) => l.level)).toEqual(['warn', 'debug']);
+    });
+
+    it('still emits the unattributed count somewhere', () => {
+      // Computing it and never logging it would be the same defect one layer
+      // down: recorded, and never read.
+      const lines = warmStartSkipLogs({ byArm: {}, unattributed: 210 }, 3488, ['claude']);
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0]?.context['skippedUnattributed']).toBe(210);
+    });
+
+    it('emits nothing at all when nothing was skipped', () => {
+      expect(warmStartSkipLogs({ byArm: {}, unattributed: 0 }, 10, ['claude'])).toEqual([]);
+    });
+
+    it('reports nothing for a clean warm-start', () => {
+      // The empty case, stated: an empty byArm has to mean "every arm with
+      // history warm-started", which is the whole point of the field.
+      const skips = partitionWarmStartSkips(new Map());
+
+      expect(skips.byArm).toEqual({});
+      expect(skips.unattributed).toBe(0);
     });
   });
 

--- a/packages/nexus-agents/src/cli-adapters/linucb-bandit.ts
+++ b/packages/nexus-agents/src/cli-adapters/linucb-bandit.ts
@@ -11,6 +11,7 @@
 import type { BanditContext, LinUCBConfig } from './budget-router-types.js';
 import { DEFAULT_LINUCB_CONFIG, LinUCBConfigSchema } from './budget-router-types.js';
 import { createLogger } from '../core/index.js';
+import { partitionWarmStartSkips, warmStartSkipLogs } from './warm-start-skips.js';
 import type { TaskOutcome } from '../orchestration/outcomes/outcome-types.js';
 import {
   createIdentityMatrix,
@@ -328,12 +329,13 @@ export class LinUCBBandit {
       this.recordWarmStartModelStat(outcome.cli, outcome.model, outcome.success);
       replayed++;
     }
-    if (skippedArms.size > 0) {
-      logger.warn('Warm-start skipped outcomes for arms this bandit does not have', {
-        skippedByArm: Object.fromEntries(skippedArms),
-        replayed,
-        knownArms: this.armNames,
-      });
+    for (const line of warmStartSkipLogs(
+      partitionWarmStartSkips(skippedArms),
+      replayed,
+      this.armNames
+    )) {
+      if (line.level === 'warn') logger.warn(line.message, line.context);
+      else logger.debug(line.message, line.context);
     }
     return replayed;
   }

--- a/packages/nexus-agents/src/cli-adapters/warm-start-skips.ts
+++ b/packages/nexus-agents/src/cli-adapters/warm-start-skips.ts
@@ -1,0 +1,83 @@
+/**
+ * What a warm-start reports about the outcomes it could not replay (#4904).
+ *
+ * Its own module so the reporting decision is a pure function: the choice of
+ * WHICH skips warrant a warning is the thing that was wrong, and testing it
+ * through a module-level logger would mean mocking `createLogger` wholesale.
+ *
+ * @module cli-adapters/warm-start-skips
+ */
+
+/**
+ * The arm id recorded when an outcome's executing CLI cannot be resolved
+ * (#3624). It is not an arm and can never warm-start, by design.
+ */
+const UNATTRIBUTED_ARM = 'unknown';
+
+/** A warm-start's skipped outcomes, split by whether the skip is expected. */
+export interface WarmStartSkips {
+  /** Arm-shaped ids that failed to match — the case worth warning about. */
+  readonly byArm: Readonly<Record<string, number>>;
+  /** Outcomes with no resolvable CLI. Expected, and counted rather than dropped. */
+  readonly unattributed: number;
+}
+
+/** One log line a warm-start wants emitted, with the level it warrants. */
+export interface WarmStartSkipLog {
+  readonly level: 'warn' | 'debug';
+  readonly message: string;
+  readonly context: Record<string, unknown>;
+}
+
+/**
+ * Separate the skip that means something from the skip that always happens.
+ *
+ * `skippedByArm` exists to surface an arm that SHOULD have warm-started and did
+ * not — #4400 added it after `api:*` arms silently discarded their whole
+ * history. Reporting the permanent, by-design `'unknown'` bucket in the same
+ * field made a regression render identically to a line printed on every run,
+ * which dilutes the signal rather than raising it (#4904).
+ *
+ * The unattributed count is kept, not filtered away: its volume says how much
+ * execution cannot be attributed to a CLI, which is worth seeing.
+ */
+export function partitionWarmStartSkips(skipped: ReadonlyMap<string, number>): WarmStartSkips {
+  const byArm: Record<string, number> = {};
+  let unattributed = 0;
+  for (const [arm, count] of skipped) {
+    if (arm === UNATTRIBUTED_ARM) unattributed += count;
+    else byArm[arm] = count;
+  }
+  return { byArm, unattributed };
+}
+
+/**
+ * The log lines a warm-start should emit for its skips.
+ *
+ * Returned rather than logged so the level attached to each bucket is
+ * assertable. An unmatched arm is a `warn`; the unattributed bucket is a
+ * `debug`, because warning about something that happens on every run is what
+ * taught operators to skip past the field that reports real regressions.
+ */
+export function warmStartSkipLogs(
+  skips: WarmStartSkips,
+  replayed: number,
+  knownArms: readonly string[]
+): readonly WarmStartSkipLog[] {
+  const lines: WarmStartSkipLog[] = [];
+  if (Object.keys(skips.byArm).length > 0) {
+    lines.push({
+      level: 'warn',
+      message: 'Warm-start skipped outcomes for arms this bandit does not have',
+      context: { skippedByArm: skips.byArm, replayed, knownArms },
+    });
+  }
+  if (skips.unattributed > 0) {
+    lines.push({
+      level: 'debug',
+      message: 'Warm-start skipped outcomes with no resolvable CLI',
+      context: { skippedUnattributed: skips.unattributed, replayed },
+    });
+  }
+  return lines;
+}


### PR DESCRIPTION
Closes #4904. Found in the logs of a live `nexus-agents vote --quick` during the 2026-08-25 e2e validation, not by reading code.

## Observed

```
warn  Warm-start skipped outcomes for arms this bandit does not have
      skippedByArm: {"unknown": 210}
      replayed: 3488
      knownArms: ["claude","gemini","codex","opencode"]
```

## Why this is a reporting defect, not a data defect

`'unknown'` is deliberate (#3624): outcomes whose executing CLI cannot be resolved are recorded as `'unknown'` rather than fabricated. `warmStart` matching arms by name and skipping it is **correct**.

The problem is what the field was for. #4400 added `skippedByArm` for the opposite case, and its own docstring says why:

> that skip used to be entirely silent, which hid a real defect: `api:*` arms could not be represented in `TaskOutcome.cli` at all, so every API arm discarded its whole history and began cold each process with nothing reported.

So the field exists to surface **an arm that should have warm-started and did not** — and it was also reporting an entry that can never warm-start by design, on every run, in the same shape.

If `api:anthropic` regressed and started appearing there, it would render exactly like a `warn` operators have been trained by repetition to ignore. 210 of 3,698 records is modest noise today, but it is unconditional and grows with history.

## The change

An unmatched arm-shaped id still warns. The unattributed bucket is counted and logged at **debug**. An empty `skippedByArm` again means what the field was built to mean.

The count is kept rather than filtered away — its volume says how much execution cannot be attributed to a CLI, and dropping it would be the same defect one layer down.

## Why a separate module

Both the partition and the *level* each bucket warrants are now pure functions in `warm-start-skips.ts`. The level is the actual fix, and asserting it through a module-level `logger` would mean mocking `createLogger` wholesale. Returning the log lines makes it directly testable — and gives the export a real cross-file consumer, which the producer/consumer ratchet correctly demands.

## Mutations

| mutation | result |
| --- | --- |
| no partition (restore old behaviour) | 3 failed |
| filter `'unknown'` away instead of counting it | 3 failed |
| drop the debug line entirely | 2 failed |
| log the unattributed bucket at `warn` again | 1 failed |

The second and third rows are the ones I wanted covered: filtering the bucket out would empty `skippedByArm` and satisfy every assertion about the warning, while quietly discarding a real signal; computing the count and never emitting it is the same thing one step later.
