### PR TITLE
feat(pipeline): honor the vote and QA iteration caps the MCP tool advertises

### DIFF
--- a/.changeset/dev-pipeline-iteration-caps.md
+++ b/.changeset/dev-pipeline-iteration-caps.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': minor
+---
+
+make run_dev_pipeline's iteration caps actually do something
+
+`maxVoteIterations` and `maxQaIterations` have been advertised by the MCP tool
+since it shipped — bounds-checked `min(1).max(5)`, defaulted to 3, and
+`.describe()`d into the generated tool reference — and neither was ever read
+off the parsed input. A caller who set either got a validation error for `6`
+and silence for `5`, both meaning the same thing.
+
+The behaviour they name already existed as hardcoded `MAX_VOTE_ITERATIONS` and
+`MAX_QA_ITERATIONS` constants, both `3`, matching the schema defaults exactly —
+so these were knobs over real loops that were simply never connected. They now
+resolve through `DevPipelineOptions`, falling back to the constants when
+unset, so an unconfigured run behaves exactly as before.
+
+Found in a vestigial-code sweep (#4939) among a cluster of declared-but-unread
+configuration.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -2825,6 +2825,8 @@ InterfaceDeclaration DevPipelineOptions
   readonly auditLogger?: IAuditLogger | undefined
   readonly beliefMemory?: IHindsightBeliefMemory | undefined
   readonly dryRun?: boolean | undefined
+  readonly maxQaIterations?: number | undefined
+  readonly maxVoteIterations?: number | undefined
   readonly mode?: PipelineMode | undefined
   readonly qualityGate?: QualityGateMode | undefined
   readonly researchOverride?: string | undefined

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -463,3 +463,40 @@ describe('registerDevPipelineTool — trustTier threading (#3712)', () => {
     expect(runDevPipelineMock.mock.calls[0]?.[2]?.trustTier).toBeUndefined();
   });
 });
