### PR TITLE
feat(audit): carry read coverage on the chain verification verdict

### DIFF
--- a/.changeset/chain-verification-coverage.md
+++ b/.changeset/chain-verification-coverage.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': minor
+---
+
+carry read coverage on the audit-chain verdict itself
+
+`verify_audit_chain` reported `skippedLines` and `unreadableFiles` as sibling
+fields of its response, but `ChainVerification` — the object a caller reads to
+decide whether tamper-evidence holds — was unchanged. A log two lines of which
+were never parsed still produced a clean, complete-looking verdict.
+
+`ChainVerification` now carries an optional `coverage: { skipped,
+unreadableFiles }`, attached by the tool, which is the only party that knows
+what the loader dropped. `withCoverage` is how a caller states it.
+
+Three deliberate boundaries. Absent coverage means UNKNOWN, not complete —
+`verifyChain` receives only events and cannot know, so defaulting to zero would
+manufacture the assurance the field exists to stop manufacturing. `skipped: 0`
+is therefore a positive claim of full coverage rather than an omission.
+`notVerified` keeps its meaning of "nothing was verified"; a partial read
+checked real links and is a different axis, so it is not overloaded. And a
+failing verdict is returned untouched, since it already names a specific event
+index that coverage does not qualify.
+
+Resolves the #4805 fork by a 7-voter `higher_order` panel: Option A, 4-1 among
+approvers, `unattributedApprovals: 0`.

--- a/packages/nexus-agents/src/audit/audit-chain-verify.test.ts
+++ b/packages/nexus-agents/src/audit/audit-chain-verify.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect } from 'vitest';
 import * as crypto from 'node:crypto';
-import { verifyChain } from './audit-logger.js';
+import { verifyChain, withCoverage } from './audit-logger.js';
 import type { AuditEvent } from './audit-types.js';
 
 function realHash(event: AuditEvent): string {
@@ -248,5 +248,65 @@ describe('front-truncation is detected (#4703)', () => {
         expect(r.eventCount).toBe(3);
       }
     });
+  });
+});
+
+// ============================================================================
+// Coverage travels with the verdict (#4805, panel Option A 4-1)
+// ============================================================================
+
+describe('withCoverage (#4805)', () => {
+  it('states full coverage positively rather than by omission', () => {
+    // `skipped: 0` is a claim. An absent `coverage` is not the same claim —
+    // that distinction is the entire point of the field.
+    const r = withCoverage(verifyChain(chain(3)), { skipped: 0, unreadableFiles: 0 });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.coverage).toEqual({ skipped: 0, unreadableFiles: 0 });
+  });
+
+  it('carries a partial read on the verdict, not only beside it', () => {
+    // The reported case: the tool already published `skippedLines` as a sibling
+    // field, but `ChainVerification` is what gets serialized and passed on
+    // without its siblings.
+    const r = withCoverage(verifyChain(chain(3)), { skipped: 2, unreadableFiles: 1 });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.coverage).toEqual({ skipped: 2, unreadableFiles: 1 });
+  });
+
+  it('leaves coverage absent when nobody stated it', () => {
+    // `verifyChain` receives only events, so it cannot know. Absent must mean
+    // UNKNOWN — defaulting it to zero would manufacture the assurance this
+    // field exists to stop manufacturing.
+    const r = verifyChain(chain(3));
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.coverage).toBeUndefined();
+  });
+
+  it('does not overload notVerified, which is a different axis', () => {
+    // `notVerified` means nothing was verified. A partial read verified real
+    // links, just not all of them — conflating them would break the meaning
+    // #4768/#4660 gave that field.
+    const r = withCoverage(verifyChain(chain(3)), { skipped: 2, unreadableFiles: 0 });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.notVerified).toBeUndefined();
+  });
+
+  it('leaves a failing verdict untouched', () => {
+    // A detected break names an event index; coverage does not qualify it, and
+    // spreading onto the failure shape would invent fields on it.
+    const broken = chain(3);
+    broken[1] = { ...broken[1]!, hash: 'tampered' };
+    const r = withCoverage(verifyChain(broken), { skipped: 5, unreadableFiles: 0 });
+
+    expect(r.ok).toBe(false);
+    expect(r).not.toHaveProperty('coverage');
   });
 });

