### PR TITLE
fix(ci): stop a knip failure reporting zero orphans

### DIFF
--- a/.changeset/knip-failure-reads-as-clean.md
+++ b/.changeset/knip-failure-reads-as-clean.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+fix(ci): stop a knip failure reporting zero orphans
+
+`runKnip` returned a bare array and yielded `[]` on every failure path — empty
+stdout, unparseable JSON, a throw with no usable stdout — with stderr set to
+`'ignore'` so knip's own error was discarded. `[]` is also what a clean scan
+produces, so a knip broken by a reporter or config change printed
+`Total orphans (knip): 0 / ✓ No flagged orphans` and the gate exited 0.
+
+This repo carries 22 allowlisted orphans, so `total === 0` is in fact the
+signature of a dead run, and nothing asserted that baseline.
+
+The run outcome now carries `ran`, the check verdict fails when the scan did not
+happen, and the message says UNMEASURED rather than clean. The stdout
+classification is extracted as a pure `classifyKnipOutput` so the empty and
+unparseable cases are testable without shelling out.

--- a/scripts/check-orphans.test.ts
+++ b/scripts/check-orphans.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest';
 
 import {
+  classifyKnipOutput,
   globToRegExp,
   isAllowlisted,
   extractOrphans,
@@ -214,14 +215,61 @@ describe('isAllowlisted honours expiry (#4583)', () => {
   });
 });
 
+describe('classifyKnipOutput (#5028)', () => {
+  it('reports empty output as not run, not as a clean scan', () => {
+    const run = classifyKnipOutput('   ');
+
+    expect(run.ran).toBe(false);
+    expect(run.issues).toEqual([]);
+  });
+
+  it('reports unparseable output as not run', () => {
+    // A knip bumped past a reporter change emits something that is not JSON.
+    const run = classifyKnipOutput('Error: unknown --reporter');
+
+    expect(run.ran).toBe(false);
+    expect(String(run.reason)).toContain('parseable');
+  });
+
+  it('reports a genuine empty result as a completed scan', () => {
+    // The pair: a real clean repo must not be reported as unmeasured.
+    const run = classifyKnipOutput('{"files":[]}');
+
+    expect(run.ran).toBe(true);
+  });
+});
+
 describe('isPassing (#4583 — the gate blocks instead of always returning true)', () => {
   it('fails when any orphan is flagged', () => {
-    expect(isPassing({ total: 1, allowlisted: 0, flagged: ['packages/foo/src/orphan.ts'] })).toBe(
-      false
-    );
+    expect(
+      isPassing({
+        total: 1,
+        allowlisted: 0,
+        flagged: ['packages/foo/src/orphan.ts'],
+        scanned: true,
+      })
+    ).toBe(false);
   });
 
   it('passes when nothing is flagged', () => {
-    expect(isPassing({ total: 22, allowlisted: 22, flagged: [] })).toBe(true);
+    expect(isPassing({ total: 22, allowlisted: 22, flagged: [], scanned: true })).toBe(true);
+  });
+
+  it('fails when knip never ran, rather than reporting a clean repo (#5028)', () => {
+    // `runKnip` returned `[]` on every failure path — empty stdout,
+    // unparseable JSON, a throw — with stderr suppressed, and `[]` is also
+    // what a clean scan produces. A knip broken by a reporter or config change
+    // printed "Total orphans (knip): 0 / ✓ No flagged orphans" and exited 0.
+    // This repo carries 22 allowlisted orphans, so total===0 is in fact the
+    // signature of a dead run.
+    expect(
+      isPassing({
+        total: 0,
+        allowlisted: 0,
+        flagged: [],
+        scanned: false,
+        unscannedReason: 'knip produced no output',
+      })
+    ).toBe(false);
   });
 });

--- a/scripts/check-orphans.ts
+++ b/scripts/check-orphans.ts
@@ -255,8 +255,46 @@ function normalizeKnipJson(parsed: unknown): readonly KnipIssue[] {
   return [];
 }
 
