### PR TITLE
fix(run): honor dryRun instead of implementing for real

### DIFF
--- a/.changeset/run-dryrun-ignored.md
+++ b/.changeset/run-dryrun-ignored.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix(run): honor dryRun instead of implementing for real
+
+`run({ goal, forceStrategy: 'dev-pipeline', execute: true, dryRun: true })`
+decomposed, implemented, QA'd and security-scanned the goal. `runDevPipelineForGoal`
+parsed `dryRun` into an input object that only `createStages` reads, then built
+the pipeline options from `trustTier` alone — so the dry-run short-circuit never
+fired. The direct `run_dev_pipeline` handler forwarded it correctly, which is
+what made this an asymmetry rather than a missing feature.
+
+Wiring it exposed the other half. `buildDryRunResult` returns `completed: false`
+by design, and `run`'s engine-failure check reads `completed === false` as a
+fault — so a successful dry run would have come back as
+"Engine reported failure: the run stopped before the security gate", with the
+plan buried in `detail` and the job marked failed on the async path. The result
+now carries `dryRun: true` to say WHY completion is false, and the check exempts
+it — except when the planner returned nothing, which is still a failure.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -2835,6 +2835,7 @@ InterfaceDeclaration DevPipelineOptions
   readonly untrustedInputGuard?: (() => void) | undefined
 InterfaceDeclaration DevPipelineResult
   readonly completed: boolean
+  readonly dryRun?: true | undefined
   readonly plan: string
   readonly planStatus?: "empty" | undefined
   readonly qaIterations: number

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -29,19 +29,26 @@ const PIPELINE_RESULT = {
   securityPassed: true,
 };
 const runDevPipelineMock = vi.fn(
-  (_task: string, _stages: unknown, _options?: { trustTier?: string }) =>
+  (_task: string, _stages: unknown, _options?: { trustTier?: string; dryRun?: boolean }) =>
     Promise.resolve(PIPELINE_RESULT)
 );
 vi.mock('../../pipeline/dev-pipeline.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../pipeline/dev-pipeline.js')>();
   return {
     ...actual,
-    runDevPipeline: (task: string, stages: unknown, options?: { trustTier?: string }) =>
-      runDevPipelineMock(task, stages, options),
+    runDevPipeline: (
+      task: string,
+      stages: unknown,
+      options?: { trustTier?: string; dryRun?: boolean }
+    ) => runDevPipelineMock(task, stages, options),
   };
 });
 
-import { DevPipelineInputSchema, registerDevPipelineTool } from './dev-pipeline-tool.js';
+import {
+  DevPipelineInputSchema,
+  registerDevPipelineTool,
+  runDevPipelineForGoal,
+} from './dev-pipeline-tool.js';
 import { ERROR_ENVELOPE_META_KEY } from '../error-envelope.js';
 import { readJobResult } from '../jobs/job-result-store.js';
 import { _resetForTests as resetJobConcurrency } from '../jobs/job-concurrency.js';
