### PR TITLE
fix(cli): forward vote options through the command handler

### DIFF
--- a/.changeset/vote-options-reach-the-command.md
+++ b/.changeset/vote-options-reach-the-command.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+make `vote --option` actually reach the engine
+
+The flag parsed, validated and appeared in `parseCliArgs` output, and
+`handleVoteCommand` then rebuilt `VoteCommandOptions` field by field without
+naming it — so every multi-option vote from the CLI still recorded
+`optionTally: null`, exactly as before the flag existed.
+
+Caught by running it: a vote declaring three alternatives persisted a null
+tally, and passing a single `--option` did not trip the engine's `min(2)`
+validation, which proved the field never reached `ConsensusVoteInput`.

--- a/packages/nexus-agents/src/cli-commands-handlers.test.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.test.ts
@@ -30,6 +30,7 @@ vi.mock('./cli/index.js', async (importOriginal) => {
     // CliExitResult maps the underlying 0|non-0 status to SUCCESS|SERVER_START_FAILED.
     expertListCommand: vi.fn().mockReturnValue(0),
     helloCommand: vi.fn().mockReturnValue(0),
+    voteCommand: vi.fn().mockResolvedValue(0),
   };
 });
 
@@ -38,8 +39,15 @@ import {
   handleExpertCommand,
   handleHelloCommand,
   handleUnimplementedCommand,
+  handleVoteCommand,
 } from './cli-commands-handlers.js';
-import { configCommand, configInitCommand, expertListCommand, helloCommand } from './cli/index.js';
+import {
+  configCommand,
+  configInitCommand,
+  expertListCommand,
+  helloCommand,
+  voteCommand,
+} from './cli/index.js';
 
 /**
  * Creates a ParsedCliArgs object with default values.
@@ -475,5 +483,53 @@ describe('handleUnimplementedCommand (#3207)', () => {
   it('does not suggest when the subcommand is empty', () => {
     handleUnimplementedCommand('expert ');
     expect(stderrOutput()).not.toContain('Did you mean');
+  });
+});
+
+// =============================================================================
+// The vote handler forwards every option it was given (#4963)
+// =============================================================================
+
+describe('handleVoteCommand forwards --option (#4963)', () => {
+  // This handler rebuilds `VoteCommandOptions` field by field, so any field it
+  // does not name is silently dropped. `--option` parsed correctly, reached
+  // `args.options.options`, and died here — with a `parseCliArgs` test on one
+  // side and a `voteCommand` test on the other, both green.
+  //
+  // Verified live before fixing: `nexus-agents vote --option A --option B`
+  // produced a record with `optionTally: null`, and a single `--option` did not
+  // trip the engine's `min(2)` validation, which proved the field never
+  // reached `ConsensusVoteInput`.
+  const voteMock = voteCommand as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    voteMock.mockClear();
+    voteMock.mockResolvedValue(0);
+  });
+
+  it('passes the declared alternatives to voteCommand', async () => {
+    const base = createMockArgs();
+    await handleVoteCommand({
+      ...base,
+      command: 'vote',
+      options: { ...base.options, proposal: 'pick one', options: ['A', 'B'] },
+      positionals: ['vote'],
+    });
+
+    expect(voteMock.mock.calls[0]?.[0]).toMatchObject({ options: ['A', 'B'] });
+  });
+
+  it('omits the field for an ordinary yes/no vote', async () => {
+    // The pair: a present-but-empty array tells the engine this is a
+    // multi-option vote and adds the leading-option bar to a plain vote.
+    const base = createMockArgs();
+    await handleVoteCommand({
+      ...base,
+      command: 'vote',
+      options: { ...base.options, proposal: 'ship it' },
+      positionals: ['vote'],
+    });
+
+    expect(voteMock.mock.calls[0]?.[0]).not.toHaveProperty('options');
   });
 });

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -322,6 +322,10 @@ export async function handleVoteCommand(args: ParsedCliArgs): Promise<CliExitRes
 
   const exitCode = await voteCommand({
     proposal,
+    // #4963: this handler rebuilds VoteCommandOptions field by field, so a new
+    // field is dropped unless it is named here. `--option` parsed, reached
+    // `args.options.options`, and died at this line.
+    ...(args.options.options !== undefined && { options: args.options.options }),
     ...(validThreshold !== undefined && { threshold: validThreshold }),
     ...(validErrorPolicy !== undefined && { errorPolicy: validErrorPolicy }),
     ...(args.options.onNoQuorum !== undefined && { onNoQuorum: args.options.onNoQuorum }),

--- a/packages/nexus-agents/src/cli-types.ts
+++ b/packages/nexus-agents/src/cli-types.ts
@@ -226,6 +226,8 @@ export interface ParsedCliArgs {
     errorPolicy?: ErrorPolicy;
     /** #4135 — how the vote command maps a `no_quorum` decision. Default `fail`. */
     onNoQuorum?: NoQuorumPolicy;
+    /** #4472 / #4941 — repeatable `--option`, the named alternatives to tally. */
+    options?: string[];
     // SWE-bench command options
     variant?: 'lite' | 'verified' | 'full';
     limit?: number;


### PR DESCRIPTION
`vote --option` never worked. The flag I shipped in #4948 parsed correctly and was dropped one link further down than either of my tests reached.

## How it surfaced

I ran a real three-option vote through the CLI to validate the feature end to end — the flag is meant to make a multi-option decision recordable, and I had only ever exercised the MCP path. The persisted record said:

```json
"optionTally": null,
"optionCoverage": null
```

Identical to before the flag existed.

**The decisive probe** was cheap: the engine's schema declares `options` as `.min(2)`, so passing a *single* `--option` should fail validation. It did not — the vote proceeded to collect votes. That distinguishes "voters declined to select an option" from "the field never reached `ConsensusVoteInput`", and it was the second.

## Where it died

`cli-commands-handlers.ts:323`. The handler rebuilds `VoteCommandOptions` field by field:

```ts
const exitCode = await voteCommand({
  proposal,
  ...(validThreshold !== undefined && { threshold: validThreshold }),
  ...(validErrorPolicy !== undefined && { errorPolicy: validErrorPolicy }),
  ...(args.options.onNoQuorum !== undefined && { onNoQuorum: args.options.onNoQuorum }),
  dryRun: args.options.dryRun,
  quick: args.options.quick,
  verbose: args.options.verbose,
});
```

Any field not named here is silently dropped. `options` was not named.

## Why the tests missed it, which is the part worth reading

#4948 had **three** tests along this chain: `PARSE_ARGS_CONFIG` collects the repeats, `buildVoteOptions` maps them onto the parsed options object, and `voteCommand` forwards them to the engine. I added the middle one specifically because I had learned that day to test the middle link.

There were two middle links. I tested the one I knew about.

The chain is `parseArgs → buildVoteOptions → handleVoteCommand → voteCommand`, and the third arrow had no test on either side of it — a handler that rebuilds its argument by hand is exactly the shape where a new field vanishes, and nothing in the type system objects because every field is optional.

That is the seventh untested join today. The transferable lesson is not "test the middle link" but **"enumerate the links first"** — I asserted the ends and one interior point and assumed that covered it.

## Fix

`options` is declared on `ParsedCliArgs` and forwarded by the handler. Mutations: dropping the forward fails 1, and forwarding `?? []` fails 1 — the empty array matters because the engine reads a *present* `options` array as "multi-option vote" and adds the leading-option bar to what should be a plain yes/no.

6864 CLI tests pass; public API surface unchanged.
