### PR TITLE
fix(cli): pad boxes by display width so coloured lines keep their border

### DIFF
--- a/.changeset/box-ansi-aware-padding.md
+++ b/.changeset/box-ansi-aware-padding.md
@@ -22,3 +22,11 @@ emitted whole and still overflows — visibly, rather than silently truncated.
 
 The regression test that found these now covers the whole rendered report
 rather than one section.
+
+`centerText` had the identical defect and is fixed alongside: it computed
+`BOX_WIDTH - text.length - 2`, so coloured text drifted left by half the escape
+length.
+
+`visibleWidth` lives in its own module. Measuring display columns is not
+box-specific, and the producer/consumer ratchet is right that a test importing
+a symbol is not a consumer of it.

--- a/.changeset/box-ansi-aware-padding.md
+++ b/.changeset/box-ansi-aware-padding.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+measure box padding in display columns, not bytes
+
+`boxLine` padded with `String.prototype.length`, which counts ANSI escape
+bytes — an escape occupies zero columns — so every coloured line was padded
+short by however many escapes it happened to contain and its right border
+landed in the wrong place. Three call sites in the routing audit had grown
+hand-tuned `BOX_WIDTH + 8` / `+ 11` / `+ 7` compensations, each correct only
+for that line's exact colours and all of them over-padding under `NO_COLOR`.
+
+`visibleWidth` strips SGR escapes before measuring, and the five fudge factors
+are gone.
+
+One line overflowed for a different reason: the task-analysis summary is a
+single pipe-joined string that reached 78 display columns in a 63-column box.
+No padding scheme fixes content that does not fit, so `formatTaskAnalysis`
+wraps it on the `|` separators. A single segment wider than the box is still
+emitted whole and still overflows — visibly, rather than silently truncated.
+
+The regression test that found these now covers the whole rendered report
+rather than one section.

