### PR TITLE
fix(cli): honor vote --timeout and document the real default

### DIFF
--- a/.changeset/vote-timeout-and-help-default.md
+++ b/.changeset/vote-timeout-and-help-default.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+make `vote --timeout` take effect, and document its real default
+
+The same handler that dropped `--option` also dropped `timeoutMs`, so every
+vote used the 300s default however the operator set it — the "timeout: 300s
+each" line reported the default rather than the request.
+
+The help was separately wrong: it advertised `default: 90` when
+`VOTE_TIMEOUTS.defaultMs` has been 300 since it was raised from 180, on the
+observation that architecture and security voters average 315s. An operator
+reading 90 would conclude a 250s vote had hung. A test now ties the documented
+value to the constant so they cannot drift again.
+
+The mapping from parsed args to `VoteCommandOptions` is extracted into one
+function. Every field on that type is optional, so the compiler cannot notice a
+missing one — enumerating them inline is what let two flags disappear.

--- a/packages/nexus-agents/src/cli-command-help.test.ts
+++ b/packages/nexus-agents/src/cli-command-help.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect } from 'vitest';
 
 import { COMMAND_HELP, formatCommandHelp, formatAllCommandsHelp } from './cli-command-help.js';
 import { getCommandDescription } from './cli-command-catalog.js';
+import { VOTE_TIMEOUTS } from './config/timeouts.js';
 
 // ============================================================================
 // Help metadata registry
@@ -137,5 +138,22 @@ describe('formatAllCommandsHelp', () => {
     const output = formatAllCommandsHelp();
     expect(output).toContain('Execute a task');
     expect(output).toContain('consensus vote');
+  });
+});
+
+// =============================================================================
+// Documented defaults match the code (#4965)
+// =============================================================================
+
+describe('vote --timeout documents the real default (#4965)', () => {
+  // The help said 90; `VOTE_TIMEOUTS.defaultMs` has been 300 since #1640 raised
+  // it from 180, noting architecture and security voters average 315s. An
+  // operator reading 90 would conclude a 250s vote had hung.
+  it('matches VOTE_TIMEOUTS.defaultMs', () => {
+    const vote = COMMAND_HELP.find((c) => c.command === 'vote');
+    const flag = vote?.flags?.find((f) => f.flag.startsWith('--timeout'));
+
+    expect(flag).toBeDefined();
+    expect(flag?.defaultValue).toBe(String(VOTE_TIMEOUTS.defaultMs / 1000));
   });
 });

--- a/packages/nexus-agents/src/cli-command-help.ts
+++ b/packages/nexus-agents/src/cli-command-help.ts
@@ -80,7 +80,13 @@ const VOTE_HELP: CommandHelpEntry = {
     },
     { flag: '--quick', description: 'Use 3 agents instead of the full 7 for faster votes' },
     { flag: '--dry-run', description: 'Simulate votes without agent execution' },
