### PR TITLE
fix(adapters): let an open circuit recover while traffic continues

### DIFF
--- a/.changeset/circuit-breaker-reset-window.md
+++ b/.changeset/circuit-breaker-reset-window.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix(adapters): let an open circuit recover while traffic continues
+
+The reset window was measured from `lastFailureTime`, and `onFailure` updated
+that field unconditionally — including while the circuit was already open. Since
+an open circuit does not shed load on the default paths (`base-adapter` and
+`resilient-adapter` never consult `canExecute`), traffic kept arriving, kept
+failing occasionally, and each failure pushed the half-open probe another 30s
+out. Recovery required a 30-second window containing zero failures; under
+concurrent panel traffic with a 5% residual error rate that window never
+arrived, and `isCliServingForVoters` kept the CLI out of every voter panel until
+a manual `reset()`.
+
+A failure recorded while open is now ignored, and the window is measured from
+the state transition rather than the last failure. Remedy chosen by a 7-voter
+panel: Option A, 4 of 5 approvers, audit record #79 — the load-shedding half
+(gating the default call paths on `canExecute`) was deliberately not taken.

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
@@ -135,6 +135,34 @@ describe('CliCircuitBreaker', () => {
       expect(fn).not.toHaveBeenCalled();
     });
 
+    it('recovers on schedule even while failures keep arriving (#5011)', () => {
+      // The defect: the reset window was measured from `lastFailureTime`, and
+      // `onFailure` updated it unconditionally — including while already open.
+      // Since an open circuit does not shed load on the default paths, traffic
+      // kept arriving and each failure pushed the half-open probe another
+      // 30s out. A CLI serving 95% of requests correctly stayed evicted from
+      // every voter panel until a manual reset.
+      expect(breaker.getState()).toBe('open');
+
+      // Two-thirds of the way through the window, a straggler fails.
+      vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs * 0.7);
+      breaker.recordFailure('unknown');
+
+      // Past the window measured from the TRANSITION, not from that failure.
+      vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs * 0.4);
+
+      expect(breaker.getState()).toBe('half-open');
+    });
+
+    it('does not re-probe before the window has elapsed', () => {
+      // The pair: fixing the restart must not make the circuit probe early.
+      expect(breaker.getState()).toBe('open');
+
+      vi.advanceTimersByTime(DEFAULT_CIRCUIT_BREAKER_CONFIG.resetTimeoutMs - 1);
+
+      expect(breaker.getState()).toBe('open');
+    });
+
     it('should transition to half-open after reset timeout', () => {
       expect(breaker.getState()).toBe('open');
 

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
@@ -179,8 +179,17 @@ export class CliCircuitBreaker implements ICircuitBreaker {
   }
 
   private checkStateTransition(): void {
-    if (this.state === 'open' && this.lastFailureTime !== null) {
-      const elapsed = getTimeProvider().now() - this.lastFailureTime;
+    if (this.state === 'open') {
+      // #5011: measured from the TRANSITION, not from the last failure. Keyed
+      // on `lastFailureTime` the window restarted on every failure recorded
+      // while open — and an open circuit does not shed load on the default
+      // paths (`base-adapter` and `resilient-adapter` never consult
+      // `canExecute`), so traffic kept arriving, kept failing occasionally, and
+      // kept pushing the half-open probe another 30s out. A CLI serving 95% of
+      // requests correctly stayed evicted from every voter panel until a manual
+      // `reset()`. Panel choice: fix the timer, leave load-shedding alone
+      // (7-voter panel, Option A, 4 of 5 approvers, audit record #79).
+      const elapsed = getTimeProvider().now() - this.lastStateChange;
       if (elapsed >= this.config.resetTimeoutMs) {
         this.transitionTo('half-open', 'Reset timeout elapsed');
       }
@@ -200,6 +209,16 @@ export class CliCircuitBreaker implements ICircuitBreaker {
   }
 
   private onFailure(category: FailureCategory): void {
+    // #5011: a failure recorded while the circuit is already open carries no
+    // information — the circuit is open, that is the verdict — and updating
+    // `lastFailureTime` here is what delayed recovery. This is the operative
+    // half of the fix; the `lastStateChange` change in `checkStateTransition`
+    // is redundant with it (nothing else advances `lastFailureTime` while
+    // open) and is kept because measuring recovery from the transition is what
+    // the window actually means. `failureCount` stays put too: it drives the
+    // closed-state threshold and is reset on the transition back to closed.
+    if (this.state === 'open') return;
+
     this.failureCount++;
     this.lastFailureTime = getTimeProvider().now();
 


### PR DESCRIPTION
Closes #5011. Remedy chosen by a 7-voter panel: **Option A**, 4 of 5 approvers, 83.3%, audit record #79.

## The defect

`checkStateTransition` measured the reset window from `lastFailureTime`, and `onFailure` set that field unconditionally — including when the state was already `open`, where neither transition branch runs. So the sole effect of recording a failure on an open circuit was pushing the half-open probe another 30s out.

Harmless under the classic pattern, where an open circuit sheds load and records no further failures. It does not shed load here: `canExecute` is reachable only through `CircuitBreaker.execute()`, whose one production caller is `cli-circuit-breaker.ts:245`, and the only non-test construction of that integration is in `expert-bridge.ts:286`. `base-adapter.ts:194-203` and `resilient-adapter.ts:116-137` both dispatch without consulting it.

Result: five failures open claude's circuit, `isCliServingForVoters` drops claude from every voter panel, traffic keeps flowing, and `onSuccess` handles only `closed` and `half-open` — so successes while open do nothing. Recovery needed a 30-second window with zero failures. At a 5% residual error rate under panel traffic that window never arrives, and only a manual `reset()` clears it.

## What the panel chose not to do

Option B/C would have gated the default call paths on `canExecute` so an open circuit actually sheds load. The panel took A: fix the timer, leave the breaker advisory on those paths. Larger behaviour change, and calls that currently succeed against a recovering provider would start being refused.

## An honest note on the mutation table

My first pass reported two changes as independent fixes. They are not — and the mutations proved it:

| mutation | result |
| --- | --- |
| revert the timer to `lastFailureTime` | **75 passed — survived** |
| record failures while open again | **75 passed — survived** |
| revert **both** (true pre-fix state) | 1 failed |
| always re-probe (ignore the window) | 14 failed |

Each half alone masks the other: with the early return in place nothing advances `lastFailureTime` while open, so measuring from either field gives the same answer. **The early return is the operative fix.** The `lastStateChange` change is redundant given it, and is kept because measuring recovery from the transition is what the window actually means — not because it is load-bearing. The comment in the code now says that rather than implying two fixes.

I would have shipped this with a table showing two clean kills if I had not run each mutation separately.

2,713 tests pass across `src/cli-adapters`.