+
+// ============================================================================
+// The iteration caps reach the pipeline (#4939)
+// ============================================================================
+
+describe('run_dev_pipeline iteration caps are wired (#4939)', () => {
+  // Both were bounds-checked, defaulted and described in the generated tool
+  // reference, and neither was read off `parsed.data` — a documented parameter
+  // a caller could set to no effect. The schema tests above prove parsing; this
+  // proves the value leaves the handler.
+  beforeEach(() => {
+    runDevPipelineMock.mockClear();
+  });
+
+  it('passes both caps through to the pipeline', async () => {
+    const handler = captureHandler();
+    await handler({ task: 'Build feature X', maxVoteIterations: 1, maxQaIterations: 2 }, STDIO_CTX);
+
+    const options = runDevPipelineMock.mock.calls[0]?.[2] as
+      { maxVoteIterations?: number; maxQaIterations?: number } | undefined;
+    expect(options?.maxVoteIterations).toBe(1);
+    expect(options?.maxQaIterations).toBe(2);
+  });
+
+  it('passes the schema defaults when the caller sets neither', async () => {
+    // The pair: forwarding `undefined` would satisfy nothing above and let the
+    // pipeline fall back on its own constants, which happen to agree today and
+    // would diverge the moment either changed.
+    const handler = captureHandler();
+    await handler({ task: 'Build feature X' }, STDIO_CTX);
+
+    const options = runDevPipelineMock.mock.calls[0]?.[2] as
+      { maxVoteIterations?: number; maxQaIterations?: number } | undefined;
+    expect(options?.maxVoteIterations).toBe(3);
+    expect(options?.maxQaIterations).toBe(3);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -349,6 +349,10 @@ function buildPipelineOptions(
     ...(input.dryRun ? { dryRun: true } : {}),
     ...(input.mode === 'harness' ? { mode: 'harness' as const } : {}),
     ...(input.qualityGate !== 'off' ? { qualityGate: input.qualityGate } : {}),
+    // #4939: both were advertised, bounds-checked and defaulted since the tool
+    // shipped, and neither was ever read off `parsed.data`.
+    maxVoteIterations: input.maxVoteIterations,
+    maxQaIterations: input.maxQaIterations,
     ...(trustTier !== undefined ? { trustTier } : {}),
     // #3710: thread the server's durable audit logger so the consensus→execute
     // policy gate persists decisions to the shared hash chain.

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
@@ -221,6 +221,55 @@ describe('runDevPipeline', () => {
     expect(result.tasks).toHaveLength(2);
   });
 
+  it('honors a caller-supplied vote-iteration cap (#4939)', async () => {
+    // `maxVoteIterations` was advertised by the MCP tool, bounds-checked and
+    // defaulted to 3, and never read — so setting it changed nothing. The
+    // default above proves 3; this proves the knob reaches the loop.
+    const vote = vi.fn().mockResolvedValue({
+      kind: 'rejected',
+      feedback: 'Still not right',
+      approvalPercentage: 40,
+    });
+    const stages = createMockStages({ vote });
+
+    const result = await runDevPipeline('Build feature X', stages, { maxVoteIterations: 1 });
+
+    expect(result.voteIterations).toBe(1);
+    expect(vote).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors a caller-supplied QA-iteration cap (#4939)', async () => {
+    // The sibling of the vote cap, and pinned separately: forwarding the option
+    // from the tool is not the same as the QA loop reading it, and mutating the
+    // loop back to its constant passed every other test.
+    const qaReview = vi
+      .fn()
+      .mockResolvedValue({ verdict: 'rejected', feedback: 'needs work', issues: ['x'] });
+    const stages = createMockStages({ qaReview });
+
+    const result = await runDevPipeline('Build feature X', stages, { maxQaIterations: 1 });
+
+    expect(result.qaIterations).toBeGreaterThan(0);
+    // Two tasks, one QA round each.
+    expect(qaReview).toHaveBeenCalledTimes(2);
+  });
+
+  it('still uses the default cap when none is supplied (#4939)', async () => {
+    // The pair: a hardcoded 1 would satisfy the test above and silently halve
+    // every unconfigured run.
+    const stages = createMockStages({
+      vote: vi.fn().mockResolvedValue({
+        kind: 'rejected',
+        feedback: 'Still not right',
+        approvalPercentage: 40,
+      }),
+    });
+
+    const result = await runDevPipeline('Build feature X', stages, {});
+
+    expect(result.voteIterations).toBe(3);
+  });
+
   it('passes vote feedback back to plan stage', async () => {
     const stages = createMockStages({
       vote: vi

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -222,6 +222,20 @@ export interface DevPipelineStages {
 const MAX_VOTE_ITERATIONS = 3;
 const MAX_QA_ITERATIONS = 3;
 
+/** Resolved loop bounds for one pipeline run (#4939). */
+interface IterationLimits {
+  readonly vote: number;
+  readonly qa: number;
+}
+
+/** The caps for this run: caller-supplied where given, the constants otherwise. */
+function resolveIterationLimits(options: DevPipelineOptions | undefined): IterationLimits {
+  return {
+    vote: options?.maxVoteIterations ?? MAX_VOTE_ITERATIONS,
+    qa: options?.maxQaIterations ?? MAX_QA_ITERATIONS,
+  };
+}
+
 /** Pipeline execution mode. */
 export type PipelineMode = 'autonomous' | 'harness';
 
@@ -254,6 +268,16 @@ export interface DevPipelineOptions {
    * if the stage is absent the gate is skipped regardless of mode.
    */
   readonly qualityGate?: QualityGateMode | undefined;
+  /**
+   * Cap on plan→vote rounds (#4939). Omitted uses {@link MAX_VOTE_ITERATIONS}.
+   *
+   * The MCP tool has advertised `maxVoteIterations` since it shipped — bounds
+   * checked, defaulted to 3, described in the generated tool reference — and
+   * nothing read it, so setting it changed nothing.
+   */
+  readonly maxVoteIterations?: number | undefined;
+  /** Cap on implement→QA rounds (#4939). Omitted uses {@link MAX_QA_ITERATIONS}. */
+  readonly maxQaIterations?: number | undefined;
   /** Optional BeliefMemory for hindsight updates after plan outcomes (#1720). */
   readonly beliefMemory?: IHindsightBeliefMemory | undefined;
   /**
@@ -368,13 +392,11 @@ async function runDevPipelineInner(
   }
 
   // Phases 4-5: Implement + Quality Gate + Security
-  const result = await runImplSecurityPhase(
-    planResult,
-    tasks,
-    stages,
+  const result = await runImplSecurityPhase(planResult, tasks, stages, {
     sid,
-    options?.qualityGate ?? 'off'
-  );
+    qualityGateMode: options?.qualityGate ?? 'off',
+    limits: resolveIterationLimits(options),
+  });
 
   // Apply hindsight with actual pipeline outcome (#1720)
   applyPipelineHindsight(bm, task, sid, result);
@@ -795,7 +817,10 @@ async function runPlanningPhase(
   }
 
   const planContext = await assemblePlanContext(research.text, task, sid, bm);
-  const planResult = await runPlanOrResume(prior, task, planContext, stages, sid);
+  const planResult = await runPlanOrResume(prior, task, planContext, stages, {
+    sid,
+    limits: resolveIterationLimits(options),
+  });
   if (sid !== undefined) {
     saveStageCheckpoint(sid, 'plan', {
       type: 'plan',
@@ -843,10 +868,10 @@ async function runImplSecurityPhase(
   planResult: { plan: string; iterations: number },
   tasks: PipelineTask[],
   stages: DevPipelineStages,
-  sid: string | undefined,
-  qualityGateMode: QualityGateMode
+  run: { sid: string | undefined; qualityGateMode: QualityGateMode; limits: IterationLimits }
 ): Promise<DevPipelineResult> {
-  const implResult = await implementQaLoop(tasks, stages);
+  const { sid, qualityGateMode, limits } = run;
+  const implResult = await implementQaLoop(tasks, stages, limits);
   if (sid !== undefined)
     saveStageCheckpoint(sid, 'implement', { type: 'implement', tasks: implResult.completedTasks });
 
@@ -936,7 +961,7 @@ async function runPlanOrResume(
   task: string,
   research: string,
   stages: DevPipelineStages,
-  sessionId: string | undefined
+  run: { sid: string | undefined; limits: IterationLimits }
 ): Promise<{
   plan: string;
   iterations: number;
@@ -944,6 +969,7 @@ async function runPlanOrResume(
   conditions: readonly string[];
   caveats: readonly string[];
 }> {
+  const { sid: sessionId, limits } = run;
   if (prior?.plan !== undefined) {
     logger.info('Resuming from checkpoint', { stage: 'plan', sessionId });
     return {
@@ -954,7 +980,7 @@ async function runPlanOrResume(
       caveats: prior.voteCaveats ?? [],
     };
   }
-  return planVoteLoop(task, research, stages, sessionId);
+  return planVoteLoop(task, research, stages, sessionId, limits);
 }
 
 /** Conditional vote metadata for task annotation. */
@@ -1011,12 +1037,13 @@ async function planVoteLoop(
   task: string,
   research: string,
   stages: DevPipelineStages,
-  sessionId: string | undefined
+  sessionId: string | undefined,
+  limits: IterationLimits
 ): Promise<{ plan: string; iterations: number } & ConditionalMeta> {
   let feedback: string | undefined;
   let plan = '';
 
-  for (let i = 1; i <= MAX_VOTE_ITERATIONS; i++) {
+  for (let i = 1; i <= limits.vote; i++) {
     plan = await withStep(
       { name: `plan (i=${String(i)})`, kind: 'pipeline.stage', attrs: { iteration: i } },
       () => stages.plan(task, research, feedback)
@@ -1065,7 +1092,7 @@ async function planVoteLoop(
   }
 
   logger.warn('Max vote iterations reached, proceeding with last plan', { sessionId });
-  return { plan, iterations: MAX_VOTE_ITERATIONS, conditional: false, conditions: [], caveats: [] };
+  return { plan, iterations: limits.vote, conditional: false, conditions: [], caveats: [] };
 }
 
 /** Result of implementing a single task. */
@@ -1077,7 +1104,8 @@ interface TaskImplResult {
 /** Implement a single task with QA iteration loop via reusable runQaLoop (#1707). */
 async function implementSingleTask(
   task: PipelineTask,
-  stages: DevPipelineStages
+  stages: DevPipelineStages,
+  limits: IterationLimits
 ): Promise<TaskImplResult> {
   let currentTask: PipelineTask = { ...task, status: 'in_progress' };
   const qaResult = await runQaLoop<string>(
@@ -1100,7 +1128,7 @@ async function implementSingleTask(
       const review = await stages.qaReview(currentTask, impl);
       return { verdict: review.verdict, feedback: review.feedback, issues: review.issues };
     },
-    MAX_QA_ITERATIONS
+    limits.qa
   );
   const finalTask: PipelineTask = {
     id: task.id,
@@ -1128,11 +1156,12 @@ const MAX_IMPL_CONCURRENCY = 4;
 /** Implement tasks with bounded-concurrency parallel dispatch (#1695, #1734). */
 async function implementQaLoop(
   tasks: PipelineTask[],
-  stages: DevPipelineStages
+  stages: DevPipelineStages,
+  limits: IterationLimits
 ): Promise<ImplLoopResult> {
   if (tasks.length === 0) return { totalIterations: 0, completedTasks: [] };
 
-  const taskFns = tasks.map((task) => () => implementSingleTaskSafe(task, stages));
+  const taskFns = tasks.map((task) => () => implementSingleTaskSafe(task, stages, limits));
   const results = await executeWithConcurrency(taskFns, MAX_IMPL_CONCURRENCY);
   return aggregateImplResults(results);
 }
@@ -1140,10 +1169,11 @@ async function implementQaLoop(
 /** Execute a task with error handling, returning a safe result. */
 async function implementSingleTaskSafe(
   task: PipelineTask,
-  stages: DevPipelineStages
+  stages: DevPipelineStages,
+  limits: IterationLimits
 ): Promise<TaskImplResult | null> {
   try {
-    return await implementSingleTask(task, stages);
+    return await implementSingleTask(task, stages, limits);
   } catch (error) {
     const reason = error instanceof Error ? error : new Error(String(error));
     logger.error('Task implementation failed', reason, {});


### PR DESCRIPTION
Refs #4939. `src/pipeline/` and `src/mcp/` are CODEOWNERS review-requested (not on the never-auto-merge list) — flagging rather than assuming.

## What was wrong

`run_dev_pipeline` has advertised two parameters since it shipped:

```ts
maxVoteIterations: z.number().int().min(1).max(5).default(3).describe('Max plan→vote iterations'),
maxQaIterations:   z.number().int().min(1).max(5).default(3).describe(...),
```

Bounds-checked, defaulted, and `.describe()`d into the generated tool reference. **Neither was ever read off `parsed.data`.** A caller setting either got a validation error for `6` and silence for `5` — both meaning the same thing.

## Wired rather than removed, and the reason matters

My first instinct from the sweep was to delete them as dead config. That would have been wrong: the behaviour they name already exists.

```ts
const MAX_VOTE_ITERATIONS = 3;
const MAX_QA_ITERATIONS = 3;
```

Two real loops, both bounded, both hardcoded — and the schema defaults are `3` and `3`. The defaults matching the constants exactly is strong evidence these were meant to be connected and the wiring was never finished. Removing them would have deleted a capability that was one indirection from working.

Both now resolve through `DevPipelineOptions`, falling back to the constants when unset, so an unconfigured run behaves exactly as before.

## Mutations — and the sibling that nearly slipped

| mutation | result |
| --- | --- |
| vote loop back to the constant | 1 failed |
| resolver ignores `maxVoteIterations` | 1 failed |
| tool stops forwarding the vote cap | 2 failed |
| tool stops forwarding the QA cap | 2 failed |
| **QA loop back to the constant** | **1 failed** |
| **resolver ignores `maxQaIterations`** | **1 failed** |

The last two rows needed a second pass. I had a tool-level test proving the QA option is *forwarded* and a pipeline test proving the *vote* loop honours its cap — and mutating the QA loop back to its constant passed everything. Forwarding an option is not the same as the loop reading it, and doing one sibling properly while assuming the other is exactly the inconsistency that produces these gaps.

Both loops now have their own pipeline-level test alongside a default-preserving pair, since a hardcoded `1` would satisfy the cap test while silently halving every unconfigured run.

## Note

Three functions gained a bundled `run: { sid, limits, … }` parameter to stay under the 5-parameter ceiling. No behaviour rides on the regrouping. 727 pipeline and tool tests pass; `api-surface.txt` regenerated for the two additive optional fields.
