### PR TITLE
chore(cli-adapters): remove two config fields nothing reads

### DIFF
--- a/.changeset/remove-two-dead-config-fields.md
+++ b/.changeset/remove-two-dead-config-fields.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+remove two configuration fields nothing reads
+
+`RouterConfig.minCapacityThreshold` was declared on the interface and in
+`RouterConfigSchema` with a `0.1` default, and had exactly two occurrences
+repo-wide — both of them those declarations. No reader, no test, no consumer.
+`RouterConfigSchema` is not strict, so a YAML that still sets the key is
+ignored rather than rejected.
+
+`BaseAdapter.lastHealthCheck` was assigned after every health check and never
+read by the base class or any subclass. `checkHealth` already returns the
+status it was caching.
+
+Public API surface is unchanged by both, confirming neither was reachable from
+outside the package. Found in a vestigial-code sweep (#4939).

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.ts
@@ -85,7 +85,6 @@ export abstract class BaseCliAdapter implements ICliAdapter {
   protected readonly logger: ILogger;
   protected capacityTracker: CapacityTracker | null = null;
   protected initialized = false;
-  protected lastHealthCheck?: HealthStatus;
   protected cachedVersion?: string;
 
   constructor(logger?: ILogger) {
@@ -269,7 +268,6 @@ export abstract class BaseCliAdapter implements ICliAdapter {
         ...(message !== undefined && { message }),
       };
 
-      this.lastHealthCheck = status;
       return status;
     } catch (error) {
       return {

--- a/packages/nexus-agents/src/cli-adapters/router-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/router-types.ts
@@ -52,8 +52,6 @@ export interface RoutingDecision {
 export interface RouterConfig {
   /** Logger instance */
   readonly logger?: ILogger;
-  /** Minimum capacity threshold (0-1) */
-  readonly minCapacityThreshold?: number;
   /** Whether to prefer cost-efficient adapters */
   readonly preferCostEfficient?: boolean;
   /** Maximum routing decision time in ms */
@@ -64,7 +62,6 @@ export interface RouterConfig {
  * Configuration schema for validation.
  */
 export const RouterConfigSchema = z.object({
-  minCapacityThreshold: z.number().min(0).max(1).default(0.1),
   preferCostEfficient: z.boolean().default(false),
   maxDecisionTimeMs: z.number().min(1).max(1000).default(100),
 });


### PR DESCRIPTION
Refs #4939. The two entries from that sweep where removal is unambiguous — no consumer, no test, no public surface.

## `RouterConfig.minCapacityThreshold`

Two occurrences repo-wide, both declarations:

```
router-types.ts:56  readonly minCapacityThreshold?: number;
router-types.ts:67  minCapacityThreshold: z.number().min(0).max(1).default(0.1),
```

No reader, no test, nothing in any YAML. `RouterConfigSchema` is not strict, so a config that still sets the key is ignored rather than rejected — removal cannot break an existing deployment.

## `BaseAdapter.lastHealthCheck`

Assigned at `base-adapter.ts:272` after every health check and never read — not by the base class, not by any subclass, not by a test. `checkHealth` already returns the status it was caching, so the field was a write-only copy.

It was `protected`, so an out-of-tree subclass could in principle have read it. `pnpm api:surface` reports **unchanged**, which confirms it was not reachable from the package's public surface.

## Why these two and not the rest of the sweep

The other declared-but-unread items in #4939 are not this clean, and I deliberately left them:

- **`maxCostPerRequest`** turns out to be the exact twin of #4907's `maxLatencyMs` — YAML-plumbed through the config adapter into `TopsisConfig` and never enforced. That is a silent no-op *constraint*, and enforce-vs-remove is a behaviour question, so it belongs on #4907 rather than in a cleanup PR. Noted there.
- **The sixteen env vars** behind the four dead getters cannot be removed without touching `env-schema.ts`, which drags in the registry-coverage peer requirement and therefore `CLAUDE.md` — see #4931. Removing them also needs the tombstone treatment `env-schema.ts:43` already models, so a user who had one set learns it stopped meaning something.
- **`maxDecisionTimeMs`** already carries an in-code disclosure (`capacity-stage.ts:247` says it is declared but not enforced), so it is documented rather than silent.

2705 `cli-adapters` tests pass; lint and typecheck clean.
