### PR TITLE
fix(routing+governance): match the bandit vectors and record a voided vote as void

### DIFF
--- a/.changeset/bandit-vector-parity-and-voided-record.md
+++ b/.changeset/bandit-vector-parity-and-voided-record.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': patch
+---
+
+fix two defects introduced by yesterday's own fixes
+
+**The bandit trained on a different feature vector than it scored, on three
+columns.** The previous fix corrected `budgetUtilization` and asserted the
+invariant that `update` must see the vector `selectArm` scored — while the two
+paths went through different converters. The select path builds via
+`TaskProfile`, which quantizes complexity to 0.1 steps, adds a legacy +500
+token offset, and emits `isReasoningTask` as 0/1; the update path used the
+analysis directly, giving continuous complexity, no offset, and 0/0.5/1. The
+half-unit error on `isReasoningTask` was an order of magnitude larger than the
+budget column that was fixed. The update path now uses the same chain, and a
+test asserts the whole vector rather than one column.
+
+**A policy-voided vote recorded from the CLI as `rejected`.** The MCP writer
+passes `errorVoided`; the CLI writer added yesterday passed four fields and not
+that one, so `outcomeToDecision` read it as false. The CLI printed `no_quorum`
+and the chain said `rejected`. Narrower than it sounds — the all-errors
+fallback still catches the common case — but an error-policy short-circuit
+where some voters returned was misrecorded, which is the distinction #4053
+added the field for.
+
+Both were found by an adversarial review of the commits that introduced them,
+and both had tests that could not fail: the first compared one column of six,
+the second asserted what was passed to a mocked recorder rather than what the
+recorder would write.

--- a/packages/nexus-agents/src/cli-adapters/composite-router-outcome.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-outcome.test.ts
@@ -521,3 +521,66 @@ describe('composite-router-outcome', () => {
     });
   });
 });
