### PR TITLE
fix(research): exclude an unmeasured recency from the composite instead of defaulting it

### DIFF
--- a/.changeset/recency-unmeasured-excluded.md
+++ b/.changeset/recency-unmeasured-excluded.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+stop an undated research source scoring as well as a fresh one
+
+`NEUTRAL_RECENCY` is 0.5, chosen when recency decayed linearly — where 0.5 was
+the one-year point, comfortably mid-range. Switching to exponential decay moved
+0.5 to the two-year point without moving the constant, so a source with **no
+publication date at all** scored exactly as well as a real one-year-old source:
+0.28 composite for both.
+
+An unmeasured recency is now excluded from the composite and the remaining
+weights renormalised, rather than filled in with a default. The undated source
+is judged on its measured dimensions — neither credited for freshness it has
+not demonstrated nor punished for a date nobody recorded.
+
+This also gives `recencyMeasured` its first reader. The flag was added so a
+consumer could tell a measurement from a default, and until now nothing read
+it: two occurrences in the tree, both in the file that produces it.

--- a/packages/nexus-agents/src/cli/research-helpers-scoring.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-scoring.test.ts
@@ -228,3 +228,70 @@ describe('rankDiscoveredItems', () => {
     expect(ranked[0]?.score.composite).toBeGreaterThan(0);
   });
 });
+
+// =============================================================================
+// An unmeasured recency is excluded, not defaulted (#4956)
+// =============================================================================
+
+describe('undated sources get no recency credit (#4956)', () => {
+  // `NEUTRAL_RECENCY` is 0.5. Under the old LINEAR curve that was the one-year
+  // point — mid-range. Under exponential decay it is the two-year point, so an
+  // undated source scored EXACTLY as well as a real one-year-old source: 0.28
+  // composite for both. Changing the curve should have moved the constant with
+  // it. Excluding the term instead means it cannot drift again.
+
+  function undated(): DiscoveredSource {
+    const item = createItem();
+    delete (item as { publishedAt?: string }).publishedAt;
+    return item;
+  }
+
+  it('no longer ties a genuinely fresh source', () => {
+    // The concrete regression: before this, both scored 0.28.
+    const fresh = scoreDiscoveredItem(createItem({ publishedAt: daysAgo(365) }), 'test');
+    const unknown = scoreDiscoveredItem(undated(), 'test');
+
+    expect(unknown.composite).toBeLessThan(fresh.composite);
+  });
+
+  it('is scored purely on its measured dimensions', () => {
+    // Recency excluded and the remaining weights renormalised, so the missing
+    // term contributes nothing in either direction.
+    const unknown = scoreDiscoveredItem(undated(), 'test');
+    const measuredOnly =
+      (0.35 * unknown.relevance + 0.25 * unknown.impact + 0.2 * unknown.reproducibility) / 0.8;
+
+    expect(Math.abs(unknown.composite - measuredOnly)).toBeLessThan(0.02);
+  });
+
+  it('is not punished for the missing date either', () => {
+    // The pair. Absence of a date is not evidence of freshness, and it is not
+    // evidence of staleness — an undated source must still outrank one known
+    // to be twenty years old.
+    const ancient = scoreDiscoveredItem(createItem({ publishedAt: daysAgo(20 * 365) }), 'test');
+    const unknown = scoreDiscoveredItem(undated(), 'test');
+
+    expect(unknown.composite).toBeGreaterThan(ancient.composite);
+  });
+
+  it('leaves a dated source scored over all four dimensions', () => {
+    // The other pair: renormalising unconditionally would inflate every score.
+    const dated = scoreDiscoveredItem(createItem({ publishedAt: daysAgo(365) }), 'test');
+    const allFour =
+      0.35 * dated.relevance +
+      0.25 * dated.impact +
+      0.2 * dated.recency +
+      0.2 * dated.reproducibility;
+
+    expect(Math.abs(dated.composite - allFour)).toBeLessThan(0.02);
+  });
+
+  it('reports recencyMeasured so a consumer can tell the two apart', () => {
+    // The flag existed since #4841 with no reader anywhere. The composite is
+    // now its first consumer; this pins that it still says which case it was.
+    expect(scoreDiscoveredItem(undated(), 'test').recencyMeasured).toBe(false);
+    expect(
+      scoreDiscoveredItem(createItem({ publishedAt: daysAgo(365) }), 'test').recencyMeasured
+    ).toBe(true);
+  });
+});

