### PR TITLE
fix(vote): judge panel independence after detection, not on placeholders

### DIFF
--- a/.changeset/panel-independence-unmeasured.md
+++ b/.changeset/panel-independence-unmeasured.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+fix(vote): stop the panel-correlation warning firing on placeholder model ids
+
+The #4390 check asked whether every voter was running the same model by
+comparing the adapters' `modelId` at assignment time. Adapter detection is lazy
+(#811), so at that point all of them report the same `pending-detection`
+placeholder — which reads as one model. The warning fired on every CLI-path
+vote, and a panel that genuinely had collapsed onto one model produced the
+identical line. Both directions were wrong, and the second is the one that
+matters: the safeguard could not distinguish the condition it exists to catch.
+
+`assessPanelIndependence` now returns `unmeasured` / `collapsed` / `diverse`
+instead of a boolean, so an unresolved panel is neither accused nor cleared, and
+the real judgement moved to after the votes are collected — the first moment the
+adapters have actually resolved. An empty panel is `unmeasured` rather than
+`diverse`, since no adapters is not a healthy spread.
+
+The gateway path is unaffected: its adapters are built from a probed model
+catalog and carry real ids from construction.

--- a/packages/nexus-agents/src/adapters/resilient-adapter.ts
+++ b/packages/nexus-agents/src/adapters/resilient-adapter.ts
@@ -25,6 +25,7 @@ import { ModelError, ConfigError } from '../core/errors.js';
 import type { ILogger } from '../core/index.js';
 import { getTimeProvider, getRandomProvider } from '../core/index.js';
 import { getErrorMessage, createLogger } from '../core/index.js';
+import { UNRESOLVED_MODEL_ID } from '../config/model-equivalence.js';
 
 import { createAutoAdapter, type AdapterSelection } from './auto-adapter.js';
 import {
@@ -103,7 +104,7 @@ export class ResilientAdapter implements IResilientAdapter {
   }
 
   get modelId(): string {
-    return this.currentAdapter?.modelId ?? 'pending-detection';
+    return this.currentAdapter?.modelId ?? UNRESOLVED_MODEL_ID;
   }
 
   get capabilities(): readonly ModelCapability[] {

--- a/packages/nexus-agents/src/cli/panel-independence.ts
+++ b/packages/nexus-agents/src/cli/panel-independence.ts
@@ -1,0 +1,65 @@
+/**
+ * Reporting for consensus-panel model independence (#4983).
+ *
+ * Split from `voter-agents` so the verdict-to-log rendering is testable
+ * without standing up a vote, and so the two call sites — assignment time and
+ * after the votes are in — render the same verdict the same way.
+ *
+ * @module cli/panel-independence
+ */
+
+import type { ILogger, IModelAdapter } from '../core/index.js';
+import { assessPanelIndependence } from '../config/model-equivalence.js';
+
+/**
+ * When the check runs. Adapter detection is lazy (#811), so at `assignment`
+ * every CLI adapter still reports a placeholder and an unmeasured verdict is
+ * expected. By `post-vote` each has resolved, so unmeasured means the panel
+ * finished without anyone being able to say whether its members were
+ * independent — which is worth a warning.
+ */
+export type PanelCheckPhase = 'assignment' | 'post-vote';
+
+/**
+ * Classifies the panel from its adapters' model ids and logs the verdict.
+ *
+ * A single-role panel cannot correlate with itself, so nothing is reported.
+ */
+export function reportPanelIndependence(
+  adapters: readonly IModelAdapter[],
+  roleCount: number,
+  phase: PanelCheckPhase,
+  logger: ILogger
+): void {
+  if (roleCount <= 1) return;
+  const verdict = assessPanelIndependence(adapters.map((a) => a.modelId));
+
+  if (verdict.kind === 'collapsed') {
+    logger.warn('Consensus panel ran on ONE model — votes may correlate', {
+      model: verdict.model,
+      roleCount,
+      phase,
+    });
+    return;
+  }
+  if (verdict.kind === 'diverse') {
+    logger.debug('Consensus panel spans distinct models', {
+      distinctModels: verdict.distinct,
+      roleCount,
+      phase,
+    });
+    return;
+  }
+  const context = { unresolved: verdict.unresolved, total: verdict.total, roleCount };
+  if (phase === 'post-vote') {
+    logger.warn(
+      'Panel independence UNMEASURED after voting — cannot say whether votes correlate',
+      context
+    );
+    return;
+  }
+  logger.debug(
+    'Panel independence not yet measurable (adapters have not detected their model)',
+    context
+  );
+}

--- a/packages/nexus-agents/src/cli/panel-independence.ts
+++ b/packages/nexus-agents/src/cli/panel-independence.ts
@@ -10,6 +10,7 @@
 
 import type { ILogger, IModelAdapter } from '../core/index.js';
 import { assessPanelIndependence } from '../config/model-equivalence.js';
+import type { PanelIndependence } from '../config/model-equivalence.js';
 
 /**
  * When the check runs. Adapter detection is lazy (#811), so at `assignment`
@@ -32,7 +33,7 @@ export function reportPanelIndependence(
   logger: ILogger
 ): void {
   if (roleCount <= 1) return;
-  const verdict = assessPanelIndependence(adapters.map((a) => a.modelId));
+  const verdict: PanelIndependence = assessPanelIndependence(adapters.map((a) => a.modelId));
 
   if (verdict.kind === 'collapsed') {
     logger.warn('Consensus panel ran on ONE model — votes may correlate', {

--- a/packages/nexus-agents/src/cli/voter-agents.test.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.test.ts
@@ -30,6 +30,7 @@ import type { VoterRole } from './vote-types.js';
 import type { IModelAdapter, CompletionResponse, ILogger } from '../core/index.js';
 import type { Result } from '../core/index.js';
 import { createLogger } from '../core/index.js';
+import { UNRESOLVED_MODEL_ID } from '../config/model-equivalence.js';
 
 describe('voter-agents', () => {
   describe('VOTER_SYSTEM_PROMPTS', () => {
@@ -621,6 +622,63 @@ That's my vote.`;
       const warnings = await warningsFor(['some-private-model', 'another-private-model']);
 
       expect(warnings.some((w) => w.includes('collapsed to a single gateway model'))).toBe(false);
+    });
+  });
+
+  describe('panel independence is judged after detection (#4983)', () => {
+    // The bug: lazy detection (#811) means every CLI adapter reports
+    // `pending-detection` at assignment time, so an equality check saw "one
+    // model" and warned on EVERY vote — while a genuinely collapsed panel
+    // produced the identical line. Both directions are pinned here.
+    function votingAdapter(modelId: string): IModelAdapter {
+      return {
+        modelId,
+        complete: vi.fn().mockResolvedValue({
+          ok: true,
+          value: {
+            content: [
+              {
+                type: 'text' as const,
+                text: '{"decision":"approve","confidence":0.9,"reasoning":"Test vote."}',
+              },
+            ],
+          },
+        }),
+      } as unknown as IModelAdapter;
+    }
+
+    async function warnsAfterVoting(modelId: string): Promise<string[]> {
+      const warnings: string[] = [];
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn((message: string) => warnings.push(message)),
+        error: vi.fn(),
+      } as unknown as ILogger;
+
+      await collectRealVotes({
+        roles: ['architect', 'security', 'devex'] as VoterRole[],
+        proposal: 'Panel independence',
+        adapter: votingAdapter(modelId),
+        interAgentDelayMs: 0,
+        logger,
+      });
+      return warnings;
+    }
+
+    it('warns when every role really did run on one model', async () => {
+      const warnings = await warnsAfterVoting('gpt-5.5');
+
+      expect(warnings.some((w) => w.includes('ran on ONE model'))).toBe(true);
+    });
+
+    it('does not claim correlation from an undetected placeholder', async () => {
+      // `pending-detection` is what four DIFFERENT CLIs report before they have
+      // looked. Reading that as one model is the false positive.
+      const warnings = await warnsAfterVoting(UNRESOLVED_MODEL_ID);
+
+      expect(warnings.some((w) => w.includes('ran on ONE model'))).toBe(false);
+      expect(warnings.some((w) => w.includes('UNMEASURED'))).toBe(true);
     });
   });
 

--- a/packages/nexus-agents/src/cli/voter-agents.ts
+++ b/packages/nexus-agents/src/cli/voter-agents.ts
@@ -29,6 +29,7 @@ import { authRemediation } from '../cli-adapters/cli-error-envelope.js';
 import type { CliName } from '../cli-adapters/types.js';
 import { checkCodexConcurrency } from '../cli-adapters/codex-limits.js';
 import { countDistinctModels } from '../config/model-equivalence.js';
+import { reportPanelIndependence } from './panel-independence.js';
 
 // Re-export prompts for backward compatibility
 export { VOTER_SYSTEM_PROMPTS, SIMULATED_VOTE_REASONING } from './voter-prompts.js';
@@ -455,14 +456,12 @@ async function resolveDiverseAdapters(
   // claude CLI, for instance — and a panel spread across them is no more
   // independent than one on a single arm. The gateway path had this check; the
   // CLI path had none.
-  const cliModels = [...cliAdapters.values()].map((a) => a.modelId);
-  if (roles.length > 1 && countDistinctModels(cliModels) === 1) {
-    logger.warn('Consensus panel spans multiple CLIs serving ONE model — votes may correlate', {
-      cliCount: cliAdapters.size,
-      model: cliModels[0],
-      roleCount: roles.length,
-    });
-  }
+  // #4983: detection is lazy, so at assignment time every adapter still
+  // reports the same `pending-detection` placeholder — which an equality check
+  // reads as "one model" and warns on EVERY vote. Say unmeasured here and make
+  // the real judgement in `warnIfPanelCorrelated`, after the votes have run and
+  // each adapter has resolved.
+  reportPanelIndependence([...cliAdapters.values()], roles.length, 'assignment', logger);
 
   return assignRoundRobinAdapters(
     roles,
@@ -595,7 +594,7 @@ export async function collectRealVotes(
   };
   const interDelay = options.interAgentDelayMs ?? DEFAULT_INTER_AGENT_DELAY_MS;
 
-  return launchStaggeredVotes({
+  const results = await launchStaggeredVotes({
     roles,
     proposal,
     roleAdapters,
@@ -604,6 +603,12 @@ export async function collectRealVotes(
     voteOptions,
     interDelay,
   });
+
+  // #4983: the only point the question is answerable. Lazy detection means the
+  // adapters carry a placeholder until they have actually run, so a check at
+  // assignment time compares placeholders; by here each has resolved.
+  reportPanelIndependence([...roleAdapters.values()], roles.length, 'post-vote', logger);
+  return results;
 }
 
 /**

--- a/packages/nexus-agents/src/config/model-equivalence.test.ts
+++ b/packages/nexus-agents/src/config/model-equivalence.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { canonicalModelKey, countDistinctModels } from './model-equivalence.js';
+import {
+  canonicalModelKey,
+  countDistinctModels,
+  assessPanelIndependence,
+  UNRESOLVED_MODEL_ID,
+} from './model-equivalence.js';
 
 describe('canonicalModelKey', () => {
   it('collapses gateway-prefixed forms of one model', () => {
@@ -84,5 +89,62 @@ describe('countDistinctModels', () => {
   it('is order-independent', () => {
     const a = ['claude-sonnet-4-6', 'anthropic/claude-sonnet-4-6', 'gpt-5.5'];
     expect(countDistinctModels(a)).toBe(countDistinctModels([...a].reverse()));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assessPanelIndependence (#4983)
+// ---------------------------------------------------------------------------
+
+describe('assessPanelIndependence', () => {
+  it('reports a genuinely collapsed panel', () => {
+    // The condition #4390 exists to catch: three arms, one set of weights.
+    const result = assessPanelIndependence([
+      'claude-sonnet-4-6',
+      'anthropic/claude-sonnet-4-6',
+      'custom/claude-sonnet-4-6',
+    ]);
+    expect(result).toEqual({ kind: 'collapsed', model: 'claude-sonnet-4-6' });
+  });
+
+  it('reports a diverse panel', () => {
+    const result = assessPanelIndependence(['claude-sonnet-4-6', 'gpt-5.5', 'gemini-3-pro']);
+    expect(result).toEqual({ kind: 'diverse', distinct: 3 });
+  });
+
+  it('refuses to judge a panel whose adapters have not detected their model', () => {
+    // The live defect: lazy detection (#811) means every CLI adapter reports
+    // the same placeholder, which an equality check reads as one model.
+    const result = assessPanelIndependence([
+      UNRESOLVED_MODEL_ID,
+      UNRESOLVED_MODEL_ID,
+      UNRESOLVED_MODEL_ID,
+      UNRESOLVED_MODEL_ID,
+    ]);
+    expect(result).toEqual({ kind: 'unmeasured', unresolved: 4, total: 4 });
+  });
+
+  it('refuses to judge when only some adapters have resolved', () => {
+    // The resolved two collide, but the unresolved one could be anything —
+    // concluding either way would be inventing a measurement.
+    const result = assessPanelIndependence([
+      'claude-sonnet-4-6',
+      'anthropic/claude-sonnet-4-6',
+      UNRESOLVED_MODEL_ID,
+    ]);
+    expect(result).toEqual({ kind: 'unmeasured', unresolved: 1, total: 3 });
+  });
+
+  it('treats an adapter reporting no model id at all as unresolved', () => {
+    // Reachable: an adapter built without a model reports `undefined` despite
+    // the `string` in the interface, and this classifier runs after the votes
+    // are collected — throwing there would throw away the panel's results.
+    const result = assessPanelIndependence(['gpt-5.5', undefined]);
+    expect(result).toEqual({ kind: 'unmeasured', unresolved: 1, total: 2 });
+  });
+
+  it('calls an empty panel unmeasured rather than diverse', () => {
+    // Absence must not render as health: no adapters is not a diverse panel.
+    expect(assessPanelIndependence([])).toEqual({ kind: 'unmeasured', unresolved: 0, total: 0 });
   });
 });

--- a/packages/nexus-agents/src/config/model-equivalence.ts
+++ b/packages/nexus-agents/src/config/model-equivalence.ts
@@ -59,3 +59,56 @@ export function countDistinctModels(modelIds: readonly string[]): number {
   }
   return distinct.size;
 }
+
+/**
+ * What a {@link ResilientAdapter} reports as its `modelId` before lazy
+ * detection (#811) resolves a concrete CLI behind it.
+ *
+ * It is a placeholder, not a model. The distinction matters because
+ * {@link countDistinctModels} treats two identical unrecognised strings as one
+ * model — true of two adapters configured alike, false of two adapters that
+ * have merely not looked yet.
+ */
+export const UNRESOLVED_MODEL_ID = 'pending-detection';
+
+/**
+ * Whether a voter panel's roles run on genuinely different models.
+ *
+ * `unmeasured` is a distinct outcome rather than a defaulted `diverse` or
+ * `collapsed`: a panel nobody could measure is not a healthy panel and not a
+ * correlated one, and reporting either would be inventing a measurement
+ * (#4983).
+ */
+export type PanelIndependence =
+  | { readonly kind: 'unmeasured'; readonly unresolved: number; readonly total: number }
+  | { readonly kind: 'collapsed'; readonly model: string }
+  | { readonly kind: 'diverse'; readonly distinct: number };
+
+/**
+ * Classifies a panel from the model ids its role adapters report.
+ *
+ * Any unresolved id makes the whole panel unmeasured. Concluding from the
+ * resolved subset would be guessing: two resolved ids that collide say nothing
+ * about the arm that has not reported yet.
+ */
+export function assessPanelIndependence(
+  modelIds: readonly (string | undefined)[]
+): PanelIndependence {
+  // `undefined` is in the input type because real adapters supply it: the
+  // interface declares `modelId: string`, but an adapter constructed without
+  // one reports undefined at runtime, and this runs AFTER the votes are in —
+  // a diagnostic that throws here would discard a completed panel's results.
+  const resolved = modelIds.filter(
+    (id): id is string => typeof id === 'string' && id !== '' && id !== UNRESOLVED_MODEL_ID
+  );
+  const unresolved = modelIds.length - resolved.length;
+  // An empty panel is unmeasured, not diverse — `countDistinctModels([])` is 0,
+  // which would otherwise slip past the `=== 1` collapse test and report the
+  // absence of any adapter as a healthy spread.
+  if (unresolved > 0 || modelIds.length === 0) {
+    return { kind: 'unmeasured', unresolved, total: modelIds.length };
+  }
+  const distinct = countDistinctModels(resolved);
+  if (distinct === 1) return { kind: 'collapsed', model: resolved[0] ?? '' };
+  return { kind: 'diverse', distinct };
+}


### PR DESCRIPTION
Closes #4983.

## The defect, from a live log

Two consensus votes today, one 3-voter and one 7-voter, both logged this:

```
"Consensus panel spans multiple CLIs serving ONE model — votes may correlate"
{"cliCount":4,"model":"pending-detection","roleCount":7}
```

`model` is the value the check compared. `ResilientAdapter.modelId` returns `pending-detection` until lazy detection (#811) resolves a CLI behind it, so at assignment time all four adapters report the *same placeholder* and `countDistinctModels` correctly collapses them to one.

`countDistinctModels` is not at fault — its contract is that two identical unrecognised ids are the same adapter config, which is true of two adapters configured alike and false of two that have merely not looked yet.

## Why it matters in the direction that isn't obvious

The false positive is the small half. The real problem is that a panel which genuinely *had* collapsed onto one model — opencode fronting the same weights as the claude CLI, the exact case #4390 was filed for — produced a byte-identical log line. An operator cannot tell the two apart, and having been trained by the noise to skip the line, will not look. The safeguard spent its attention on healthy panels and had none left for the unhealthy one.

## The fix

`assessPanelIndependence` replaces the boolean with three outcomes:

| verdict | meaning |
| --- | --- |
| `collapsed` | every role really is on one model — warn |
| `diverse` | genuinely distinct models — debug |
| `unmeasured` | at least one id unresolved — say so, accuse nothing |

Any unresolved id makes the whole panel unmeasured. Concluding from the resolved subset would be guessing: two ids that collide say nothing about the arm that has not reported.

And the judgement moved to where it can be made. `collectRealVotes` now checks **after** `launchStaggeredVotes` returns, the first point every adapter has resolved. At assignment `unmeasured` is expected and logged at debug; after voting it is a warning, because a panel that finished without anyone being able to say whether its members were independent is itself the finding.

Suppressing the false positive alone would have left a check that can never fire — which is the defect class this repo has been working through all week, not a fix for it.

## Empty and absent cases, named

`assessPanelIndependence([])` returns `unmeasured`, not `diverse`. `countDistinctModels([])` is 0, which slips past the `=== 1` collapse test, so absence of any adapter would otherwise have rendered as a healthy spread.

The input type is `(string | undefined)[]` rather than `string[]`, and that is not defensive padding — an existing test's adapter reports `undefined` despite the interface declaring `string`, and `normaliseModelId` throws on it. This runs *after* the votes are collected, so a diagnostic that throws would discard a completed panel's results.

## Mutations

| mutation | result |
| --- | --- |
| delete the post-vote check | 2 failed |
| `unresolved` always 0 (never unmeasured) | 4 failed |

New tests pin both directions through `collectRealVotes`: a uniform panel on a real model id warns; the same panel on `pending-detection` does not, and reports unmeasured instead.

## Scope

`reportPanelIndependence` moved to `cli/panel-independence.ts` — `voter-agents.ts` was at the 400-line ceiling and both call sites should render one verdict the same way.

The gateway path is untouched and unaffected: `tryWireGatewayAdapters` builds adapters from a probed model catalog (`cli-server-gateway.ts:60`), so those ids are real at construction.

6,925 tests pass across `src/cli`, `src/config/model-equivalence`, and `src/adapters/resilient-adapter`.
