### PR TITLE
feat(jobs): record whether a job's tool accepts the abort signal

### DIFF
--- a/.changeset/job-signal-accepted.md
+++ b/.changeset/job-signal-accepted.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': minor
+---
+
+say on the job record whether a cancel can reach the tool
+
+`cancel_job` writes a `cancelled` record whether or not the tool can act on the
+signal. `cancel-job-tool.ts` is explicit that a tool ignoring the signal "still
+runs to completion… but its record stays `cancelled`" — and no adopter of
+`runAsJob` accepts the signal today, so every cancelled record has claimed more
+than was known, with the caveat visible only in source.
+
+The record now carries `signalAccepted`, derived from the run callback's arity.
+It is a structural fact, not a behavioural one: `true` means cancellation can
+reach the tool, not that the work stopped, and absent means the writer did not
+report it rather than `false`. That is the honest limit of what arity proves —
+and it makes signal adoption measurable instead of assumed.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -3919,7 +3919,7 @@ InterfaceDeclaration GetJobResultResponse
   readonly errorMessage?: string | undefined
   readonly found: boolean
   readonly jobId: string
-  readonly record?: { completedAt?: string | undefined; createdAt: string; error?: string | undefined; jobId: string; result?: unknown; status: "pending" | "failed" | "cancelled" | "complete"; toolName: string; v: 1; } | undefined
+  readonly record?: { completedAt?: string | undefined; createdAt: string; error?: string | undefined; jobId: string; result?: unknown; signalAccepted?: boolean | undefined; status: "pending" | "failed" | "cancelled" | "complete"; toolName: string; v: 1; } | undefined
 FunctionDeclaration getKnownNexusVarNames
   : typeof getKnownNexusVarNames
 FunctionDeclaration getOutcomeStore

--- a/packages/nexus-agents/src/mcp/jobs/job-result-store.ts
+++ b/packages/nexus-agents/src/mcp/jobs/job-result-store.ts
@@ -65,6 +65,22 @@ export const JobResultSchema = z.object({
    * `result` — the discriminator is `status`.
    */
   error: z.string().optional(),
+  /**
+   * Whether the tool's `run` callback accepts `runAsJob`'s `AbortSignal`
+   * (#4972).
+   *
+   * `cancel_job` writes a `cancelled` record whether or not the tool can act
+   * on the signal — as `cancel-job-tool.ts` says, "a tool that IGNORES the
+   * signal still runs to completion… but its record stays `cancelled`". A
+   * reader of that record could not tell the two apart, so `cancelled` claimed
+   * more than was known.
+   *
+   * This is a STRUCTURAL fact — the callback's arity — not a behavioural one.
+   * A tool may accept the signal and never await on it, so `true` means
+   * "cancellation can reach this tool", not "the work stopped". Absent means
+   * the writer did not report it, which is not the same as `false`.
+   */
+  signalAccepted: z.boolean().optional(),
 });
 export type JobResult = z.infer<typeof JobResultSchema>;
 
