### PR TITLE
test(routing): pin the warm-start skip log levels at the seam

### DIFF
--- a/.changeset/warmstart-log-level-test.md
+++ b/.changeset/warmstart-log-level-test.md
@@ -1,0 +1,14 @@
+---
+'nexus-agents': patch
+---
+
+test(routing): pin the warm-start skip log levels at the seam
+
+`warmStartSkipLogs` decides which skip bucket is a `warn` and which is a
+`debug`, and is unit-tested. Whether `warmStart` honours that decision was not:
+collapsing the mapping to a single `logger.warn` left the entire suite green, so
+the drowned-signal regression #4904 fixed could return unnoticed.
+
+Asserted on the bytes the process actually writes at the default `info` level
+rather than through a mocked logger — that `debug` is dropped is the behaviour
+being protected, and a mock would assert the intent instead of the outcome.

--- a/packages/nexus-agents/src/cli-adapters/linucb-bandit.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/linucb-bandit.test.ts
@@ -382,6 +382,59 @@ describe('LinUCBBandit', () => {
     });
   });
 
+  describe('warm-start skip log levels reach the real logger (#4935)', () => {
+    // `warmStartSkipLogs` decides the level and is unit-tested; whether
+    // `warmStart` honours it was not. Reverting the mapping to a single
+    // `logger.warn` left the whole suite green, so the drowned-signal
+    // regression #4904 fixed could come back unnoticed. Asserted on the bytes
+    // the process actually emits, at the default `info` level, rather than on
+    // a mocked logger — the suppression of `debug` is the behaviour.
+    function captureLogOutput(run: () => void): string {
+      const written: string[] = [];
+      const record = (chunk: unknown): boolean => {
+        written.push(String(chunk));
+        return true;
+      };
+      const originalOut = process.stdout.write;
+      const originalErr = process.stderr.write;
+      process.stdout.write = record;
+      process.stderr.write = record;
+      try {
+        run();
+      } finally {
+        process.stdout.write = originalOut;
+        process.stderr.write = originalErr;
+      }
+      return written.join('');
+    }
+
+    function outcomesFor(cli: string): Parameters<LinUCBBandit['warmStart']>[0] {
+      return [{ cli, model: 'some-model', success: true }] as unknown as Parameters<
+        LinUCBBandit['warmStart']
+      >[0];
+    }
+
+    it('keeps the every-run unattributed skip out of warn', () => {
+      const bandit = new LinUCBBandit(armNames);
+
+      const output = captureLogOutput(() => bandit.warmStart(outcomesFor('unknown')));
+
+      // Emitted at debug, which the default `info` level drops entirely. If the
+      // level mapping is lost this line reappears — 210 of them in a real run —
+      // and buries the warn below.
+      expect(output).not.toContain('no resolvable CLI');
+    });
+
+    it('still warns about an arm the bandit genuinely does not have', () => {
+      const bandit = new LinUCBBandit(armNames);
+
+      const output = captureLogOutput(() => bandit.warmStart(outcomesFor('api:openai')));
+
+      expect(output).toContain('arms this bandit does not have');
+      expect(output).toContain('"level":"warn"');
+    });
+  });
+
   describe('warm-start skip partitioning (#4904)', () => {
     // `skippedByArm` was added by #4400 to surface an arm that SHOULD have
     // warm-started and did not — `api:*` arms were discarding their whole


### PR DESCRIPTION
Found by an adversarial review agent over eight of today's self-merged fixes, then reproduced.

## The gap

#4935 (`89a907886a`) split warm-start skips into two buckets so the every-run unattributed skip stops burying the one that signals a real regression. `warmStartSkipLogs` returns the level per bucket and is unit-tested. The line that *acts* on it —

```ts
if (line.level === 'warn') logger.warn(line.message, line.context);
else logger.debug(line.message, line.context);
```

— was not covered. Collapsing it to a single `logger.warn` for both lines leaves **2,709 tests green**. A live warm-start with 210 `'unknown'` skips would go straight back to printing at `warn`, which is the exact state #4904 was filed for.

Same shape as the six other untested seams found this week: both ends pinned, middle link deletable with the suite green.

## What the test asserts

The bytes the process actually writes, at the default `info` level, with `process.stdout`/`stderr` spied — not a mocked logger. The behaviour being protected is that `debug` gets *dropped*, and a mock would assert my intent rather than the outcome.

- unattributed skip → the line does not appear at all
- a genuinely unknown arm (`api:openai`) → the line appears, tagged `"level":"warn"`

## Mutations

| mutation | result |
| --- | --- |
| always `logger.warn` | 1 failed |
| always `logger.debug` | 1 failed |

Test-only; no production change.
