### PR TITLE
fix(security): stop an OSV outage reading as a clean dependency scan

### DIFF
--- a/.changeset/osv-outage-reads-as-clean.md
+++ b/.changeset/osv-outage-reads-as-clean.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+fix(security): stop an OSV outage reading as a clean dependency scan
+
+`runOsvCheck` flat-mapped only `vulnerabilities` off each lookup and discarded
+the `error` field. `queryOsv` returns `{ vulnerabilities: [], error }` on a
+non-200 or a timeout, so an unreachable OSV API produced an empty array —
+byte-identical to a clean scan — and `buildScanSummary` appended "none
+blocking". The OSV half of the gate could not fail when the network was down.
+
+The summary now says how many lookups failed instead, and states the
+denominator the OSV verdict covers: the query is capped at 20 dependencies and
+`devDependencies` are never queried, neither of which was disclosed.
+
+This is the claim `run_quality_gate`'s own description makes — "a run in which
+nothing executed reports verdict 'skip', never 'pass': no evidence is not a
+pass" — applied to the dimension that was not honouring it.

--- a/packages/nexus-agents/src/pipeline/security-gate.test.ts
+++ b/packages/nexus-agents/src/pipeline/security-gate.test.ts
@@ -6,6 +6,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { checkSecurityScan } from './security-gate.js';
 
 // Mock the security scan to avoid needing semgrep
+const queryOsvBatchMock = vi.fn();
+vi.mock('../security/osv-lookup.js', () => ({
+  queryOsvBatch: (deps: unknown): unknown => queryOsvBatchMock(deps),
+}));
+
 vi.mock('../mcp/tools/security-scan.js', () => ({
   executeSecurityScan: vi.fn(),
 }));
@@ -163,5 +168,38 @@ describe('checkSecurityScan', () => {
     // because its verdict went missing (fail-safe). Pre-#2933 the count was 1.
     expect(result.verdict).toBe('fail');
     expect(result.details).toContain('2 confirmed blocking');
+  });
+});
+
+describe('OSV lookup failures are not a clean scan (#5018)', () => {
+  const cleanScan = { scanner: 'semgrep', totalFindings: 0, findings: [] };
+
+  it('says OSV was not checked when the lookups errored', async () => {
+    // `queryOsv` returns `{ vulnerabilities: [], error: 'HTTP 503' }` on a
+    // non-200 or a timeout. `runOsvCheck` flat-mapped only `vulnerabilities`,
+    // so an unreachable OSV API was byte-identical to a clean dependency scan
+    // and the summary said "none blocking".
+    mockScan.mockResolvedValue(cleanScan as never);
+    queryOsvBatchMock.mockResolvedValue([
+      { packageName: 'left-pad', vulnerabilities: [], error: 'HTTP 503' },
+    ]);
+
+    const result = await checkSecurityScan(process.cwd(), ['p/default'], { enableOsv: true })();
+
+    expect(result.details).toContain('OSV not checked');
+    expect(result.details).not.toContain('none blocking');
+  });
+
+  it('still says none blocking when OSV genuinely found nothing', async () => {
+    // The pair: a real clean result must not be reported as unchecked.
+    mockScan.mockResolvedValue(cleanScan as never);
+    queryOsvBatchMock.mockResolvedValue([
+      { packageName: 'left-pad', vulnerabilities: [], error: null },
+    ]);
+
+    const result = await checkSecurityScan(process.cwd(), ['p/default'], { enableOsv: true })();
+
+    expect(result.details).toContain('none blocking');
+    expect(result.details).not.toContain('OSV not checked');
   });
 });