--- a/packages/nexus-agents/src/audit/audit-logger.ts
+++ b/packages/nexus-agents/src/audit/audit-logger.ts
@@ -96,6 +96,19 @@ function computeEventHash(event: AuditEvent): string {
  * Discriminated result from `verifyChain()`. Either the chain validates cleanly,
  * or one of three named tampering signals fires at a specific event index.
  */
+/**
+ * How much of a log a {@link ChainVerification} actually covers (#4805).
+ *
+ * `skipped: 0` is a positive statement of full coverage, distinct from an
+ * absent `coverage`, which means nobody said.
+ */
+export interface ChainCoverage {
+  /** Lines the loader saw that never became events. */
+  readonly skipped: number;
+  /** Files the loader could not read at all. */
+  readonly unreadableFiles: number;
+}
+
 export type ChainVerification =
   | {
       ok: true;
@@ -122,6 +135,26 @@ export type ChainVerification =
        * "default reported as a measurement" shape the mission text rules out.
        */
       notVerified?: 'empty' | 'unchained';
+      /**
+       * Set when the verdict covers only PART of the log it was asked about
+       * (#4805, panel Option A 4-1).
+       *
+       * A different axis from {@link notVerified}, which says nothing was
+       * verified. Here real links WERE checked — just not over every line the
+       * loader saw. `skipped` counts the lines that never became events
+       * (unparseable, schema-rejected, or in a file that could not be read).
+       *
+       * The tool reports coverage as sibling fields too, but this type is the
+       * evidence artifact: it is serialized, persisted, and passed around
+       * without its siblings, and the doctrine is that provenance travels WITH
+       * the evidence rather than beside it.
+       *
+       * Absent means coverage is UNKNOWN, not complete — the verifier is given
+       * only the events, so a caller that did not supply coverage cannot be
+       * reported as having full coverage. {@link withCoverage} is how a caller
+       * that knows says so, including saying "nothing was skipped".
+       */
+      coverage?: ChainCoverage;
     }
   | {
       ok: false;
@@ -184,6 +217,21 @@ function verifyEvent(
  * @param events - Sequence of AuditEvent in append order
  * @returns ChainVerification result
  */
+/**
+ * Attach coverage to a passing verdict — the caller that read the log is the
+ * only one who knows what it skipped (#4805).
+ *
+ * A failing verdict is returned unchanged: it already names a specific event
+ * index, and coverage does not qualify a detected break.
+ */
+export function withCoverage(
+  verification: ChainVerification,
+  coverage: ChainCoverage
+): ChainVerification {
+  if (!verification.ok) return verification;
+  return { ...verification, coverage };
+}
+
 export function verifyChain(events: readonly AuditEvent[]): ChainVerification {
   // Both early exits below are honest `ok: true` verdicts — there is nothing to
   // contradict — but neither verified anything, so they say so. #4768: an empty

--- a/packages/nexus-agents/src/audit/index.ts
+++ b/packages/nexus-agents/src/audit/index.ts
@@ -52,9 +52,10 @@ export {
   AuditLogger,
   createAuditLogger,
   verifyChain,
+  withCoverage,
   extractTierTransition,
 } from './audit-logger.js';
-export type { ChainVerification } from './audit-logger.js';
+export type { ChainVerification, ChainCoverage } from './audit-logger.js';
 
 // Storage
 export { FileAuditStorage, InMemoryAuditStorage } from './audit-storage.js';

--- a/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.test.ts
@@ -187,6 +187,36 @@ describe('verify_audit_chain handler behavior', () => {
       expect(body.verification.ok).toBe(true);
     });
 
+    it('states the partial read on the verdict itself, not only beside it (#4805)', async () => {
+      // The sibling `skippedLines` above is read only by a caller who knows to
+      // look. `ChainVerification` is the artifact that gets serialized and
+      // passed on alone, so the coverage has to travel with it. Panel Option A,
+      // 4-1.
+      const good = chain(3).map((e) => JSON.stringify(e));
+      fs.writeFileSync(
+        path.join(tmpDir, 'audit-2026-04-28-12-00-00.jsonl'),
+        [good[0]!, 'not json at all', good[1]!, '{"id":"x"}', good[2]!].join('\n') + '\n'
+      );
+
+      const body = await callHandler(tmpDir);
+
+      expect(body.verification.ok).toBe(true);
+      if (!body.verification.ok) return;
+      expect(body.verification.coverage).toEqual({ skipped: 2, unreadableFiles: 0 });
+    });
+
+    it('states full coverage positively when nothing was skipped (#4805)', async () => {
+      // The pair. A tool that hardcoded `skipped: 0` would satisfy nothing
+      // above and everything here, so both directions are needed.
+      writeAuditFile('audit-2026-04-28-12-00-00.jsonl', chain(3));
+
+      const body = await callHandler(tmpDir);
+
+      expect(body.verification.ok).toBe(true);
+      if (!body.verification.ok) return;
+      expect(body.verification.coverage).toEqual({ skipped: 0, unreadableFiles: 0 });
+    });
+
     it('omits the count when nothing was skipped, so absence stays meaningful', async () => {
       writeAuditFile('audit-2026-04-28-12-00-00.jsonl', chain(3));
 

--- a/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/verify-audit-chain-tool.ts
@@ -29,7 +29,7 @@ import {
   type BaseMcpToolDeps,
   type ToolResult,
 } from './tool-result.js';
-import { verifyChain, type ChainVerification } from '../../audit/audit-logger.js';
+import { verifyChain, withCoverage, type ChainVerification } from '../../audit/audit-logger.js';
 import { AuditEventSchema, type AuditEvent } from '../../audit/audit-types.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
@@ -157,7 +157,12 @@ async function handler(args: unknown, ctx: HandlerContext): Promise<ToolResult> 
     resolvedDir,
     ctx.logger
   );
-  const verification = verifyChain(events);
+  // The loader is the only party that knows what was skipped, so it is the one
+  // that can state coverage on the verdict itself (#4805).
+  const verification = withCoverage(verifyChain(events), {
+    skipped: skippedLines,
+    unreadableFiles,
+  });
 
   // Omitted when zero so absence means full coverage rather than "unreported".
   const response: VerifyAuditChainResponse = {


### PR DESCRIPTION
Closes #4805. **`src/audit/` is on the never-auto-merge list — owner ratification required.** Not self-merging.

## The decision was the panel's, not mine

The issue offered three options and I deliberately did not pick one. A 7-voter `higher_order` panel with the options declared:

```
decision: approved   approval: 83.3%   5 approve / 1 reject / 0 abstain / 1 error

A: extend ChainVerification with a coverage field the tool populates   4
B: pass a loader coverage hint into verifyChain                        1

optionCoverage: { approverCount: 5, selectedCount: 5, unattributedApprovals: 0 }
```

Every approver named an option, so the 4-1 is a real preference rather than an artifact of the approve/reject bar. Vote record sequence 68.

Worth reading the architect's reasoning before reviewing: **B** was rejected on layering — threading loader state into `verifyChain` mixes the I/O axis (what was read) with the logic axis (do the links hold), and forces the question of what verdict a *valid but partial* chain gets, which mutates existing fields for no gain over A. **C** was rejected because `ChainVerification` is the evidence artifact: it gets serialized, persisted, and passed around **without** its sibling fields, which is exactly when "the coverage is on a sibling" stops being true.

The dissenting voter was `catfish` at 0.95 confidence — a confident contrarian on a governor-path change is the voice the panel exists to surface, and worth your reading directly.

## Three boundaries the implementation holds

**Absent means unknown, not complete.** `verifyChain` receives only events and cannot know what the loader dropped, so it attaches nothing. Defaulting to zero would manufacture precisely the assurance this field exists to stop manufacturing. `skipped: 0` is therefore a *positive claim* of full coverage, which only a caller who read the log can make.

**`notVerified` is not overloaded.** It means nothing was verified (`'empty'`, `'unchained'`). A partial read verified real links — a different axis — so it gets its own field rather than a third enum value that would change what #4768/#4660 gave that one.

**A failing verdict is returned untouched.** It already names a specific event index, and coverage does not qualify a detected break.

## Mutations

| mutation | result |
| --- | --- |
| never attach coverage | 2 failed |
| attach to failing verdicts too | 1 failed |
| tool hardcodes `skipped: 0` | 1 failed |
| tool stops attaching entirely | 2 failed |

The third row needed a second pass. With only the unit tests, hardcoding `skipped: 0` in the tool left **all 318 tests green** — the type-level behaviour was pinned and the wiring was not, the same seam gap as #4910 and #4940. There is now a tool-level test that writes a log with unparseable lines and asserts the verdict itself reports `skipped: 2`, plus its pair asserting a clean log reports `skipped: 0` rather than nothing.

Public API surface unchanged; 320 audit and tool tests pass.