@@ -498,5 +505,40 @@ describe('run_dev_pipeline iteration caps are wired (#4939)', () => {
       { maxVoteIterations?: number; maxQaIterations?: number } | undefined;
     expect(options?.maxVoteIterations).toBe(3);
     expect(options?.maxQaIterations).toBe(3);
+  });
+});
+
+describe('runDevPipelineForGoal — dryRun reaches the pipeline (#4806)', () => {
+  beforeEach(() => runDevPipelineMock.mockClear());
+
+  // The seam. `run-tool.test.ts` asserts that `run` calls
+  // `runDevPipelineForGoal` with `dryRun: true`, and stops there — one link
+  // short of the only place the flag does anything. This function parsed the
+  // flag into `input`, which only `createStages` reads, and then built the
+  // options from `trustTier` alone, so `dev-pipeline.ts`'s dry-run
+  // short-circuit never fired and the "plan and vote only" run implemented,
+  // QA'd and security-scanned for real.
+  it('passes dryRun through to runDevPipeline options', async () => {
+    await runDevPipelineForGoal('add retry logic', undefined, true);
+
+    expect(runDevPipelineMock).toHaveBeenCalledTimes(1);
+    expect(runDevPipelineMock.mock.calls[0]?.[2]?.dryRun).toBe(true);
+  });
+
+  it('leaves dryRun unset on an ordinary run', async () => {
+    // The pair: a fix that hardcoded `dryRun: true` would pass the test above
+    // while turning every `run` into a no-op.
+    await runDevPipelineForGoal('add retry logic', undefined, undefined);
+
+    expect(runDevPipelineMock.mock.calls[0]?.[2]?.dryRun).toBeUndefined();
+  });
+
+  it('still threads trustTier alongside it', async () => {
+    await runDevPipelineForGoal('add retry logic', '3', true);
+
+    expect(runDevPipelineMock.mock.calls[0]?.[2]).toMatchObject({
+      trustTier: '3',
+      dryRun: true,
+    });
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -285,7 +285,14 @@ export async function runDevPipelineForGoal(
   // (never infer trust from absence). The `run` entry point passes the caller's
   // real RequestContext.trustTier here — closing the run-path hole where a
   // possibly-untrusted goal ran a real research stage with an absent tier.
-  return runDevPipeline(goal, stages, trustTier !== undefined ? { trustTier } : undefined);
+  return runDevPipeline(goal, stages, {
+    ...(trustTier !== undefined ? { trustTier } : {}),
+    // #4806 said `dryRun` is the one pipeline option `run` forwards. It parsed
+    // the flag into `input` — which only `createStages` reads — and then built
+    // the options from `trustTier` alone, so the short-circuit at
+    // `dev-pipeline.ts:367` never fired and a dry run implemented for real.
+    ...(input.dryRun ? { dryRun: true as const } : {}),
+  });
 }
 
 // ============================================================================

--- a/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.test.ts
@@ -23,6 +23,7 @@ interface FakeDevPipelineResult {
   securityPassed: boolean;
   securityRan?: boolean;
   planStatus?: 'empty';
+  dryRun?: true;
 }
 const runDevPipelineForGoalMock = vi.fn(
   (_goal: string, _trustTier?: string, _dryRun?: boolean): Promise<FakeDevPipelineResult> =>
@@ -608,6 +609,87 @@ describe('run async dispatch (execute:true, #3732)', () => {
           undefined,
           true
         );
+      });
+
+      it('does not call a successful dry run an engine failure', async () => {
+        // `buildDryRunResult` returns `completed: false` BY DESIGN — the run
+        // stopped where it was told to. `detectEngineFailure` treats
+        // `completed === false` as a fault, so wiring dryRun through without
+        // this would hand the caller
+        // "Engine reported failure: the run stopped before the security gate"
+        // for precisely the outcome they asked for, and fail the job on the
+        // async path. The plan would survive only inside `detail`.
+        runDevPipelineForGoalMock.mockResolvedValueOnce({
+          completed: false,
+          dryRun: true,
+          plan: 'the plan',
+          tasks: [],
+          voteIterations: 2,
+          qaIterations: 0,
+          securityPassed: false,
+          securityRan: false,
+        });
+        const handler = captureHandler();
+
+        const result = await handler({
+          goal: 'implement the feature',
+          forceStrategy: 'dev-pipeline',
+          execute: true,
+          dryRun: true,
+        });
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content[0]?.text).toContain('the plan');
+      });
+
+      it('still reports a dry run whose planner produced nothing', async () => {
+        // The pair. Stopping early is the request; coming back with no plan is
+        // a failure, and the exemption above must not swallow it.
+        runDevPipelineForGoalMock.mockResolvedValueOnce({
+          completed: false,
+          dryRun: true,
+          plan: '',
+          tasks: [],
+          voteIterations: 1,
+          qaIterations: 0,
+          securityPassed: false,
+          securityRan: false,
+          planStatus: 'empty',
+        });
+        const handler = captureHandler();
+
+        const result = await handler({
+          goal: 'implement the feature',
+          forceStrategy: 'dev-pipeline',
+          execute: true,
+          dryRun: true,
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0]?.text).toContain('planner returned no plan');
+      });
+
+      it('still reports an ordinary run that did not complete', async () => {
+        // Guard the guard: the exemption keys on `dryRun`, so a real pipeline
+        // failure must be unaffected by it.
+        runDevPipelineForGoalMock.mockResolvedValueOnce({
+          completed: false,
+          plan: 'the plan',
+          tasks: [],
+          voteIterations: 1,
+          qaIterations: 1,
+          securityPassed: false,
+          securityRan: false,
+        });
+        const handler = captureHandler();
+
+        const result = await handler({
+          goal: 'implement the feature',
+          forceStrategy: 'dev-pipeline',
+          execute: true,
+        });
+
+        expect(result.isError).toBe(true);
       });
 
       it('leaves the pipeline untouched when dryRun is omitted', async () => {

--- a/packages/nexus-agents/src/mcp/tools/run-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool.ts
@@ -433,6 +433,10 @@ function detectEngineFailure(
     return { message: `Engine reported failure: ${detail}` };
   }
   if (record['completed'] === false) {
+    // A dry run stops before completion BY REQUEST, so `completed: false` is
+    // the outcome the caller asked for rather than an engine fault. An empty
+    // plan is still a failure — producing one is the whole point of the run.
+    if (record['dryRun'] === true && record['planStatus'] !== 'empty') return null;
     return { message: describeIncompletePipeline(record), detail: record };
   }
   return null;

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.test.ts
@@ -301,6 +301,9 @@ describe('runDevPipeline', () => {
 
     expect(result.planStatus).toBe('empty');
     expect(result.plan).toBe('');
+    // Both markers: stopped by request AND produced nothing. A consumer needs
+    // the pair to tell an honest dry run from one whose planner failed.
+    expect(result.dryRun).toBe(true);
     // Voting on an empty plan wastes a panel and yields a verdict about no
     // proposal — the loop must stop before it.
     expect(stages.vote).not.toHaveBeenCalled();
@@ -318,6 +321,10 @@ describe('runDevPipeline', () => {
     // #4772: `securityPassed: false` here means the gate never ran, not that it
     // rejected. Without this the two are indistinguishable to a caller.
     expect(result.securityRan).toBe(false);
+    // #4806: and says WHY completion is false. Without this marker a consumer
+    // reading `completed` cannot tell "stopped as asked" from "failed", and
+    // `run`'s engine-failure check reported a successful dry run as a fault.
+    expect(result.dryRun).toBe(true);
     // A real plan came back, so no failure marker.
     expect(result.planStatus).toBeUndefined();
     // Should NOT have called decompose, implement, qa, or security

--- a/packages/nexus-agents/src/pipeline/dev-pipeline.ts
+++ b/packages/nexus-agents/src/pipeline/dev-pipeline.ts
@@ -173,6 +173,15 @@ export interface DevPipelineResult {
    * stages voted on the input text.
    */
   readonly planStatus?: 'empty';
+  /**
+   * Whether this run stopped after plan+vote because the caller asked it to.
+   *
+   * `completed: false` alone cannot distinguish "the pipeline failed" from "the
+   * pipeline did exactly what was requested and stopped" — and a consumer that
+   * reads `completed` as the verdict reports a successful dry run as an engine
+   * fault. Absent means a normal run.
+   */
+  readonly dryRun?: true;
 }
 
 // ============================================================================
@@ -741,6 +750,8 @@ function buildDryRunResult(planResult: {
 }): DevPipelineResult {
   return {
     completed: false,
+    // Says WHY completion is false: by request, not by fault.
+    dryRun: true,
     plan: planResult.plan,
     tasks: [],
     voteIterations: planResult.iterations,


### PR DESCRIPTION
Found by an adversarial review of the `run` entry point, then reproduced against the code.

## `run`'s dryRun did nothing

```
run({ goal: "add retry logic to the fetch helper",
      forceStrategy: "dev-pipeline", execute: true, dryRun: true })
```

decomposed the goal, **implemented** it, ran QA and ran the security scan, and returned `completed: true, securityRan: true` with implemented tasks. The caller asked to plan and vote only.

`runDevPipelineForGoal` (`dev-pipeline-tool.ts:278`) parses `dryRun` into `input` — which only `createStages` consumes — and then calls:

```ts
runDevPipeline(goal, stages, trustTier !== undefined ? { trustTier } : undefined);
```

The short-circuit at `dev-pipeline.ts:367` keys on `options?.dryRun === true`, so it never fired. The direct `run_dev_pipeline` handler builds its options correctly (`:349`), which is what makes this an asymmetry rather than an unimplemented feature — and the function's own comment says "`dryRun` is the one pipeline option `run` forwards."

This is the outcome `run-tool.ts`'s refusal path exists to prevent. `run` refuses `dryRun` for strategies that cannot honor it; the one strategy that advertises support dropped the flag.

## The seam the existing test missed

`run-tool.test.ts:597` asserts `runDevPipelineForGoalMock` was called with `(goal, undefined, true)` — one link short of the only place the flag does anything. Deleting the `...(dryRun !== undefined ? { dryRun } : {})` in the function under test would also have failed nothing.

The new tests assert **`runDevPipeline`'s third argument**, with a paired case so a fix that hardcoded `dryRun: true` — passing the first test while turning every `run` into a no-op — fails.

## Fixing it activated a second misreport

`buildDryRunResult` returns `completed: false` by design, and `detectEngineFailure` treats `completed === false` as a fault unconditionally. Wiring dryRun through without touching that would have handed the caller:

> Engine reported failure: the run stopped before the security gate, which never ran

for exactly the outcome they requested — with the plan surviving only inside `detail`, and `executeRunBodyOrThrow` converting it into a **failed job** on the async path. The run-tool test fake returns `completed: true` regardless of the `dryRun` argument, so it could not have caught this.

The result now carries `dryRun: true` to say *why* completion is false — the same treatment `securityRan` and `planStatus` already give the other two ambiguous cases. `detectEngineFailure` exempts it, **except** when `planStatus === 'empty'`: coming back with no plan is still a failure, because producing one is the point of the run.

## Mutations

| mutation | result |
| --- | --- |
| drop the forward | 2 failed |
| hardcode `dryRun: true` | 1 failed |
| remove the dry-run exemption | 1 failed |
| exemption swallows the empty plan | 1 failed |
| `buildDryRunResult` drops the marker | 2 failed |

That last one **survived at first** — I had fixed producer and consumer independently, and nothing pinned that the real `buildDryRunResult` sets the marker the consumer keys on. The run-tool fake supplied it. Same untested-seam shape as the bug, inside the fix for it; the two `dev-pipeline.test.ts` assertions close it.

2,692 tests pass across `src/mcp/tools` and the pipeline suite. `api-surface.txt` gains one additive optional field.

## Not fixed here

The review also found `ExecuteEnvelopeRefusalError` classified as `errorCategory: 'internal'` when it is a deliberate policy refusal (`run({ goal, execute: true })` on any strategy without an execute envelope — `single-shot`, `graph-workflow`, `orchestrate`, `spec`), and the shadow-selection sink written on every `run` call and read by nobody. Both are separate concerns; filing rather than folding them in.
