### PR TITLE
fix(run): classify policy refusals structurally, not by class list

### DIFF
--- a/.changeset/envelope-refusal-category.md
+++ b/.changeset/envelope-refusal-category.md
@@ -1,0 +1,18 @@
+---
+'nexus-agents': patch
+---
+
+fix(run): report an undeclared execute envelope as a refusal, not an engine fault
+
+`classifyDispatchError` enumerated refusal classes with `instanceof`.
+`ExecuteEnvelopeRefusalError` — added later, and deliberately not a subclass of
+`AuthorityRefusalError` because it answers a different question — was not in the
+list, so it fell through to `errorCategory: 'internal'`. A plain
+`run({ goal, execute: true })` routes to `single-shot`, which declares no
+execute envelope, so an ordinary call told the caller the engine had a defect;
+on the async path the job was recorded failed with the same framing.
+
+The three refusal types now share a `PolicyRefusalError` base and the classifier
+keys on that. The classification is structural rather than a list: a new refusal
+type is a `business` outcome by construction and has to opt out, instead of
+being misclassified by omission — which is how this one was missed.

--- a/packages/nexus-agents/src/mcp/tools/run-tool-dry-run.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool-dry-run.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Dispatch-error classification: a policy refusal is a `business` outcome, an
+ * engine fault is `internal` (#4994).
+ *
+ * @module mcp/tools/run-tool-dry-run.test
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { classifyDispatchError, DryRunUnsupportedError } from './run-tool-dry-run.js';
+import {
+  AuthorityRefusalError,
+  ExecuteEnvelopeRefusalError,
+} from '../../orchestration/authority-tier-guard.js';
+import { MetaDispatchError } from '../../orchestration/meta-dispatcher.js';
+
+describe('classifyDispatchError', () => {
+  it('classifies an undeclared execute envelope as a business outcome', () => {
+    // The regression. `ExecuteEnvelopeRefusalError` is deliberately not an
+    // `AuthorityRefusalError` — it answers a different question — so the
+    // instanceof list missed it and a documented fail-closed refusal reached
+    // the caller as "the engine has an internal defect". Reachable from a plain
+    // `run({ goal, execute: true })`: that routes to `single-shot`, which
+    // declares no execute envelope.
+    expect(classifyDispatchError(new ExecuteEnvelopeRefusalError('single-shot'))).toBe('business');
+  });
+
+  it('classifies the other two refusals as business outcomes', () => {
+    expect(
+      classifyDispatchError(
+        new AuthorityRefusalError({
+          code: 'above_declared_tier',
+          strategy: 'dev-pipeline',
+          declaredTier: 'T1',
+          attemptedAction: 'write',
+        })
+      )
+    ).toBe('business');
+    expect(classifyDispatchError(new DryRunUnsupportedError('graph-workflow'))).toBe('business');
+  });
+
+  it('classifies a missing executor as a business outcome', () => {
+    expect(classifyDispatchError(new MetaDispatchError('no_executor', 'nothing wired'))).toBe(
+      'business'
+    );
+  });
+
+  it('still calls a genuine fault internal', () => {
+    // Guard the guard: broadening the refusal test must not launder real
+    // defects into "the caller asked for this".
+    expect(classifyDispatchError(new Error('null is not an object'))).toBe('internal');
+    expect(classifyDispatchError(new TypeError('boom'))).toBe('internal');
+  });
+
+  it('classifies a non-no_executor dispatch error as internal', () => {
+    // `MetaDispatchError` is only a business outcome for one code; the others
+    // are wiring faults.
+    expect(classifyDispatchError(new MetaDispatchError('executor_threw', 'boom'))).toBe('internal');
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/run-tool-dry-run.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool-dry-run.test.ts
@@ -31,8 +31,9 @@ describe('classifyDispatchError', () => {
         new AuthorityRefusalError({
           code: 'above_declared_tier',
           strategy: 'dev-pipeline',
-          declaredTier: 'T1',
-          attemptedAction: 'write',
+          declaredTier: 'suggest',
+          attemptedAction: 'enforce',
+          message: 'above declared tier',
         })
       )
     ).toBe('business');
@@ -40,9 +41,11 @@ describe('classifyDispatchError', () => {
   });
 
   it('classifies a missing executor as a business outcome', () => {
-    expect(classifyDispatchError(new MetaDispatchError('no_executor', 'nothing wired'))).toBe(
-      'business'
-    );
+    expect(
+      classifyDispatchError(
+        new MetaDispatchError('no_executor', 'single-shot', 'dec-1', 'nothing wired')
+      )
+    ).toBe('business');
   });
 
   it('still calls a genuine fault internal', () => {
@@ -55,6 +58,10 @@ describe('classifyDispatchError', () => {
   it('classifies a non-no_executor dispatch error as internal', () => {
     // `MetaDispatchError` is only a business outcome for one code; the others
     // are wiring faults.
-    expect(classifyDispatchError(new MetaDispatchError('executor_threw', 'boom'))).toBe('internal');
+    expect(
+      classifyDispatchError(
+        new MetaDispatchError('executor_failed', 'dev-pipeline', 'dec-2', 'boom')
+      )
+    ).toBe('internal');
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/run-tool-dry-run.ts
+++ b/packages/nexus-agents/src/mcp/tools/run-tool-dry-run.ts
@@ -14,7 +14,7 @@
  * @module mcp/tools/run-tool-dry-run
  */
 import { MetaDispatchError } from '../../orchestration/meta-dispatcher.js';
-import { AuthorityRefusalError } from '../../orchestration/authority-tier-guard.js';
+import { PolicyRefusalError } from '../../orchestration/authority-tier-guard.js';
 
 /** The only strategy whose executor stops before implementing. */
 const DRY_RUN_CAPABLE = 'dev-pipeline';
@@ -27,7 +27,7 @@ const DRY_RUN_CAPABLE = 'dev-pipeline';
  * coherent that this route cannot provide. Refusing is the point — executing a
  * run the caller asked to be dry would be worse than any error.
  */
-export class DryRunUnsupportedError extends Error {
+export class DryRunUnsupportedError extends PolicyRefusalError {
   constructor(readonly strategy: string) {
     super(
       `dryRun is not supported by the '${strategy}' strategy — only '${DRY_RUN_CAPABLE}' stops after plan+vote. ` +
@@ -56,8 +56,10 @@ export function assertDryRunSupported(dryRun: boolean | undefined, strategy: str
  * (#4806) are all fail-closed POLICY results, not defects.
  */
 export function classifyDispatchError(err: unknown): 'business' | 'internal' {
-  const noExecutor = err instanceof MetaDispatchError && err.code === 'no_executor';
-  const refused = err instanceof AuthorityRefusalError;
-  const dryRunUnsupported = err instanceof DryRunUnsupportedError;
-  return noExecutor || refused || dryRunUnsupported ? 'business' : 'internal';
+  // #4994: keyed on the shared base rather than a list of classes. Enumerating
+  // them meant `ExecuteEnvelopeRefusalError` — reachable from a plain
+  // `run({ goal, execute: true })`, which routes to a strategy with no execute
+  // envelope — was reported to the caller as an internal defect.
+  if (err instanceof PolicyRefusalError) return 'business';
+  return err instanceof MetaDispatchError && err.code === 'no_executor' ? 'business' : 'internal';
 }

--- a/packages/nexus-agents/src/orchestration/authority-tier-guard.ts
+++ b/packages/nexus-agents/src/orchestration/authority-tier-guard.ts
@@ -135,6 +135,23 @@ export function dispatchActionClass(_mode: DispatchMode): ActionClass {
 export type AuthorityRefusalCode = 'above_declared_tier' | 'tier_undeclared';
 
 /**
+ * Base for fail-closed POLICY refusals — outcomes the caller asked for and can
+ * act on, never engine defects.
+ *
+ * `classifyDispatchError` used to enumerate refusal classes with `instanceof`,
+ * and {@link ExecuteEnvelopeRefusalError} — added later, and deliberately NOT a
+ * subclass of {@link AuthorityRefusalError} because it answers a different
+ * question — fell through to `internal`. So a documented refusal reached the
+ * caller as "the engine has a defect", and on the async path failed the job
+ * with the same framing (#4994).
+ *
+ * A shared base makes the classification structural: a new refusal type is
+ * `business` by construction, and has to opt OUT rather than be silently
+ * misclassified by omission.
+ */
+export abstract class PolicyRefusalError extends Error {}
+
+/**
  * Typed, structured refusal an authority guard produces when a strategy would act
  * above its declared tier. Mirrors {@link MetaDispatchError}'s shape (code +
  * strategy + message) so the dispatch/routing layer reasons about both failures
@@ -142,7 +159,7 @@ export type AuthorityRefusalCode = 'above_declared_tier' | 'tier_undeclared';
  * boundary, but the pure {@link evaluateAuthority} path returns it as data so the
  * router can refuse without exceptions.
  */
-export class AuthorityRefusalError extends Error {
+export class AuthorityRefusalError extends PolicyRefusalError {
   readonly code: AuthorityRefusalCode;
   readonly strategy: ExecutionStrategy;
   /** The tier the strategy's manifest declared (undefined ⇒ none declared). */
@@ -259,7 +276,7 @@ export function guardAuthority(strategy: ExecutionStrategy, actionClass: ActionC
  * above-tier action behind one code, and the operator response differs:
  * declare an envelope vs. seek ratification for a promotion.
  */
-export class ExecuteEnvelopeRefusalError extends Error {
+export class ExecuteEnvelopeRefusalError extends PolicyRefusalError {
   readonly code = 'envelope_undeclared' as const;
   readonly strategy: ExecutionStrategy;
 


### PR DESCRIPTION
Closes finding 1 of #4994. The shadow-sink finding stays open there.

## A documented refusal reported as an engine defect

```
run({ goal: "fix the typo in the README", execute: true })
```

routes to `single-shot` (rule priority 40, sequential + simple), which declares no `executeEnvelope`, so `guardExecuteEnvelope` throws `ExecuteEnvelopeRefusalError` — a deliberate fail-closed policy result whose own message tells the operator what to do about it. The caller was told `errorCategory: 'internal'`, i.e. the engine has a defect. On `dispatch: 'async'` the job was recorded failed with the same framing.

`classifyDispatchError` enumerated refusals with `instanceof`:

```ts
const noExecutor = err instanceof MetaDispatchError && err.code === 'no_executor';
const refused = err instanceof AuthorityRefusalError;
const dryRunUnsupported = err instanceof DryRunUnsupportedError;
```

`ExecuteEnvelopeRefusalError` extends `Error`, not `AuthorityRefusalError` — and that separation is correct and documented in place: the tier guard asks "is this above the strategy's declared authority?", the envelope guard asks "has it declared what executing it can touch at all?", and the operator response differs. The bug was the classifier assuming refusals form a class hierarchy it already knew.

## Fixed structurally, because a list gets it wrong again

Adding one more `instanceof` would fix today's case and lose the next one the same way. The three refusal types now share an abstract `PolicyRefusalError` base and the classifier keys on that:

```ts
if (err instanceof PolicyRefusalError) return 'business';
return err instanceof MetaDispatchError && err.code === 'no_executor' ? 'business' : 'internal';
```

A new refusal type is now a `business` outcome by construction and must opt *out*, rather than being misclassified by omission. `MetaDispatchError` stays a special case because only one of its codes is a policy result; the rest are wiring faults.

`AuthorityRefusalError`'s subclass relationship is unchanged, so every existing `instanceof AuthorityRefusalError` check still behaves identically.

## Tests

`classifyDispatchError` had no test file at all. There is one now, covering all three refusals, both `MetaDispatchError` codes, and two genuine faults.

| mutation | result |
| --- | --- |
| key on `AuthorityRefusalError` again | 2 failed |
| classify everything as `business` | 2 failed |

The second is the guard-the-guard case: broadening the refusal test must not launder real defects into "the caller asked for this."

3,847 tests pass across `src/mcp/tools` and `src/orchestration`. `api-surface.txt` unchanged.