--- a/packages/nexus-agents/src/cli/research-helpers-scoring.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-scoring.ts
@@ -135,6 +135,39 @@ function scoreReproducibility(source: string): number {
  * @param topic - The search topic for relevance scoring
  * @returns Quality score breakdown and composite
  */
+/**
+ * Weighted composite, with an UNMEASURED recency excluded rather than defaulted.
+ *
+ * `NEUTRAL_RECENCY` is 0.5, which was mid-range under the old linear curve but
+ * is the two-year point under exponential decay — so scoring an undated source
+ * at 0.5 made it beat a real three-year-old source by 0.075 composite, above
+ * the resolution of the 0.6 review gate. Absence of a publication date is not
+ * evidence of freshness, and it must not be evidence of staleness either
+ * (#4956).
+ *
+ * Excluding the term and renormalising the rest is the same treatment the
+ * unmeasured-token and unscored-step aggregates get: judge on what was
+ * measured, over the weight that was measured.
+ */
+function compositeOf(parts: {
+  relevance: number;
+  impact: number;
+  recency: { value: number; measured: boolean };
+  reproducibility: number;
+}): number {
+  const measuredWeight =
+    WEIGHTS.relevance +
+    WEIGHTS.impact +
+    WEIGHTS.reproducibility +
+    (parts.recency.measured ? WEIGHTS.recency : 0);
+  const weighted =
+    WEIGHTS.relevance * parts.relevance +
+    WEIGHTS.impact * parts.impact +
+    WEIGHTS.reproducibility * parts.reproducibility +
+    (parts.recency.measured ? WEIGHTS.recency * parts.recency.value : 0);
+  return weighted / measuredWeight;
+}
+
 export function scoreDiscoveredItem(item: DiscoveredSource, topic: string): QualityScore {
   const relevance =
     topic !== '' ? scoreRelevance(item.title, topic) : relevanceLabelToScore(item.relevance);
@@ -142,11 +175,7 @@ export function scoreDiscoveredItem(item: DiscoveredSource, topic: string): Qual
   const recency = scoreRecency(item.publishedAt);
   const reproducibility = scoreReproducibility(item.source);
 
-  const composite =
-    WEIGHTS.relevance * relevance +
-    WEIGHTS.impact * impact +
-    WEIGHTS.recency * recency.value +
-    WEIGHTS.reproducibility * reproducibility;
+  const composite = compositeOf({ relevance, impact, recency, reproducibility });
 
   return {
     relevance: Math.round(relevance * 100) / 100,


### PR DESCRIPTION
Refs #4956, items 2 and 3. Item 1 (the 2dp rounding that moved saturation to 7.7 years) is left open deliberately — see below.

## The defect

`NEUTRAL_RECENCY = 0.5` was chosen when recency decayed **linearly**, where 0.5 was the one-year point — comfortably mid-range for "we do not know". Switching to exponential decay in #4908 moved 0.5 to the **two-year** point and did not move the constant with it.

Measured before this change:

```
undated   recency 0.5 (measured: false)   composite 0.28
1y old    recency 0.5 (measured: true)    composite 0.28
3y old    recency 0.12                    composite 0.21
```

A source with **no publication date at all** scored exactly as well as a real one-year-old source. `executeReview` files GitHub issues from the top 5 above a 0.6 gate, so that is a ranking input, not a display value.

## The fix, and why not just pick a better constant

An unmeasured recency is now **excluded** and the remaining weights renormalised, rather than filled in. Any constant is a guess that drifts the moment the curve changes — which is exactly what happened here. Excluding the term cannot drift, and it matches the treatment the unmeasured-token and unscored-step aggregates already get: judge on what was measured, over the weight that was measured.

After:

```
1y old    0.28     <- fresh still wins
undated   0.23     <- judged on its three measured dimensions
3y old    0.21
20y old   0.19     <- undated still beats known-ancient
```

## This gives `recencyMeasured` its first reader

The flag was added by #4841 precisely so a consumer could tell a measurement from a default, and nothing read it — two occurrences in the tree, both in the file that produces it. The composite is now its consumer, which is what makes the exclusion expressible at all.

## A test I had to throw away

My first assertion was "an undated source must not outrank a dated three-year-old one". It failed, and it was **wrong**. With the free credit removed, the three-year-old is legitimately discounted for age while the undated one is scored on its merits — so undated landing above it is the honest result, not a bug. Punishing a missing date is the error this issue explicitly warns against.

The invariant that survives is narrower and correct: an undated source gets *no recency credit*, and its composite equals the renormalised measured-only score.

| mutation | result |
| --- | --- |
| always divide by the full weight | 2 failed |
| always include the recency term | 2 failed |
| drop the renormalisation | 2 failed |

## Left open

Item 1 of #4956 — `Math.round(value * 100) / 100` makes everything past ~7.7 years report exactly `0`, so #4908's claim that the curve "approaches zero without reaching it" is not true of the reported value. `composite` is rounded the same way and recency is weighted 0.2, so no precision change alters ranking beyond ~10 years. That is a decision about what to claim rather than a defect to patch, and it should not ride along with this.

475 research tests pass; public API surface unchanged.
