### PR TITLE
fix(pipeline): surface the dryRun marker on the run_dev_pipeline envelope

### DIFF
--- a/.changeset/dryrun-marker-not-surfaced.md
+++ b/.changeset/dryrun-marker-not-surfaced.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+fix(pipeline): surface the dryRun marker on the run_dev_pipeline envelope
+
+`buildStructuredOutput` builds the MCP response from an explicit field list.
+#4772 added `securityRan` and `planStatus` to `DevPipelineResult`, omitted them
+here, and had to be fixed — leaving a comment that says exactly why: "They were
+added to DevPipelineResult and then not listed here, so they never reached the
+MCP surface."
+
+#4993 then added `dryRun` to the same type, for the same reason (it says
+`completed: false` was the request, not a fault), and did not list it here
+either. A live `run_dev_pipeline({ dryRun: true })` came back with no field
+distinguishing a successful dry run from a failed pipeline.

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.test.ts
@@ -397,6 +397,32 @@ describe('run_dev_pipeline simulateVotes fail-closed gate (#4170)', () => {
     expect(output['planStatus']).toBe('empty');
   });
 
+  it('surfaces the dryRun marker too', async () => {
+    // #4993 added `dryRun` to DevPipelineResult for the same reason as the two
+    // fields above — `completed: false` was the request, not a fault — and then
+    // did not list it in `buildStructuredOutput` either. A live
+    // `run_dev_pipeline({ dryRun: true })` came back with no way to tell a
+    // successful dry run from a failed pipeline. Same omission, same function,
+    // under the comment describing it.
+    runDevPipelineMock.mockResolvedValueOnce({
+      completed: false,
+      dryRun: true,
+      plan: 'a real plan',
+      tasks: [],
+      voteIterations: 2,
+      qaIterations: 0,
+      securityPassed: false,
+      securityRan: false,
+    } as never);
+    const handler = captureHandler();
+
+    const result = await handler({ task: 'Build feature X', dryRun: true }, STDIO_CTX);
+    const output = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
+
+    expect(output['dryRun']).toBe(true);
+    expect(output['completed']).toBe(false);
+  });
+
   it('omits both fields when the pipeline did not report them', async () => {
     // Absent means the producer predates the distinction — not false, not 'empty'.
     const handler = captureHandler();
@@ -406,6 +432,8 @@ describe('run_dev_pipeline simulateVotes fail-closed gate (#4170)', () => {
 
     expect(output).not.toHaveProperty('securityRan');
     expect(output).not.toHaveProperty('planStatus');
+    // The pair for dryRun: an ordinary run must not claim to have been one.
+    expect(output).not.toHaveProperty('dryRun');
   });
 
   it('stays allowed inside a test runner with no simulated flag (existing suites unaffected)', async () => {

--- a/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/dev-pipeline-tool.ts
@@ -317,6 +317,12 @@ function buildStructuredOutput(
     // here, so they never reached the MCP surface.
     ...(result.securityRan !== undefined ? { securityRan: result.securityRan } : {}),
     ...(result.planStatus !== undefined ? { planStatus: result.planStatus } : {}),
+    // #4993 added `dryRun` to DevPipelineResult for exactly the reason above —
+    // it says `completed: false` was the request, not a fault — and then did
+    // not list it here either. Same omission, same function, under the comment
+    // describing it. A live `run_dev_pipeline({ dryRun: true })` came back with
+    // no way to tell a successful dry run from a failed pipeline.
+    ...(result.dryRun !== undefined ? { dryRun: result.dryRun } : {}),
     voteIterations: result.voteIterations,
     qaIterations: result.qaIterations,
     plan: result.plan,


### PR DESCRIPTION
Found by running the tool against the freshly updated install rather than by reading code.

```
run_dev_pipeline({ task: '...', dryRun: true, quickMode: true })
→ {"completed":false,"securityPassed":false,"securityRan":false,
   "planStatus":"empty","voteIterations":1,"qaIterations":0,"plan":"","tasks":[]}
```

No `dryRun` field. `buildStructuredOutput` (`dev-pipeline-tool.ts:303`) builds the response from an explicit field list, and #4993 added `dryRun` to `DevPipelineResult` without listing it there.

## This is the second time in the same function

#4772 added `securityRan` and `planStatus`, omitted them from this list, and the follow-up fix left a comment saying why it matters:

> They were added to DevPipelineResult and then not listed here, so they never reached the MCP surface.

There is even a test for it (`dev-pipeline-tool.test.ts:378`) whose comment reads *"The field exists" and "a caller sees it" are different claims.* I added a field to that type and repeated the omission underneath both.

The marker is what tells a caller that `completed: false` was the request rather than a fault, so without it the MCP surface still cannot distinguish a successful dry run from a failed pipeline — which is the whole point of #4993.

| mutation | result |
| --- | --- |
| drop the field again | 1 failed |
| claim `dryRun: true` unconditionally | 1 failed |

The second is the pair: an ordinary run must not claim to have been a dry run. Extended the existing omission test to cover it.