### PR TITLE
fix(observability): stop a non-auditable fitness result emitting a below-floor signal

### DIFF
--- a/.changeset/fitness-signal-unauditable.md
+++ b/.changeset/fitness-signal-unauditable.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix(observability): stop a non-auditable fitness result emitting a below-floor signal
+
+`emitFitnessDeclinedSignal` gated only on `audit.score >= fitnessFloor`. Its
+sibling `detectFitnessSignals` has refused `auditable === false` since #3621 —
+the not-source-repo sentinel carries a meaningless score of 0, which is "could
+not audit", not "fitness is low" — and both are handed the same audit object.
+
+So `improvement_review` run from the global npm install, where the bundled
+`src/` lacks `cli-adapters/`, emitted `signal.fitness_declined { score: 0,
+floor: 90 }` onto the pipeline bus, and `tune-stage` turned that into a
+"fitness 0 below floor 90" tech-debt flag for a repo that was never audited. The
+response payload carries no fitness field, so the fabricated signal was
+invisible at the tool boundary.
+
+The rule now lives in one exported predicate, `isAuditableScore`, that both
+consumers call, so they cannot drift apart again.

--- a/packages/nexus-agents/src/governance/fitness-score.ts
+++ b/packages/nexus-agents/src/governance/fitness-score.ts
@@ -172,6 +172,21 @@ export interface FitnessAudit {
 }
 
 /**
+ * Whether an audit's score is a real measurement rather than the
+ * "could not audit from here" sentinel (#3621).
+ *
+ * Exported as one predicate because the guard was applied by
+ * `detectFitnessSignals` and missed by `emitFitnessDeclinedSignal`, which was
+ * handed the same audit object and emitted `signal.fitness_declined` with the
+ * sentinel's score of 0 — a tech-debt signal claiming catastrophic fitness for
+ * a repo that was never audited (#5014). Two consumers of one rule should not
+ * each carry their own copy of it.
+ */
+export function isAuditableScore(audit: Pick<FitnessAudit, 'auditable'>): boolean {
+  return audit.auditable !== false;
+}
+
+/**
  * Individual finding from audit.
  */
 export interface FitnessFinding {
@@ -242,9 +257,7 @@ export class FitnessScoreCalculator {
     reg('configSimplicity', 'Config Simplicity', () => this.checkConfigSimplicity());
     reg('layerSeparation', 'Layer Separation', () => this.checkLayerSeparation());
     reg('operatorErgonomics', 'Operator Ergonomics', () => this.checkOperatorErgonomics());
-    reg('governanceIntegration', 'Governance Integration', () =>
-      this.checkGovernanceIntegration()
-    );
+    reg('governanceIntegration', 'Governance Integration', () => this.checkGovernanceIntegration());
   }
 
   /** Run full fitness audit. */

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-signals.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-signals.test.ts
@@ -156,3 +156,59 @@ describe('end-to-end: declined fitness → signal → shadow TuneStage (#3147)',
     );
   });
 });
