### PR TITLE
fix(memory): report what memory_write actually persisted

### DIFF
--- a/.changeset/memory-write-reports-persistence.md
+++ b/.changeset/memory-write-reports-persistence.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+fix(memory): report what memory_write actually persisted
+
+`memory_write` returned `{ success: true }` for writes the backend had
+rejected. `recordKnowledge`, `storeAdaptive` and `storeTyped` returned `void`,
+checking their `Result` only to emit a `debug` line; `recordBelief` never
+inspected its `Result` at all. The caller had no value to look at, so the tool
+reported success unconditionally and the declared `error` field was reachable
+only for an unconfigured backend — never for a runtime write failure. A
+read-only SQLite file was indistinguishable from a successful write.
+
+All four now return a `MemoryStoreOutcome` and the tool reports the reason.
+
+The dedup cache had two related defects. It recorded the write _before_
+dispatch, so a failed write poisoned it and the identical retry returned
+`success: true, deduplicated: true` — asserting content was already stored that
+nothing had ever stored. And its key omitted the backend, so writing the same
+key+content to `session` and then `belief` reported the second as a duplicate
+while the belief store never received it. The key now includes the backend and
+the full content (the old 100-character prefix collided), and only a write that
+landed is remembered.

--- a/packages/nexus-agents/src/mcp/tools/memory-write-persistence.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-write-persistence.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `memory_write` must report what actually persisted (#4997).
+ *
+ * Drives the callback the tool really registers, with a controllable
+ * ToolMemory, so the assertions are about the response a caller receives
+ * rather than about a mock the test itself configured.
+ *
+ * @module mcp/tools/memory-write-persistence.test
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { registerMemoryWriteTool } from './memory-write.js';
+import { RateLimiter } from '../middleware/rate-limiter.js';
+
+const memory = {
+  recordKnowledge: vi.fn(),
+  recordBelief: vi.fn(),
+  storeAdaptive: vi.fn(),
+  storeTyped: vi.fn(),
+  recordLearning: vi.fn(),
+  getBeliefCount: vi.fn(() => 0),
+  isAgenticMemoryAvailable: vi.fn(() => true),
+  isAdaptiveMemoryAvailable: vi.fn(() => true),
+  isTypedMemoryAvailable: vi.fn(() => true),
+};
+
+vi.mock('./tool-memory.js', () => ({
+  getToolMemory: () => memory,
+}));
+
+type SdkCallback = (args: unknown) => Promise<{ content: readonly { text: string }[] }>;
+
+async function callMemoryWrite(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+  let registered: SdkCallback | undefined;
+  const server = {
+    registerTool: (_name: string, _config: unknown, callback: SdkCallback): void => {
+      registered = callback;
+    },
+  };
+  registerMemoryWriteTool(server as never, {
+    rateLimiter: new RateLimiter({ capacity: 100, refillRate: 100 }),
+  });
+  if (registered === undefined) throw new Error('memory_write registered no callback');
+  const result = await registered(args);
+  return JSON.parse(result.content[0]?.text ?? '{}') as Record<string, unknown>;
+}
+
+describe('memory_write reports persistence, not intent (#4997)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memory.isAgenticMemoryAvailable.mockReturnValue(true);
+    memory.getBeliefCount.mockReturnValue(0);
+  });
+
+  it('reports failure when the backend rejected the write', async () => {
+    // The store helpers used to return `void`, logging a rejected Result at
+    // debug — so the tool had nothing to inspect and said `success: true` for
+    // a write that never landed. A configured backend whose SQLite file has
+    // gone read-only is the realistic case.
+    memory.recordKnowledge.mockResolvedValue({ persisted: false, reason: 'disk is read-only' });
+
+    const body = await callMemoryWrite({
+      key: 'k',
+      content: 'some knowledge',
+      backend: 'agentic',
+    });
+
+    expect(body['success']).toBe(false);
+    expect(String(body['error'])).toContain('read-only');
+  });
+
+  it('reports success when the backend persisted', async () => {
+    // The pair: a hardcoded `success: false` would pass the test above.
+    memory.recordKnowledge.mockResolvedValue({ persisted: true });
+
+    const body = await callMemoryWrite({ key: 'k2', content: 'c2', backend: 'agentic' });
+
+    expect(body['success']).toBe(true);
+  });
+
+  it('does not treat a retry after a failed write as already stored', async () => {
+    // The dedup cache recorded intent: it was populated BEFORE dispatch, so a
+    // failed write poisoned it and the identical retry came back
+    // `success: true, deduplicated: true` — asserting content was stored that
+    // nothing had ever stored.
+    memory.recordKnowledge.mockResolvedValueOnce({ persisted: false, reason: 'backend down' });
+    const first = await callMemoryWrite({ key: 'retry', content: 'c', backend: 'agentic' });
+    expect(first['success']).toBe(false);
+
+    memory.recordKnowledge.mockResolvedValueOnce({ persisted: true });
+    const second = await callMemoryWrite({ key: 'retry', content: 'c', backend: 'agentic' });
+
+    expect(second['success']).toBe(true);
+    expect(second).not.toHaveProperty('deduplicated');
+    expect(memory.recordKnowledge).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not dedup across different backends', async () => {
+    // The cache key was `${key}::${content.slice(0, 100)}` — no backend. So
+    // writing the same content to `agentic` and then `typed` reported the
+    // second as already stored while the typed store never received it.
+    memory.recordKnowledge.mockResolvedValue({ persisted: true });
+    memory.storeTyped.mockResolvedValue({ persisted: true });
+
+    await callMemoryWrite({ key: 'shared', content: 'same text', backend: 'agentic' });
+    const second = await callMemoryWrite({ key: 'shared', content: 'same text', backend: 'typed' });
+
+    expect(second).not.toHaveProperty('deduplicated');
+    expect(memory.storeTyped).toHaveBeenCalledTimes(1);
+  });
+
+  it('still dedups a genuine repeat to the same backend', async () => {
+    // Guard the guard: the fixes above must not disable deduplication.
+    memory.recordKnowledge.mockResolvedValue({ persisted: true });
+
+    await callMemoryWrite({ key: 'dup', content: 'same text', backend: 'agentic' });
+    const second = await callMemoryWrite({ key: 'dup', content: 'same text', backend: 'agentic' });
+
+    expect(second['deduplicated']).toBe(true);
+    expect(memory.recordKnowledge).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/memory-write.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-write.ts
@@ -113,9 +113,14 @@ async function writeToBelief(
 ): Promise<MemoryWriteResponse> {
   const toolMemory = getToolMemory();
   const countBefore = toolMemory.getBeliefCount();
-  await toolMemory.recordBelief(key, 'has_knowledge', content, confidence);
-  const countAfter = toolMemory.getBeliefCount();
-  const deduplicated = countAfter === countBefore;
+  const outcome = await toolMemory.recordBelief(key, 'has_knowledge', content, confidence);
+  if (!outcome.persisted) {
+    return { success: false, backend: 'belief', key, error: outcome.reason };
+  }
+  // An unchanged count after a PERSISTED retain means the triple was already
+  // held. Before #4997 the count was the only signal, so a rejected write and a
+  // deduplicated one were the same observation.
+  const deduplicated = toolMemory.getBeliefCount() === countBefore;
   return { success: true, backend: 'belief', key, ...(deduplicated ? { deduplicated: true } : {}) };
 }
 
@@ -137,10 +142,13 @@ async function writeToAgentic(
       error: 'Agentic memory backend unavailable (requires SQLite)',
     };
   }
-  await toolMemory.recordKnowledge(key, content, {
+  const outcome = await toolMemory.recordKnowledge(key, content, {
     importance: confidence,
     tags: metadata !== undefined ? Object.keys(metadata) : [],
   });
+  if (!outcome.persisted) {
+    return { success: false, backend: 'agentic', key, error: outcome.reason };
+  }
   return { success: true, backend: 'agentic', key };
 }
 
@@ -162,7 +170,10 @@ async function writeToAdaptive(
     };
   }
   const importance = confidence === 'high' ? 0.9 : confidence === 'medium' ? 0.7 : 0.5;
-  await toolMemory.storeAdaptive(key, content, importance);
+  const outcome = await toolMemory.storeAdaptive(key, content, importance);
+  if (!outcome.persisted) {
+    return { success: false, backend: 'adaptive', key, error: outcome.reason };
+  }
   return { success: true, backend: 'adaptive', key };
 }
 
