### PR TITLE
fix(review): stop a PR review where every expert failed from approving

### DIFF
--- a/.changeset/pr-review-failed-experts.md
+++ b/.changeset/pr-review-failed-experts.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+fix(review): stop a PR review where every expert failed from approving
+
+`createFailedReview` returned `approved: true` — "don't block on failures" — so
+an expert whose adapter never ran was indistinguishable from one that read the
+diff and had no objection. With the default three experts and an unavailable
+adapter, `determineDecision` saw no findings and unanimous approval, resolved to
+`approve` at 100% consensus, and `postReviewToGitHub` submitted a real APPROVE
+event on a PR nobody read.
+
+It also defeated the guard added for exactly this class: `allOf(reviews, …,
+whenEmpty: false)` (#4581) refuses to call _zero_ reviews unanimous approval,
+and three synthetic approvals walked around it by making the list non-empty.
+
+`ExpertReviewResult` now carries `errored`, a failed expert is `approved: false`,
+and the decision is computed over experts that produced a verdict — refusing to
+approve when none did. A HIGH finding on an unreviewed PR still reports
+`request_changes`, not `comment`.

--- a/packages/nexus-agents/src/dogfooding/pr-review-types.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-review-types.ts
@@ -123,6 +123,18 @@ export interface ExpertReviewResult {
   readonly durationMs: number;
   /** Confidence in review (0-1) */
   readonly confidence: number;
+  /**
+   * The expert never produced a verdict — its adapter failed or returned
+   * nothing (#5012).
+   *
+   * `approved` cannot express this. A failed expert used to be recorded as
+   * `approved: true` ("don't block on failures"), so a review in which every
+   * expert failed resolved to `approve` at 100% consensus and was posted to
+   * GitHub as a real APPROVE. Absence of a review is not approval — a consumer
+   * must be able to tell them apart, and `confidence: 0` was already present
+   * and already ignored.
+   */
+  readonly errored?: boolean;
 }
 
 /**

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.test.ts
@@ -368,6 +368,41 @@ describe('Decision Helpers', () => {
       expect(determineDecision([], findings)).toBe('request_changes');
     });
 
+    it('does not approve when every expert failed (#5012)', () => {
+      // The defect: `createFailedReview` returned `approved: true`, so three
+      // failed experts became three synthetic approvals — `findings` empty,
+      // `allApproved` true — and the review resolved to APPROVE at 100%
+      // consensus, then posted to GitHub as a real approval event.
+      const reviews: ExpertReviewResult[] = [
+        createFailedReview('security-expert', 'security', 10, 'adapter unavailable'),
+        createFailedReview('quality-expert', 'code_quality', 10, 'adapter unavailable'),
+        createFailedReview('testing-expert', 'testing', 10, 'adapter unavailable'),
+      ];
+
+      expect(determineDecision(reviews, [])).toBe('comment');
+    });
+
+    it('still approves when a real expert reviewed and found nothing', () => {
+      // The pair: refusing to approve an unreviewed PR must not stop a genuine
+      // clean review from approving.
+      const reviews: ExpertReviewResult[] = [createMockExpertReview({ approved: true })];
+
+      expect(determineDecision(reviews, [])).toBe('approve');
+    });
+
+    it('does not let a failed expert downgrade a HIGH finding (#5012)', () => {
+      // The #4581 guard — `allOf(reviews, …, whenEmpty: false)` — exists so an
+      // unreviewed PR cannot count as unanimous approval and quietly downgrade
+      // `request_changes` to `comment`. A synthetic `approved: true` for a
+      // failed expert defeated it by making the list non-empty.
+      const reviews: ExpertReviewResult[] = [
+        createFailedReview('testing-expert', 'testing', 10, 'timeout'),
+      ];
+      const findings: ReviewFinding[] = [createMockFinding({ severity: 'high' })];
+
+      expect(determineDecision(reviews, findings)).toBe('request_changes');
+    });
+
     it('should comment when medium/low findings exist', () => {
       const findings: ReviewFinding[] = [createMockFinding({ severity: 'medium' })];
       const reviews: ExpertReviewResult[] = [createMockExpertReview({ approved: true })];
@@ -677,12 +712,16 @@ describe('GitHub Comment Formatting', () => {
 
 describe('Failed Review Factory', () => {
   describe('createFailedReview', () => {
-    it('should create failed review with default approved=true', () => {
+    it('marks a failed review as errored, not approved (#5012)', () => {
+      // Was `approved: true` — "don't block on failures" — which made an expert
+      // that never ran indistinguishable from one that read the diff and had no
+      // objection. Three of those resolved to an APPROVE posted to GitHub.
       const review = createFailedReview('security-expert', 'security', 100, 'Timeout');
 
       expect(review.expertId).toBe('security-expert');
       expect(review.expertType).toBe('security');
-      expect(review.approved).toBe(true); // Don't block on failures
+      expect(review.approved).toBe(false);
+      expect(review.errored).toBe(true);
       expect(review.summary).toContain('Timeout');
       expect(review.findings).toEqual([]);
       expect(review.durationMs).toBe(100);

--- a/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.ts
+++ b/packages/nexus-agents/src/dogfooding/pr-reviewer-helpers.ts
@@ -255,16 +255,24 @@ export function determineDecision(
   reviews: ExpertReviewResult[],
   findings: ReviewFinding[]
 ): ReviewDecision {
+  // #5012: an expert that errored produced no verdict, so it can neither
+  // approve nor object. `allOf(reviews, …, false)` already refuses to call
+  // ZERO reviews unanimous approval (#4581); feeding it synthetic approvals
+  // for failed experts defeated that guard by making the list non-empty.
+  const verdicts = reviews.filter((r) => r.errored !== true);
   const hasCritical = findings.some((f) => f.severity === 'critical');
   const hasHigh = findings.some((f) => f.severity === 'high');
   // Zero expert reviews is not unanimous approval (#4581): with `true` here the
   // `hasHigh && !allApproved` branch could never fire on an unreviewed PR, so a
   // HIGH finding silently downgraded from request_changes to comment.
-  const allApproved = allOf(reviews, (r) => r.approved, false);
+  const allApproved = allOf(verdicts, (r) => r.approved, false);
 
   if (hasCritical) return 'request_changes';
   if (hasHigh && !allApproved) return 'request_changes';
   if (findings.length > 0) return 'comment';
+  // Nothing read the diff, so there is nothing to approve. `comment` posts the
+  // failure summaries without asserting the change is fine.
+  if (verdicts.length === 0) return 'comment';
   return 'approve';
 }
 
@@ -428,7 +436,12 @@ export function createFailedReview(
   return {
     expertId,
     expertType: category,
-    approved: true, // Don't block on failures
+    // #5012: NOT `approved: true`. "Don't block on failures" made an expert
+    // that never ran indistinguishable from one that read the diff and had no
+    // objection, and `determineDecision` turned three of those into an APPROVE
+    // posted to GitHub.
+    approved: false,
+    errored: true,
     summary: `Review failed: ${error}`,
     findings: [],
     durationMs,


### PR DESCRIPTION
Closes #5012.

## A review where nothing ran approves the PR on GitHub

`createFailedReview` (`pr-reviewer-helpers.ts:431`) returned a synthetic approval on every failure path:

```ts
approved: true, // Don't block on failures
summary: `Review failed: ${error}`,
findings: [],
confidence: 0,
```

Default config is three experts and `dryRun: false`. If the adapter is unavailable for all three, `determineDecision` sees no findings and unanimous approval → `'approve'`, `calculateConsensus` returns `3/3`, and `pr-reviewer.ts:118` calls `provider.createReview(prNumber, body, 'approve')`. The CLI prints `Decision: APPROVE / Consensus: 100% / No issues found.` — the `"Review failed: …"` strings appear only under `--verbose`.

Reachable whenever `ANTHROPIC_API_KEY` is unset or the circuit breaker is open — and per #5011 an open circuit can persist indefinitely under load.

## It walked around the guard built for this

`determineDecision:262` uses `allOf(reviews, r => r.approved, false)` with `whenEmpty: false`, added by #4581 so that zero reviews is not unanimous approval. Three fabricated approvals defeat it by making the list non-empty. `confidence: 0` was already on the record and already ignored.

## The fix, and the ordering mistake I made first

`ExpertReviewResult` gains `errored`; a failed expert is `approved: false, errored: true`; the decision is computed over experts that produced a verdict.

My first attempt early-returned `'comment'` when no verdicts existed — which broke #4581's own case, because a HIGH finding on an unreviewed PR must still be `request_changes`. The existing test caught it immediately. The no-verdict guard belongs **after** the severity checks, so an unreviewed PR with a HIGH finding still blocks.

## Tests

`pr-reviewer-helpers.test.ts:685` asserted `review.approved).toBe(true)` as intended behaviour — updated, since the behaviour was the bug.

| mutation | result |
| --- | --- |
| restore `approved: true` | 3 failed |
| drop the no-verdict guard | 1 failed |

Three new tests: all-experts-failed does not approve; a genuine clean review still does; and a single failed expert cannot downgrade a HIGH finding — that last one discriminates the fix, since the old code produced `comment` there and the new code produces `request_changes`.

169 tests pass across `src/dogfooding`. `api-surface.txt` unchanged.