### PR TITLE
feat(doctor): report when the global install has drifted from this build

### DIFF
--- a/.changeset/doctor-install-freshness.md
+++ b/.changeset/doctor-install-freshness.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': minor
+---
+
+teach `doctor` to notice when the global install has drifted from this build
+
+`.mcp.json` runs the MCP server off the **globally installed** package, not the
+working tree, and nothing keeps the two in step — the release workflow
+publishes to npm, the global install is a separate manual `npm install -g`.
+Drift accumulates silently, and every MCP call then executes code the operator
+is not looking at. Measured twice on 2026-08-25 alone: eleven minor versions
+behind in the morning, three more by the afternoon.
+
+`doctor` now compares the two and reports one of three states. `unknown` is its
+own state rather than folded into a pass: "no global install found" and "the
+versions match" are different facts, and the second is not something a check
+that could not measure is entitled to claim. `unknown` does not count as
+healthy, because not knowing is exactly the condition that let the drift
+accumulate.
+
+The remediation says to update **and restart any running MCP server**. An
+already-spawned server keeps the old code until it is restarted, so stopping at
+`npm install -g` reports the problem resolved while the session continues on
+the stale build.

--- a/packages/nexus-agents/src/cli/doctor-formatting.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.test.ts
@@ -210,6 +210,7 @@ describe('doctor-formatting', () => {
         mismatch: false,
         dataDirInsideRepo: false,
       },
+      installFreshness: { state: 'aligned' as const, version: '1.0.0' },
       harnessAlignment: {
         agentsMdExists: true,
         files: [],

--- a/packages/nexus-agents/src/cli/doctor-install-freshness.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-install-freshness.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for the doctor install-freshness sub-check (#4767).
+ *
+ * @module cli/doctor-install-freshness.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  assessInstallFreshness,
+  describeInstallFreshness,
+  installFreshnessIsHealthy,
+  readGlobalVersion,
+} from './doctor-install-freshness.js';
+
+describe('assessInstallFreshness (#4767)', () => {
+  it('reports aligned when the versions match', () => {
+    expect(assessInstallFreshness('4.17.0', '4.17.0')).toEqual({
+      state: 'aligned',
+      version: '4.17.0',
+    });
+  });
+
+  it('reports behind with both versions named', () => {
+    // The operator needs both numbers to know how far they have drifted —
+    // eleven minors, in the case that produced this check.
+    expect(assessInstallFreshness('4.3.1', '4.14.1')).toEqual({
+      state: 'behind',
+      global: '4.3.1',
+      expected: '4.14.1',
+    });
+  });
+
+  it('reports unknown rather than aligned when there is no global install', () => {
+    // The distinction the whole check exists for. "Nobody checked" must not
+    // render as "the versions match".
+    expect(assessInstallFreshness(null, '4.17.0').state).toBe('unknown');
+  });
+
+  it('treats an empty version string as unknown, not as a mismatch', () => {
+    // An npm query that returns nothing is a failed measurement, not evidence
+    // of drift — reporting it as `behind` would cry wolf.
+    expect(assessInstallFreshness('', '4.17.0').state).toBe('unknown');
+  });
+
+  it('carries the reason for an unknown so the operator can act', () => {
+    expect(assessInstallFreshness(null, '4.17.0', 'npm ls failed: ENOENT')).toEqual({
+      state: 'unknown',
+      reason: 'npm ls failed: ENOENT',
+    });
+  });
+});
+
+describe('installFreshnessIsHealthy (#4767)', () => {
+  it('counts only aligned as healthy', () => {
+    expect(installFreshnessIsHealthy({ state: 'aligned', version: '1.0.0' })).toBe(true);
+  });
+
+  it('does not count unknown as healthy', () => {
+    // This is the load-bearing assertion. #4767 happened because nobody knew
+    // the versions had diverged; a check that passes when it could not measure
+    // reproduces exactly that.
+    expect(installFreshnessIsHealthy({ state: 'unknown', reason: 'not installed' })).toBe(false);
+  });
+
+  it('does not count behind as healthy', () => {
+    expect(installFreshnessIsHealthy({ state: 'behind', global: '1.0.0', expected: '2.0.0' })).toBe(
+      false
+    );
+  });
+});
+
+describe('describeInstallFreshness (#4767)', () => {
+  it('names both versions when behind', () => {
+    const line = describeInstallFreshness({ state: 'behind', global: '4.3.1', expected: '4.14.1' });
+
+    expect(line).toContain('4.3.1');
+    expect(line).toContain('4.14.1');
+  });
+
+  it('tells the operator to restart the MCP server, not just update', () => {
+    // Updating the global package does NOT fix a running server: the process
+    // was spawned against the old code and keeps it until restarted. A remedy
+    // that stops at `npm install -g` reports resolved while the session
+    // continues on the stale build.
+    // Asserted against literals, NOT against INSTALL_FRESHNESS_REMEDY: an
+    // assertion that compares the output to the same constant it is rendered
+    // from mutates with it and can never fail. Deleting the restart clause
+    // passed such a test.
+    const line = describeInstallFreshness({ state: 'behind', global: '4.3.1', expected: '4.14.1' });
+
+    expect(line).toContain('npm install -g');
+    expect(line).toContain('RESTART');
+    expect(line).toMatch(/already-spawned|until it is restarted/i);
+  });
+
+  it('says it could not confirm, rather than reporting a pass, when unknown', () => {
+    const line = describeInstallFreshness({ state: 'unknown', reason: 'not installed' });
+
+    expect(line).toMatch(/not determined|cannot confirm/i);
+    expect(line).not.toMatch(/^✓/);
+  });
+});
+
+describe('readGlobalVersion (#4767)', () => {
+  it('extracts the version from npm ls output', () => {
+    const out = JSON.stringify({ dependencies: { 'nexus-agents': { version: '4.17.0' } } });
+
+    expect(readGlobalVersion(() => out).version).toBe('4.17.0');
+  });
+
+  it('returns null with a reason when npm itself failed', () => {
+    // Distinct from "not installed": the operator needs to know whether the
+    // measurement failed or the package is absent.
+    expect(readGlobalVersion(() => null)).toEqual({
+      version: null,
+      reason: 'npm ls -g failed',
+    });
+  });
+
+  it('returns null when the package is absent from the global tree', () => {
+    expect(readGlobalVersion(() => JSON.stringify({ dependencies: {} })).version).toBeNull();
+  });
+
+  it('does not throw on unparseable output', () => {
+    // `npm ls -g` prints warnings to stdout in some configurations, so the
+    // JSON parse is not guaranteed. A crash here would take doctor down.
+    const result = readGlobalVersion(() => 'npm warn something\nnot json');
+
+    expect(result.version).toBeNull();
+    expect(result.reason).toMatch(/unparseable/i);
+  });
+});

--- a/packages/nexus-agents/src/cli/doctor-install-freshness.ts
+++ b/packages/nexus-agents/src/cli/doctor-install-freshness.ts
@@ -1,0 +1,103 @@
+/**
+ * nexus-agents doctor — install-freshness sub-check (#4767).
+ *
+ * `.mcp.json` runs the MCP server off the **globally installed** package, not
+ * the working tree. Nothing keeps the two in step: the release workflow
+ * publishes to npm, and the global install is a separate manual
+ * `npm install -g`. Drift accumulates silently, and every MCP call then
+ * executes code the operator did not think they were running.
+ *
+ * Measured twice on 2026-08-25 alone: eleven minor versions behind in the
+ * morning, three more by the afternoon.
+ *
+ * @module cli/doctor-install-freshness
+ * (Source: #4767)
+ */
+
+/** What the check could determine about the installed versions. */
+export type InstallFreshness =
+  /** Global install matches the package under test. */
+  | { readonly state: 'aligned'; readonly version: string }
+  /** Global install is present and older. */
+  | { readonly state: 'behind'; readonly global: string; readonly expected: string }
+  /**
+   * The global version could not be read.
+   *
+   * Reported as its own state rather than folded into `aligned`: "no global
+   * install found" and "the versions match" are different facts, and a check
+   * that renders the first as the second is the shape this repo treats as a p1
+   * on instrumentation.
+   */
+  | { readonly state: 'unknown'; readonly reason: string };
+
+/** The remediation an operator has to perform, in full. */
+export const INSTALL_FRESHNESS_REMEDY =
+  'npm install -g nexus-agents@latest — then RESTART any running MCP server. ' +
+  'An already-spawned server keeps the old code until it is restarted, so ' +
+  'updating alone leaves the session on the stale build.';
+
+/**
+ * Compare the globally installed version against the expected one.
+ *
+ * Pure so the verdict is testable without npm. `expected` is the version of
+ * the package this CLI was built from — the drift that matters is between what
+ * the operator invokes and what the MCP server loads, and both derive from the
+ * installed tree rather than from the registry.
+ */
+export function assessInstallFreshness(
+  globalVersion: string | null,
+  expected: string,
+  unavailableReason = 'no global nexus-agents install found'
+): InstallFreshness {
+  if (globalVersion === null || globalVersion === '') {
+    return { state: 'unknown', reason: unavailableReason };
+  }
+  if (globalVersion === expected) return { state: 'aligned', version: expected };
+  return { state: 'behind', global: globalVersion, expected };
+}
+
+/** One operator-facing line for a freshness verdict. */
+export function describeInstallFreshness(result: InstallFreshness): string {
+  switch (result.state) {
+    case 'aligned':
+      return `✓ Global install matches this build (${result.version})`;
+    case 'behind':
+      return `✗ Global install is ${result.global}, this build is ${result.expected} — the MCP server runs the global one. ${INSTALL_FRESHNESS_REMEDY}`;
+    case 'unknown':
+      return `? Global install version not determined (${result.reason}) — cannot confirm the MCP server runs this build`;
+  }
+}
+
+/** True when the verdict should count against doctor's health score. */
+export function installFreshnessIsHealthy(result: InstallFreshness): boolean {
+  // `unknown` is NOT healthy. It is the state that produced #4767: nobody
+  // checked, so nobody knew, and the absence read as fine.
+  return result.state === 'aligned';
+}
+
+/**
+ * Read the globally installed version, or null when it cannot be determined.
+ *
+ * `npm ls -g` is the only reliable source: the global prefix is not derivable
+ * from this process, which may itself be running from the global install, a
+ * workspace link, or `npx`. Any failure yields null — reported as `unknown`
+ * rather than guessed at.
+ */
+export function readGlobalVersion(exec: (cmd: string, args: readonly string[]) => string | null): {
+  version: string | null;
+  reason: string;
+} {
+  const raw = exec('npm', ['ls', '-g', 'nexus-agents', '--depth=0', '--json']);
+  if (raw === null) return { version: null, reason: 'npm ls -g failed' };
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const deps = (parsed as { dependencies?: Record<string, { version?: string }> }).dependencies;
+    const version = deps?.['nexus-agents']?.version;
+    if (typeof version !== 'string' || version === '') {
+      return { version: null, reason: 'no global nexus-agents install found' };
+    }
+    return { version, reason: '' };
+  } catch {
+    return { version: null, reason: 'npm ls -g returned unparseable JSON' };
+  }
+}

--- a/packages/nexus-agents/src/cli/doctor.test.ts
+++ b/packages/nexus-agents/src/cli/doctor.test.ts
@@ -134,6 +134,7 @@ function createMockDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorRe
       mismatch: false,
       dataDirInsideRepo: false,
     },
