### PR TITLE
fix(doctor): print the install-freshness verdict it already computes

### DIFF
--- a/.changeset/doctor-print-install-freshness.md
+++ b/.changeset/doctor-print-install-freshness.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+actually print the global-install freshness verdict
+
+The check computed its verdict, stored it on `DoctorResult`, and nothing
+rendered it — `nexus-agents doctor` showed no line at all. A check whose output
+never reaches the operator is the recorded-but-unread shape the check itself
+exists to catch, one layer up.
+
+Found by running the command against the freshly published build rather than by
+reading the code: every test asserted the verdict object, and none asserted the
+output.

--- a/packages/nexus-agents/src/cli/doctor-formatting.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.test.ts
@@ -142,6 +142,15 @@ describe('doctor-formatting', () => {
     ...(options.fix !== undefined && { fix: options.fix }),
   });
 
+  /** Default freshness for fixtures that do not care about it. */
+  const ALIGNED_INSTALL = { state: 'aligned' as const, version: '1.0.0' };
+
+  /** Applied outside the fixture arrow, which is already at its complexity cap. */
+  const withInstallFreshness = (
+    base: DoctorResult,
+    freshness: DoctorResult['installFreshness'] | undefined
+  ): DoctorResult => (freshness === undefined ? base : { ...base, installFreshness: freshness });
+
   const createDoctorResult = (
     options: {
       allHealthy?: boolean;
@@ -153,9 +162,10 @@ describe('doctor-formatting', () => {
       mcpClientReady?: boolean;
       voterTransport?: { configured: boolean };
       scratchSpace?: DoctorResult['scratchSpace'];
+      installFreshness?: DoctorResult['installFreshness'];
     } = {}
-  ): DoctorResult =>
-    withScratch(options.scratchSpace, {
+  ): DoctorResult => {
+    const base = withScratch(options.scratchSpace, {
       allHealthy: options.allHealthy ?? true,
       nodeVersion: options.nodeVersion ?? createNodeVersionCheck(true, 'v22.0.0'),
       apiKeys: options.apiKeys ?? [],
@@ -210,7 +220,7 @@ describe('doctor-formatting', () => {
         mismatch: false,
         dataDirInsideRepo: false,
       },
-      installFreshness: { state: 'aligned' as const, version: '1.0.0' },
+      installFreshness: ALIGNED_INSTALL,
       harnessAlignment: {
         agentsMdExists: true,
         files: [],
@@ -222,6 +232,8 @@ describe('doctor-formatting', () => {
       scratchSpace: DEFAULT_SCRATCH_SPACE,
       timestamp: new Date('2024-01-01T00:00:00Z'),
     });
+    return withInstallFreshness(base, options.installFreshness);
+  };
 
   describe('printDoctorResults', () => {
     it('should print header and section titles', () => {
@@ -235,6 +247,43 @@ describe('doctor-formatting', () => {
       expect(calls.some((call) => call.includes('Checking MCP configuration'))).toBe(true);
       expect(calls.some((call) => call.includes('Checking capabilities'))).toBe(true);
       expect(calls.some((call) => call.includes('Checking data storage'))).toBe(true);
+    });
+
+    // #4951 computed the freshness verdict, put it on `DoctorResult`, and
+    // nothing printed it — `nexus-agents doctor` showed no line at all. Found
+    // by running the command: every unit test asserted the verdict object and
+    // none asserted the output (#4959).
+    it('prints the global-install drift with both versions', () => {
+      printDoctorResults(
+        createDoctorResult({
+          installFreshness: { state: 'behind', global: '4.3.1', expected: '4.18.0' },
+        })
+      );
+
+      const out = getCalls().join('');
+      expect(out).toContain('4.3.1');
+      expect(out).toContain('4.18.0');
+    });
+
+    it('prints the restart instruction, not just the update', () => {
+      // A remedy stopping at `npm install -g` reports the problem resolved
+      // while an already-spawned MCP server keeps the old code.
+      printDoctorResults(
+        createDoctorResult({
+          installFreshness: { state: 'behind', global: '4.3.1', expected: '4.18.0' },
+        })
+      );
+
+      expect(getCalls().join('')).toContain('RESTART');
+    });
+
+    it('prints something for the unknown case rather than staying silent', () => {
+      // Silence is what the bug was: an unmeasurable check must still say so.
+      printDoctorResults(
+        createDoctorResult({ installFreshness: { state: 'unknown', reason: 'not installed' } })
+      );
+
+      expect(getCalls().join('')).toMatch(/not determined|cannot confirm/i);
     });
 
     it('should print healthy status when all checks pass', () => {

--- a/packages/nexus-agents/src/cli/doctor-formatting.ts
+++ b/packages/nexus-agents/src/cli/doctor-formatting.ts
@@ -28,6 +28,7 @@ import type {
 import { colors, symbols, writeLine } from './ansi-output.js';
 import { capitalize } from '../utils/text-utils.js';
 import { allOf } from '../utils/verdict-aggregation.js';
+import { describeInstallFreshness } from './doctor-install-freshness.js';
 
 /** Required Node.js major version (for warning message). */
 const REQUIRED_NODE_MAJOR = 22;
@@ -479,7 +480,23 @@ export function printDoctorResults(result: DoctorResult): void {
 
   printHarnessAlignment(result.harnessAlignment);
 
+  printInstallFreshness(result.installFreshness);
+
   printDoctorSummary(result);
+}
+
+/**
+ * Prints whether the global install matches this build (#4767).
+ *
+ * The check computed the verdict and nothing printed it — running `doctor`
+ * showed no line at all, which is the recorded-but-unread shape the check
+ * itself exists to catch (#4959).
+ */
+function printInstallFreshness(check: DoctorResult['installFreshness']): void {
+  writeLine(`${colors.cyan}Checking global install freshness...${colors.reset}`);
+  writeLine('');
+  writeLine(`  ${describeInstallFreshness(check)}`);
+  writeLine('');
 }
 
 /**


### PR DESCRIPTION
Follow-up to #4951, merged an hour ago.

## What happened

I updated the global install to the published build and ran `nexus-agents doctor` to see the new check. There was no line for it. The verdict was computed, stored on `DoctorResult`, and never rendered.

So the check built to detect a silently-drifting install was itself silently doing nothing — the recorded-but-unread shape, one layer up from the gap it exists to close.

## Why the tests did not catch it

Every test in #4951 asserted the **verdict object**: `assessInstallFreshness` returns the right state, `installFreshnessIsHealthy` rejects `unknown`, `describeInstallFreshness` produces the right sentence. All true, all still passing, and none of them touched the renderer. The formatter was the one link with no test on either side of it.

That is the same both-halves-correct-join-untested shape as #4910, #4940, #4944, #4945 and #4948 — the sixth today — except this time the missing join was between the check and the human, which is the only consumer that mattered.

## What this adds

`printInstallFreshness` in the formatter, plus three output assertions: that a drift prints both versions, that it prints the RESTART instruction rather than just the update, and that the `unknown` case prints something rather than staying silent. Removing the print call fails all three.

The fixture needed rework to accept an override — and the fact that it did not already is part of the same story: no test had ever varied this field, because no test looked at the output.

146 doctor tests pass.
