### PR TITLE
fix(mcp): register consensus_vote's full input schema so async dispatch is reachable

### DIFF
--- a/.changeset/consensus-vote-async-reachable.md
+++ b/.changeset/consensus-vote-async-reachable.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': minor
+---
+
+make `consensus_vote`'s async dispatch reachable
+
+The tool's description tells callers `Supports async mode (mode: 'async') —
+returns a jobId to poll via get_job_result`, and the schema it registered with
+MCP omitted `mode`, so the SDK stripped the field before the handler saw it.
+Passing it produced a 78-second synchronous run with no jobId and no error.
+
+`idempotencyKey` was omitted the same way, taking the replay-safe
+"same key, same inputs returns the existing job" behaviour with it — along with
+the documented `cancel_job` semantics that preserve partial votes.
+
+The registered schema is now `ConsensusVoteInputSchema.shape` rather than a
+hand-copied subset, matching `run_dev_pipeline`. The existing drift contract
+exempted these two fields as "not user-facing vote inputs", which contradicted
+the description; it now asserts full parity with no exemptions.
+
+This matters most where the sync path is weakest: a 7-voter `higher_order`
+panel measured 548s against the 900s MCP request ceiling, and the field's own
+description recommends async for exactly that case.

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -1415,13 +1415,23 @@ describe('CONSENSUS_VOTE_TOOL_SCHEMA input drift contract (#4494 follow-up)', ()
     expect(advertised).toContain('options');
   });
 
-  it('advertises every input the handler accepts, except documented internals', () => {
-    // `mode` and `idempotencyKey` are async-dispatch plumbing added by the
-    // job wrapper, not user-facing vote inputs.
-    const INTERNAL_ONLY = new Set(['mode', 'idempotencyKey']);
-    const missing = internal.filter((k) => !INTERNAL_ONLY.has(k) && !advertised.includes(k));
+  it('advertises every input the handler accepts, with no exemptions', () => {
+    // This assertion used to exempt `mode` and `idempotencyKey` as
+    // "async-dispatch plumbing… not user-facing vote inputs". That exemption
+    // contradicted the tool's own description, which tells callers
+    // `Supports async mode (mode: 'async')`, and nothing set the field on
+    // their behalf — so the documented async path could not be invoked at all
+    // (#4969). The schema is now registered from the internal shape, so there
+    // is no subset to exempt from.
+    expect(internal.filter((k) => !advertised.includes(k))).toEqual([]);
+  });
 
-    expect(missing).toEqual([]);
+  it('advertises the async-dispatch fields the description promises', () => {
+    // Named explicitly, not just covered by the parity check above: these two
+    // are the ones that were exempted, and a future exemption would want to
+    // start with them again.
+    expect(advertised).toContain('mode');
+    expect(advertised).toContain('idempotencyKey');
   });
 
   it('advertises nothing the handler would reject', () => {

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -45,11 +45,9 @@ import {
   saveCorrelationData,
 } from '../../consensus/correlation-persistence.js';
 import {
-  MAX_PROPOSAL_LENGTH,
   VotingStrategySchema,
   VoteDecisionStatusSchema,
   VoteThresholdSchema,
-  ErrorPolicySchema,
   ConsensusVoteInputSchema,
   buildResponse,
   getDefaultErrorPolicy,
@@ -1153,46 +1151,16 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
 };
 
 /** Advertised MCP input schema for consensus_vote (hoisted to keep the register fn within its line budget). */
-export const CONSENSUS_VOTE_TOOL_SCHEMA = {
-  proposal: z.string().min(1).max(MAX_PROPOSAL_LENGTH).describe('Proposal text to vote on'),
-  options: z
-    .array(z.string().min(1).max(200))
-    .min(2)
-    .max(10)
-    .optional()
-    .describe(
-      'Named alternatives for a multi-option proposal (#4472). When present, the threshold must ' +
-        'ALSO be cleared by the leading option: `unanimous` requires every approver to have chosen ' +
-        "the SAME option, and `supermajority`/`majority` measure the leading option's share of " +
-        'approvers. An approving voter whose selection is absent or matches no declared option ' +
-        'stays in the denominator and credits no option, so a degraded response can only lower the ' +
-        'leading share, never raise it. Omit for an ordinary yes/no vote.'
-    ),
-  threshold: z
-    .enum(['majority', 'supermajority', 'unanimous'])
-    .optional()
-    .describe('Voting threshold (legacy). Use strategy instead.'),
-  strategy: VotingStrategySchema.optional().describe(
-    'Voting strategy: simple_majority (default), supermajority, unanimous, proof_of_learning, or higher_order'
-  ),
-  errorPolicy: ErrorPolicySchema.optional().describe(
-    'How to treat errored/timed-out voters (#2630): reduce_denominator (default non-strict) | count_as_abstain | fail_closed (default unanimous) | absolute_quorum (#4132 opt-in — an errored voter, esp. the contrarian, degrades the verdict to no_quorum instead of being dropped; never manufactures approved/rejected from an induced error). Errors > 50% always fails.'
-  ),
-  quickMode: z.boolean().optional().default(false).describe('Use 3 agents instead of 7'),
-  simulateVotes: z
-    .boolean()
-    .optional()
-    .default(false)
-    .describe('TESTS ONLY — random output, must not be used for real decisions (#2319)'),
-  ratifies: z
-    .string()
-    .min(1)
-    .max(256)
-    .optional()
-    .describe(
-      'Authority-tier ratification subject (#4004) — the loop/strategy id this vote ratifies for an authority-ladder promotion. Bound into the authentic vote record so the promotion gate can verify it. Omit for ordinary votes.'
-    ),
-};
+/**
+ * The schema advertised to MCP clients.
+ *
+ * Registered from {@link ConsensusVoteInputSchema}'s shape rather than
+ * hand-copied. A subset drifts: `options` shipped internally in #4494 and was
+ * unreachable through the tool until someone noticed, and `mode` stayed
+ * unadvertised while this tool's own description told callers to pass it —
+ * so the documented async path could not be invoked at all (#4969).
+ */
+export const CONSENSUS_VOTE_TOOL_SCHEMA = ConsensusVoteInputSchema.shape;
 
 /** Advertised MCP tool description for consensus_vote. */
 const CONSENSUS_VOTE_DESCRIPTION =


### PR DESCRIPTION
Closes #4969. Found by following up your question about whether votes run as jobs.

## The contradiction

Three artifacts in one file disagreed about whether `mode` is a caller-facing parameter.

The tool **description** (`consensus-vote.ts:1206`) tells clients to pass it:

> `Supports async mode (mode: 'async') — returns a jobId to poll via get_job_result.`

The registered **schema** omitted it, so the SDK stripped it before `safeParse` ran and `mode === 'async'` was never true.

The **drift test** justified that omission:

```ts
// `mode` and `idempotencyKey` are async-dispatch plumbing added by the
// job wrapper, not user-facing vote inputs.
const INTERNAL_ONLY = new Set(['mode', 'idempotencyKey']);
```

No job wrapper sets `mode` on a caller's behalf — grepping production code for a producer finds only descriptions and `runAsJob` reading `args.mode`. So the exemption assumed a layer that does not exist, and the documented usage was impossible.

## Measured

```
consensus_vote { proposal, quickMode: true, mode: 'async' }
→ no jobId, no error, 78s synchronous, full result returned
```

Against a freshly spawned `--mode=server`. An earlier run with `dispatch: 'async'` behaved identically — that is the sibling tools' field name, filed separately as #4968, and re-running with the correct name is what isolated this.

## What was unreachable

Everything Stage 4 of epic #2631 built: async dispatch and `runAsJob`, the per-tool concurrency cap, `idempotencyKey`'s replay-safe semantics from #3042, and the `cancel_job` behaviour documented on the `mode` field that preserves `partialVotes` from voters who finished before the abort. Plus #4362's fix making a dead voter panel reject rather than record a successful job — a correctness fix on a path that could not execute.

It bites where the sync path is weakest: a 7-voter `higher_order` panel measured **548s** today against the 900s ceiling, and the field's own description recommends async for precisely that case.

## The fix, and the contract

`inputSchema` is now `ConsensusVoteInputSchema.shape` — the same thing `run_dev_pipeline` registers, which is why its `dispatch` works. No subset means nothing to drift.

The drift test now asserts **full parity with no exemptions**, plus a named assertion for the two fields that were exempted, since a future exemption would start with them again. Reverting to a hand-copied subset fails 3 tests.

## Correction

I filed #4969 claiming the schemas had "drifted" with "no cross-check". Both wrong — the cross-check exists (added after #4494 shipped `options` unreachably, the same bug) and the omission was deliberate. Corrected on the issue. The conclusion held; the diagnosis did not, and the difference changed the fix: the test's exemption had to be removed too, or the change would fail the very contract documenting the old behaviour as intended.

127 consensus-vote tests pass; public API surface unchanged.