-/** Run knip --reporter json and return the parsed array of issues. */
-export function runKnip(cwd: string = REPO_ROOT): readonly KnipIssue[] {
+/**
+ * Outcome of a knip run, able to say it did not happen (#5028).
+ *
+ * `runKnip` used to return a bare array and yielded `[]` on every failure —
+ * empty stdout, unparseable JSON, a throw with no usable stdout — with stderr
+ * set to `'ignore'` so knip's own error was discarded. `[]` is also what a
+ * clean repo produces, so a knip that never ran reported "no orphans" and the
+ * gate exited 0.
+ */
+export interface KnipRun {
+  readonly issues: readonly KnipIssue[];
+  /** False when knip produced no parseable output — the verdict is unmeasured. */
+  readonly ran: boolean;
+  readonly reason?: string;
+}
+
+/**
+ * Classifies knip's stdout into a run outcome (#5028).
+ *
+ * Pure and exported so the empty-output and unparseable cases are testable
+ * without shelling out — the classification is the whole point of the fix, and
+ * a mutation of it survived until this existed.
+ */
+export function classifyKnipOutput(stdout: string): KnipRun {
+  if (stdout.trim().length === 0) {
+    return { issues: [], ran: false, reason: 'knip produced no output' };
+  }
+  try {
+    return { issues: normalizeKnipJson(JSON.parse(stdout)), ran: true };
+  } catch (error: unknown) {
+    return {
+      issues: [],
+      ran: false,
+      reason: `knip output was not parseable JSON: ${getErrorText(error)}`,
+    };
+  }
+}
+
+/** Run knip --reporter json and return the parsed issues, or say it did not run. */
+export function runKnip(cwd: string = REPO_ROOT): KnipRun {
   try {
     const out = execFileSync('npx', ['knip', '--reporter', 'json'], {
       cwd,
@@ -264,22 +302,29 @@ export function runKnip(cwd: string = REPO_ROOT): readonly KnipIssue[] {
       maxBuffer: 16 * 1024 * 1024, // knip output can be ~400KB+
       stdio: ['ignore', 'pipe', 'ignore'],
     });
-    if (out.trim().length === 0) return [];
-    return normalizeKnipJson(JSON.parse(out));
+    return classifyKnipOutput(out);
   } catch (error: unknown) {
     // knip exits non-zero when issues exist; that's fine — we still get JSON on stdout.
     if (error !== null && typeof error === 'object' && 'stdout' in error) {
       const stdout = (error as { stdout?: string }).stdout;
+      // knip exits non-zero when issues exist; the JSON is still on stdout.
       if (typeof stdout === 'string' && stdout.trim().length > 0) {
-        try {
-          return normalizeKnipJson(JSON.parse(stdout));
-        } catch {
-          /* fall through */
-        }
+        const classified = classifyKnipOutput(stdout);
+        if (classified.ran) return classified;
       }
     }
-    return [];
+    return {
+      issues: [],
+      ran: false,
+      reason: `knip failed to produce parseable JSON: ${getErrorText(error)}`,
+    };
   }
+}
+
+/** Best-effort message for a thrown value, for the unmeasured reason string. */
+function getErrorText(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
 }
 
 // ============================================================================
@@ -314,6 +359,14 @@ interface CheckResult {
   readonly total: number;
   readonly allowlisted: number;
   readonly flagged: readonly string[];
+  /**
+   * Whether knip actually produced a verdict (#5028). `false` means the scan
+   * did not run — NOT that the repo is clean. The two used to be the same
+   * observation, and this repo carries allowlisted orphans, so `total === 0`
+   * is in fact the signature of a dead run.
+   */
+  readonly scanned: boolean;
+  readonly unscannedReason?: string;
 }
 
 export function performCheck(now: Date = new Date()): CheckResult | null {
@@ -330,19 +383,25 @@ export function performCheck(now: Date = new Date()): CheckResult | null {
     return null;
   }
 
-  const issues = runKnip();
-  const all = extractOrphans(issues);
+  const knip = runKnip();
+  const all = extractOrphans(knip.issues);
   const flagged = filterOrphans(all, allowlist, now);
 
   return {
     total: all.length,
     allowlisted: all.length - flagged.length,
     flagged,
+    scanned: knip.ran,
+    ...(knip.reason !== undefined ? { unscannedReason: knip.reason } : {}),
   };
 }
 
-/** The gate's verdict: any flagged orphan fails the check. */
+/**
+ * The gate's verdict: any flagged orphan fails — and so does a scan that never
+ * ran (#5028). No evidence is not a pass.
+ */
 export function isPassing(result: CheckResult): boolean {
+  if (!result.scanned) return false;
   return result.flagged.length === 0;
 }
 
@@ -352,6 +411,12 @@ function checkOrphans(verbose: boolean): boolean {
 
   const result = performCheck();
   if (result === null) return false;
+
+  if (!result.scanned) {
+    console.error(`✗ knip did not run — orphan detection is UNMEASURED, not clean.`);
+    console.error(`  ${result.unscannedReason ?? 'no reason reported'}\n`);
+    return false;
+  }
 
   console.log(`Total orphans (knip): ${String(result.total)}`);
   console.log(`Allowlisted: ${String(result.allowlisted)}`);


### PR DESCRIPTION
Closes finding 3 of #5028.

## A dead scan and a clean repo were the same observation

`runKnip` returned a bare array with three paths to `return []` — empty stdout, unparseable JSON, a throw with no usable stdout — and set stderr to `'ignore'`, discarding knip's own error. `normalizeKnipJson` also returns `[]` for any unrecognised shape. Downstream, `flagged.length === 0 → exit 0`.

So a PR that bumps knip past a JSON-reporter or config-schema break could land an unreferenced subtree, and CI would print `Total orphans (knip): 0 / ✓ No flagged orphans.` and go green.

**This repo carries 22 allowlisted orphans** — verified by running the gate, which reports exactly that — so `total === 0` is in fact the signature of a dead run, and no baseline asserted it.

## Fix

The run outcome carries `ran`; `isPassing` fails when the scan did not happen; the message says the check is UNMEASURED rather than clean. That is the repo's own convention — `notVerified`, `securityRan`, `tokensMeasured` — applied to a gate that lacked it.

## The mutation that made me extract a function

| mutation | result |
| --- | --- |
| drop the unmeasured guard | 1 failed |
| unmeasured passes | 1 failed |
| **empty stdout counts as `ran`** | **survived → classifier extracted + tested** |
| revert the whole diff | 4 failed |

The third survived because the `isPassing` tests construct a `CheckResult` directly and nothing exercised `runKnip`'s own classification — which is the entire point of the fix. Rather than test through a shell-out, the stdout decision is now a pure exported `classifyKnipOutput` with three cases: empty → not run, unparseable → not run, valid-but-empty → a completed scan.

That last case is the pair: a genuinely clean repo must not be reported as unmeasured.

Third time today a solo mutation caught something a batch run would have shown clean.

28 tests pass; the gate runs green against the real repo.