@@ -95,7 +111,7 @@ function persistJobRecord(path: string, record: JobResult): void {
  * Caller responsibility: generate a fresh `jobId` per call (Stage 1
  * doesn't yet deduplicate via idempotencyKey — that's #3042 follow-up).
  */
-export function writeJobPending(jobId: string, toolName: string): void {
+export function writeJobPending(jobId: string, toolName: string, signalAccepted?: boolean): void {
   const path = jobResultPath(jobId);
   if (existsSync(path)) {
     logger.debug('Job result file already exists — leaving in place', { jobId });
@@ -107,9 +123,10 @@ export function writeJobPending(jobId: string, toolName: string): void {
     toolName,
     status: 'pending',
     createdAt: new Date().toISOString(),
+    ...(signalAccepted !== undefined ? { signalAccepted } : {}),
   };
   persistJobRecord(path, record);
-  logger.debug('Wrote pending job record', { jobId, toolName });
+  logger.debug('Wrote pending job record', { jobId, toolName, signalAccepted });
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/jobs/run-as-job.test.ts
+++ b/packages/nexus-agents/src/mcp/jobs/run-as-job.test.ts
@@ -66,6 +66,36 @@ describe('runAsJob', () => {
     expect(getInFlight('orchestrate')).toBe(1);
   });
 
+  // #4972: `cancel_job` writes `cancelled` whether or not the tool can act on
+  // the signal — `cancel-job-tool.ts` is explicit that an ignoring tool "still
+  // runs to completion… but its record stays `cancelled`". None of the ten
+  // adopters accepts the signal today, so every cancelled record claims more
+  // than is known. The record now says which case it is.
+  it('records signalAccepted:false when the run callback does not take the signal', () => {
+    runAsJob<DummyInput, { ok: true }>({
+      toolName: 'orchestrate',
+      input: { task: 'x' },
+      freshJobId: () => 'job-sig-none',
+      // Two parameters — the shape every current adopter uses.
+      run: (_jobId, _input) => new Promise(() => {}),
+    });
+
+    expect(readJobResult('job-sig-none')?.signalAccepted).toBe(false);
+  });
+
+  it('records signalAccepted:true when it does', () => {
+    // The pair: hardcoding false would be indistinguishable from today's state
+    // and would stay wrong as tools adopt the signal.
+    runAsJob<DummyInput, { ok: true }>({
+      toolName: 'orchestrate',
+      input: { task: 'x' },
+      freshJobId: () => 'job-sig-yes',
+      run: (_jobId, _input, _signal) => new Promise(() => {}),
+    });
+
+    expect(readJobResult('job-sig-yes')?.signalAccepted).toBe(true);
+  });
+
   it('returns a busy envelope when the per-tool cap is full', () => {
     const cap = getJobCap('consensus_vote'); // 2 by default
     for (let i = 0; i < cap; i++) {

--- a/packages/nexus-agents/src/mcp/jobs/run-as-job.ts
+++ b/packages/nexus-agents/src/mcp/jobs/run-as-job.ts
@@ -308,7 +308,10 @@ export function runAsJob<I, R, E = ToolResult>(params: RunAsJobParams<I, R, E>):
 
   const jobId = idempotency.jobId;
   // Step 3: pending record + idempotency index entry.
-  writeJobPending(jobId, params.toolName);
+  // #4972: record whether this tool can even receive a cancel. `run.length`
+  // is the callback's declared arity, so >= 3 means it takes the `signal`
+  // parameter. Structural, not behavioural — see `signalAccepted`'s doc.
+  writeJobPending(jobId, params.toolName, params.run.length >= 3);
   if (params.idempotencyKey !== undefined && params.idempotencyKey !== '') {
     registerIdempotentJob({
       tool: params.toolName,


### PR DESCRIPTION
Refs #4972, finding 1 — the disclosure half. Signal adoption per tool is the real work and stays open.

## The gap

`cancel_job` writes a `cancelled` record whether or not the tool can act on the signal. `cancel-job-tool.ts:20-26` says so plainly:

> A tool that IGNORES the signal still runs to completion (you cannot stop an unyielding Promise from outside) — but its record stays `cancelled`.

That is an honest comment in a place no caller reads. `get_job_result` returns `status: 'cancelled'` and the caller cannot tell *"the work stopped"* from *"a cancel was recorded against a tool that cannot stop"*.

And it is not hypothetical: **none of the ten `runAsJob` adopters accepts the signal.** Every `run` callback is `run: ()`, `run: (jobId)` or `run: (_jobId, input)` — the contract's third parameter (`run-as-job.ts:194`) is unused everywhere. So today *every* cancelled record is the second case.

## What this adds

`signalAccepted` on the job record, derived from `params.run.length >= 3`.

**Deliberately narrow.** Arity proves the callback *takes* the signal, not that it awaits on it — a tool could accept and ignore. So the field is named for the structural fact and its doc says exactly that: `true` means cancellation can reach the tool, not that the work stopped. Absent means the writer did not report it, which is not the same as `false`.

I considered calling it `cancellationHonored`, which is what a reader wants to know. That would claim something arity cannot establish, and inventing a confident name for an uncertain fact is the failure this whole issue is about.

## Why it is worth shipping before the adoption work

It turns an invisible property into a measurable one. Right now "no tool accepts the signal" is a fact you discover by grepping ten files; afterwards it is a field on every job record, and adoption progress shows up in the data rather than in a checklist. The next tool that threads the signal flips its own records to `true` with no further work.

## Mutations

| mutation | result |
| --- | --- |
| omit the disclosure entirely | 2 failed |
| always report `true` | 1 failed |
| always report `false` | 1 failed |

The third row matters most: hardcoding `false` matches today's reality exactly, so without the positive-case test it would look correct indefinitely and silently stay wrong as tools adopt the signal.

105 job tests pass. `api-surface.txt` regenerated — additive optional field on the job record, hence minor.