+
+// =============================================================================
+// The update vector equals the select vector (#4953)
+// =============================================================================
+
+describe('bandit train/score vector parity (#4953)', () => {
+  // #4911 fixed `budgetUtilization` and asserted this invariant in prose, then
+  // tested only that one column. Three others were already mismatched, because
+  // the two paths used different converters: the select path goes through
+  // `TaskProfile` (0-10 scale, +500 token offset), the update path did not.
+  //
+  // This asserts the WHOLE vector, which is the invariant LinUCB actually
+  // needs — a per-column test cannot notice a column nobody thought to add.
+
+  /** The vector the select path builds, reproduced from its own call chain. */
+  async function selectVector(
+    content: string,
+    budgetUtilization?: number
+  ): Promise<Record<string, number>> {
+    const { createSharedTaskAnalyzer, taskAnalysisResultToTaskProfile } =
+      await import('../core/index.js');
+    const { taskProfileToBanditContext } = await import('./composite-router-helpers.js');
+    const analysis = createSharedTaskAnalyzer().analyze({
+      id: 't',
+      description: content,
+      context: {},
+    });
+    return taskProfileToBanditContext(
+      taskAnalysisResultToTaskProfile(analysis),
+      budgetUtilization
+    ) as unknown as Record<string, number>;
+  }
+
+  function updateVector(bandit: LinUCBBandit): Record<string, number> {
+    return vi.mocked(bandit.update).mock.calls[0]?.[1] as unknown as Record<string, number>;
+  }
+
+  it.each([
+    ['Write a function to reverse a string'],
+    ['Design the architecture for a distributed consensus layer'],
+    ['fix typo'],
+  ])('matches the select vector for %s', async (content) => {
+    const bandit = createMockLinUCBBandit();
+    const deps = createBaseDeps({ linucbBandit: bandit });
+
+    recordBanditOutcome('claude', createCliTask(content), 0.85, deps);
+
+    expect(updateVector(bandit)).toEqual(await selectVector(content));
+  });
+
+  it('matches on every column when a budget is configured too', async () => {
+    // The pair for #4911: fixing the budget column must not be undone, and the
+    // other five must agree at the same time.
+    const bandit = createMockLinUCBBandit();
+    const budgetRouter = createMockBudgetRouter(0.03);
+    const budgetConstraints = { maxCostUsd: 0.05 };
+    const deps = createBaseDeps({ linucbBandit: bandit, budgetRouter, budgetConstraints });
+
+    recordBanditOutcome('claude', createCliTask('build a parser'), 0.85, deps);
+
+    expect(updateVector(bandit)).toEqual(await selectVector('build a parser', 0.6));
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/composite-router-outcome.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-outcome.ts
@@ -7,7 +7,7 @@ import {
   type ILogger,
   createLogger,
   createSharedTaskAnalyzer,
-  taskAnalysisResultToBanditContext,
+  taskAnalysisResultToTaskProfile,
   getTimeProvider,
 } from '../core/index.js';
 import type { CliName, CliTask, RoutingArmId } from './types.js';
@@ -19,6 +19,7 @@ import {
   cliTaskToTask,
   buildDifficultyOutcome,
   budgetUtilizationForTask,
+  taskProfileToBanditContext,
 } from './composite-router-helpers.js';
 import type { BudgetRouter } from './budget-router.js';
 import type { CompositeRouterConfig } from './composite-router-types.js';
@@ -75,9 +76,15 @@ export function recordBanditOutcome(
     deps.budgetRouter,
     deps.budgetConstraints
   );
-  const context = taskAnalysisResultToBanditContext(
-    analysis,
-    budgetUtilization === undefined ? {} : { budgetUtilization }
+  // Built through the SAME converter chain the select path uses
+  // (`composite-router-stages.ts:666`). LinUCB is only consistent if `update`
+  // sees the vector `selectArm` scored, and the two converters disagree on
+  // three of six columns: `taskProfileToBanditContext` quantizes complexity to
+  // 0.1 steps, adds the legacy +500 token offset, and emits `isReasoningTask`
+  // as 0/1 where the analysis-based one emits 0/0.5/1 (#4953).
+  const context = taskProfileToBanditContext(
+    taskAnalysisResultToTaskProfile(analysis),
+    budgetUtilization
   );
   deps.linucbBandit.update(armIndex, context, reward);
   deps.logger.debug('Recorded outcome', { cliName, reward });

--- a/packages/nexus-agents/src/cli/vote-command.test.ts
+++ b/packages/nexus-agents/src/cli/vote-command.test.ts
@@ -564,3 +564,56 @@ describe('voteCommand forwards options to the engine (#4941)', () => {
     expect(input).not.toHaveProperty('options');
   });
 });
+
+// =============================================================================
+// A voided vote is recorded as a void, not a rejection (#4953)
+// =============================================================================
+
+describe('voteCommand records an error-policy void correctly (#4953)', () => {
+  // #4925 added the CLI audit record and passed four fields, omitting
+  // `errorVoided`. `outcomeToDecision` then reads it as false and returns
+  // `rejected` — the CLI prints `no_quorum` and the chain disagrees.
+  //
+  // Every test in #4925 asserted what was passed TO the mocked recorder, so
+  // the one field missing from the call was the one field no assertion
+  // mentioned. These assert it explicitly.
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  function voidedResult() {
+    return {
+      proposal: 'p',
+      threshold: 'unanimous',
+      result: createMockConsensusResult({ outcome: 'rejected' }),
+      votes: [],
+      totalTimeMs: 5,
+      simulateVotes: false,
+      strategy: 'unanimous',
+      decision: 'no_quorum',
+      policyReason: 'fail_closed: 4 voters errored',
+    };
+  }
+
+  beforeEach(() => {
+    executeVotingMock.mockReset();
+    recordAuthenticVoteMock.mockClear();
+  });
+
+  it('flags the record as voided when an error policy short-circuited', async () => {
+    executeVotingMock.mockResolvedValue(voidedResult());
+
+    await voteCommand({ proposal: 'p' });
+
+    const call = recordAuthenticVoteMock.mock.calls[0] as unknown[] | undefined;
+    expect(call?.[0]).toMatchObject({ errorVoided: true });
+  });
+
+  it('does not flag an ordinary rejection as voided', async () => {
+    // The pair. Always-true would make every genuine rejection read as a void,
+    // which is the same conflation in the other direction.
+    executeVotingMock.mockResolvedValue({ ...voidedResult(), policyReason: undefined });
+
+    await voteCommand({ proposal: 'p' });
+
+    const call = recordAuthenticVoteMock.mock.calls[0] as unknown[] | undefined;
+    expect(call?.[0]).toMatchObject({ errorVoided: false });
+  });
+});

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -279,9 +279,13 @@ export function recordVoteToGitHub(
  * CLI-specific concerns (timeout clamping + diagnostic line) remain here
  * because they belong to the operator UX, not the voting flow itself.
  */
-async function runVote(
-  options: VoteCommandOptions
-): Promise<VotingResult & { readonly decision: VoteDecisionStatus; readonly strategy: string }> {
+async function runVote(options: VoteCommandOptions): Promise<
+  VotingResult & {
+    readonly decision: VoteDecisionStatus;
+    readonly strategy: string;
+    readonly policyReason?: string;
+  }
+> {
   // Validate and constrain timeout to allowed range (Issue #607). Done at
   // the CLI boundary so the operator sees the adjustment immediately.
   const requestedTimeoutMs = options.timeoutMs ?? DEFAULT_VOTE_TIMEOUT_MS;
@@ -328,6 +332,9 @@ async function runVote(
     // Carried past the narrowing above so the audit record states the strategy
     // that was applied. `threshold` is the display value and can differ (#4924).
     strategy: result.strategy,
+    // Likewise: an error-policy short-circuit voided the vote, and without it
+    // the record calls a void a `rejected` (#4953).
+    ...(result.policyReason !== undefined ? { policyReason: result.policyReason } : {}),
   };
 }
 
@@ -398,7 +405,7 @@ function exitCodeForDecision(decision: VoteDecisionStatus, policy: NoQuorumPolic
  */
 function persistToAuditChain(
   options: VoteCommandOptions,
-  result: VotingResult & { readonly strategy: string }
+  result: VotingResult & { readonly strategy: string; readonly policyReason?: string }
 ): void {
   if (options.dryRun === true) return;
   writeLine(
@@ -408,6 +415,9 @@ function persistToAuditChain(
         strategy: result.strategy,
         result: result.result,
         votes: result.votes,
+        // A vote an error policy voided is not a rejection. Without this the
+        // chain records `rejected` while the CLI exits `no_quorum` (#4953).
+        errorVoided: result.policyReason !== undefined,
       })
     )
   );


### PR DESCRIPTION
Closes #4953. Both defects are in commits I merged today, found by an adversarial review of those commits and verified against the tree before acting.

## 1. The bandit trained on a different vector than it scored — three columns, not one

#4911 fixed `budgetUtilization` and asserted the invariant in its own description: *"the feature vector handed to `update` must be the one `selectArm` scored."* Three of six columns violated it, and had before that change, because the two paths used **different converters**:

| column | select — via `TaskProfile` | update — from the analysis |
| --- | --- | --- |
| `taskComplexity` | `Math.round(score * 10) / 10` — quantized to 0.1 | continuous |
| `contextLengthNormalized` | `(tokens + 500) / 100000` — legacy offset | `tokens / 100000` |
| `isReasoningTask` | `0` or `1` | `0`, `0.5`, or `1` |

`isReasoningTask` is the one that matters: a half-unit error on a unit-scaled feature, an order of magnitude worse than the budget column that was fixed. Neither converter is wrong on its own — the select path goes through `TaskProfile` because routing wants a 0-10 scale — but using both for one bandit is.

The update path now builds through the same chain, so the vectors are identical by construction.

**The test is the point.** #4911's tests compared `budgetUtilization` and nothing else, and a per-column test cannot notice a column nobody thought to add. The new one asserts the **whole vector** across three task shapes, plus a budget-configured case so the earlier fix stays pinned. Reverting the converter fails 4 tests.

## 2. A policy-voided CLI vote recorded as `rejected`

#4925 gave the CLI an audit record and passed four fields. The MCP writer passes a fifth:

```ts
errorVoided: result.policyReason !== undefined,   // consensus-vote.ts:856
```

Without it `outcomeToDecision` reads false and returns `'rejected'`. The CLI prints and exits `no_quorum`; the chain disagrees.

**Scope, stated rather than assumed:** the `allErrors` fallback in `outcomeToDecision` still catches a run where every voter errored, so the common no-quorum case was already correct. What was misrecorded is the **policy-voided** case — a `fail_closed` or `absolute_quorum` short-circuit where some voters returned. That is exactly the distinction #4053 added the field for.

`policyReason` now rides past `runVote`'s narrowing, which already carries `strategy` for the same reason.

## Both tests failed the same way, and it is worth naming

Every assertion in #4925 checked what was passed **to the mocked recorder**, never what the recorder would write. So the one field missing from the call was the one field no assertion mentioned. Mocking a collaborator tests the caller's intent, not the outcome — and intent was exactly what was wrong.

## Mutations

| mutation | result |
| --- | --- |
| revert the update path to the analysis converter | 4 failed |
| omit `errorVoided` again | 2 failed |
| always pass `errorVoided: true` | 1 failed |
| drop `policyReason` at the narrowing | 1 failed |

2747 tests pass across `cli-adapters` and the vote command; public API surface unchanged.
