### PR TITLE
fix(collaboration): count the token contributions the Aegean protocol could not measure

### DIFF
--- a/.changeset/aegean-unmeasured-tokens.md
+++ b/.changeset/aegean-unmeasured-tokens.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+stop the Aegean protocol reporting a partly-blind token total as a measurement
+
+`aegean-protocol.ts` read `metadata.tokensUsed` from every proposal and vote and
+never consulted `metadata.tokensMeasured`, which `ResultMetadata` has carried
+since #4734. A contributor whose adapter reported no usage therefore added `0`
+to the round total, and the total could not say how many of its contributors
+were silent — an under-count, which for anything cap-shaped is the dangerous
+direction.
+
+The placeholder now stays out of the sum and is counted instead, so
+`tokensUsed` is a total of measurements and `unmeasuredTokenContributions`
+says how far short of complete it is. Downstream, `buildSessionTaskResult`
+turns a non-zero count into `tokensMeasured: false` on the `TaskResult` it
+submits — the disclosure the rest of the tree already reads, rather than a new
+field only this module understands.
+
+A vote that timed out or whose agent was missing still contributes zero by a
+different route — nothing executed — and is deliberately not counted as
+unmeasured.

--- a/packages/nexus-agents/src/agents/collaboration/aegean-helpers.test.ts
+++ b/packages/nexus-agents/src/agents/collaboration/aegean-helpers.test.ts
@@ -16,6 +16,7 @@ import type { CollaborationConfig } from './collaboration-types.js';
 import {
   buildAegeanConfig,
   buildAegeanResult,
+  tokensFromMetadata,
   createRoundData,
   determineIterationAction,
   determinePreRoundAction,
@@ -134,6 +135,7 @@ describe('buildAegeanResult', () => {
       terminationReason: 'consensus',
       startTime: 1000,
       tokensUsed: 500,
+      unmeasuredTokenContributions: 0,
     });
 
     expect(result.consensusReached).toBe(true);
@@ -151,6 +153,7 @@ describe('buildAegeanResult', () => {
       terminationReason: 'max_rounds',
       startTime: 500,
       tokensUsed: 1000,
+      unmeasuredTokenContributions: 0,
     });
 
     expect(result.consensusReached).toBe(false);
@@ -287,14 +290,14 @@ describe('determineIterationAction', () => {
 
 describe('determinePreRoundAction', () => {
   it('returns result when cancelled', () => {
-    const result = determinePreRoundAction(true, [], 1000, 200);
+    const result = determinePreRoundAction(true, [], 1000, 200, 0);
     expect(result).not.toBeNull();
     expect(result?.terminationReason).toBe('error');
     expect(result?.consensusReached).toBe(false);
   });
 
   it('returns null when not cancelled', () => {
-    const result = determinePreRoundAction(false, [makeRound()], 1000, 200);
+    const result = determinePreRoundAction(false, [makeRound()], 1000, 200, 0);
     expect(result).toBeNull();
   });
 });
@@ -306,7 +309,7 @@ describe('determinePreRoundAction', () => {
 describe('createIterationContext', () => {
   it('creates context with provided values', () => {
     const rounds = [makeRound()];
-    const ctx = createIterationContext(rounds, 1000, 500);
+    const ctx = createIterationContext(rounds, 1000, 500, 0);
     expect(ctx.rounds).toBe(rounds);
     expect(ctx.startTime).toBe(1000);
     expect(ctx.tokensUsed).toBe(500);
@@ -319,7 +322,12 @@ describe('createIterationContext', () => {
 
 describe('processIterationAction', () => {
   const emitEvent = vi.fn();
-  const ctx = { rounds: [makeRound()], startTime: 1000, tokensUsed: 300 };
+  const ctx = {
+    rounds: [makeRound()],
+    startTime: 1000,
+    tokensUsed: 300,
+    unmeasuredTokenContributions: 0,
+  };
 
   it('returns result for consensus action', () => {
     const result = processIterationAction({
@@ -386,7 +394,14 @@ describe('processIterationAction', () => {
 describe('buildLoopResult', () => {
   it('delegates to buildAegeanResult', () => {
     const rounds = [makeRound()];
-    const result = buildLoopResult(rounds, 'final', 'consensus', 1000, 400);
+    const result = buildLoopResult({
+      rounds,
+      consensusValue: 'final',
+      terminationReason: 'consensus',
+      startTime: 1000,
+      tokensUsed: 400,
+      unmeasuredTokenContributions: 0,
+    });
     expect(result.consensusReached).toBe(true);
     expect(result.consensusValue).toBe('final');
     expect(result.totalRounds).toBe(1);
@@ -480,6 +495,7 @@ describe('buildSessionTaskResult', () => {
       totalRounds: 3,
       totalDurationMs: 5000,
       tokensUsed: 1200,
+      unmeasuredTokenContributions: 0,
       rounds: [],
       terminationReason: 'consensus',
     };
@@ -496,5 +512,110 @@ describe('buildSessionTaskResult', () => {
     expect(taskResult.metadata.model).toBe('aegean-protocol');
     expect(taskResult.metadata.tokensUsed).toBe(1200);
     expect(taskResult.metadata.durationMs).toBe(1000); // 2000 - 1000
+  });
+});
+
+// ============================================================================
+// tokensFromMetadata (#4743)
+// ============================================================================
+
+describe('tokensFromMetadata (#4743)', () => {
+  it('passes a measured figure through and counts nothing', () => {
+    expect(tokensFromMetadata({ tokensUsed: 1200, tokensMeasured: true })).toEqual({
+      tokens: 1200,
+      unmeasured: 0,
+    });
+  });
+
+  it('treats an absent flag as measured — only an explicit false is a disclosure', () => {
+    // `tokensMeasured` is optional (#4734); absence is the pre-existing shape
+    // and must not be read as "unmeasured", or every legacy adapter would
+    // suddenly count as silent.
+    expect(tokensFromMetadata({ tokensUsed: 900 })).toEqual({ tokens: 900, unmeasured: 0 });
+  });
+
+  it('contributes zero and counts one when the adapter reported no usage', () => {
+    // The placeholder must not enter the sum: adding it under-counts, and
+    // under-counting is the dangerous direction for anything cap-shaped.
+    expect(tokensFromMetadata({ tokensUsed: 0, tokensMeasured: false })).toEqual({
+      tokens: 0,
+      unmeasured: 1,
+    });
+  });
+
+  it('drops a non-zero placeholder rather than summing it', () => {
+    // `tokensUsed` is meaningless when `tokensMeasured` is false, whatever it
+    // holds — a stale or default value must not reach the total.
+    expect(tokensFromMetadata({ tokensUsed: 4321, tokensMeasured: false })).toEqual({
+      tokens: 0,
+      unmeasured: 1,
+    });
+  });
+});
+
+// ============================================================================
+// buildAegeanResult carries the unmeasured count (#4743)
+// ============================================================================
+
+describe('buildAegeanResult unmeasured disclosure (#4743)', () => {
+  const base = {
+    rounds: [],
+    consensusValue: null,
+    terminationReason: 'max_rounds' as const,
+    startTime: 0,
+  };
+
+  it('reports the count so the total reads as a lower bound', () => {
+    const result = buildAegeanResult({ ...base, tokensUsed: 500, unmeasuredTokenContributions: 3 });
+
+    expect(result.unmeasuredTokenContributions).toBe(3);
+  });
+
+  it('does not silently zero a real count', () => {
+    // The pair for the default above: `?? 0` applied to a supplied value would
+    // satisfy the default test while discarding every measurement.
+    expect(
+      buildAegeanResult({ ...base, tokensUsed: 0, unmeasuredTokenContributions: 7 })
+        .unmeasuredTokenContributions
+    ).toBe(7);
+  });
+});
+
+// ============================================================================
+// The count becomes a tokensMeasured disclosure downstream (#4743)
+// ============================================================================
+
+describe('buildSessionTaskResult token disclosure (#4743)', () => {
+  function aegeanResult(tokensUsed: number, unmeasured: number): AegeanResult {
+    return {
+      consensusValue: 'x',
+      consensusReached: true,
+      totalRounds: 1,
+      totalDurationMs: 10,
+      tokensUsed,
+      unmeasuredTokenContributions: unmeasured,
+      rounds: [],
+      terminationReason: 'consensus',
+    };
+  }
+
+  it('marks the total unmeasured when any contributor reported nothing', () => {
+    // This is where the count has to land: `ResultMetadata.tokensMeasured` is
+    // the disclosure the rest of the tree already reads (#4734). Without it the
+    // count would stop at a type nothing downstream consults.
+    const task = buildSessionTaskResult('t1', aegeanResult(500, 2), 0);
+
+    expect(task.metadata.tokensMeasured).toBe(false);
+  });
+
+  it('marks it measured when every contributor reported', () => {
+    // The pair: always-false would make every aegean total look untrustworthy.
+    const task = buildSessionTaskResult('t1', aegeanResult(500, 0), 0);
+
+    expect(task.metadata.tokensMeasured).toBe(true);
+  });
+
+  it('still passes the total through either way', () => {
+    expect(buildSessionTaskResult('t1', aegeanResult(500, 2), 0).metadata.tokensUsed).toBe(500);
   });
 });

--- a/packages/nexus-agents/src/agents/collaboration/aegean-helpers.ts
+++ b/packages/nexus-agents/src/agents/collaboration/aegean-helpers.ts
@@ -78,6 +78,35 @@ export interface BuildResultOptions {
   readonly terminationReason: AegeanResult['terminationReason'];
   readonly startTime: number;
   readonly tokensUsed: number;
+  /**
+   * How many contributors reported no usage (#4743).
+   *
+   * Required, not defaulted: this type has five call sites and an optional
+   * field let four of them silently omit it, so the count reached only the
+   * least-common exit path. The compiler names them instead.
+   */
+  readonly unmeasuredTokenContributions: number;
+}
+
+/**
+ * The token figure from a result's metadata, and whether it was a measurement.
+ *
+ * `ResultMetadata.tokensMeasured === false` means the adapter reported no
+ * usage, so `tokensUsed` is a placeholder rather than a count (#4734). Summing
+ * it as `0` is an UNDER-count, which for anything cap-shaped is the dangerous
+ * direction — so the placeholder contributes nothing to the total and is
+ * counted separately, letting the total be read as a lower bound (#4743).
+ *
+ * Scope: this counts contributions the adapter declared unmeasured. A vote that
+ * timed out or whose agent was missing contributes zero by a different route —
+ * no execution to measure — and is not counted here.
+ */
+export function tokensFromMetadata(metadata: {
+  readonly tokensUsed: number;
+  readonly tokensMeasured?: boolean | undefined;
+}): { readonly tokens: number; readonly unmeasured: number } {
+  if (metadata.tokensMeasured === false) return { tokens: 0, unmeasured: 1 };
+  return { tokens: metadata.tokensUsed, unmeasured: 0 };
 }
 
 /** Builds the final Aegean result. */
@@ -88,6 +117,7 @@ export function buildAegeanResult(opts: BuildResultOptions): AegeanResult {
     totalRounds: opts.rounds.length,
     totalDurationMs: getTimeProvider().now() - opts.startTime,
     tokensUsed: opts.tokensUsed,
+    unmeasuredTokenContributions: opts.unmeasuredTokenContributions,
     rounds: opts.rounds,
     terminationReason: opts.terminationReason,
   };
@@ -159,7 +189,8 @@ export function determinePreRoundAction(
   cancelled: boolean,
   rounds: readonly AegeanRound[],
   startTime: number,
-  tokensUsed: number
+  tokensUsed: number,
+  unmeasuredTokenContributions: number
 ): AegeanResult | null {
   if (cancelled) {
     return buildAegeanResult({
@@ -168,6 +199,7 @@ export function determinePreRoundAction(
       terminationReason: 'error',
       startTime,
       tokensUsed,
+      unmeasuredTokenContributions,
     });
   }
   return null;
@@ -178,15 +210,20 @@ export interface IterationContext {
   readonly rounds: readonly AegeanRound[];
   readonly startTime: number;
   readonly tokensUsed: number;
+  /** Carried beside the total so every exit path reports it (#4743). */
+  readonly unmeasuredTokenContributions: number;
 }
 
 /** Creates context object for iteration handling. */
 export function createIterationContext(
   rounds: readonly AegeanRound[],
   startTime: number,
-  totalTokensUsed: number
+  totalTokensUsed: number,
+  // Required, like the field it feeds: a default here is what let the protocol
+  // omit the count and report every round as fully measured (#4743).
+  unmeasuredTokenContributions: number
 ): IterationContext {
-  return { rounds, startTime, tokensUsed: totalTokensUsed };
+  return { rounds, startTime, tokensUsed: totalTokensUsed, unmeasuredTokenContributions };
 }
 
 // =============================================================================
@@ -221,6 +258,7 @@ export function processIterationAction(opts: ProcessIterationActionOptions): Aeg
         terminationReason: 'consensus',
         startTime: ctx.startTime,
         tokensUsed: ctx.tokensUsed,
+        unmeasuredTokenContributions: ctx.unmeasuredTokenContributions,
       });
     case 'early_termination':
       if (onEarlyTermination) onEarlyTermination(round);
@@ -231,6 +269,7 @@ export function processIterationAction(opts: ProcessIterationActionOptions): Aeg
         terminationReason: 'max_rounds',
         startTime: ctx.startTime,
         tokensUsed: ctx.tokensUsed,
+        unmeasuredTokenContributions: ctx.unmeasuredTokenContributions,
       });
     case 'continue':
       emitIterationEvent(round, 'in_progress', sessionId);
@@ -242,6 +281,7 @@ export function processIterationAction(opts: ProcessIterationActionOptions): Aeg
         terminationReason: 'error',
         startTime: ctx.startTime,
         tokensUsed: ctx.tokensUsed,
+        unmeasuredTokenContributions: ctx.unmeasuredTokenContributions,
       });
   }
 }
@@ -251,14 +291,8 @@ export function processIterationAction(opts: ProcessIterationActionOptions): Aeg
 // =============================================================================
 
 /** Builds the final loop result with provided parameters. */
-export function buildLoopResult(
-  rounds: readonly AegeanRound[],
-  consensusValue: unknown,
-  terminationReason: AegeanResult['terminationReason'],
-  startTime: number,
-  tokensUsed: number
-): AegeanResult {
-  return buildAegeanResult({ rounds, consensusValue, terminationReason, startTime, tokensUsed });
+export function buildLoopResult(opts: BuildResultOptions): AegeanResult {
+  return buildAegeanResult(opts);
 }
 
 // =============================================================================
@@ -315,6 +349,10 @@ export function buildSessionTaskResult(
     metadata: {
       durationMs: getTimeProvider().now() - startTime,
       tokensUsed: result.tokensUsed,
+      // The count becomes the disclosure the rest of the tree already reads
+      // (#4734): a total assembled from contributors that reported nothing is
+      // a lower bound, and must not be handed on as a measurement (#4743).
+      tokensMeasured: result.unmeasuredTokenContributions === 0,
       toolsUsed: [],
       model: 'aegean-protocol',
     },

--- a/packages/nexus-agents/src/agents/collaboration/aegean-protocol.test.ts
+++ b/packages/nexus-agents/src/agents/collaboration/aegean-protocol.test.ts
@@ -3,11 +3,11 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { IAgent, Task } from '../../core/index.js';
+import type { IAgent, ResultMetadata, Task } from '../../core/index.js';
 import { ok } from '../../core/index.js';
 import { AegeanProtocol, createAegeanProtocol } from './aegean-protocol.js';
 import { calculateQuorumSize, hasAcceptQuorum, isConsensusFailed } from './aegean-types.js';
-import type { CollaborationConfig } from './collaboration-types.js';
+import type { CollaborationConfig, CollaborationResult } from './collaboration-types.js';
 import type { IEventBus, TypedEvent } from './event-bus-types.js';
 
 /** Creates a mock EventBus for testing event emission. */
@@ -54,6 +54,26 @@ function createMockAgent(id: string, output: unknown): IAgent {
     handleMessage: vi.fn().mockResolvedValue(ok({ messageId: 'msg', status: 'completed' })),
     initialize: vi.fn().mockResolvedValue(ok(undefined)),
     cleanup: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** A mock agent whose adapter reports it could not measure token usage. */
+function createUnmeasuredAgent(id: string, output: unknown): IAgent {
+  return {
+    ...createMockAgent(id, output),
+    execute: vi.fn().mockResolvedValue(
+      ok({
+        taskId: 'test',
+        output,
+        metadata: {
+          durationMs: 100,
+          tokensUsed: 0,
+          tokensMeasured: false,
+          toolsUsed: [],
+          model: 'test',
+        },
+      })
+    ),
   };
 }
 
@@ -415,5 +435,52 @@ describe('AegeanProtocol EventBus integration', () => {
   it('should use global EventBus when none provided', () => {
     const protocol = createAegeanProtocol();
     expect(protocol.pattern).toBe('aegean');
+  });
+});
+
+// ============================================================================
+// The unmeasured count survives the whole chain (#4743)
+// ============================================================================
+
+describe('AegeanProtocol unmeasured token disclosure (#4743)', () => {
+  // A seam test. `tokensFromMetadata` and `buildSessionTaskResult` are each unit
+  // tested, and deleting the single `+=` that accumulates between them left all
+  // 991 collaboration tests green — the same both-halves-correct-join-untested
+  // shape as #4910. This asserts through the protocol's real output.
+  function submittedMetadata(result: CollaborationResult): ResultMetadata | undefined {
+    return result.expertResults.find((e) => e.result !== undefined)?.result?.metadata;
+  }
+
+  it('marks the session result unmeasured when adapters reported no usage', async () => {
+    const protocol = createAegeanProtocol();
+    const config = createTestConfig(['agent1', 'agent2', 'agent3']);
+    const agents = new Map([
+      ['agent1', createUnmeasuredAgent('agent1', 'I propose this solution')],
+      ['agent2', createUnmeasuredAgent('agent2', 'I ACCEPT this proposal')],
+      ['agent3', createUnmeasuredAgent('agent3', 'Yes, I accept and approve')],
+    ]);
+
+    const result = await protocol.execute(config, agents);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(submittedMetadata(result.value)?.tokensMeasured).toBe(false);
+  });
+
+  it('marks it measured when every adapter reported', async () => {
+    // The pair: always-false would make every aegean total look untrustworthy.
+    const protocol = createAegeanProtocol();
+    const config = createTestConfig(['agent1', 'agent2', 'agent3']);
+    const agents = new Map([
+      ['agent1', createMockAgent('agent1', 'I propose this solution')],
+      ['agent2', createMockAgent('agent2', 'I ACCEPT this proposal')],
+      ['agent3', createMockAgent('agent3', 'Yes, I accept and approve')],
+    ]);
+
+    const result = await protocol.execute(config, agents);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(submittedMetadata(result.value)?.tokensMeasured).toBe(true);
   });
 });

--- a/packages/nexus-agents/src/agents/collaboration/aegean-protocol.ts
+++ b/packages/nexus-agents/src/agents/collaboration/aegean-protocol.ts
@@ -238,28 +238,9 @@ export class AegeanProtocol implements ICollaborationProtocol {
 
     this.announceRoundStart(roundNumber, leaderId, config.sessionId);
 
-    // Phase 1: Leader proposes
-    const proposalResult = await this.generateProposal(leader, leaderId, config.task, roundNumber);
-    if (!proposalResult.ok) return err(proposalResult.error);
-
-    const {
-      proposal,
-      tokensUsed: proposalTokens,
-      unmeasured: proposalUnmeasured,
-    } = proposalResult.value;
-
-    // Phase 2: Collect votes
-    const votesResult = await this.collectVotes({
-      experts: config.experts,
-      agents,
-      proposal,
-      leaderId,
-      roundNumber,
-      sessionId: config.sessionId,
-    });
-    if (!votesResult.ok) return err(votesResult.error);
-
-    const { votes, tokensUsed: voteTokens, unmeasured: voteUnmeasured } = votesResult.value;
+    const gathered = await this.gatherRound(leader, leaderId, config, agents, roundNumber);
+    if (!gathered.ok) return err(gathered.error);
+    const { proposal, votes, tokensUsed, unmeasured } = gathered.value;
 
     // Phase 3: Evaluate quorum
     const quorumStatus = this.evaluateQuorum(
@@ -279,8 +260,44 @@ export class AegeanProtocol implements ICollaborationProtocol {
     });
     this.logger.debug('Round complete', { roundNumber, ...quorumStatus });
 
+    return ok({ roundData, tokensUsed, unmeasured });
+  }
+
+  /** Phases 1 and 2 of a round: the leader's proposal, then the votes on it. */
+  private async gatherRound(
+    leader: IAgent,
+    leaderId: string,
+    config: CollaborationConfig,
+    agents: Map<string, IAgent>,
+    roundNumber: number
+  ): Promise<
+    Result<
+      { proposal: Proposal; votes: AgentVote[]; tokensUsed: number; unmeasured: number },
+      AgentError
+    >
+  > {
+    const proposalResult = await this.generateProposal(leader, leaderId, config.task, roundNumber);
+    if (!proposalResult.ok) return err(proposalResult.error);
+    const {
+      proposal,
+      tokensUsed: proposalTokens,
+      unmeasured: proposalUnmeasured,
+    } = proposalResult.value;
+
+    const votesResult = await this.collectVotes({
+      experts: config.experts,
+      agents,
+      proposal,
+      leaderId,
+      roundNumber,
+      sessionId: config.sessionId,
+    });
+    if (!votesResult.ok) return err(votesResult.error);
+    const { votes, tokensUsed: voteTokens, unmeasured: voteUnmeasured } = votesResult.value;
+
     return ok({
-      roundData,
+      proposal,
+      votes,
       tokensUsed: proposalTokens + voteTokens,
       unmeasured: proposalUnmeasured + voteUnmeasured,
     });

--- a/packages/nexus-agents/src/agents/collaboration/aegean-protocol.ts
+++ b/packages/nexus-agents/src/agents/collaboration/aegean-protocol.ts
@@ -52,6 +52,7 @@ import {
   buildSessionTaskResult,
   type CollectVotesOptions,
   type IterationContext,
+  tokensFromMetadata,
 } from './aegean-helpers.js';
 
 /** Options for the Aegean protocol. */
@@ -133,24 +134,46 @@ export class AegeanProtocol implements ICollaborationProtocol {
     const startTime = getTimeProvider().now();
     const rounds: AegeanRound[] = [];
     let totalTokensUsed = 0;
+    let unmeasuredTokenContributions = 0;
 
     for (let round = 0; round < this.config.maxRounds; round++) {
-      const preAction = determinePreRoundAction(this.cancelled, rounds, startTime, totalTokensUsed);
+      const preAction = determinePreRoundAction(
+        this.cancelled,
+        rounds,
+        startTime,
+        totalTokensUsed,
+        unmeasuredTokenContributions
+      );
       if (preAction) return ok(preAction);
 
       const roundResult = await this.executeRound(round, config, agents);
       if (!roundResult.ok) return err(roundResult.error);
 
-      const { roundData, tokensUsed } = roundResult.value;
+      const { roundData, tokensUsed, unmeasured } = roundResult.value;
       rounds.push(roundData);
       totalTokensUsed += tokensUsed;
+      unmeasuredTokenContributions += unmeasured;
 
-      const ctx = createIterationContext(rounds, startTime, totalTokensUsed);
+      const ctx = createIterationContext(
+        rounds,
+        startTime,
+        totalTokensUsed,
+        unmeasuredTokenContributions
+      );
       const iterAction = this.handleIterationAction(round, roundData, config, ctx);
       if (iterAction) return ok(iterAction);
     }
 
-    return ok(buildLoopResult(rounds, null, 'max_rounds', startTime, totalTokensUsed));
+    return ok(
+      buildLoopResult({
+        rounds,
+        consensusValue: null,
+        terminationReason: 'max_rounds',
+        startTime,
+        tokensUsed: totalTokensUsed,
+        unmeasuredTokenContributions,
+      })
+    );
   }
 
   /** Handles post-round iteration actions. */
@@ -202,7 +225,9 @@ export class AegeanProtocol implements ICollaborationProtocol {
     roundNumber: number,
     config: CollaborationConfig,
     agents: Map<string, IAgent>
-  ): Promise<Result<{ roundData: AegeanRound; tokensUsed: number }, AgentError>> {
+  ): Promise<
+    Result<{ roundData: AegeanRound; tokensUsed: number; unmeasured: number }, AgentError>
+  > {
     const roundStart = getTimeProvider().now();
     const leaderId = selectLeader(config.experts, roundNumber);
     const leader = agents.get(leaderId);
@@ -211,21 +236,17 @@ export class AegeanProtocol implements ICollaborationProtocol {
       return err(new AgentError(`Leader agent not found: ${leaderId}`));
     }
 
-    this.logger.debug('Starting round', { roundNumber, leaderId });
-
-    // Emit round started event (Issue #216)
-    emitAegeanRoundStarted(this.eventBus, {
-      round: roundNumber,
-      maxRounds: this.config.maxRounds,
-      leaderId,
-      sessionId: config.sessionId,
-    });
+    this.announceRoundStart(roundNumber, leaderId, config.sessionId);
 
     // Phase 1: Leader proposes
     const proposalResult = await this.generateProposal(leader, leaderId, config.task, roundNumber);
     if (!proposalResult.ok) return err(proposalResult.error);
 
-    const { proposal, tokensUsed: proposalTokens } = proposalResult.value;
+    const {
+      proposal,
+      tokensUsed: proposalTokens,
+      unmeasured: proposalUnmeasured,
+    } = proposalResult.value;
 
     // Phase 2: Collect votes
     const votesResult = await this.collectVotes({
@@ -238,7 +259,7 @@ export class AegeanProtocol implements ICollaborationProtocol {
     });
     if (!votesResult.ok) return err(votesResult.error);
 
-    const { votes, tokensUsed: voteTokens } = votesResult.value;
+    const { votes, tokensUsed: voteTokens, unmeasured: voteUnmeasured } = votesResult.value;
 
     // Phase 3: Evaluate quorum
     const quorumStatus = this.evaluateQuorum(
@@ -258,7 +279,11 @@ export class AegeanProtocol implements ICollaborationProtocol {
     });
     this.logger.debug('Round complete', { roundNumber, ...quorumStatus });
 
-    return ok({ roundData, tokensUsed: proposalTokens + voteTokens });
+    return ok({
+      roundData,
+      tokensUsed: proposalTokens + voteTokens,
+      unmeasured: proposalUnmeasured + voteUnmeasured,
+    });
   }
 
   /** Generates a proposal from the leader. */
@@ -267,49 +292,37 @@ export class AegeanProtocol implements ICollaborationProtocol {
     leaderId: string,
     task: Task,
     round: number
-  ): Promise<Result<{ proposal: Proposal; tokensUsed: number }, AgentError>> {
+  ): Promise<Result<{ proposal: Proposal; tokensUsed: number; unmeasured: number }, AgentError>> {
     const result = await leader.execute(createProposalTask(task, round));
     if (!result.ok) return err(result.error);
+    const { tokens, unmeasured } = tokensFromMetadata(result.value.metadata);
     return ok({
       proposal: createProposal(round, leaderId, result.value.output),
-      tokensUsed: result.value.metadata.tokensUsed,
+      tokensUsed: tokens,
+      unmeasured,
     });
   }
 
   /** Collects votes from all agents. */
   private async collectVotes(
     opts: CollectVotesOptions
-  ): Promise<Result<{ votes: AgentVote[]; tokensUsed: number }, AgentError>> {
+  ): Promise<Result<{ votes: AgentVote[]; tokensUsed: number; unmeasured: number }, AgentError>> {
     const { experts, agents, proposal, leaderId, roundNumber, sessionId } = opts;
     const votes: AgentVote[] = [];
     let totalTokens = 0;
+    let totalUnmeasured = 0;
     const quorumSize = calculateQuorumSize(experts.length, this.config.byzantineTolerance);
 
     const voterIds = experts.filter((id) => id !== leaderId);
 
-    const votePromises = voterIds.map(async (agentId) => {
-      const agent = agents.get(agentId);
-      if (agent === undefined) {
-        return { agentId, vote: createTimeoutVote(agentId, proposal.proposalId), tokens: 0 };
-      }
+    const results = await Promise.all(
+      voterIds.map((agentId) => this.voteOrTimeout(agents.get(agentId), agentId, proposal))
+    );
 
-      const voteResult = await this.getAgentVote(agent, agentId, proposal);
-      if (!voteResult.ok) {
-        return {
-          agentId,
-          vote: createTimeoutVote(agentId, proposal.proposalId),
-          tokens: 0,
-        };
-      }
-
-      return { agentId, vote: voteResult.value.vote, tokens: voteResult.value.tokensUsed };
-    });
-
-    const results = await Promise.all(votePromises);
-
-    for (const { vote, tokens } of results) {
+    for (const { vote, tokens, unmeasured } of results) {
       votes.push(vote);
       totalTokens += tokens;
+      totalUnmeasured += unmeasured;
 
       // Emit vote collected event (Issue #216)
       emitAegeanVoteCollected(this.eventBus, {
@@ -324,7 +337,47 @@ export class AegeanProtocol implements ICollaborationProtocol {
     // Leader implicitly accepts their own proposal
     votes.push(createLeaderVote(leaderId, proposal.proposalId));
 
-    return ok({ votes, tokensUsed: totalTokens });
+    return ok({ votes, tokensUsed: totalTokens, unmeasured: totalUnmeasured });
+  }
+
+  /** Logs and emits the round-started event (Issue #216). */
+  private announceRoundStart(roundNumber: number, leaderId: string, sessionId: string): void {
+    this.logger.debug('Starting round', { roundNumber, leaderId });
+    emitAegeanRoundStarted(this.eventBus, {
+      round: roundNumber,
+      maxRounds: this.config.maxRounds,
+      leaderId,
+      sessionId,
+    });
+  }
+
+  /**
+   * One voter's contribution, or a timeout vote when the agent is missing or
+   * errored. A timeout contributes no tokens by a different route than an
+   * unmeasured one — nothing executed — so it is not counted as unmeasured.
+   */
+  private async voteOrTimeout(
+    agent: IAgent | undefined,
+    agentId: string,
+    proposal: Proposal
+  ): Promise<{ agentId: string; vote: AgentVote; tokens: number; unmeasured: number }> {
+    const timedOut = {
+      agentId,
+      vote: createTimeoutVote(agentId, proposal.proposalId),
+      tokens: 0,
+      unmeasured: 0,
+    };
+    if (agent === undefined) return timedOut;
+
+    const voteResult = await this.getAgentVote(agent, agentId, proposal);
+    if (!voteResult.ok) return timedOut;
+
+    return {
+      agentId,
+      vote: voteResult.value.vote,
+      tokens: voteResult.value.tokensUsed,
+      unmeasured: voteResult.value.unmeasured,
+    };
   }
 
   /** Gets a vote from an agent. */
@@ -332,19 +385,20 @@ export class AegeanProtocol implements ICollaborationProtocol {
     agent: IAgent,
     agentId: string,
     proposal: Proposal
-  ): Promise<Result<{ vote: AgentVote; tokensUsed: number }, AgentError>> {
+  ): Promise<Result<{ vote: AgentVote; tokensUsed: number; unmeasured: number }, AgentError>> {
     const result = await agent.execute(createVoteTask(proposal, agentId));
     if (!result.ok) {
-      return ok({ vote: createTimeoutVote(agentId, proposal.proposalId), tokensUsed: 0 });
+      return ok({
+        vote: createTimeoutVote(agentId, proposal.proposalId),
+        tokensUsed: 0,
+        unmeasured: 0,
+      });
     }
-    return ok(
-      createVoteFromOutput(
-        agentId,
-        proposal.proposalId,
-        result.value.output,
-        result.value.metadata.tokensUsed
-      )
-    );
+    const { tokens, unmeasured } = tokensFromMetadata(result.value.metadata);
+    return ok({
+      ...createVoteFromOutput(agentId, proposal.proposalId, result.value.output, tokens),
+      unmeasured,
+    });
   }
 
   /** Evaluates quorum status from votes. */

--- a/packages/nexus-agents/src/agents/collaboration/aegean-types.ts
+++ b/packages/nexus-agents/src/agents/collaboration/aegean-types.ts
@@ -123,13 +123,17 @@ export interface AegeanResult {
   readonly totalRounds: number;
   readonly totalDurationMs: number;
   readonly tokensUsed: number;
+  /**
+   * How many contributions reported no token usage (#4743).
+   *
+   * `tokensUsed` is a sum of measured values only, so a non-zero count here
+   * makes it a LOWER BOUND rather than a total. Without it a round where every
+   * adapter went silent is indistinguishable from one that spent nothing.
+   */
+  readonly unmeasuredTokenContributions: number;
   readonly rounds: readonly AegeanRound[];
   readonly terminationReason:
-    | 'consensus'
-    | 'max_rounds'
-    | 'timeout'
-    | 'byzantine_failure'
-    | 'error';
+    'consensus' | 'max_rounds' | 'timeout' | 'byzantine_failure' | 'error';
 }
 
 export const AegeanResultSchema = z.object({
@@ -138,6 +142,7 @@ export const AegeanResultSchema = z.object({
   totalRounds: z.number().int().min(0),
   totalDurationMs: z.number(),
   tokensUsed: z.number().int().min(0),
+  unmeasuredTokenContributions: z.number().int().min(0).default(0),
   rounds: z.array(AegeanRoundSchema).readonly(),
   terminationReason: z.enum(['consensus', 'max_rounds', 'timeout', 'byzantine_failure', 'error']),
 });


### PR DESCRIPTION
Refs #4743 — the one part of that issue that survived re-measurement. See [my correction on the issue](https://github.com/nexus-substrate/nexus-agents/issues/4743#issuecomment-5415167764): the helper it was built around never existed, and two of its named call sites contain no token code.

## The real defect

`aegean-protocol.ts` reads `result.value.metadata.tokensUsed` for every proposal and vote and never consults `metadata.tokensMeasured`, which `ResultMetadata` has carried since #4734. Those feed `proposalTokens + voteTokens` into a round total, and the totals into `AegeanResult.tokensUsed`.

So a contributor whose adapter reported nothing added `0`, and the total could not say how many contributors were silent. An under-count, and for anything cap-shaped that is the dangerous direction.

## Where the count lands

Not in a new field only this module understands. `buildSessionTaskResult` already converts `AegeanResult` into a `TaskResult`, so a non-zero count becomes **`tokensMeasured: false`** on the metadata the rest of the tree reads. The count is the mechanism; the existing disclosure flag is the output.

Timeouts are deliberately excluded: a vote whose agent was missing or errored contributes zero by a different route — nothing executed — so counting it as unmeasured would overstate the blindness.

## The seam test found two wiring gaps in my own change

I nearly shipped this twice with the plumbing incomplete, and both times the unit tests were green.

**First**, `AegeanResult` is built at **five** exit paths — consensus, early termination, max rounds, pre-round cancel, mid-loop cancel — and my first pass threaded the count through only `max_rounds`, the least common one. An optional field on `BuildResultOptions` let the other four omit it silently. Making it **required** turned that into four compile errors that named each path.

**Second**, with all five paths wired, the seam test *still* failed: `createIterationContext` took the count as an optional parameter with a `= 0` default, and the protocol's call site passed three arguments. The default absorbed it, and every round reported as fully measured. Both parameters are now required for the same reason.

That is the same defect class this PR is fixing — a value quietly defaulted where it should have been demanded — committed twice while fixing it.

## Mutations

| mutation | result |
| --- | --- |
| sum the placeholder instead of dropping it | 1 failed |
| treat an absent `tokensMeasured` as unmeasured | 1 failed |
| always report `tokensMeasured: true` downstream | 1 failed |
| **delete the `+=` that accumulates across rounds** | **1 failed** |

The last row is the one that matters. Before the end-to-end test, deleting that single line left **all 991 collaboration tests green** — the same both-halves-correct-join-untested shape as #4910. It asserts through `protocol.execute`'s real output rather than an internal type.

993 collaboration tests pass. Public API surface unchanged. Three functions were extracted to stay under the line and parameter ceilings; no behaviour rides on them.
