### PR TITLE
fix(doctor): report unknown instead of false drift when running from source

### DIFF
--- a/.changeset/doctor-freshness-dev-build.md
+++ b/.changeset/doctor-freshness-dev-build.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+stop the install-freshness check reporting false drift from a source checkout
+
+`VERSION` is `'dev'` when `__NEXUS_VERSION__` was not injected — i.e. the CLI is
+running from source rather than a build. Comparing a real global version
+against that string reported drift on every developer checkout:
+
+```
+✗ Global install is 4.18.1, this build is dev — the MCP server runs the global one.
+```
+
+There is no version to compare, so the check now reports `unknown` with that as
+its reason. A check that cries wolf in the commonest context is one people
+learn to skip past, which is the failure mode it exists to prevent.

--- a/packages/nexus-agents/src/cli/doctor-install-freshness.test.ts
+++ b/packages/nexus-agents/src/cli/doctor-install-freshness.test.ts
@@ -30,6 +30,24 @@ describe('assessInstallFreshness (#4767)', () => {
     });
   });
 
+  it('reports unknown when this build has no version, not a false drift', () => {
+    // `VERSION` is `'dev'` when running from source. Comparing a real global
+    // version against it reported `behind` on every developer checkout —
+    // observed live: "Global install is 4.18.1, this build is dev". A check
+    // that cries wolf in the commonest context is one people learn to skip,
+    // which is the failure #4904 was about.
+    const result = assessInstallFreshness('4.18.1', 'dev');
+
+    expect(result.state).toBe('unknown');
+    if (result.state !== 'unknown') return;
+    expect(result.reason).toMatch(/from source|no version/i);
+  });
+
+  it('still compares two real versions', () => {
+    // The pair: short-circuiting on any expected value would disable the check.
+    expect(assessInstallFreshness('4.18.1', '4.19.0').state).toBe('behind');
+  });
+
   it('reports unknown rather than aligned when there is no global install', () => {
     // The distinction the whole check exists for. "Nobody checked" must not
     // render as "the versions match".

--- a/packages/nexus-agents/src/cli/doctor-install-freshness.ts
+++ b/packages/nexus-agents/src/cli/doctor-install-freshness.ts
@@ -30,6 +30,9 @@ export type InstallFreshness =
    */
   | { readonly state: 'unknown'; readonly reason: string };
 
+/** `version.ts` reports this when `__NEXUS_VERSION__` was never injected. */
+const UNVERSIONED_BUILD = 'dev';
+
 /** The remediation an operator has to perform, in full. */
 export const INSTALL_FRESHNESS_REMEDY =
   'npm install -g nexus-agents@latest — then RESTART any running MCP server. ' +
@@ -49,6 +52,17 @@ export function assessInstallFreshness(
   expected: string,
   unavailableReason = 'no global nexus-agents install found'
 ): InstallFreshness {
+  // `VERSION` is `'dev'` when `__NEXUS_VERSION__` was not injected — i.e. the
+  // CLI is running from source rather than a build. There is no version to
+  // compare against, so the honest answer is `unknown`. Reporting `behind`
+  // would fire on every developer checkout and train people to ignore the one
+  // line that matters on a real install (#4959).
+  if (expected === UNVERSIONED_BUILD) {
+    return {
+      state: 'unknown',
+      reason: 'running from source — this build has no version to compare',
+    };
+  }
   if (globalVersion === null || globalVersion === '') {
     return { state: 'unknown', reason: unavailableReason };
   }


### PR DESCRIPTION
Third follow-up in the #4767 chain, and again found by running the thing rather than reading it.

## What running it showed

After #4959 made the verdict print, I ran `doctor` from the source tree to confirm the fix. It printed:

```
✗ Global install is 4.18.1, this build is dev — the MCP server runs the global one.
```

`VERSION` is `'dev'` whenever `__NEXUS_VERSION__` was not injected at build time, so **every developer checkout** reports drift against a build that has no version. The remediation it then offers — reinstall and restart — would not change anything.

## Why that is worth a fix rather than a shrug

A check that fires in the commonest context is one people learn to skip. That is precisely the failure #4904 documented: `warmStart`'s skip warning became invisible because a benign entry printed on every run, so a real regression rendered identically to noise. This check exists to be noticed once every few weeks; making it shout on every local run would have guaranteed nobody reads it when it matters.

There is no version to compare, so the honest state is `unknown` — the state this check already distinguishes from `aligned` for exactly this reason.

```
? Global install version not determined (running from source — this build has no
  version to compare) — cannot confirm the MCP server runs this build
```

## Mutations

| mutation | result |
| --- | --- |
| remove the unversioned-build guard | 1 failed |
| always report `unknown` | 4 failed |

The second row is the pair that matters: short-circuiting on any expected value would silence the check entirely while making the new test pass.

## Note on the chain

This is the third defect in the same feature, each found by executing it and none by review: the verdict was computed but never printed (#4959), and now the verdict itself was wrong in the context I was running it from. The unit tests were green throughout — they assert the state machine, and the state machine was never the problem.