+
+describe('emitFitnessDeclinedSignal — non-auditable results (#5014)', () => {
+  function bus(): { emit: ReturnType<typeof vi.fn> } {
+    return { emit: vi.fn() };
+  }
+  const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  it('emits nothing when the audit could not run', () => {
+    // `auditable: false` is the not-source-repo sentinel: score 0 means "could
+    // not audit", not "fitness is low". `detectFitnessSignals` has refused this
+    // since #3621; this emitter was handed the same audit object and did not,
+    // so `improvement_review` run from the global npm install published
+    // `signal.fitness_declined { score: 0, floor: 90 }` and `tune-stage` turned
+    // it into a "fitness 0 below floor 90" tech-debt flag for a repo nobody
+    // audited. The response payload carries no fitness field, so the fabricated
+    // signal was invisible at the tool boundary.
+    const b = bus();
+
+    emitFitnessDeclinedSignal(
+      {
+        score: 0,
+        auditable: false,
+        findings: [],
+        dimensions: {},
+        timestamp: '',
+        version: '',
+      } as never,
+      90,
+      b as never,
+      logger as never
+    );
+
+    expect(b.emit).not.toHaveBeenCalled();
+  });
+
+  it('still emits for a genuine below-floor audit', () => {
+    // The pair: refusing the sentinel must not silence real low fitness.
+    const b = bus();
+
+    emitFitnessDeclinedSignal(
+      {
+        score: 40,
+        auditable: true,
+        findings: [],
+        dimensions: {},
+        timestamp: '',
+        version: '',
+      } as never,
+      90,
+      b as never,
+      logger as never
+    );
+
+    expect(b.emit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nexus-agents/src/mcp/tools/improvement-review-signals.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review-signals.ts
@@ -14,6 +14,7 @@
 import { getErrorMessage, getTimeProvider } from '../../core/index.js';
 import type { ILogger } from '../../core/index.js';
 import type { FitnessAudit } from '../../governance/fitness-score.js';
+import { isAuditableScore } from '../../governance/fitness-score.js';
 import type { IEventBus } from '../../pipeline/event-types.js';
 
 /** The dimension of the finding that deducted the most points, if any. */
@@ -38,6 +39,11 @@ export function emitFitnessDeclinedSignal(
   bus: IEventBus,
   logger: ILogger
 ): void {
+  // #5014: a non-auditable result carries a meaningless score of 0 — "could
+  // not audit", not "fitness is low". `detectFitnessSignals` has guarded this
+  // since #3621; this emitter was handed the same audit object and did not,
+  // so it published a below-floor tech-debt signal for a repo nobody audited.
+  if (!isAuditableScore(audit)) return;
   if (audit.score >= fitnessFloor) return;
   try {
     const dimension = worstDimension(audit);

--- a/packages/nexus-agents/src/mcp/tools/improvement-review.ts
+++ b/packages/nexus-agents/src/mcp/tools/improvement-review.ts
@@ -25,6 +25,7 @@ import { createLogger, formatZodError, getErrorMessage, type ILogger } from '../
 import { wrapToolWithTimeout, toSdkCallback, getToolTimeout } from '../middleware/tool-wrapper.js';
 import { createSecureHandler, type HandlerContext } from '../middleware/secure-handler.js';
 import { withPrerequisite } from '../middleware/tool-prerequisites.js';
+import { isAuditableScore } from '../../governance/fitness-score.js';
 import {
   toolStructuredError,
   toolSuccessStructured,
@@ -477,9 +478,8 @@ const MAX_FINDINGS_IN_DIMENSION_BODY = 10;
  * explicit, documented mechanism: add a dimension here (with the reason) rather
  * than letting a perpetually-below-target dimension spam the loop.
  */
-const STRUCTURALLY_UNREACHABLE_DIMENSIONS: ReadonlySet<FitnessDimension> = new Set<FitnessDimension>(
-  []
-);
+const STRUCTURALLY_UNREACHABLE_DIMENSIONS: ReadonlySet<FitnessDimension> =
+  new Set<FitnessDimension>([]);
 
 /** The closed set of known dimensions — validate findings-as-data against this. */
 const KNOWN_DIMENSIONS: ReadonlySet<FitnessDimension> = new Set(
@@ -521,9 +521,12 @@ function buildCriticalFindingSignal(finding: FitnessFinding): ImprovementSignal 
     signalKey: `tech-debt:fitness-critical:${finding.dimension}`,
     severity: 'critical',
     title: `tech-debt: critical fitness finding in ${finding.dimension}`,
-    body: [`Fitness audit returned a CRITICAL finding.`, '', `- Dimension: \`${finding.dimension}\``, ...findingBodyLines(finding)].join(
-      '\n'
-    ),
+    body: [
+      `Fitness audit returned a CRITICAL finding.`,
+      '',
+      `- Dimension: \`${finding.dimension}\``,
+      ...findingBodyLines(finding),
+    ].join('\n'),
     evidence: { observedValue: -finding.pointsDeducted },
   };
 }
@@ -663,8 +666,9 @@ export function detectFitnessSignals(
   const signals: ImprovementSignal[] = [];
   // #3621: a non-auditable result (e.g. run from the global npm install) has a
   // meaningless score of 0 — it is "could not audit", not "fitness is low". Do
-  // not emit a spurious below-floor tech-debt signal for it.
-  if (audit.auditable === false) return signals;
+  // not emit a spurious below-floor tech-debt signal for it. Shared predicate
+  // since #5014, where the sibling emitter carried no copy of this rule.
+  if (!isAuditableScore(audit)) return signals;
   if (audit.score < fitnessFloor) signals.push(buildFloorSignal(audit, fitnessFloor));
   for (const finding of audit.findings) {
     if (finding.severity === 'critical') signals.push(buildCriticalFindingSignal(finding));


### PR DESCRIPTION
Closes #5014.

## One audit object, two consumers, one guard

`emitFitnessDeclinedSignal` (`improvement-review-signals.ts:41`) gated only on `audit.score >= fitnessFloor`. Its sibling `detectFitnessSignals` (`improvement-review.ts:667`) has refused `auditable === false` since #3621, with the reason written down: the not-source-repo sentinel carries a meaningless score of 0, and that is *"could not audit"*, not *"fitness is low"*. `improvement-review.ts:1027` hands both functions the same object.

So `improvement_review` run through the global npm install — the configured `.mcp.json` path, where the bundled `src/` lacks `cli-adapters/` — emitted `signal.fitness_declined { score: 0, floor: 90 }`, and `tune-stage` turned it into a `flag_tech_debt` reading "fitness 0 below floor 90" for a repo nobody audited. The response payload has no fitness field, so nothing at the tool boundary disclosed it.

## Hoisted, not copied

A second copy of the guard fixes today's case and leaves the next consumer free to miss it identically. The rule is now one exported predicate, `isAuditableScore`, called by both — which is also where the `auditable` field's contract ("consumers MUST NOT treat a `false` audit's score as a signal") can actually live.

| mutation | result |
| --- | --- |
| drop the emitter guard | 1 failed |
| emitter never emits | 6 failed |

The second is the pair: refusing the sentinel must not silence genuine low fitness. `improvement-review-signals.test.ts` had no `auditable` case at all; it has both directions now.

52 tests pass across the improvement-review suites. `api-surface.txt` unchanged.

## A wrong turn worth recording

Mid-investigation I grepped for `auditable` across the tree, found no consumer outside the type definition, and started writing up a strictly worse finding: that **nothing** guarded this. It was wrong — I had already rewritten the sibling's `audit.auditable === false` into `!isAuditableScore(audit)`, so my own edit had removed the string I was searching for. The compiler caught it (missing import) before it reached the issue. "Grep finds nothing" is only evidence when the tree is clean.