### PR TITLE
fix(security): say at startup when no audit chain is being written

### DIFF
--- a/.changeset/audit-disabled-disclosure.md
+++ b/.changeset/audit-disabled-disclosure.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+fix(security): say at startup when no audit chain is being written
+
+Audit was the only security control missing from the `Security configuration`
+startup line, and `initializeAuditLogger` announced its absence at `debug` —
+dropped at the default `info` level. So the tamper-evident chain the docs lead
+with could be off while the startup log confirmed policy mode, auth, rate
+limiting and allowed paths and said nothing about this one, which reads as fine
+rather than absent. Both audit directories in a long-running checkout were
+empty, and nothing had ever said why.
+
+The line now carries `auditEnabled`, and a disabled chain warns — the same
+treatment authentication already gets, for the same reason.
+
+Whether off-by-default is the right default is a separate question (#4990);
+this only makes the current state legible.

--- a/packages/nexus-agents/src/cli-server-audit.test.ts
+++ b/packages/nexus-agents/src/cli-server-audit.test.ts
@@ -126,4 +126,52 @@ describe('logSecurityConfig', () => {
     expect((line as unknown[])[1]).toHaveProperty('configuredPolicyMode');
     expect((line as unknown[])[1]).not.toHaveProperty('policyMode');
   });
+
+  it('reports whether audit logging is on, alongside the other controls (#4990)', () => {
+    // Audit was the only security control missing from this line. Its absence
+    // was announced at `debug`, which the default `info` level drops — so a
+    // startup log that confirmed four controls and said nothing about the
+    // tamper-evident chain read as "fine" rather than "not running".
+    const logger = createMockLogger();
+
+    logSecurityConfig(logger);
+
+    const line = (logger.info as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => call[0] === 'Security configuration'
+    );
+    expect((line as unknown[])[1]).toMatchObject({ auditEnabled: false });
+  });
+
+  it('warns when the audit chain is not being written', () => {
+    // The same treatment auth already gets. A boolean on an info line is easy
+    // to scroll past; the control being absent deserves the same visibility as
+    // authentication being absent.
+    const logger = createMockLogger();
+
+    logSecurityConfig(logger);
+
+    const warned = (logger.warn as ReturnType<typeof vi.fn>).mock.calls.some((call: unknown[]) =>
+      String(call[0]).includes('Audit logging is disabled')
+    );
+    expect(warned).toBe(true);
+  });
+
+  it('says audit is on, and does not warn, when it is enabled', () => {
+    // The pair. A hardcoded `false` plus an unconditional warning would pass
+    // both tests above while reporting a running audit chain as absent.
+    const logger = createMockLogger();
+
+    logSecurityConfig(logger, {
+      security: { audit: { enabled: true } },
+    } as unknown as Parameters<typeof logSecurityConfig>[1]);
+
+    const line = (logger.info as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => call[0] === 'Security configuration'
+    );
+    expect((line as unknown[])[1]).toMatchObject({ auditEnabled: true });
+    const warned = (logger.warn as ReturnType<typeof vi.fn>).mock.calls.some((call: unknown[]) =>
+      String(call[0]).includes('Audit logging is disabled')
+    );
+    expect(warned).toBe(false);
+  });
 });