-    { flag: '--timeout=<seconds>', description: 'Timeout per vote in seconds', defaultValue: '90' },
+    {
+      flag: '--timeout=<seconds>',
+      description: 'Timeout per vote in seconds',
+      // VOTE_TIMEOUTS.defaultMs, raised to 300s by #1640 after architecture and
+      // security voters were observed averaging 315s. The help said 90 (#4965).
+      defaultValue: '300',
+    },
     {
       flag: '--error-policy <p>',
       description:

--- a/packages/nexus-agents/src/cli-commands-handlers.test.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.test.ts
@@ -519,6 +519,35 @@ describe('handleVoteCommand forwards --option (#4963)', () => {
     expect(voteMock.mock.calls[0]?.[0]).toMatchObject({ options: ['A', 'B'] });
   });
 
+  it('passes --timeout through as timeoutMs', async () => {
+    // #4965: same handler, same shape. Every vote today printed
+    // "timeout: 300s each" — the default — however the operator set it,
+    // because this field was never named here.
+    const base = createMockArgs();
+    await handleVoteCommand({
+      ...base,
+      command: 'vote',
+      options: { ...base.options, proposal: 'p', timeoutMs: 250_000 },
+      positionals: ['vote'],
+    });
+
+    expect(voteMock.mock.calls[0]?.[0]).toMatchObject({ timeoutMs: 250_000 });
+  });
+
+  it('omits timeoutMs when the operator did not set one', async () => {
+    // The pair: forwarding a default here would override the engine's own,
+    // which is the value the help now documents.
+    const base = createMockArgs();
+    await handleVoteCommand({
+      ...base,
+      command: 'vote',
+      options: { ...base.options, proposal: 'p' },
+      positionals: ['vote'],
+    });
+
+    expect(voteMock.mock.calls[0]?.[0]).not.toHaveProperty('timeoutMs');
+  });
+
   it('omits the field for an ordinary yes/no vote', async () => {
     // The pair: a present-but-empty array tells the engine this is a
     // multi-option vote and adds the leading-option bar to a plain vote.

--- a/packages/nexus-agents/src/cli-commands-handlers.ts
+++ b/packages/nexus-agents/src/cli-commands-handlers.ts
@@ -57,6 +57,7 @@ import {
   type ParsedCliArgs,
 } from './cli-types.js';
 import { startServer, type OrchestratorModeOptions } from './cli-server.js';
+import type { VoteCommandOptions } from './cli/vote-types.js';
 import {
   isValidExpertListFormat,
   isValidThreshold,
@@ -306,33 +307,44 @@ export function handleSystemReviewCommand(args: ParsedCliArgs): CliExitResult {
  * Handles the vote command for consensus voting.
  * (Source: Issue #212, Process Automation Epic #209)
  */
-export async function handleVoteCommand(args: ParsedCliArgs): Promise<CliExitResult> {
-  const proposal = args.options.proposal;
-  if (proposal === undefined) {
-    printVoteUsage();
-    return cliExit(EXIT_CODES.INVALID_ARGS);
-  }
+/** A defined value that passes its guard, or undefined. */
+function validated<T>(value: T | undefined, guard: (v: T) => boolean): T | undefined {
+  return value !== undefined && guard(value) ? value : undefined;
+}
 
-  const threshold = args.options.threshold;
-  const validThreshold =
-    threshold !== undefined && isValidThreshold(threshold) ? threshold : undefined;
-  const errorPolicy = args.options.errorPolicy;
-  const validErrorPolicy =
-    errorPolicy !== undefined && isValidErrorPolicy(errorPolicy) ? errorPolicy : undefined;
+/**
+ * Map parsed CLI args onto {@link VoteCommandOptions}.
+ *
+ * Extracted so the mapping is one reviewable list rather than an inline
+ * enumeration inside the handler. Every field on `VoteCommandOptions` is
+ * optional, so the compiler cannot notice one that is missing — `--option` and
+ * `--timeout` were both dropped here (#4963, #4965). When adding a field to
+ * that type, add it here too.
+ */
+function buildVoteCommandOptions(args: ParsedCliArgs): VoteCommandOptions {
+  const validThreshold = validated(args.options.threshold, isValidThreshold);
+  const validErrorPolicy = validated(args.options.errorPolicy, isValidErrorPolicy);
 
-  const exitCode = await voteCommand({
-    proposal,
-    // #4963: this handler rebuilds VoteCommandOptions field by field, so a new
-    // field is dropped unless it is named here. `--option` parsed, reached
-    // `args.options.options`, and died at this line.
+  return {
+    proposal: args.options.proposal ?? '',
     ...(args.options.options !== undefined && { options: args.options.options }),
     ...(validThreshold !== undefined && { threshold: validThreshold }),
     ...(validErrorPolicy !== undefined && { errorPolicy: validErrorPolicy }),
     ...(args.options.onNoQuorum !== undefined && { onNoQuorum: args.options.onNoQuorum }),
+    ...(args.options.timeoutMs !== undefined && { timeoutMs: args.options.timeoutMs }),
     dryRun: args.options.dryRun,
     quick: args.options.quick,
     verbose: args.options.verbose,
-  });
+  };
+}
+
+export async function handleVoteCommand(args: ParsedCliArgs): Promise<CliExitResult> {
+  if (args.options.proposal === undefined) {
+    printVoteUsage();
+    return cliExit(EXIT_CODES.INVALID_ARGS);
+  }
+
+  const exitCode = await voteCommand(buildVoteCommandOptions(args));
   // #4135: use `cliExit` (not `cliExitFromStatus`) so a distinct `--on-no-quorum=exit2`
   // code (2) survives to the process instead of being collapsed to 1. Codes 0/1 map
   // identically, so back-compat holds.


### PR DESCRIPTION
Closes #4965. Same handler as #4963, two more fields — found by checking the rest of it after the first one.

## `--timeout` did nothing

`handleVoteCommand` rebuilt `VoteCommandOptions` field by field and never named `timeoutMs`. Every vote I ran today passed `--timeout=250` and every one printed:

```
Collecting votes from 3 agents (timeout: 300s each)
```

300s is `VOTE_TIMEOUTS.defaultMs`. The line reports the default, not the request. I read it repeatedly today without registering that it disagreed with the argument I had just typed — output only helps if you check it against what you asked for.

## The help was wrong in the other direction

```
--timeout=<seconds>   Timeout per vote in seconds (default: 90)
```

The default is **300**, raised from 180 by #1640 with the note that architecture and security voters *"regularly exceed 180s on complex proposals (avg 315s observed)"*. So the documentation understated it by more than 3x — an operator reading 90 would conclude a 250s vote had hung.

There is now a test asserting the documented value equals `VOTE_TIMEOUTS.defaultMs / 1000`, so the two cannot drift apart again. Reverting the help to `90` fails it.

## The structural half

The mapping is extracted into `buildVoteCommandOptions`. Every field on `VoteCommandOptions` is optional, so the compiler never objects to a missing one — enumerating them inline inside the handler is precisely what let two flags disappear, and it would have let a third. One reviewable list is not a guarantee, but it is the difference between "add it here too" being visible and being folklore.

I considered making the mapping exhaustive at the type level instead. It cannot be done cheaply while every field is optional, which is the real root cause and a larger change than this fix warrants.

## Mutations

| mutation | result |
| --- | --- |
| drop `timeoutMs` again | 1 failed |
| handler injects its own 90s default | 1 failed |
| help default back to `90` | 1 failed |
| drop `options` again (regression guard from #4963) | 1 failed |

`createIssue` and `issueNumber` are still unreachable — no flag advertises them, and `voteCommand` implements the behaviour. That is a feature with no route from the command line rather than a broken flag, so it stays on #4965 for a decision between wiring and removal.

6869 CLI tests pass.