--- a/packages/nexus-agents/src/pipeline/security-gate.ts
+++ b/packages/nexus-agents/src/pipeline/security-gate.ts
@@ -135,7 +135,8 @@ async function runTriagePipeline(
   recordTriageLifecycle(triageResult.triaged, lifecycleEntries);
 
   // Step 3: OSV dependency check (#1773)
-  const osvVulns = await runOsvCheck(targetDir, config.enableOsv ?? true);
+  const osv = await runOsvCheck(targetDir, config.enableOsv ?? true);
+  const osvVulns = osv.vulnerabilities;
   lastOsvVulnerabilities = osvVulns;
 
   // Assess: only confirmed findings block
@@ -145,7 +146,8 @@ async function runTriagePipeline(
     sarifResult.totalFindings,
     confirmed.length,
     lifecycle.falsePositiveCount,
-    osvVulns.length
+    osvVulns.length,
+    osv
   );
 
   logger.info('Security gate complete', {
@@ -153,6 +155,7 @@ async function runTriagePipeline(
     confirmed: confirmed.length,
     falsePositives: lifecycle.falsePositiveCount,
     osvVulns: osvVulns.length,
+    osvFailedLookups: osv.failedLookups,
   });
 
   const failed = confirmed.length > 0 || osvVulns.some((v) => v.severity === 'CRITICAL');
@@ -186,28 +189,63 @@ function recordTriageLifecycle(
 }
 
 /** Run OSV dependency check if enabled (#1773). */
-async function runOsvCheck(targetDir: string, enabled: boolean): Promise<OsvVulnerability[]> {
-  if (!enabled) return [];
+/**
+ * Result of the OSV dependency lookup, carrying what it could NOT check.
+ *
+ * #5018: this returned a bare array, so an unreachable OSV API produced `[]`
+ * — byte-identical to a clean scan — and `buildScanSummary` folded it into
+ * "none blocking". `queryOsv` reports `{ vulnerabilities: [], error }` on a
+ * non-200 or a timeout; the error was never read.
+ */
+interface OsvCheckResult {
+  readonly vulnerabilities: OsvVulnerability[];
+  /** Lookups that returned an error rather than a verdict. */
+  readonly failedLookups: number;
+  /** Dependencies queried, and how many the manifest declared. */
+  readonly queried: number;
+  readonly declared: number;
+}
+
+const OSV_EMPTY: OsvCheckResult = {
+  vulnerabilities: [],
+  failedLookups: 0,
+  queried: 0,
+  declared: 0,
+};
+
+/** Dependencies queried per run. The cap is disclosed in the scan summary. */
+const OSV_DEPENDENCY_CAP = 20;
+
+async function runOsvCheck(targetDir: string, enabled: boolean): Promise<OsvCheckResult> {
+  if (!enabled) return OSV_EMPTY;
   try {
     const fs = await import('node:fs');
     const path = await import('node:path');
     const pkgPath = path.join(targetDir, 'package.json');
-    if (!fs.existsSync(pkgPath)) return [];
+    if (!fs.existsSync(pkgPath)) return OSV_EMPTY;
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as {
       dependencies?: Record<string, string>;
     };
+    const declared = Object.keys(pkg.dependencies ?? {}).length;
     const deps = Object.entries(pkg.dependencies ?? {})
-      .slice(0, 20)
+      .slice(0, OSV_DEPENDENCY_CAP)
       .map(([name, version]) => ({
         name,
         version: version.replace(/^[\^~>=<]+/, ''),
       }));
-    if (deps.length === 0) return [];
+    if (deps.length === 0) return OSV_EMPTY;
     const results = await queryOsvBatch(deps);
-    return results.flatMap((r) => [...r.vulnerabilities]);
+    return {
+      vulnerabilities: results.flatMap((r) => [...r.vulnerabilities]),
+      // The half that used to be dropped: a 503 or a timeout yields an empty
+      // `vulnerabilities` array with an `error` set, which read as "clean".
+      failedLookups: results.filter((r) => r.error !== null).length,
+      queried: deps.length,
+      declared,
+    };
   } catch (error) {
     logger.debug('OSV check skipped', { error: String(error) });
-    return [];
+    return OSV_EMPTY;
   }
 }
 
@@ -239,12 +277,28 @@ function buildScanSummary(
   total: number,
   confirmed: number,
   falsePositives: number,
-  osvCount: number
+  osvCount: number,
+  osv?: OsvCheckResult
 ): string {
   const parts = [`${String(total)} SAST findings`];
   if (falsePositives > 0) parts.push(`${String(falsePositives)} filtered as false positives`);
   if (confirmed > 0) parts.push(`${String(confirmed)} confirmed blocking`);
   if (osvCount > 0) parts.push(`${String(osvCount)} OSV dependency vulnerabilities`);
-  if (confirmed === 0 && osvCount === 0) parts.push('none blocking');
+  // #5018: an OSV outage used to land here as "none blocking". A lookup that
+  // errored produced no vulnerabilities, which is not the same as finding none.
+  if (osv !== undefined && osv.failedLookups > 0) {
+    parts.push(
+      `OSV not checked for ${String(osv.failedLookups)} of ${String(osv.queried)} dependencies (lookup failed)`
+    );
+  } else if (confirmed === 0 && osvCount === 0) {
+    parts.push('none blocking');
+  }
+  // State the denominator the OSV verdict actually covers: the query is capped,
+  // and devDependencies are never queried at all.
+  if (osv !== undefined && osv.declared > osv.queried) {
+    parts.push(
+      `OSV covered ${String(osv.queried)} of ${String(osv.declared)} declared dependencies`
+    );
+  }
   return parts.join(', ');
 }


### PR DESCRIPTION
Closes #5018.

## The OSV half of the gate could not fail

`runOsvCheck` flat-mapped only `vulnerabilities` and discarded each lookup's `error`. `queryOsv` returns `{ vulnerabilities: [], error: 'HTTP 503' }` on a non-200 and the same shape on timeout, so an unreachable OSV API produced an empty array — byte-identical to a clean scan — and `buildScanSummary` appended `'none blocking'`.

Reachable by default: `run_quality_gate({ checks: ['security'] })` passes `config = {}`, so `enableOsv` defaults to `true`. The only existing test passes `enableOsv: false`, so the default-on path had no coverage.

It also contradicts the tool's own description: *"a run in which nothing executed reports verdict 'skip', never 'pass': no evidence is not a pass."*

## Two undisclosed denominators, fixed alongside

The query is capped at 20 dependencies (`.slice(0, 20)`) and reads only `pkg.dependencies` — **`devDependencies` are never queried**. "none blocking" was reported over that unstated denominator. The summary now states `OSV covered N of M declared dependencies` when the cap bites.

## What I deliberately did not change

The verdict still does not fail on an OSV outage. Turning a dependency-service outage into a red gate is a policy decision with real cost — CI goes red because someone else's API is down — and the honest report is the prerequisite for making that call, not a substitute for it. Filed the question rather than deciding it in a bug fix.

| mutation | result |
| --- | --- |
| never count failed lookups | 1 failed |
| always claim unchecked | 2 failed |

The second is the pair: a genuinely clean OSV result must still say "none blocking".

695 tests pass across `src/pipeline`.

## Note on the `error` contract

First pass used `r.error !== undefined`; the field is `string | null` (`osv-lookup.ts:41`), so that predicate was always true and lint's `no-unnecessary-condition` caught it. Worth noting because the mutation table above would still have looked green — the always-true version fails only the second test, not the first.