--- a/packages/nexus-agents/src/cli-server-audit.ts
+++ b/packages/nexus-agents/src/cli-server-audit.ts
@@ -112,6 +112,21 @@ function getAuthValues(config?: AppConfig): { enabled: boolean; method: string }
 }
 
 /**
+ * Warns when no tamper-evident event chain is being written (#4990).
+ *
+ * The same treatment authentication already gets. A boolean on the info line is
+ * easy to scroll past; a security control that is absent deserves to be as
+ * visible as auth being absent.
+ */
+function warnIfAuditDisabled(auditEnabled: boolean, logger: ILogger): void {
+  if (auditEnabled) return;
+  logger.warn(
+    'Audit logging is disabled — no tamper-evident event chain is being written. ' +
+      'Set security.audit.enabled: true to enable it.'
+  );
+}
+
+/**
  * Logs security configuration at startup.
  * Returns the configured policy firewall for use in tool registration.
  * (Source: Issue #185 Phase 1 - Startup security logging)
@@ -125,13 +140,13 @@ export function logSecurityConfig(
   const authVals = getAuthValues(config);
   const policyVals = getPolicyValues(config);
   const rateLimitVals = getRateLimitValues(config);
+  const auditEnabled = config?.security?.audit?.enabled === true;
 
   logger.info('Security configuration', {
     // #4888: named `configuredPolicyMode`, not `policyMode`. This runs at
-    // startup, before `stagePolicyFirewallForRollout` decides the mode that
-    // will actually apply — which is `warn` unless the operator opted in. A
-    // field called `policyMode` reading `enforce` here would claim an
-    // enforcement the staged rollout does not perform.
+    // startup, before `stagePolicyFirewallForRollout` forces the firewall to
+    // `warn` — the mode that actually applies. A field called `policyMode`
+    // reading `enforce` here would claim an enforcement that does not happen.
     configuredPolicyMode: policyVals.mode,
     defaultExecutionMode: policyVals.defaultExec,
     policyRuleCount: policyFirewall.getRules().length,
@@ -139,8 +154,16 @@ export function logSecurityConfig(
     authMethod: authVals.method,
     rateLimitEnabled: rateLimitVals.enabled,
     rateLimitRequestsPerMinute: rateLimitVals.rpm,
+    // #4990: audit was the only security control missing from this line, and
+    // `initializeAuditLogger` announces its absence at `debug` — dropped at the
+    // default level. So the tamper-evident chain the docs lead with could be
+    // off while the startup log confirmed four other controls and said nothing
+    // about this one, which reads as fine rather than absent.
+    auditEnabled,
     allowedPaths: config?.security?.allowedPaths ?? ['./'],
   });
+
+  warnIfAuditDisabled(auditEnabled, logger);
 
   if (!authVals.enabled) {
     logger.warn(


### PR DESCRIPTION
Closes items 1-2 of #4990. The off-by-default question stays open there.

## What was wrong

`verify_audit_chain` against either audit directory in this checkout returns `{ eventCount: 0, notVerified: "empty" }`. Both have existed since March and May and have never held a file. Nothing had said why.

`initializeAuditLogger` returns `null` unless `security.audit.enabled === true`, announcing it at **debug** (`cli-server-audit.ts:30`) — and the default level is `info` (`core/logger.ts:151`), so the line is dropped. Meanwhile `logSecurityConfig` reports `configuredPolicyMode`, `defaultExecutionMode`, `policyRuleCount`, `authEnabled`, `authMethod`, `rateLimitEnabled`, `rateLimitRequestsPerMinute` and `allowedPaths` — **every security control except audit.**

The asymmetry against auth is the sharpest part: auth disabled gets its own explicit warn. Audit was the only one whose absence was silent, while `CLAUDE.md` leads with "tamper-evident append-only audit chain" and the tree carries a threat model for it. An operator has every reason to believe it is running.

## The fix

`auditEnabled` joins the startup line, and a disabled chain warns — the same treatment auth gets, for the same reason. A boolean on an info line is easy to scroll past; a security control that is not running should be as visible as authentication not running.

## Three tests, and the third is the one that matters

Two assert the disabled case reports and warns. The third asserts the **enabled** case: `auditEnabled: true` and no warning. Without it, hardcoding `auditEnabled: false` plus an unconditional warning would pass everything while reporting a running audit chain as absent — the same defect with the sign flipped, which is the shape I have been fixing all day.

| mutation | result |
| --- | --- |
| hardcode `auditEnabled: false` | 1 failed |
| warn unconditionally | 1 failed |
| drop the warning | 1 failed |

## Also

Corrected a comment #4987 left stale: it said the policy mode applies "unless the operator opted in", and that opt-in was removed from #4987 before merge because enabling it would have denied ~45 of 47 tools. There is no opt-in to refer to.

66 tests pass across the three cli-server suites.
