### PR TITLE
fix(ci): fail when a pnpm filter matches no package

### DIFF
--- a/.changeset/pnpm-filter-no-match.md
+++ b/.changeset/pnpm-filter-no-match.md
@@ -1,0 +1,17 @@
+---
+'nexus-agents': patch
+---
+
+fix(ci): fail when a pnpm filter matches no package
+
+`pnpm --filter <name> …` exits 0 when the filter matches nothing — verified:
+`pnpm --filter nonexistent exec node -e 1` returns 0, and with
+`--fail-if-no-match` returns 1. So `set -euo pipefail` in `verify-refresh.sh`
+could not catch a silently-skipped suite: renaming the package, or moving it
+outside the workspace globs, would print "verify-refresh: all gates passed"
+having run zero tests. That is the #4340 shape the comment above that line says
+the gate exists to prevent.
+
+`--fail-if-no-match` added to the eight unguarded `pnpm --filter` invocations
+across `verify-refresh.sh` and five workflows, so a build or test step that
+matches nothing is a red job rather than a quiet no-op.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
       # generate-tool-reference.test.ts transitively imports tool schemas that
       # reach `nexus-memory`; build it first (mirrors docs-check.yml).
       - name: Build nexus-memory (workspace dep)
-        run: pnpm --filter nexus-memory build
+        run: pnpm --filter nexus-memory --fail-if-no-match build
 
       - name: Run script tests
         run: pnpm test:scripts

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -61,11 +61,11 @@ jobs:
         run: |
           # nexus-memory must be built first so TypeDoc can resolve its types
           # (#2766 Phase 5+ adds nexus-memory as a workspace dep of nexus-agents).
-          pnpm --filter nexus-memory build
+          pnpm --filter nexus-memory --fail-if-no-match build
           # The markdown output is what the website renders, so that is the one
           # whose generation must be green. A failure here means the published
           # API reference would be missing, not merely stale.
-          pnpm --filter nexus-agents docs:api:md
+          pnpm --filter nexus-agents --fail-if-no-match docs:api:md
 
       # #4504: "some pages exist" is too weak a check — three declared entry
       # points silently emitted nothing for months, so `PipelineRunner` (a
@@ -357,7 +357,7 @@ jobs:
         # The generator now imports the real tool modules to introspect their Zod
         # input schemas (#3688); tool-memory.ts transitively imports `nexus-memory`,
         # so its dist must be built before the generator runs (mirrors the TypeDoc job).
-        run: pnpm --filter nexus-memory build
+        run: pnpm --filter nexus-memory --fail-if-no-match build
 
       - name: Check generated tool reference
         run: |

--- a/.github/workflows/meta-shadow-soak.yml
+++ b/.github/workflows/meta-shadow-soak.yml
@@ -122,7 +122,7 @@ jobs:
       # a bare `pnpm install`. Mirrors the "Script Tests" CI job.
       - name: Build nexus-memory (workspace dep)
         if: steps.check.outputs.has_key == 'true'
-        run: pnpm --filter nexus-memory build
+        run: pnpm --filter nexus-memory --fail-if-no-match build
 
       # Restore the prior soak so this run APPENDS to it — the shadow-training
       # sink appends-on-write and the selector hydrates-on-construct, so a

--- a/.github/workflows/npm-verify.yml
+++ b/.github/workflows/npm-verify.yml
@@ -51,8 +51,8 @@ jobs:
           # `nexus-memory` is a workspace dep of `nexus-agents` (#2766 Phase 5+).
           # Build it first so its dist/index.d.ts exists when tsup resolves
           # `import { ... } from 'nexus-memory'` in nexus-agents.
-          pnpm --filter nexus-memory build
-          pnpm --filter nexus-agents build
+          pnpm --filter nexus-memory --fail-if-no-match build
+          pnpm --filter nexus-agents --fail-if-no-match build
           cd packages/nexus-agents
           npm pack --pack-destination "${{ runner.temp }}"
           ls "${{ runner.temp }}"/*.tgz

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -98,7 +98,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm --filter nexus-agents build
+        run: pnpm --filter nexus-agents --fail-if-no-match build
 
       - name: Compute PR diff
         id: diff

--- a/scripts/verify-refresh.sh
+++ b/scripts/verify-refresh.sh
@@ -42,7 +42,13 @@ echo "::group::full test suite"
 #
 # Cost is ~3 minutes on a weekly cron. That is cheap next to shipping a red
 # main and then bisecting it.
-pnpm --filter nexus-agents exec vitest run
+# #5028: `--fail-if-no-match` is load-bearing. Without it pnpm exits 0 when the
+# filter matches nothing (verified: `pnpm --filter nonexistent exec node -e 1`
+# → exit 0), so `set -euo pipefail` cannot catch a silently-skipped suite. A
+# package rename or a workspace-glob change would make this gate print
+# "all gates passed" having run zero tests — the exact #4340 shape the comment
+# above says it exists to prevent.
+pnpm --filter nexus-agents --fail-if-no-match exec vitest run
 echo "::endgroup::"
 
 echo "::group::catalogue drift (advisory)"


### PR DESCRIPTION
Closes finding 4 of #5028.

## A filter that matches nothing is a green job

```
pnpm --filter nonexistent exec node -e 1                      → exit 0
pnpm --filter nonexistent --fail-if-no-match exec node -e 1   → exit 1
pnpm --filter nexus-agents --fail-if-no-match exec node -e 1  → exit 0
```

So `set -euo pipefail` in `verify-refresh.sh` could not catch a silently-skipped suite. Rename the package in `packages/nexus-agents/package.json`, or move it outside the workspace globs, and the registry-refresh gate prints `verify-refresh: all gates passed` having run zero tests — the exact #4340 shape the comment directly above that line says the gate exists to prevent.

Applied to all eight unguarded `pnpm --filter` invocations, not just the one the audit named: `verify-refresh.sh` plus `ci.yml`, `docs-check.yml`, `meta-shadow-soak.yml`, `npm-verify.yml` and `pr-review.yml`. A build step that matches nothing has the same failure mode as a test step that matches nothing.

## Verification note

My first attempt at measuring this was wrong in a way worth recording. I ran the command piped to `tail` and read `$?`, which reports **tail's** status, not pnpm's — so `--fail-if-no-match` appeared to change nothing. Re-run without the pipe, the flag behaves exactly as documented.

That is the same class of defect as the ones in #5028 itself: a measurement that cannot observe what it claims to. I nearly concluded the recommended fix did not work.

All five changed workflows parse as valid YAML; `pnpm --filter nexus-memory --fail-if-no-match build` exits 0 against the real workspace.