@@ -184,7 +195,10 @@ async function writeToTyped(
     };
   }
   const importance = confidence === 'high' ? 'high' : confidence === 'medium' ? 'medium' : 'low';
-  await toolMemory.storeTyped(key, content, importance);
+  const outcome = await toolMemory.storeTyped(key, content, importance);
+  if (!outcome.persisted) {
+    return { success: false, backend: 'typed', key, error: outcome.reason };
+  }
   return { success: true, backend: 'typed', key };
 }
 
@@ -201,24 +215,39 @@ const MAX_DEDUP_CACHE = 200;
  * Session-level dedup: prevent writing the same key+content twice.
  * Returns true if this is a duplicate that should be skipped.
  */
-function isDuplicateWrite(key: string, content: string): boolean {
-  const cacheKey = `${key}::${content.slice(0, 100)}`;
-  if (recentWriteKeys.has(cacheKey)) return true;
-  // Prune if cache is too large
+function dedupCacheKey(input: MemoryWriteInput): string {
+  // #4997: the backend is part of the identity. Without it, writing the same
+  // key+content to `session` and then to `belief` reported the second as
+  // `deduplicated: true` while the belief store never received it.
+  return `${input.backend}::${input.key}::${input.content}`;
+}
+
+function isDuplicateWrite(input: MemoryWriteInput): boolean {
+  return recentWriteKeys.has(dedupCacheKey(input));
+}
+
+/**
+ * Remembers a write that actually landed (#4997).
+ *
+ * Recording it before dispatch cached intent rather than persistence: a write
+ * that failed still populated the cache, so the identical retry came back
+ * `success: true, deduplicated: true` — the tool asserting the content was
+ * already stored when nothing had ever stored it.
+ */
+function rememberWrite(input: MemoryWriteInput): void {
   if (recentWriteKeys.size >= MAX_DEDUP_CACHE) {
     const firstKey = recentWriteKeys.keys().next().value;
     if (firstKey !== undefined) recentWriteKeys.delete(firstKey);
   }
-  recentWriteKeys.set(cacheKey, new Date().toISOString());
-  return false;
+  recentWriteKeys.set(dedupCacheKey(input), new Date().toISOString());
 }
 
 async function executeMemoryWrite(
   input: MemoryWriteInput,
   logger: ILogger
 ): Promise<MemoryWriteResponse> {
-  // Session-level dedup: skip if same key+content was written recently
-  if (isDuplicateWrite(input.key, input.content)) {
+  // Session-level dedup: skip if the same key+content reached this backend
+  if (isDuplicateWrite(input)) {
     logger.debug('Skipping duplicate memory write', { key: input.key, backend: input.backend });
     return { success: true, backend: input.backend, key: input.key, deduplicated: true };
   }
@@ -229,6 +258,13 @@ async function executeMemoryWrite(
     contentLength: input.content.length,
   });
 
+  const response = await dispatchWrite(input);
+  // Only a write that landed is worth deduplicating against.
+  if (response.success) rememberWrite(input);
+  return response;
+}
+
+async function dispatchWrite(input: MemoryWriteInput): Promise<MemoryWriteResponse> {
   switch (input.backend) {
     case 'session':
       return writeToSession(input.key, input.content, input.confidence);

--- a/packages/nexus-agents/src/mcp/tools/memory-write.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-write.ts
@@ -24,6 +24,7 @@ import {
   type BaseMcpToolDeps,
 } from './tool-result.js';
 import { getToolMemory } from './tool-memory.js';
+import type { MemoryStoreOutcome } from './tool-memory.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
 // ============================================================================
@@ -113,7 +114,12 @@ async function writeToBelief(
 ): Promise<MemoryWriteResponse> {
   const toolMemory = getToolMemory();
   const countBefore = toolMemory.getBeliefCount();
-  const outcome = await toolMemory.recordBelief(key, 'has_knowledge', content, confidence);
+  const outcome: MemoryStoreOutcome = await toolMemory.recordBelief(
+    key,
+    'has_knowledge',
+    content,
+    confidence
+  );
   if (!outcome.persisted) {
     return { success: false, backend: 'belief', key, error: outcome.reason };
   }
@@ -142,7 +148,7 @@ async function writeToAgentic(
       error: 'Agentic memory backend unavailable (requires SQLite)',
     };
   }
-  const outcome = await toolMemory.recordKnowledge(key, content, {
+  const outcome: MemoryStoreOutcome = await toolMemory.recordKnowledge(key, content, {
     importance: confidence,
     tags: metadata !== undefined ? Object.keys(metadata) : [],
   });
@@ -170,7 +176,7 @@ async function writeToAdaptive(
     };
   }
   const importance = confidence === 'high' ? 0.9 : confidence === 'medium' ? 0.7 : 0.5;
-  const outcome = await toolMemory.storeAdaptive(key, content, importance);
+  const outcome: MemoryStoreOutcome = await toolMemory.storeAdaptive(key, content, importance);
   if (!outcome.persisted) {
     return { success: false, backend: 'adaptive', key, error: outcome.reason };
   }
@@ -195,7 +201,7 @@ async function writeToTyped(
     };
   }
   const importance = confidence === 'high' ? 'high' : confidence === 'medium' ? 'medium' : 'low';
-  const outcome = await toolMemory.storeTyped(key, content, importance);
+  const outcome: MemoryStoreOutcome = await toolMemory.storeTyped(key, content, importance);
   if (!outcome.persisted) {
     return { success: false, backend: 'typed', key, error: outcome.reason };
   }

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -175,6 +175,17 @@ export async function reinitializeMemoryBackends(): Promise<MemoryBackendStatus>
 // ============================================================================
 
 /**
+ * Whether a best-effort store actually persisted (#4997).
+ *
+ * These helpers used to return `void` and log a failed `Result` at `debug`, so
+ * `memory_write` had nothing to inspect and reported `success: true` for a
+ * write the backend had rejected. A caller that cannot see the failure cannot
+ * report it, and a tool that always says `success` is not reporting anything.
+ */
+export type MemoryStoreOutcome =
+  { readonly persisted: true } | { readonly persisted: false; readonly reason: string };
+
+/**
  * Manages session memory for MCP tool execution.
  * Auto-initializes a session and provides safe recording methods
  * that silently degrade if memory is unavailable.
@@ -512,9 +523,9 @@ export class ToolMemoryManager {
     predicate: string,
     object: string,
     confidence: 'high' | 'medium' | 'low' = 'medium'
-  ): Promise<void> {
+  ): Promise<MemoryStoreOutcome> {
     try {
-      await this.beliefs.retain({
+      const result = await this.beliefs.retain({
         subject,
         predicate,
         object,
@@ -522,8 +533,18 @@ export class ToolMemoryManager {
         sourceType: BeliefSourceType.OBSERVATION,
         sourceRef: 'mcp-tool-execution',
       });
+      // `retain` converts its own throws into `err`, so the catch below is
+      // nearly unreachable and this branch is where a real failure shows up.
+      // It was discarded entirely before #4997.
+      if (!result.ok) {
+        this.log.debug('Failed to record belief', { subject, error: result.error.message });
+        return { persisted: false, reason: result.error.message };
+      }
+      return { persisted: true };
     } catch (error) {
-      this.log.debug('Failed to record belief', { subject, error });
+      const reason = getErrorMessage(error);
+      this.log.debug('Failed to record belief', { subject, error: reason });
+      return { persisted: false, reason };
     }
   }
 
@@ -627,25 +648,34 @@ export class ToolMemoryManager {
     return this.adaptive !== null;
   }
 
-  /** Store knowledge with auto-extracted attributes (AgenticMemory). Best-effort. */
-  async recordKnowledge(key: string, value: unknown, metadata: MemoryMetadata): Promise<void> {
-    if (this.agentic === null) return;
+  /** Store knowledge with auto-extracted attributes (AgenticMemory). */
+  async recordKnowledge(
+    key: string,
+    value: unknown,
+    metadata: MemoryMetadata
+  ): Promise<MemoryStoreOutcome> {
+    if (this.agentic === null) return { persisted: false, reason: 'agentic backend unavailable' };
     try {
       const result = await this.agentic.storeWithAttributes(key, value, metadata);
       if (!result.ok) {
         this.log.debug('Failed to record knowledge', { key, error: result.error.message });
+        return { persisted: false, reason: result.error.message };
       }
+      return { persisted: true };
     } catch (error: unknown) {
-      this.log.debug('Knowledge recording failed', {
-        key,
-        error: getErrorMessage(error),
-      });
+      const reason = getErrorMessage(error);
+      this.log.debug('Knowledge recording failed', { key, error: reason });
+      return { persisted: false, reason };
     }
   }
 
-  /** Store a value in AdaptiveMemory with importance scoring. Best-effort. */
-  async storeAdaptive(key: string, value: unknown, importance: number): Promise<void> {
-    if (this.adaptive === null) return;
+  /** Store a value in AdaptiveMemory with importance scoring. */
+  async storeAdaptive(
+    key: string,
+    value: unknown,
+    importance: number
+  ): Promise<MemoryStoreOutcome> {
+    if (this.adaptive === null) return { persisted: false, reason: 'adaptive backend unavailable' };
     try {
       const level = importance >= 0.8 ? 'high' : importance >= 0.6 ? 'medium' : 'low';
       const result = await this.adaptive.store(key, value, {
@@ -654,18 +684,24 @@ export class ToolMemoryManager {
       });
       if (!result.ok) {
         this.log.debug('Failed to store adaptive memory', { key, error: result.error.message });
+        return { persisted: false, reason: result.error.message };
       }
+      return { persisted: true };
     } catch (error: unknown) {
-      this.log.debug('Adaptive memory store failed', {
-        key,
-        error: getErrorMessage(error),
-      });
+      const reason = getErrorMessage(error);
+      this.log.debug('Adaptive memory store failed', { key, error: reason });
+      return { persisted: false, reason };
     }
   }
 
-  /** Store a value in TypedMemory (via HybridMemoryBackend). Best-effort. */
-  async storeTyped(key: string, value: unknown, importance: MemoryImportance): Promise<void> {
-    if (this.typedBackend === null) return;
+  /** Store a value in TypedMemory (via HybridMemoryBackend). */
+  async storeTyped(
+    key: string,
+    value: unknown,
+    importance: MemoryImportance
+  ): Promise<MemoryStoreOutcome> {
+    if (this.typedBackend === null)
+      return { persisted: false, reason: 'typed backend unavailable' };
     try {
       const result = await this.typedBackend.store(`semantic ${key}`, value, {
         importance,
@@ -673,12 +709,13 @@ export class ToolMemoryManager {
       });
       if (!result.ok) {
         this.log.debug('Failed to store typed memory', { key, error: result.error.message });
+        return { persisted: false, reason: result.error.message };
       }
+      return { persisted: true };
     } catch (error: unknown) {
-      this.log.debug('Typed memory store failed', {
-        key,
-        error: getErrorMessage(error),
-      });
+      const reason = getErrorMessage(error);
+      this.log.debug('Typed memory store failed', { key, error: reason });
+      return { persisted: false, reason };
     }
   }
 


### PR DESCRIPTION
Closes #4997.

## `memory_write` said success for writes that never landed

Three store helpers returned `void`, checking their `Result` only to emit a `debug` line. `recordBelief` never inspected its `Result` at all — and since `retainInternal` converts its own throws into `err(...)`, the surrounding catch was nearly unreachable, so the failure was discarded entirely.

With no value to inspect, `memory_write` returned `{ success: true }` unconditionally. The declared `error` field was reachable for exactly one case — an unconfigured backend — and unreachable for every runtime write failure. A configured backend whose SQLite file goes read-only was indistinguishable from a successful write.

All four helpers now return a `MemoryStoreOutcome` and the tool reports the reason. This is the `#4827` pattern from next door in the same subsystem: hand the `Result` through instead of collapsing it.

## The dedup cache recorded intent, not persistence

Two defects, both reachable:

- **Populated before dispatch**, so a *failed* write poisoned it and the identical retry returned `success: true, deduplicated: true` — the tool asserting content was already stored when nothing had ever stored it. Now only a write that landed is remembered.
- **The key omitted the backend** (`${key}::${content.slice(0, 100)}`), so the same key+content written to `session` and then `belief` reported the second as a duplicate while the belief store never received it. The 100-character prefix also collided two distinct 5,000-character contents. The key is now `${backend}::${key}::${content}`.

`writeToBelief`'s dedup inference is now sound as a consequence: an unchanged count after a **persisted** retain means the triple was already held. Previously an unchanged count also meant "retain returned `err`", so success, dedup and failure were one observation.

## About the tests

`memory-write.test.ts`'s "memory write logic" block calls a `vi.fn()` with an object the test just built and asserts it was called with that object. It exercises no production code, and would pass with `memory-write.ts` deleted. I left it alone and added a real file that registers the tool on a stub server and drives the callback it actually registers, with a controllable `ToolMemory`.

| mutation | result |
| --- | --- |
| ignore the agentic outcome | 2 failed |
| remember failed writes too | 1 failed |
| drop the backend from the cache key | 1 failed |
| disable dedup entirely | 1 failed |

The last one is the guard-the-guard case: three of these fixes loosen deduplication, and none of them may switch it off.

2,636 tests pass across `src/mcp/tools`. `api-surface.txt` unchanged.

## Not in this PR

The same audit found the read path cannot report a backend that errored or was skipped, and that `memory_stats.session` returns three numbers that measure nothing — `tasksCount` and `errorsCount` are initialised to `0` and never assigned. Filed separately; they need their own decisions about response shape.
