### PR TITLE
fix(mcp): register run_workflow's full schema and gate hand-copied tool schemas

### DIFF
--- a/.changeset/run-workflow-schema-parity.md
+++ b/.changeset/run-workflow-schema-parity.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+make `run_workflow`'s idempotency key reachable, and stop hand-copied tool schemas drifting
+
+`RunWorkflowInputSchema` declares `idempotencyKey` and the dispatcher reads it,
+but the schema registered with MCP was a hand-written mirror that omitted it —
+so the SDK stripped the field, every async dispatch minted a fresh jobId, and
+the replay and collision envelopes could never fire. Registering the internal
+shape fixes it and removes the second list.
+
+This is the second instance in a week: `consensus_vote` omitted `mode` the same
+way, killing its entire async path. Both mirrors had passing test suites. A new
+test now scans every tool that calls `runAsJob` and refuses a registration that
+is not derived from a schema's `.shape`, with the three remaining mirrors on an
+allowlist that can only shrink — an entry must be removed once its tool is
+converted, so the list cannot quietly become permission.

--- a/packages/nexus-agents/src/mcp/tools/async-tool-schema-parity.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/async-tool-schema-parity.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Every async-capable tool must ADVERTISE every input its handler accepts.
+ *
+ * @module mcp/tools/async-tool-schema-parity.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TOOLS_DIR = join(import.meta.dirname);
+
+/**
+ * Tools registering `SomeSchema.shape` cannot drift; a hand-written object
+ * literal can. This finds the second kind.
+ *
+ * #4969: `consensus_vote` advertised a subset omitting `mode`, so its entire
+ * async/idempotency/cancellation path was unreachable — while the tool's own
+ * description told callers to pass it.
+ * #4972: `run_workflow` omitted `idempotencyKey`, so replay-safety was
+ * unreachable and the replay/collision envelopes could never fire.
+ *
+ * Both were hand-written mirrors. Both had passing test suites.
+ */
+function handWrittenSchemaRegistrations(): Array<{ file: string; line: number }> {
+  const found: Array<{ file: string; line: number }> = [];
+  for (const file of readdirSync(TOOLS_DIR)) {
+    if (!file.endsWith('.ts') || file.endsWith('.test.ts')) continue;
+    const src = readFileSync(join(TOOLS_DIR, file), 'utf8');
+    // A doc mention is not a call site — `cancel-job-tool.ts` discusses
+    // `runAsJob` at length and dispatches nothing.
+    if (!/runAsJob[<(]/.test(src)) continue;
+    src.split('\n').forEach((line, i) => {
+      const m = /inputSchema:\s*([A-Za-z_][A-Za-z0-9_]*)\s*,/.exec(line);
+      if (m === null) return;
+      const identifier = m[1] ?? '';
+      // A registration naming a bare identifier is only safe if that identifier
+      // is itself assigned from `.shape`.
+      const assignedFromShape = new RegExp(`${identifier}\\s*=\\s*[A-Za-z0-9_]+\\.shape`).test(src);
+      if (!assignedFromShape) found.push({ file, line: i + 1 });
+    });
+  }
+  return found;
+}
+
+/**
+ * Mirrors that exist today and match their internal schema. Each is a place the
+ * next divergence can happen; the list may only shrink. Tracked in #4972.
+ */
+const KNOWN_HAND_WRITTEN = new Set([
+  'orchestrate.ts',
+  'execute-spec-tool.ts',
+  'run-graph-workflow.ts',
+]);
+
+describe('async-capable tools advertise their full input schema (#4972)', () => {
+  it('finds the async-capable tools it is scanning', () => {
+    // Guard the guard: a scan that matched nothing would report a clean repo,
+    // which is exactly the shape these findings are about.
+    const asyncTools = readdirSync(TOOLS_DIR).filter(
+      (f) =>
+        f.endsWith('.ts') &&
+        !f.endsWith('.test.ts') &&
+        /runAsJob[<(]/.test(readFileSync(join(TOOLS_DIR, f), 'utf8'))
+    );
+
+    expect(asyncTools.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('registers no hand-copied input schema', () => {
+    // `.shape` makes the advertised surface the internal one by construction.
+    // A hand-written mirror is a second list that has now silently diverged
+    // twice; this refuses the third.
+    const fresh = handWrittenSchemaRegistrations().filter((r) => !KNOWN_HAND_WRITTEN.has(r.file));
+
+    expect(fresh).toEqual([]);
+  });
+
+  it('keeps the known-mirror list honest', () => {
+    // An allowlist nobody prunes becomes permission. If a tool on this list has
+    // been converted to `.shape`, its entry must go — otherwise the list stops
+    // describing the repo and starts excusing it.
+    const stillHandWritten = new Set(handWrittenSchemaRegistrations().map((r) => r.file));
+    const stale = [...KNOWN_HAND_WRITTEN].filter((f) => !stillHandWritten.has(f));
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/run-workflow.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-workflow.ts
@@ -8,7 +8,6 @@
  * (Refactored: Issue #531 - Use createSecureHandlerFactory)
  */
 
-import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Result } from '../../core/index.js';
 import {
@@ -266,27 +265,15 @@ async function handleRunWorkflow(
   return successResponse(executeResult.value);
 }
 
-/** Input schema for registerTool */
-const toolInputSchema = {
-  template: z.string().min(1).describe('Workflow template name (e.g., code-review) or file path'),
-  inputs: z.record(z.string().max(100), z.unknown()).describe('Workflow inputs as key-value pairs'),
-  dryRun: z.boolean().optional().default(false).describe('Validate workflow without executing'),
-  // #3017
-  timeoutMs: z
-    .number()
-    .int()
-    .min(1000)
-    .max(1_800_000)
-    .optional()
-    .describe('Per-phase execution timeout in ms (overrides workflow.timeout, bound [1s, 30min])'),
-  // #3044 / epic #2631 Stage 3
-  mode: z
-    .enum(['sync', 'async'])
-    .optional()
-    .describe(
-      'Dispatch mode (default: sync). "async" returns { jobId } immediately; poll via get_job_result.'
-    ),
-};
+/**
+ * Input schema for registerTool — the internal schema's shape, not a copy.
+ *
+ * The hand-written mirror this replaces omitted `idempotencyKey`, so the SDK
+ * stripped it, every async dispatch minted a fresh jobId, and the `replay` /
+ * `collision` envelopes below could never fire. Same cause as #4969 one tool
+ * over: a subset drifts, `.shape` cannot (#4972).
+ */
+const toolInputSchema = RunWorkflowInputSchema.shape;
 
 /**
  * Dispatch the workflow on a background promise + return a pending


### PR DESCRIPTION
Refs #4972, findings 2 and 3 — the live defect plus the gate that prevents its recurrence. Finding 1 (no tool accepts the `AbortSignal`) is a larger rollout and stays open.

## The defect

`RunWorkflowInputSchema` declares `idempotencyKey` (`run-workflow-types.ts:69`) and the dispatcher reads it (`run-workflow.ts:328`). The registered schema was a hand-written mirror listing only `template, inputs, dryRun, timeoutMs, mode`.

So the SDK stripped the field before the handler saw it, every async dispatch minted a fresh jobId, and the `replay` / `collision` envelopes at `:301-317` could never fire. Replay-safety was unreachable.

Narrower than #4969, which killed `consensus_vote`'s whole async path — but the same cause, the same week, in the same kind of hand-copied list.

## The gate is the point

Two mirrors have now silently diverged, and **both tools had passing test suites**. `consensus_vote` even had a parity test, added after #4494 shipped `options` unreachably — and it still missed `mode`, because the test carried an exemption list.

The new test scans every file that *calls* `runAsJob` and refuses any `inputSchema:` registration not derived from a schema's `.shape`. Structural rather than field-by-field, so it does not need to know what each tool's fields are — which is what let the previous parity test be talked out of its own conclusion.

Three mirrors remain (`orchestrate`, `execute_spec`, `run_graph_workflow`). All three currently match their internal schemas, so converting them is a separate change with its own API-surface review. They sit on an allowlist with a second test asserting **the list only shrinks**: if a tool is converted to `.shape`, its entry must be deleted, or the test fails. An allowlist nobody prunes stops describing the repo and starts excusing it.

## Details worth flagging

- **A doc mention is not a call site.** The first version of the scan matched `cancel-job-tool.ts`, which discusses `runAsJob` at length and dispatches nothing. Tightened to `runAsJob[<(]`.
- **Guard-the-guard included**: a scan matching zero files would report a clean repo, which is precisely the shape these findings are. It asserts at least 8 async-capable tools are found.

## Mutations

| mutation | result |
| --- | --- |
| `run_workflow` back to a hand-written mirror | 1 failed |
| remove an allowlist entry while its tool is still hand-written | 1 failed |

One process note: restoring after the second mutation needed a manual edit, because `git checkout --` does nothing for a file that is not yet tracked. I have been caught by that command before in the other direction — reverting real work — and it is worth remembering it can also silently fail to revert anything.

2628 MCP-tool tests pass; public API surface unchanged.