--- a/packages/nexus-agents/src/cli/ansi-width.ts
+++ b/packages/nexus-agents/src/cli/ansi-width.ts
@@ -1,0 +1,27 @@
+/**
+ * Display-width measurement for terminal strings.
+ *
+ * Its own module rather than a box-drawing detail: measuring how many columns a
+ * string occupies is not specific to boxes, and `box-drawing.ts` is only its
+ * first caller. Splitting it also gives the export a real cross-file consumer,
+ * which the producer/consumer ratchet is right to demand — a test importing a
+ * symbol is not a consumer of it.
+ *
+ * @module cli/ansi-width
+ */
+
+/** ANSI SGR escapes — zero display columns, non-zero `String.length`. */
+const ANSI_SGR = /\u001b\[[0-9;]*m/g;
+
+/**
+ * Display width of a string, ignoring ANSI colour escapes (#4913).
+ *
+ * `String.prototype.length` counts escape bytes, which occupy no columns. Every
+ * pad computed from it is wrong by however many escapes the caller happened to
+ * include — which is why three call sites had grown hand-tuned
+ * `BOX_WIDTH + 8` / `+ 11` / `+ 7` constants, each correct only for that line's
+ * exact colours and all of them wrong under `NO_COLOR`.
+ */
+export function visibleWidth(s: string): number {
+  return s.replace(ANSI_SGR, '').length;
+}

--- a/packages/nexus-agents/src/cli/box-drawing.test.ts
+++ b/packages/nexus-agents/src/cli/box-drawing.test.ts
@@ -14,8 +14,8 @@ import {
   boxTop,
   boxSeparator,
   boxBottom,
-  visibleWidth,
 } from './box-drawing.js';
+import { visibleWidth } from './ansi-width.js';
 
 // ============================================================================
 // BOX_WIDTH
@@ -176,6 +176,17 @@ describe('visibleWidth and ANSI-aware padding (#4913)', () => {
     // grown hand-tuned `BOX_WIDTH + n` constants compensating for exactly this.
     const plain = boxLine('abc');
     const coloured = boxLine(`${BOLD}abc${RESET}`);
+
+    expect(visibleWidth(coloured)).toBe(visibleWidth(plain));
+  });
+
+  it('centers coloured text on its display width too', () => {
+    // `centerText` had the identical defect: `BOX_WIDTH - text.length - 2`
+    // counted escape bytes, so coloured text drifted left by half the escape
+    // length. Same fix, and it needs its own assertion — the boxLine tests
+    // above pass with centerText still broken.
+    const plain = centerText('abc');
+    const coloured = centerText(`${BOLD}abc${RESET}`);
 
     expect(visibleWidth(coloured)).toBe(visibleWidth(plain));
   });

--- a/packages/nexus-agents/src/cli/box-drawing.test.ts
+++ b/packages/nexus-agents/src/cli/box-drawing.test.ts
@@ -14,6 +14,7 @@ import {
   boxTop,
   boxSeparator,
   boxBottom,
+  visibleWidth,
 } from './box-drawing.js';
 
 // ============================================================================
@@ -146,5 +147,44 @@ describe('boxBottom', () => {
   it('contains horizontal line between corners', () => {
     const result = boxBottom();
     expect(result).toContain('─');
+  });
+});
+
+// =============================================================================
+// Padding measures display columns, not bytes (#4913)
+// =============================================================================
+
+describe('visibleWidth and ANSI-aware padding (#4913)', () => {
+  // `colors.*` are empty strings under NO_COLOR / non-TTY, which is how the
+  // suite runs — so a rendered-width test cannot tell ANSI-aware padding from
+  // raw `.length`. These inject the escapes literally.
+  const BOLD = '\u001b[1m';
+  const RESET = '\u001b[0m';
+
+  it('ignores ANSI escapes when measuring', () => {
+    expect(visibleWidth(`${BOLD}abc${RESET}`)).toBe(3);
+  });
+
+  it('measures a plain string as its length', () => {
+    // The pair: stripping too eagerly would under-count ordinary text.
+    expect(visibleWidth('abc')).toBe(3);
+  });
+
+  it('pads a coloured line to the same display width as a plain one', () => {
+    // The defect: `.length` counted the escape bytes, so a coloured line got
+    // fewer pad spaces and its right border landed short. Three call sites had
+    // grown hand-tuned `BOX_WIDTH + n` constants compensating for exactly this.
+    const plain = boxLine('abc');
+    const coloured = boxLine(`${BOLD}abc${RESET}`);
+
+    expect(visibleWidth(coloured)).toBe(visibleWidth(plain));
+  });
+
+  it('does not pad content wider than the box', () => {
+    // A box cannot contain it, and truncating would hide data. The caller
+    // splits — `formatTaskAnalysis` does — and the overflow stays visible.
+    const long = 'x'.repeat(BOX_WIDTH * 2);
+
+    expect(boxLine(long)).toContain(long);
   });
 });

--- a/packages/nexus-agents/src/cli/box-drawing.ts
+++ b/packages/nexus-agents/src/cli/box-drawing.ts
@@ -8,6 +8,7 @@
  */
 
 import { colors, color } from './ansi-output.js';
+import { visibleWidth } from './ansi-width.js';
 
 // =============================================================================
 // Constants
@@ -26,22 +27,6 @@ export const BOX_WIDTH = 65;
  */
 export function horizontalLine(char = '─'): string {
   return char.repeat(BOX_WIDTH - 2);
-}
-
-/** ANSI SGR escapes — zero display columns, non-zero `String.length`. */
-const ANSI_SGR = /\u001b\[[0-9;]*m/g;
-
-/**
- * Display width of a string, ignoring ANSI colour escapes (#4913).
- *
- * `String.prototype.length` counts escape bytes, which occupy no columns. Every
- * pad computed from it is wrong by however many escapes the caller happened to
- * include — which is why three call sites had grown hand-tuned
- * `BOX_WIDTH + 8` / `+ 11` / `+ 7` constants, each correct only for that line's
- * exact colours and all of them wrong under `NO_COLOR`.
- */
-export function visibleWidth(s: string): number {
-  return s.replace(ANSI_SGR, '').length;
 }
 
 /**
@@ -66,7 +51,7 @@ export function boxLine(content: string, borderColor: string = colors.cyan): str
  * @param borderColor ANSI color code for the border (default: cyan)
  */
 export function centerText(text: string, borderColor = colors.cyan): string {
-  const padding = Math.max(0, BOX_WIDTH - text.length - 2);
+  const padding = Math.max(0, BOX_WIDTH - visibleWidth(text) - 2);
   const left = Math.floor(padding / 2);
   const right = padding - left;
   return (

--- a/packages/nexus-agents/src/cli/box-drawing.ts
+++ b/packages/nexus-agents/src/cli/box-drawing.ts
@@ -28,14 +28,36 @@ export function horizontalLine(char = '─'): string {
   return char.repeat(BOX_WIDTH - 2);
 }
 
+/** ANSI SGR escapes — zero display columns, non-zero `String.length`. */
+const ANSI_SGR = /\u001b\[[0-9;]*m/g;
+
+/**
+ * Display width of a string, ignoring ANSI colour escapes (#4913).
+ *
+ * `String.prototype.length` counts escape bytes, which occupy no columns. Every
+ * pad computed from it is wrong by however many escapes the caller happened to
+ * include — which is why three call sites had grown hand-tuned
+ * `BOX_WIDTH + 8` / `+ 11` / `+ 7` constants, each correct only for that line's
+ * exact colours and all of them wrong under `NO_COLOR`.
+ */
+export function visibleWidth(s: string): number {
+  return s.replace(ANSI_SGR, '').length;
+}
+
 /**
  * Creates a box line with content and borders.
- * Content is padded to BOX_WIDTH and bordered with │ characters.
+ *
+ * Padded to the box's content width measured in DISPLAY columns, so colour
+ * escapes do not eat the padding. Content wider than the box is returned
+ * unpadded and will overflow — the box cannot contain it, and silently
+ * truncating would hide data; callers with long content should split it.
+ *
  * @param content Content to display inside the box
  * @param borderColor ANSI color code for the border (default: cyan)
  */
-export function boxLine(content: string, borderColor = colors.cyan): string {
-  return color('│', borderColor) + content.padEnd(BOX_WIDTH - 2) + color('│', borderColor);
+export function boxLine(content: string, borderColor: string = colors.cyan): string {
+  const pad = Math.max(0, BOX_WIDTH - 2 - visibleWidth(content));
+  return color('│', borderColor) + content + ' '.repeat(pad) + color('│', borderColor);
 }
 
 /**

--- a/packages/nexus-agents/src/cli/routing-audit-format.test.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-format.test.ts
@@ -163,11 +163,9 @@ describe('routing-audit-format', () => {
       // the 63-character content area, `padEnd` no-opped, and the right border
       // was pushed off every line of the budget section.
       //
-      // Scoped to this stage. Widening it to the whole report fails on five
-      // pre-existing overflows with a different root cause — `boxLine` pads on
-      // `.length`, which counts ANSI escapes — filed separately as #4913
-      // rather than folded into a regression fix.
-      const output = formatBudgetFilter(mockResult);
+      // Widened to the whole report now that #4913 is fixed: `boxLine` measures
+      // display width, so every caller is covered rather than just this stage.
+      const output = formatAsciiOutput(mockResult, { task: 'test', explain: true }).split('\n');
       const visible = (line: string): string => line.replace(/\u001b\[[0-9;]*m/g, '');
       const overflowing = output
         .filter((line) => visible(line).startsWith('│'))

--- a/packages/nexus-agents/src/cli/routing-audit-format.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-format.ts
@@ -35,11 +35,42 @@ export function formatHeader(result: RoutingAuditResult): string[] {
 /**
  * Formats the task analysis section.
  */
+/**
+ * Pack `a | b | c` segments into lines no wider than `width` (#4913).
+ *
+ * `summarizeTaskProfile` returns a single pipe-joined string that reached 78
+ * display columns in a 63-column box. ANSI-aware padding cannot help there —
+ * the content genuinely does not fit — so the caller splits it, which is the
+ * one honest option that neither truncates nor spills.
+ *
+ * A single segment longer than `width` is emitted on its own line rather than
+ * broken mid-word; it will still overflow, and that is visible rather than
+ * silently cut.
+ */
+function wrapPipeSeparated(text: string, width: number): string[] {
+  const segments = text.split(' | ');
+  const lines: string[] = [];
+  let current = '';
+  for (const segment of segments) {
+    const candidate = current === '' ? segment : `${current} | ${segment}`;
+    if (current !== '' && candidate.length > width) {
+      lines.push(current);
+      current = segment;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current !== '') lines.push(current);
+  return lines;
+}
+
 export function formatTaskAnalysis(result: RoutingAuditResult): string[] {
   const lines: string[] = [];
   lines.push(boxLine(color(' Task Analysis:', ANSI.bold)));
   const profileSummary = summarizeTaskProfile(result.taskProfile);
-  lines.push(boxLine(`   ${profileSummary}`));
+  for (const segment of wrapPipeSeparated(profileSummary, BOX_WIDTH - 5)) {
+    lines.push(boxLine(`   ${segment}`));
+  }
   lines.push(color('├' + horizontalLine() + '┤', ANSI.cyan));
   return lines;
 }
@@ -116,7 +147,7 @@ export function formatLinUCBSelection(result: RoutingAuditResult): string[] {
     const ucb = arm.ucbScore.toFixed(2);
     const pulls = String(arm.pullCount);
     const content = `   ${arm.cliName.padEnd(8)} UCB: ${ucb.padStart(5)} pulls: ${pulls.padStart(3)} ${marker}`;
-    lines.push(color('│', ANSI.cyan) + content.padEnd(BOX_WIDTH + 8) + color('│', ANSI.cyan));
+    lines.push(boxLine(content));
   }
   lines.push(color('├' + horizontalLine() + '┤', ANSI.cyan));
   return lines;
@@ -128,7 +159,7 @@ export function formatLinUCBSelection(result: RoutingAuditResult): string[] {
 export function formatFinalSelection(result: RoutingAuditResult, explain: boolean): string[] {
   const lines: string[] = [];
   const selectionText = color(` Final Selection: ${result.selectedCli}`, ANSI.bold + ANSI.green);
-  lines.push(color('│', ANSI.cyan) + selectionText.padEnd(BOX_WIDTH + 11) + color('│', ANSI.cyan));
+  lines.push(boxLine(selectionText));
   lines.push(boxLine(`   Reason: ${result.selectionReason}`));
   lines.push(color('╰' + horizontalLine() + '╯', ANSI.cyan));
 
@@ -156,9 +187,7 @@ function formatBanditStatsHeader(): string[] {
   return [
     '',
     color('╭' + horizontalLine() + '╮', ANSI.yellow),
-    color('│', ANSI.yellow) +
-      color(' LinUCB Detailed Statistics (--bandit-stats)', ANSI.bold).padEnd(BOX_WIDTH + 7) +
-      color('│', ANSI.yellow),
+    boxLine(color(' LinUCB Detailed Statistics (--bandit-stats)', ANSI.bold), ANSI.yellow),
     color('├' + horizontalLine() + '┤', ANSI.yellow),
   ];
 }
@@ -201,18 +230,10 @@ function formatExplorationSection(stats: BanditStats): string[] {
 function formatFeatureImportanceSection(stats: BanditStats): string[] {
   const lines: string[] = [];
 
-  lines.push(
-    color('│', ANSI.yellow) +
-      color(' Feature Importance by Arm:', ANSI.bold).padEnd(BOX_WIDTH + 7) +
-      color('│', ANSI.yellow)
-  );
+  lines.push(boxLine(color(' Feature Importance by Arm:', ANSI.bold), ANSI.yellow));
 
   for (const arm of stats.detailedArms) {
-    lines.push(
-      color('│', ANSI.yellow) +
-        `   ${color(arm.cliName, ANSI.cyan)}:`.padEnd(BOX_WIDTH + 5) +
-        color('│', ANSI.yellow)
-    );
+    lines.push(boxLine(`   ${color(arm.cliName, ANSI.cyan)}:`, ANSI.yellow));
     const top3 = arm.featureImportance.slice(0, 3);
     for (const fi of top3) {
       const pct = formatPercentage(fi.importance, 1);


### PR DESCRIPTION
Closes #4913, found by a regression test written for a different bug.

## Two problems wearing one symptom

**Mis-padding.** `boxLine` padded with `String.prototype.length`, which counts ANSI escape bytes. An escape occupies zero columns, so every coloured line was padded short by however many it contained. Three call sites had already worked around this by hand:

| line | pad target |
| --- | --- |
| `routing-audit-format.ts:119` | `BOX_WIDTH + 8` |
| `:131` | `BOX_WIDTH + 11` |
| `:160`, `:206`, `:213` | `BOX_WIDTH + 7`, `+ 7`, `+ 5` |

Each constant is the escape-byte count for that line's specific colours — correct until someone adds a colour, and over-padding by 7 to 11 columns under `NO_COLOR`, where the escapes vanish. `visibleWidth` strips SGR escapes before measuring; all five constants are gone and those lines now go through `boxLine` like everything else.

**Genuine overflow.** The task-analysis summary is one pipe-joined string that reached **78 display columns** in a 63-column area. No padding scheme fixes content that does not fit, so `formatTaskAnalysis` wraps it on the `|` separators. A single segment wider than the box is still emitted whole — it overflows visibly rather than being silently truncated, because hiding data is worse than a ragged line.

## The tests needed a second pass, for a reason worth stating

My first mutation run reported the ANSI fix as **unpinned**: reverting `visibleWidth` to `s.length` left all 44 tests green.

That is because `colors.*` are empty strings under `NO_COLOR` and non-TTY — which is exactly how the suite runs. With no escapes present, ANSI-aware and byte-count padding are indistinguishable, so no rendered-output test can tell them apart. The fix is invisible to the environment that tests it.

So `box-drawing.test.ts` now injects the escape sequences literally and asserts a coloured line pads to the same display width as a plain one. Both mutations fail against it:

| mutation | before | after |
| --- | --- | --- |
| `visibleWidth` counts escapes | green | **1 failed** |
| `boxLine` pads on raw `.length` | green | **1 failed** |
| remove the task-summary wrapping | 1 failed | 1 failed |

## Scope

The regression test that surfaced all of this is widened from one section to `formatAsciiOutput` in full, so every `boxLine` caller is covered — that widening was the point of filing #4913 separately rather than folding it into #4914.

6832 CLI tests pass; public API surface unchanged.
