### PR TITLE
fix(governance): record the resolved vote decision, not a second derivation

### DIFF
--- a/.changeset/audit-record-quorum-void.md
+++ b/.changeset/audit-record-quorum-void.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): stop the audit chain recording a voided vote as approved
+
+`outcomeToDecision` returned on `result.outcome === 'approved'` before it
+consulted `errorVoided`, so the void logic could only ever convert a `rejected`
+into a `no_quorum`. An `absolute_quorum` degradation stamps its reason on the
+response and never on the result, so `errorVoided` was false, and the
+hash-chained record persisted `approved` for a vote the tool reported as
+`no_quorum`.
+
+The record now takes the decision `resolveVoteDecision` already produced, rather
+than deriving a second one from the outcome — the second derivation is what let
+the two disagree. `resolvedDecision` is a required field, including its
+`undefined` case, so the compiler names every call site instead of letting a new
+one inherit the fallback silently.
+
+Two adjacent misreports went with it. The fallback's `errorVoided` check moved
+above the `approved` short-circuit, and a non-terminal outcome is no longer
+recorded as a rejection: `ProposalStatus` also carries `timeout`, `pending`,
+`voting` and `closed`, and the old everything-else-is-rejected default
+attributed a verdict to voters who never gave one.

--- a/packages/nexus-agents/src/audit/vote-record-store.test.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.test.ts
@@ -78,6 +78,8 @@ const votes: readonly AgentVoteResult[] = [
 describe('buildVoteRecord', () => {
   it('carries the proposal hash, decision, counts, per-voter summary, and a sequence', () => {
     const record = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-1',
       proposal: 'Promote loop X to enforce',
       strategy: 'higher_order',
@@ -98,8 +100,73 @@ describe('buildVoteRecord', () => {
     expect(verifyVoteRecordSet([record])).toEqual({ ok: true, recordCount: 1 });
   });
 
+  it('records a resolved no_quorum even when the engine outcome was approved (#4986)', () => {
+    // The absolute_quorum void: `resolveVoteDecision` returns no_quorum while
+    // `result.outcome` stays 'approved' and `result.policyReason` is never set,
+    // so `errorVoided` is false. Deriving from the outcome recorded a genuine
+    // approval for a vote the tool reported as no_quorum.
+    const record = buildVoteRecord({
+      resolvedDecision: 'no_quorum',
+      id: 'vote-void',
+      proposal: 'p',
+      strategy: 'supermajority',
+      result: consensusResult({ outcome: 'approved' }),
+      votes,
+    });
+
+    expect(record.decision).toBe('no_quorum');
+  });
+
+  it('does not call an approved-but-voided vote approved (#4986)', () => {
+    // The fallback's own asymmetry: the `errorVoided` check used to sit BELOW
+    // the approved short-circuit, so it could only ever rescue a `rejected`.
+    const record = buildVoteRecord({
+      resolvedDecision: undefined,
+      id: 'vote-voided-approved',
+      proposal: 'p',
+      strategy: 'supermajority',
+      result: consensusResult({ outcome: 'approved' }),
+      votes,
+      errorVoided: true,
+    });
+
+    expect(record.decision).toBe('no_quorum');
+  });
+
+  it('does not record a timed-out panel as a rejection (#4986)', () => {
+    // `ProposalStatus` carries `timeout`/`pending`/`voting`/`closed`. The old
+    // everything-else-is-rejected default attributed a verdict to voters who
+    // never gave one.
+    const record = buildVoteRecord({
+      resolvedDecision: undefined,
+      id: 'vote-timeout',
+      proposal: 'p',
+      strategy: 'supermajority',
+      result: consensusResult({ outcome: 'timeout', quorumReached: false }),
+      votes,
+    });
+
+    expect(record.decision).toBe('no_quorum');
+  });
+
+  it('still records a genuine rejection as rejected', () => {
+    // The pair that keeps the change above from swallowing real rejections.
+    const record = buildVoteRecord({
+      resolvedDecision: undefined,
+      id: 'vote-rejected',
+      proposal: 'p',
+      strategy: 'supermajority',
+      result: consensusResult({ outcome: 'rejected' }),
+      votes,
+    });
+
+    expect(record.decision).toBe('rejected');
+  });
+
   it('omits optionTally and stays on 1.2 when no voter declared an option (#4452)', () => {
     const record = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-noopt',
       proposal: 'p',
       strategy: 'higher_order',
@@ -119,6 +186,8 @@ describe('buildVoteRecord', () => {
       selectedOption: i === 0 ? 'A' : i === 1 ? 'A' : 'C',
     }));
     const record = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-opt',
       proposal: 'p',
       strategy: 'higher_order',
@@ -146,6 +215,8 @@ describe('buildVoteRecord', () => {
       { ...agentVote('catfish', 'reject'), selectedOption: 'B' },
     ];
     const record = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-mixed',
       proposal: 'p',
       strategy: 'higher_order',
@@ -170,6 +241,8 @@ describe('buildVoteRecord', () => {
       ...(i < 2 ? { selectedOption: 'A' } : {}),
     }));
     const record = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-coverage',
       proposal: 'p',
       strategy: 'higher_order',
@@ -191,6 +264,8 @@ describe('buildVoteRecord', () => {
     // not produce different hashes.
     const mk = (opts: readonly string[]): VoteRecord =>
       buildVoteRecord({
+        // #4986: these fixtures exercise the fallback derivation.
+        resolvedDecision: undefined,
         id: 'vote-ord',
         recordedAt: '2026-06-15T00:00:00.000Z',
         proposal: 'p',
@@ -203,6 +278,8 @@ describe('buildVoteRecord', () => {
 
   it('excludes error-source voters from the per-voter summary', () => {
     const record = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-1',
       proposal: 'p',
       strategy: 'simple_majority',
@@ -214,6 +291,8 @@ describe('buildVoteRecord', () => {
 
   it('persists no_quorum (not rejected) for an error-policy short-circuit, matching the response (#4053)', () => {
     const record = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-sc',
       proposal: 'p',
       strategy: 'simple_majority',
@@ -235,6 +314,8 @@ describe('buildVoteRecord', () => {
 
   it('keeps rejected for a genuine quorum-reached rejection (#4053)', () => {
     const record = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-rej',
       proposal: 'p',
       strategy: 'simple_majority',
@@ -260,6 +341,8 @@ describe('persistVoteRecord', () => {
 
   it('persists a self-hashed record that round-trips through read', () => {
     const written = persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-1',
       proposal: 'Promote loop X to enforce',
       strategy: 'higher_order',
@@ -277,6 +360,8 @@ describe('persistVoteRecord', () => {
 
   it('assigns an incrementing sequence and an advisory previousHash on append', () => {
     const first = persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-1',
       proposal: 'first',
       strategy: 'higher_order',
@@ -285,6 +370,8 @@ describe('persistVoteRecord', () => {
       filePath,
     });
     const second = persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-2',
       proposal: 'second',
       strategy: 'higher_order',
@@ -306,6 +393,8 @@ describe('persistVoteRecord', () => {
 
   it('detects tampering with a persisted line (decision flip) via set verification', () => {
     persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-1',
       proposal: 'p',
       strategy: 'higher_order',
@@ -329,6 +418,8 @@ describe('persistVoteRecord', () => {
   it('survives a simulated two-branch concurrent merge (merge=union) as a benign fork', () => {
     // Branch base: one record at sequence 0.
     persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-base',
       proposal: 'base proposal',
       strategy: 'higher_order',
@@ -341,6 +432,8 @@ describe('persistVoteRecord', () => {
     // Two branches each fork from the same tip and append THEIR OWN sequence-1
     // record (each computed the same max sequence = 0 → next = 1).
     const branchA = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-A',
       proposal: 'branch A proposal',
       strategy: 'higher_order',
@@ -349,6 +442,8 @@ describe('persistVoteRecord', () => {
       sequence: 1,
     });
     const branchB = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-B',
       proposal: 'branch B proposal',
       strategy: 'higher_order',
@@ -376,6 +471,8 @@ describe('persistVoteRecord', () => {
 
   it("skips persistence when every vote is simulated is the caller's job; store itself writes given real votes", () => {
     const written = persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-1',
       proposal: 'p',
       strategy: 'simple_majority',
@@ -416,6 +513,8 @@ describe('vote-record path resolution via nexusDataPath (#3991, design vote 7-0)
     expect(resolveVoteRecordsPath()).toBe(envFilePath);
 
     const written = persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-env',
       proposal: 'p',
       strategy: 'higher_order',
@@ -478,6 +577,8 @@ describe('vote-record path resolution via nexusDataPath (#3991, design vote 7-0)
     vi.stubEnv(VOTE_RECORDS_PATH_ENV, envFilePath);
 
     const written = persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-opts',
       proposal: 'p',
       strategy: 'higher_order',
@@ -503,6 +604,8 @@ describe('vote-record path resolution via nexusDataPath (#3991, design vote 7-0)
     expect(resolved).toBe(join(dataRoot, 'governance', 'vote-records.jsonl'));
 
     const written = persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-global',
       proposal: 'p',
       strategy: 'higher_order',
@@ -529,6 +632,8 @@ describe('vote-record path resolution via nexusDataPath (#3991, design vote 7-0)
     expect(resolved).toBe(join(repoGovDir, 'vote-records.jsonl'));
 
     const written = persistVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vote-repo',
       proposal: 'p',
       strategy: 'higher_order',
@@ -551,6 +656,7 @@ describe('vote-record path resolution via nexusDataPath (#3991, design vote 7-0)
     let written: ReturnType<typeof persistVoteRecord>;
     expect(() => {
       written = persistVoteRecord({
+        resolvedDecision: undefined,
         id: 'vote-none',
         proposal: 'p',
         strategy: 'higher_order',

--- a/packages/nexus-agents/src/audit/vote-record-store.ts
+++ b/packages/nexus-agents/src/audit/vote-record-store.ts
@@ -105,21 +105,36 @@ export function voteRecordWriteFailedMessage(path: string): string {
 }
 
 /**
- * Map a consensus outcome to the recorded decision vocabulary. Mirrors the MCP
- * response's `buildResponse` so the persisted record and the response never
- * disagree (#4053): an error-policy short-circuit (`errorVoided`) or an
- * all-error / no-quorum void is `no_quorum`, not a genuine `rejected`.
+ * Fallback mapping from a consensus outcome to the recorded decision, for
+ * callers with no resolved decision to hand over.
+ *
+ * The void checks come FIRST. They used to sit below an
+ * `if (result.outcome === 'approved') return 'approved'` short-circuit, which
+ * meant `errorVoided` could only ever rescue a `rejected` — a voided vote whose
+ * engine outcome was `approved` persisted as a genuine approval while the tool
+ * reported `no_quorum` (#4986). #4053 fixed one half of that and the ordering
+ * hid the other.
+ *
+ * This still cannot see a void the caller knows about but the
+ * {@link ConsensusResult} does not express — the `absolute_quorum` path stamps
+ * its reason on the response, never on the result — which is why
+ * `resolvedDecision` exists and why this is only the fallback.
  */
 function outcomeToDecision(
   result: ConsensusResult,
   votes: readonly AgentVoteResult[],
   errorVoided: boolean
 ): VoteRecord['decision'] {
-  if (result.outcome === 'approved') return 'approved';
   const errorCount = votes.filter((v) => v.source === 'error').length;
   const allErrors = errorCount === votes.length && errorCount > 0;
   if (errorVoided || (!result.quorumReached && allErrors)) return 'no_quorum';
-  return 'rejected';
+  if (result.outcome === 'approved') return 'approved';
+  // Only an actual `rejected` is a rejection. `ProposalStatus` also carries
+  // `timeout` / `pending` / `voting` / `closed`, and the previous
+  // everything-else-is-rejected default recorded a panel that never concluded
+  // as one that voted the proposal down (#4986).
+  if (result.outcome === 'rejected') return 'rejected';
+  return 'no_quorum';
 }
 
 /** Build the per-voter summary from the (real) agent votes, skipping errors. */
@@ -133,6 +148,17 @@ function toVoterSummaries(votes: readonly AgentVoteResult[]): VoterSummary[] {
   return summaries;
 }
 
+/**
+ * The decision to persist: the caller's resolved answer when it has one, else
+ * the {@link outcomeToDecision} fallback.
+ */
+function recordDecisionFor(input: BuildVoteRecordInput): VoteRecord['decision'] {
+  return (
+    input.resolvedDecision ??
+    outcomeToDecision(input.result, input.votes, input.errorVoided ?? false)
+  );
+}
+
 /** Inputs for {@link buildVoteRecord} — the finalized vote data. */
 export interface BuildVoteRecordInput {
   readonly id: string;
@@ -142,6 +168,17 @@ export interface BuildVoteRecordInput {
   readonly votes: readonly AgentVoteResult[];
   /** #4053: vote voided by an error-policy short-circuit → record `no_quorum`. */
   readonly errorVoided?: boolean | undefined;
+  /**
+   * The decision the caller already resolved for this vote, recorded verbatim.
+   *
+   * `resolveVoteDecision` computes the authoritative three-valued answer once,
+   * for the response. Re-deriving it here from `result.outcome` is what let the
+   * two disagree (#4986), so a caller that has it MUST pass it. Required rather
+   * than optional — including its `undefined` case — so the compiler names
+   * every call site instead of letting a new one inherit the fallback in
+   * silence.
+   */
+  readonly resolvedDecision: VoteRecord['decision'] | undefined;
   readonly correlationId?: string | undefined;
   readonly recordedAt?: string | undefined;
   /**
@@ -267,7 +304,7 @@ export function buildVoteRecord(input: BuildVoteRecordInput): VoteRecord {
     proposalHash: hashProposal(input.proposal),
     proposal: proposalTruncated,
     strategy: input.strategy,
-    decision: outcomeToDecision(input.result, input.votes, input.errorVoided ?? false),
+    decision: recordDecisionFor(input),
     approvalPercentage: input.result.approvalPercentage,
     voteCounts: {
       approve: input.result.voteCounts.approve,

--- a/packages/nexus-agents/src/cli/vote-command.ts
+++ b/packages/nexus-agents/src/cli/vote-command.ts
@@ -32,6 +32,7 @@ import { DEFAULT_VOTE_TIMEOUT_MS, type AgentVoteResult } from './voter-agents.js
 import { validateTimeout } from '../config/timeouts.js';
 import { executeVoting } from '../mcp/tools/consensus-vote.js';
 import type { ConsensusVoteInput, VoteDecisionStatus } from '../mcp/tools/consensus-vote-types.js';
+import { toRecordDecision } from '../mcp/tools/consensus-vote-types.js';
 import { mapOutcomeToDecision } from '../mcp/tools/consensus-vote-types.js';
 import { colors, symbols, writeLine } from './ansi-output.js';
 import { recordAuthenticVote } from '../mcp/tools/consensus-vote-recording.js';
@@ -405,7 +406,14 @@ function exitCodeForDecision(decision: VoteDecisionStatus, policy: NoQuorumPolic
  */
 function persistToAuditChain(
   options: VoteCommandOptions,
-  result: VotingResult & { readonly strategy: string; readonly policyReason?: string }
+  result: VotingResult & {
+    readonly strategy: string;
+    readonly policyReason?: string;
+    // #4986: the resolved three-valued decision `runVote` carries down from
+    // `resolveVoteDecision`. Typed here so the record gets the same answer the
+    // CLI printed and exited on, rather than a second derivation.
+    readonly decision?: VoteDecisionStatus;
+  }
 ): void {
   if (options.dryRun === true) return;
   writeLine(
@@ -418,6 +426,7 @@ function persistToAuditChain(
         // A vote an error policy voided is not a rejection. Without this the
         // chain records `rejected` while the CLI exits `no_quorum` (#4953).
         errorVoided: result.policyReason !== undefined,
+        resolvedDecision: toRecordDecision(result.decision),
       })
     )
   );

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-record-decision.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-record-decision.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for narrowing a response decision to the audit record's vocabulary
+ * (#4986).
+ *
+ * @module mcp/tools/consensus-vote-record-decision.test
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { toRecordDecision } from './consensus-vote-types.js';
+
+describe('toRecordDecision (#4986)', () => {
+  it('passes the three record-vocabulary values through', () => {
+    expect(toRecordDecision('approved')).toBe('approved');
+    expect(toRecordDecision('rejected')).toBe('rejected');
+    expect(toRecordDecision('no_quorum')).toBe('no_quorum');
+  });
+
+  it('records a timeout as no_quorum, not as a rejection', () => {
+    // A panel that ran out of time gave no verdict. Calling it `rejected`
+    // attributes one to voters who never voted.
+    expect(toRecordDecision('timeout')).toBe('no_quorum');
+  });
+
+  it('has no record decision for a vote still in flight', () => {
+    // `undefined` means "fall back to derivation", the honest answer for a vote
+    // with no decision yet — inventing one would be worse than falling back.
+    expect(toRecordDecision('pending')).toBeUndefined();
+    expect(toRecordDecision(undefined)).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.test.ts
@@ -88,6 +88,7 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
 
   it('reports all-simulated when every vote is simulated', () => {
     const outcome = recordAuthenticVote({
+      resolvedDecision: undefined,
       proposal: 'p',
       strategy: 'simple_majority',
       result: consensusResult(),
@@ -116,6 +117,7 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
     vi.mocked(nexusDataPath).mockReturnValue(unwritable);
 
     const outcome = recordAuthenticVote({
+      resolvedDecision: undefined,
       proposal: 'Promote loop X to enforce',
       strategy: 'higher_order',
       result: consensusResult(),
@@ -133,6 +135,7 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
     vi.stubEnv(VOTE_RECORDS_PATH_ENV, filePath);
 
     const outcome = recordAuthenticVote({
+      resolvedDecision: undefined,
       proposal: 'Promote loop X to enforce',
       strategy: 'higher_order',
       result: consensusResult(),
@@ -154,6 +157,7 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
     vi.stubEnv(VOTE_RECORDS_PATH_ENV, filePath);
 
     const outcome = recordAuthenticVote({
+      resolvedDecision: undefined,
       proposal: 'Promote auto-remediation to enforce',
       strategy: 'higher_order',
       result: consensusResult(),
@@ -174,6 +178,7 @@ describe('recordAuthenticVote persistence outcome (#3991)', () => {
     vi.stubEnv(VOTE_RECORDS_PATH_ENV, undefined);
 
     const outcome = recordAuthenticVote({
+      resolvedDecision: undefined,
       proposal: 'p',
       strategy: 'simple_majority',
       result: consensusResult(),

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-recording.ts
@@ -150,6 +150,15 @@ export function recordAuthenticVote(args: {
   ratifies?: string | undefined;
   /** #4053: vote voided by an error-policy short-circuit → persist `no_quorum`. */
   errorVoided?: boolean | undefined;
+  /**
+   * The decision `resolveVoteDecision` already produced for the response.
+   *
+   * Required — including its `undefined` case — because deriving it a second
+   * time inside the record store is what let the chain say `approved` for a
+   * vote the tool reported as `no_quorum` (#4986). A caller that has the
+   * resolved decision must hand it over rather than let the store guess.
+   */
+  resolvedDecision: VoteRecord['decision'] | undefined;
 }): VoteRecordPersistOutcome {
   const allSimulated = args.votes.length > 0 && args.votes.every((v) => v.source === 'simulation');
   if (allSimulated) {
@@ -181,6 +190,7 @@ export function recordAuthenticVote(args: {
     strategy: toRecordStrategy(args.strategy),
     result: args.result,
     votes: args.votes,
+    resolvedDecision: args.resolvedDecision,
     ...(args.errorVoided !== undefined ? { errorVoided: args.errorVoided } : {}),
     ...(args.correlationId !== undefined ? { correlationId: args.correlationId } : {}),
     ...(args.ratifies !== undefined ? { ratifies: args.ratifies } : {}),

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote-types.ts
@@ -332,6 +332,34 @@ export const VoteDecisionStatusSchema = z.enum([
 export type VoteDecisionStatus = z.infer<typeof VoteDecisionStatusSchema>;
 
 /**
+ * Narrows a response decision to the three-value vocabulary the audit record
+ * uses (#4986).
+ *
+ * The response vocabulary is wider — it carries `timeout` and `pending` too —
+ * so the narrowing has to be stated rather than left to a cast:
+ *
+ * - `timeout` becomes `no_quorum`. A panel that ran out of time reached no
+ *   quorum; it did not reject the proposal, and recording it as `rejected`
+ *   would attribute a verdict to voters who never gave one.
+ * - `pending` returns `undefined`. A vote still in flight has no decision to
+ *   record, and inventing one would be worse than falling back.
+ */
+export function toRecordDecision(
+  status: VoteDecisionStatus | undefined
+): 'approved' | 'rejected' | 'no_quorum' | undefined {
+  switch (status) {
+    case 'approved':
+    case 'rejected':
+    case 'no_quorum':
+      return status;
+    case 'timeout':
+      return 'no_quorum';
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Higher-Order Voting metadata (Issue #514).
  *
  * ADVISORY, not the verdict (#4701). Read `appliedToDecision` before drawing

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -2066,6 +2066,8 @@ describe('#4529: an option-split veto is a rejection, not a void', () => {
     // Drive the REAL record builder rather than reimplementing its mapping —
     // a test that recomputes the thing it checks cannot fail for the bug.
     const record = buildVoteRecord({
+      // #4986: these fixtures exercise the fallback derivation.
+      resolvedDecision: undefined,
       id: 'vr-4529',
       proposal: result.proposal,
       result: result.result,

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -54,6 +54,7 @@ import {
   isHigherOrderStrategy,
   shouldEscalateLowPosterior,
   resolveVoteDecision,
+  toRecordDecision,
 } from './consensus-vote-types.js';
 import { applyErrorPolicy } from './consensus-vote-error-policy.js';
 import {
@@ -852,6 +853,12 @@ function recordVoteSideEffects(
     // #4053: an error-policy short-circuit voided the vote → the PERSISTED record
     // must record `no_quorum`, matching the MCP response (not a stale `rejected`).
     errorVoided: result.policyReason !== undefined,
+    // #4986: hand over the decision `resolveVoteDecision` already produced
+    // (stamped on the result by `executeVoting`). `errorVoided` alone cannot
+    // express an absolute_quorum void, whose reason is stamped on the response
+    // and never on the result — so the record used to say `approved` for a vote
+    // this tool reports as `no_quorum`.
+    resolvedDecision: toRecordDecision(result.decision),
     correlationId: decisionId,
     ...(ratifies !== undefined ? { ratifies } : {}),
   });


### PR DESCRIPTION
Closes #4986.

**Owner ratification required — touches `src/audit/`. I will not self-merge this.**

## The misreport

`outcomeToDecision` returned before it ever consulted `errorVoided`:

```ts
if (result.outcome === 'approved') return 'approved';   // <- short-circuit
...
if (errorVoided || (!result.quorumReached && allErrors)) return 'no_quorum';
```

So `errorVoided` could only ever convert a `rejected` into a `no_quorum`. Meanwhile `computeAbsoluteQuorumDecision` resolves `no_quorum` and `applyAbsoluteQuorumTelemetry` stamps the reason on **`response`** only (`consensus-vote-types.ts:706`) — `result.policyReason` stays `undefined`, which is exactly the field both writers use for `errorVoided`.

Response: `no_quorum`. Hash-chained record: `approved`. Reachable from MCP (`errorPolicy` is in the schema) and from the CLI (`--error-policy absolute_quorum`, forwarded since #4964).

#4953 fixed this same class in the other direction and placed its guard below the short-circuit, which is how the second half survived. The comment above it says the record and response "never disagree."

## The fix is to delete the second derivation, not patch it

`resolveVoteDecision` already computes the authoritative three-valued answer once, and `executeVoting` stamps it on the result (`consensus-vote.ts:621`). The record now takes that. `outcomeToDecision` remains only as the fallback for callers that genuinely have no resolved decision.

`resolvedDecision` is **required**, including its `undefined` case. Optional would have let a future call site inherit the fallback in silence — the exact failure mode being fixed. Making it required turned this into 13 compile errors naming every call site, which is the enumeration a test would have had to guess at.

## Two adjacent misreports found while fixing it

**A voided approval, in the fallback too.** The `errorVoided` check moved above the `approved` short-circuit, so the fallback is no longer asymmetric.

**A timed-out panel recorded as a rejection.** `ConsensusResult.outcome` is `ProposalStatus` — six values, including `timeout`, `pending`, `voting`, `closed`. The old `return 'rejected'` default recorded every one of them as the panel voting the proposal down, attributing a verdict to voters who never gave one. Now only `rejected` is a rejection; the rest are `no_quorum`.

The response vocabulary is wider than the record's, so the narrowing is stated explicitly in `toRecordDecision` rather than cast: `timeout` → `no_quorum`, `pending` → `undefined` (fall back; a vote in flight has no decision to record).

## Mutations

| mutation | result |
| --- | --- |
| ignore `resolvedDecision`, always derive | 1 failed |
| restore the original check ordering | 1 failed |
| `timeout` back to `rejected` | 1 failed |

A paired test keeps the third change from swallowing genuine rejections. 7,183 tests pass across `src/audit`, `src/cli`, and the consensus-vote suites. `api-surface.txt` is unchanged — none of these are public exports.

## Provenance

Surfaced by an adversarial review agent over eight of today's self-merged commits, then re-traced by hand. One of the agent's supporting claims — that the CLI could not reach `absolute_quorum` — was true before #4964 landed this morning and is corrected in the issue.
