### PR TITLE
feat(cli): let vote declare named options so the record says which one won

### DIFF
--- a/.changeset/cli-vote-options.md
+++ b/.changeset/cli-vote-options.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': minor
+---
+
+let `nexus-agents vote` declare named options, so a multi-option decision records which one won
+
+The engine has recorded `optionTally` and `optionCoverage` since #4472, and the
+CLI had no way to supply the options they measure. Every multi-option vote run
+from a terminal persisted as a bare `approved` with `optionTally: null` — the
+panel deliberated over three alternatives and the record could not say which it
+chose.
+
+`--option` is repeatable (2-10, enforced by the existing schema). Omit it and
+behaviour is unchanged: the field is left off entirely rather than sent as an
+empty array, because the engine treats a present `options` array as "this is a
+multi-option vote" and adds the leading-option bar on top of the ordinary
+approve/reject one.
+
+No short flag. Every free letter is taken, and the two collisions that already
+existed silently bound the wrong option (#4922).

--- a/packages/nexus-agents/src/cli-command-help.ts
+++ b/packages/nexus-agents/src/cli-command-help.ts
@@ -66,12 +66,18 @@ const VOTE_HELP: CommandHelpEntry = {
   examples: [
     'nexus-agents vote --proposal "Add caching layer"',
     'nexus-agents vote -p "Migrate to PostgreSQL" --threshold supermajority',
+    'nexus-agents vote -p "Pick a cache" --option "Redis" --option "in-process LRU"',
     'nexus-agents vote -p "Quick decision" --quick',
     'nexus-agents vote -p "Test idea" --dry-run',
   ],
   flags: [
     { flag: '-p, --proposal <text>', description: 'Proposal text to vote on (required)' },
     { flag: '--threshold <t>', description: 'Threshold: majority, supermajority, unanimous' },
+    {
+      flag: '--option <text>',
+      description:
+        'Named alternative (repeatable, 2-10). Records WHICH option won, not just approval',
+    },
     { flag: '--quick', description: 'Use 3 agents instead of the full 7 for faster votes' },
     { flag: '--dry-run', description: 'Simulate votes without agent execution' },
     { flag: '--timeout=<seconds>', description: 'Timeout per vote in seconds', defaultValue: '90' },

--- a/packages/nexus-agents/src/cli-types.test.ts
+++ b/packages/nexus-agents/src/cli-types.test.ts
@@ -52,3 +52,32 @@ describe('PARSE_ARGS_CONFIG short flags', () => {
     expect(values.task).toBeUndefined();
   });
 });
+
+describe('--option is repeatable (#4941)', () => {
+  it('collects every occurrence into an array', () => {
+    // A multi-option vote needs at least two alternatives, so a flag that kept
+    // only the last one would be useless. `multiple: true` is what makes the
+    // repetition work; without it parseArgs keeps a single string.
+    const { values } = parseArgs({
+      args: ['vote', '-p', 'pick one', '--option', 'A', '--option', 'B', '--option', 'C'],
+      options: PARSE_ARGS_CONFIG.options,
+      allowPositionals: true,
+      strict: false,
+    });
+
+    expect(values.option).toEqual(['A', 'B', 'C']);
+  });
+
+  it('leaves it undefined for an ordinary yes/no vote', () => {
+    // The pair: an empty array would reach the engine as "multi-option with no
+    // options", which the schema rejects with min(2).
+    const { values } = parseArgs({
+      args: ['vote', '-p', 'ship it'],
+      options: PARSE_ARGS_CONFIG.options,
+      allowPositionals: true,
+      strict: false,
+    });
+
+    expect(values.option).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -407,6 +407,12 @@ export const PARSE_ARGS_CONFIG = {
       type: 'string' as const,
       short: 'p',
     },
+    // Repeatable. No short letter: every free one is taken, and the two
+    // collisions that already existed silently bound the wrong option (#4922).
+    option: {
+      type: 'string' as const,
+      multiple: true as const,
+    },
     // No `short`. `parseArgs` takes one options object for every command, so
     // a short letter is global: `-t` was already `task`, which won, and
     // `vote -t supermajority` silently ran a simple-majority vote. Long form

--- a/packages/nexus-agents/src/cli.test.ts
+++ b/packages/nexus-agents/src/cli.test.ts
@@ -429,3 +429,38 @@ describe('CLI Command Priority', () => {
     expect(result.command).toBe('version');
   });
 });
+
+// =============================================================================
+// --option reaches the vote command's options (#4941)
+// =============================================================================
+
+describe('parseCliArgs carries --option through to vote options (#4941)', () => {
+  // The middle link. `PARSE_ARGS_CONFIG` collecting the repeats and
+  // `voteCommand` forwarding them were each pinned, and deleting the mapping
+  // between them in `buildVoteOptions` passed both — the same
+  // both-ends-tested-join-untested gap as #4910.
+
+  it('maps repeated flags onto options', () => {
+    const parsed = parseCliArgs([
+      'vote',
+      '-p',
+      'pick one',
+      '--option',
+      'A',
+      '--option',
+      'B',
+    ]) as ParsedCliArgs & { options?: { options?: string[] } };
+
+    expect(parsed.options?.options).toEqual(['A', 'B']);
+  });
+
+  it('leaves options absent for an ordinary vote', () => {
+    // Present-but-empty would tell the engine this is a multi-option vote and
+    // add the leading-option bar to a plain yes/no.
+    const parsed = parseCliArgs(['vote', '-p', 'ship it']) as ParsedCliArgs & {
+      options?: Record<string, unknown>;
+    };
+
+    expect(parsed.options).not.toHaveProperty('options');
+  });
+});

--- a/packages/nexus-agents/src/cli.ts
+++ b/packages/nexus-agents/src/cli.ts
@@ -121,6 +121,8 @@ interface ParsedValues {
   fix: boolean;
   proposal?: string;
   threshold?: string;
+  /** Repeatable `--option` for a multi-option vote (#4941). */
+  option?: string[];
   quick: boolean;
   timeout?: string;
   'error-policy'?: string;
@@ -234,8 +236,10 @@ function buildVoteOptions(values: ParsedValues): Record<string, unknown> {
   const timeoutMs = timeoutSec !== undefined ? timeoutSec * 1000 : undefined;
   const errorPolicy = parseErrorPolicy(values['error-policy']);
   const onNoQuorum = parseNoQuorumPolicy(values['on-no-quorum']);
+  const options = values.option;
   return {
     ...(values.proposal !== undefined && { proposal: values.proposal }),
+    ...(options !== undefined && options.length > 0 && { options }),
     ...(threshold !== undefined && { threshold }),
     ...(timeoutMs !== undefined && { timeoutMs }),
     ...(errorPolicy !== undefined && { errorPolicy }),

--- a/packages/nexus-agents/src/cli/vote-command.test.ts
+++ b/packages/nexus-agents/src/cli/vote-command.test.ts
@@ -517,3 +517,50 @@ describe('auditLineFor (#4924)', () => {
     expect(line).not.toMatch(/NOT recorded/i);
   });
 });
+
+// =============================================================================
+// Multi-option votes from the CLI (#4941)
+// =============================================================================
+
+describe('voteCommand forwards options to the engine (#4941)', () => {
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  function extendedResult() {
+    return {
+      proposal: 'p',
+      threshold: 'simple_majority',
+      result: createMockConsensusResult({ outcome: 'approved' }),
+      votes: [],
+      totalTimeMs: 5,
+      simulateVotes: false,
+      strategy: 'simple_majority',
+      decision: 'approved',
+    };
+  }
+
+  beforeEach(() => {
+    executeVotingMock.mockReset();
+    executeVotingMock.mockResolvedValue(extendedResult());
+    recordAuthenticVoteMock.mockClear();
+  });
+
+  it('passes the declared alternatives through', async () => {
+    // Without this the engine records `optionTally: null` and the decision
+    // cannot say which of A/B/C the panel chose — verified on two real votes
+    // before this flag existed.
+    await voteCommand({ proposal: 'pick one', options: ['A', 'B'] });
+
+    const input = executeVotingMock.mock.calls[0]?.[0] as { options?: string[] } | undefined;
+    expect(input?.options).toEqual(['A', 'B']);
+  });
+
+  it('omits the field entirely for an ordinary vote', async () => {
+    // The pair, and it matters: the engine treats a PRESENT `options` array as
+    // "this is a multi-option vote" and applies the leading-option bar on top
+    // of the approve/reject one. Sending an empty array would change the
+    // threshold semantics of every yes/no vote.
+    await voteCommand({ proposal: 'ship it' });
+
+    const input = executeVotingMock.mock.calls[0]?.[0] as { options?: string[] } | undefined;
+    expect(input).not.toHaveProperty('options');
+  });
+});

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -302,6 +302,7 @@ async function runVote(
 
   const input: ConsensusVoteInput = {
     proposal: options.proposal,
+    ...(options.options !== undefined ? { options: [...options.options] } : {}),
     quickMode: useQuick,
     simulateVotes: options.dryRun === true,
     ...(options.threshold !== undefined && { threshold: options.threshold }),

--- a/packages/nexus-agents/src/cli/vote-types.ts
+++ b/packages/nexus-agents/src/cli/vote-types.ts
@@ -27,6 +27,14 @@ export type NoQuorumPolicy = 'fail' | 'exit2' | 'retry';
  */
 export interface VoteCommandOptions {
   readonly proposal: string;
+  /**
+   * Named alternatives for a multi-option proposal (#4472, #4941).
+   *
+   * Without these, the record of a three-way decision reads `approved` with a
+   * null `optionTally` — it cannot say WHICH option won, which is the point of
+   * asking a panel a multi-way question in the first place.
+   */
+  readonly options?: readonly string[];
   readonly threshold?: VoteThreshold;
   /** Use simulated votes instead of LLM execution (maps from --dry-run CLI flag) */
   readonly dryRun?: boolean;


### PR DESCRIPTION
Closes #4941. Found by running two multi-option votes through the CLI today and then reading what they recorded.

## The gap

The engine has produced `optionTally` and `optionCoverage` since #4472. The CLI had no way to supply the options they measure, so a multi-option vote from a terminal persisted as:

```json
"decision": "approved",
"optionTally": null,
"optionCoverage": null
```

The same fork through the MCP tool an hour later:

```json
"optionTally": [
  { "option": "A: extend ChainVerification with a coverage field", "count": 4 },
  { "option": "B: pass a loader coverage hint into verifyChain",   "count": 1 }
],
"optionCoverage": { "approverCount": 5, "selectedCount": 5, "unattributedApprovals": 0 }
```

Same engine, same store. The first settles nothing — I could not tell afterwards whether the panel wanted A, B or C, and I had cited it as a decision. The second resolved #4805 outright and showed the split was 4-1 rather than unanimous.

## The design decision worth reviewing

**Omitting the flag omits the field**, rather than sending `[]`. That is not tidiness: the engine treats a *present* `options` array as "this is a multi-option vote" and applies the leading-option bar **in addition to** the approve/reject one. An empty array would therefore change the threshold semantics of every ordinary yes/no vote run from the CLI. Both directions have a test, and mutating the mapping to `options ?? []` fails.

No short flag. `-o` is `output` and every other free letter is taken — and the two collisions that already existed silently bound the wrong option (#4922), which is not a mistake worth repeating for convenience.

## Mutations, and the middle link that needed a third test

| mutation | result |
| --- | --- |
| drop `multiple: true` (flag not repeatable) | 1 failed |
| `voteCommand` stops forwarding options | 1 failed |
| `voteCommand` always sends an array | 1 failed |
| **`buildVoteOptions` stops mapping the flag** | **1 failed** |
| **`buildVoteOptions` always maps an array** | **1 failed** |

The bottom two initially passed. `PARSE_ARGS_CONFIG` collecting the repeats was pinned, `voteCommand` forwarding them was pinned, and deleting the `buildVoteOptions` mapping *between* them was invisible — the same both-ends-tested-join-untested gap as #4910, #4940 and #4944. There is now a `parseCliArgs` test covering that link end to end.

6828 CLI tests pass; public API surface unchanged.
