### PR TITLE
fix(ci): stop the DocOps gate inheriting [skip-docops] from the base branch

### DIFF
--- a/.changeset/docops-escape-hatch-symmetric.md
+++ b/.changeset/docops-escape-hatch-symmetric.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': patch
+---
+
+fix(ci): stop the DocOps gate inheriting [skip-docops] from the base branch
+
+The escape-hatch lookup used `git log origin/<base>...HEAD` — a **symmetric**
+difference, which also returns commits reachable from the base branch but not
+from HEAD. Six `[skip-docops]` commits are on `main` today, so any PR branch
+whose merge-base predates one of them inherited the marker and skipped the
+entire skill-sync gate, regardless of what the PR changed.
+
+Demonstrated on this repo: with a HEAD whose merge-base predates the markers,
+the three-dot range finds 7 occurrences and the two-dot range finds 0.
+
+The commit that introduced the symmetric range is itself one of the six.

--- a/scripts/check-docops-skill.test.ts
+++ b/scripts/check-docops-skill.test.ts
@@ -91,6 +91,27 @@ describe('getCommitMessagesForEscapeHatch (#2411)', () => {
     expect(out).toContain('chore: lint fix');
   });
 
+  it('does NOT inherit [skip-docops] from a commit already on the base branch (#5028)', () => {
+    // The range was `origin/main...HEAD` — symmetric — so commits on the base
+    // branch but NOT on the PR branch were searched too. Six `[skip-docops]`
+    // commits are on main today, so any branch whose merge-base predates one
+    // of them skipped the whole gate regardless of what it changed.
+    git(ctx.dir, 'checkout -q -b feature');
+    git(ctx.dir, 'commit --allow-empty -q -m "feat: an honest change"');
+
+    // main moves ahead with a bypass commit the feature branch never contains.
+    git(ctx.dir, 'checkout -q main');
+    git(ctx.dir, 'commit --allow-empty -q -m "chore: unrelated [skip-docops]"');
+    git(ctx.dir, 'update-ref refs/remotes/origin/main main');
+    git(ctx.dir, 'checkout -q feature');
+    process.env['GITHUB_BASE_REF'] = 'main';
+
+    const out = getCommitMessagesForEscapeHatch(ctx.dir);
+
+    expect(out).not.toContain('[skip-docops]');
+    expect(out).toContain('feat: an honest change');
+  });
+
   it('does NOT see [skip-docops] when only the merge-commit message has it (the original bug)', () => {
     git(ctx.dir, 'checkout -q -b feature');
     git(ctx.dir, 'commit --allow-empty -q -m "feat: real change without bypass token"');

--- a/scripts/check-docops-skill.ts
+++ b/scripts/check-docops-skill.ts
@@ -160,7 +160,13 @@ function getCommitMessagesForEscapeHatch(cwd: string = REPO_ROOT): string {
   const baseRef = safeBaseRef();
   if (baseRef !== undefined) {
     try {
-      return execFileSync('git', ['log', `origin/${baseRef}...HEAD`, '--pretty=%B'], {
+      // #5028: TWO dots. `origin/main...HEAD` is the SYMMETRIC difference, so
+      // it also returns commits reachable from the base branch but not from
+      // HEAD — including every `[skip-docops]` ever merged to main. Any branch
+      // whose merge-base predates one of those inherited the marker and
+      // silently disabled this gate. Six such commits are on main today; the
+      // commit that introduced this range is one of them.
+      return execFileSync('git', ['log', `origin/${baseRef}..HEAD`, '--pretty=%B'], {
         cwd,
         encoding: 'utf-8',
         stdio: ['ignore', 'pipe', 'ignore'],


### PR DESCRIPTION
Closes finding 1 of #5028. **This is a live, currently-exploitable CI bypass.**

## The range is symmetric

```ts
execFileSync('git', ['log', `origin/${baseRef}...HEAD`, '--pretty=%B'], …)
```

Three dots is the symmetric difference, so it also returns commits reachable from the base branch but **not** from HEAD — including every `[skip-docops]` ever merged to `main`. Six are there today, most recently `96f63f7e74` (2026-07-06).

Any PR branch whose merge-base predates one of them inherits the marker, so `runCheck` takes the `escapeHatchUsed = true; success = true` early return and exits 0 with the entire skill-sync gate skipped — regardless of what the PR changed. CI prints "Escape hatch detected" and goes green.

## Demonstrated on this repo

Using a commit that predates the markers as a stand-in HEAD:

```
three-dot (current code): 7 occurrences of [skip-docops]
two-dot  (fix):           0
```

The commit that introduced this range — `919de90479`, *"fix(ci): [skip-docops] honored on PR runs"* — is itself one of the six it now inherits.

## The regression test

The existing suite has three escape-hatch cases and none of them moves `main` forward, so the symmetric range never showed. The new test does exactly that: branch, commit an honest change, then advance `main` with an unrelated `[skip-docops]` commit the branch never contains, and assert the marker is not seen.

| mutation | result |
| --- | --- |
| restore the symmetric range | 1 failed |
| narrow to `HEAD~1..HEAD` | 1 failed |

The second is the pair — #2411 widened this range for a real reason (a merge-commit subject hides the developer's message), and the fix must not undo that.

10 tests pass.

## Not fixed here

#5028 carries four more gates in the same class, including `check-authority-tier-drift.ts`'s ratification gate, whose input file is 0 bytes with no writer in the tree — so the check that resolves a `ratificationVoteRef` against `vote-records.jsonl` cannot emit a finding. That one is on the governor path and wants its own fix.