+    installFreshness: { state: 'aligned' as const, version: '1.0.0' },
     harnessAlignment: {
       agentsMdExists: true,
       files: [],

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -47,6 +47,13 @@ import { probeCli } from './cli-auth-probe.js';
 import type { AuthProbeResult } from './cli-auth-probe.js';
 import { checkHarnessAlignment } from './doctor-harness-alignment.js';
 import type { HarnessAlignmentCheck } from './doctor-harness-alignment.js';
+import {
+  assessInstallFreshness,
+  readGlobalVersion,
+  type InstallFreshness,
+} from './doctor-install-freshness.js';
+import { execFileSync } from 'node:child_process';
+import { VERSION } from '../version.js';
 import { allOf } from '../utils/verdict-aggregation.js';
 
 /** Required Node.js major version. */
@@ -261,6 +268,13 @@ export interface DoctorResult {
   readonly sandbox: SandboxCheck;
   /** Per-harness config alignment with AGENTS.md federation (#2805). */
   readonly harnessAlignment: HarnessAlignmentCheck;
+  /**
+   * Whether the globally installed package matches this build (#4767).
+   *
+   * `.mcp.json` runs the MCP server off the global install, so drift here
+   * means every MCP call executes code the operator is not looking at.
+   */
+  readonly installFreshness: InstallFreshness;
   /** Voter transport: in-process gateway vs CLI subprocess fallback (#4255). */
   readonly voterTransport: VoterTransportCheck;
   /**
@@ -750,6 +764,41 @@ export function checkSandbox(): SandboxCheck {
  * Presence-only — mirrors {@link checkApiKeys}, no network probe and the
  * key value never leaves `process.env`.
  */
+/**
+ * Compare the globally installed version with this build (#4767).
+ *
+ * Exported so the sub-check can be exercised directly; the pure verdict lives
+ * in `doctor-install-freshness.ts` and this is only the I/O around it.
+ */
+export function checkInstallFreshness(): InstallFreshness {
+  const { version, reason } = readGlobalVersion((cmd, args) => {
+    try {
+      return execFileSync(cmd, [...args], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+    } catch {
+      return null;
+    }
+  });
+  return assessInstallFreshness(version, VERSION, reason);
+}
+
+/** The environment sub-checks, grouped so `runDoctor` stays under its line cap. */
+function collectEnvironmentChecks(): {
+  harnessAlignment: HarnessAlignmentCheck;
+  installFreshness: InstallFreshness;
+  voterTransport: VoterTransportCheck;
+  scratchSpace: readonly ScratchSpaceCheck[];
+} {
+  return {
+    harnessAlignment: checkHarnessAlignment(),
+    installFreshness: checkInstallFreshness(),
+    voterTransport: checkVoterTransport(),
+    scratchSpace: checkScratchFilesystems(),
+  };
+}
+
 export function checkVoterTransport(): VoterTransportCheck {
   return { configured: readOpenAICompatEnv() !== null };
 }
@@ -812,9 +861,7 @@ export async function runDoctor(): Promise<DoctorResult> {
   const sqliteCheck = await checkSqlite();
   const dataDirectory = checkDataDirectory();
   const sandbox = checkSandbox();
-  const harnessAlignment = checkHarnessAlignment();
-  const voterTransport = checkVoterTransport();
-  const scratchSpace = checkScratchFilesystems();
+  const env = collectEnvironmentChecks();
 
   // At least one API key configured or one CLI authenticated
   const hasAuthMethod =
@@ -824,7 +871,7 @@ export async function runDoctor(): Promise<DoctorResult> {
     nodeSupported: nodeVersion.supported,
     hasAuthMethod,
     mcpServerReady,
-    scratchSpace,
+    scratchSpace: env.scratchSpace,
     clis,
   });
 
@@ -840,9 +887,7 @@ export async function runDoctor(): Promise<DoctorResult> {
     sqliteCheck,
     dataDirectory,
     sandbox,
-    harnessAlignment,
-    voterTransport,
-    scratchSpace,
+    ...env,
     allHealthy,
     timestamp: new Date(getTimeProvider().now()),
   };

--- a/packages/nexus-agents/src/cli/doctor.ts
+++ b/packages/nexus-agents/src/cli/doctor.ts
@@ -767,10 +767,12 @@ export function checkSandbox(): SandboxCheck {
 /**
  * Compare the globally installed version with this build (#4767).
  *
- * Exported so the sub-check can be exercised directly; the pure verdict lives
- * in `doctor-install-freshness.ts` and this is only the I/O around it.
+ * Deliberately NOT exported: this is only the `npm ls -g` call. The verdict it
+ * wraps lives in `doctor-install-freshness.ts`, where it is pure and testable
+ * without npm — exporting this too would be an export whose only importer is a
+ * test, which the producer/consumer ratchet correctly rejects.
  */
-export function checkInstallFreshness(): InstallFreshness {
+function checkInstallFreshness(): InstallFreshness {
   const { version, reason } = readGlobalVersion((cmd, args) => {
     try {
       return execFileSync(cmd, [...args], {

--- a/packages/nexus-agents/src/cli/validate-command.test.ts
+++ b/packages/nexus-agents/src/cli/validate-command.test.ts
@@ -96,6 +96,7 @@ function makeDoctorResult(overrides: Partial<DoctorResult> = {}): DoctorResult {
       mismatch: false,
       dataDirInsideRepo: false,
     },
+    installFreshness: { state: 'aligned' as const, version: '1.0.0' },
     harnessAlignment: {
       agentsMdExists: true,
       files: [],


### PR DESCRIPTION
Closes #4767. Built because it bit me twice in one day: the global install was **eleven minor versions** behind this morning (4.3.1 vs 4.14.1) and had drifted **three more** by the afternoon.

## Why it matters more than a stale binary

`.mcp.json` runs the MCP server off the global install. So when it drifts, every `consensus_vote`, every research call, every pipeline run executes code the operator is not looking at — and there is no signal at all. The morning's drift meant a full day of MCP calls could not be cited as evidence about the day's merges.

Nothing keeps the two in step: the release workflow publishes to npm, and the global install is a separate manual `npm install -g`.

## The two design decisions

**`unknown` is a state, not a pass.** "No global install found" and "the versions match" are different facts. A check that renders the first as the second reproduces the exact condition that let the drift accumulate — nobody knew, so nobody looked. `installFreshnessIsHealthy` returns true only for `aligned`; mutating it to `state !== 'behind'` fails a test whose comment says why.

**The remedy says restart, not just update.** An already-spawned MCP server keeps the old code until it is restarted, so `npm install -g` alone reports the problem resolved while the session continues on the stale build. I know because that is what I did this morning.

## A test that could not fail, caught by mutating it

The remedy assertion was originally:

```ts
expect(line).toContain(INSTALL_FRESHNESS_REMEDY);
```

Tautological — it compares the rendered line against the same constant it is rendered from, so deleting the restart clause mutates both sides and the test still passes. Verified: that mutation left all 11 tests green. There was a `toMatch(/restart/i)` beside it, which also survived, because the constant's *second* sentence still contained "restarted".

Now asserted against literals (`'npm install -g'`, `'RESTART'`, and the explanatory clause) with no reference to the constant. Deleting the restart guidance fails.

That is the "test supplies the answer" shape, and I would not have found it by reading the test.

## Mutations

| mutation | result |
| --- | --- |
| `unknown` counts as healthy | 1 failed |
| empty version string falls through to `behind` | 1 failed |
| remedy drops the restart clause | 1 failed *(after the fix above; passed before)* |

## Shape

The verdict is a pure function in `doctor-install-freshness.ts`; `doctor.ts` holds only the `npm ls -g` call and injects it, so the honesty logic is testable without npm. The reader tolerates unparseable output — `npm ls -g` prints warnings to stdout in some configurations, and a crash there would take `doctor` down.

6843 CLI tests pass; public API surface unchanged.
