### PR TITLE
fix(ci): stop the script-wiring gate counting a paths: mention as wiring

### DIFF
--- a/.changeset/wiring-gate-paths-mention.md
+++ b/.changeset/wiring-gate-paths-mention.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix(ci): stop the script-wiring gate counting a paths: mention as wiring
+
+`isReachableFromCi` returned true on any textual occurrence of the script's
+basename in the workflow text — including a `paths:` trigger entry, which never
+executes anything. Deleting the
+`run: npx tsx scripts/check-governor-ratification.ts` step from
+`governor-review.yml` leaves the filename in two `paths:` blocks, so the gate
+whose job is catching unwired gates would report it reachable.
+
+The direct branch now requires an actual invocation — a runner (`tsx`, `node`,
+`ts-node`, `bash`, `sh`) followed by the path on the same line. The npm-script
+branch below it already did the careful thing; this brings the two into line.
+
+Verified against the real workflows: 29 scripts reachable before and after, so
+tightening introduced no false positives — which is the failure mode the
+function's own doc comment warns about.

--- a/scripts/check-script-wiring.test.ts
+++ b/scripts/check-script-wiring.test.ts
@@ -3,6 +3,31 @@ import { describe, expect, it } from 'vitest';
 import { assessWiring, isReachableFromCi } from './check-script-wiring.js';
 
 describe('isReachableFromCi', () => {
+  it('does not count a paths: trigger entry as wiring (#5028)', () => {
+    // The gate whose job is catching unwired gates used a bare
+    // `workflowText.includes(basename)`. Deleting the
+    // `run: npx tsx scripts/check-governor-ratification.ts` step from
+    // governor-review.yml leaves the filename in two `paths:` blocks, so the
+    // script reported as reachable while nothing executed it.
+    const pathsOnly = [
+      'on:',
+      '  pull_request:',
+      '    paths:',
+      "      - 'scripts/check-governor-ratification.ts'",
+    ].join('\n');
+
+    expect(isReachableFromCi('check-governor-ratification.ts', pathsOnly, {})).toBe(false);
+  });
+
+  it('still counts a real run: step as wiring', () => {
+    // The pair: tightening must not report a genuinely wired script as unwired,
+    // which is how a gate teaches people to ignore it.
+    const withRun =
+      'jobs:\n  x:\n    steps:\n      - run: npx tsx scripts/check-governor-ratification.ts';
+
+    expect(isReachableFromCi('check-governor-ratification.ts', withRun, {})).toBe(true);
+  });
+
   const noNpm = {};
 
   it('counts a direct filename reference in a workflow', () => {

--- a/scripts/check-script-wiring.ts
+++ b/scripts/check-script-wiring.ts
@@ -72,12 +72,31 @@ export interface WiringVerdict {
  * that as unwired would be a false positive, and false positives are what
  * teach people to ignore a gate.
  */
+/** Runners a workflow step uses to execute a script directly. */
+const INVOCATION_RUNNERS = ['tsx', 'node', 'ts-node', 'bash', 'sh'] as const;
+
+/**
+ * True when some line runs `<runner> … <basename>` — an execution, not a
+ * mention. `paths:` entries and comments name the file without running it.
+ */
+function invokesOnSomeLine(workflowText: string, runner: string, basename: string): boolean {
+  const escaped = basename.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`\\b${runner}\\s+[^\\n]*${escaped}`);
+  return pattern.test(workflowText);
+}
+
 export function isReachableFromCi(
   basename: string,
   workflowText: string,
   npmScripts: Readonly<Record<string, string>>
 ): boolean {
-  if (workflowText.includes(basename)) return true;
+  // #5028: a bare `includes` counted ANY textual occurrence — including a
+  // `paths:` trigger entry, which never executes anything. Deleting the
+  // `run: npx tsx scripts/check-governor-ratification.ts` step from
+  // governor-review.yml left the filename in two `paths:` blocks, so the gate
+  // whose job is catching unwired gates reported it reachable. Require an
+  // actual invocation: a runner followed by the path on the same line.
+  if (INVOCATION_RUNNERS.some((r) => invokesOnSomeLine(workflowText, r, basename))) return true;
 
   for (const [name, body] of Object.entries(npmScripts)) {
     if (!body.includes(basename)) continue;


### PR DESCRIPTION
Closes finding 5 of #5028.

## The meta-gate could not detect an unwired gate

`isReachableFromCi` began with `if (workflowText.includes(basename)) return true;` — any textual occurrence, including a `paths:` trigger entry that never executes the script.

**Scenario:** delete the `run: npx tsx scripts/check-governor-ratification.ts` step from `governor-review.yml`. Lines 39 and 52 still name the file in the two `paths:` blocks, so the gate whose entire job is catching unwired gates reports it reachable — and the ratification check silently stops running.

The npm-script branch directly below already did the careful thing, requiring `pnpm|npm run|yarn` followed by the script name. Only the direct branch was loose.

## Verified both directions

```
paths-only workflow text  → reachable? false
same text plus a run: step → reachable? true
```

And against the real workflows: **29 scripts reachable before and after.** Tightening introduced no false positives, which matters because the function's own doc comment says false positives are what teach people to ignore a gate. That was the risk in this change and it is worth checking rather than assuming.

| mutation | result |
| --- | --- |
| back to a bare `includes` | 1 failed |
| drop the direct branch entirely | 4 failed |

The second is the pair: requiring an invocation must not make genuinely wired scripts unreachable.

10 tests pass.