### PR TITLE
fix(governance): make the authority-tier ratification gate able to fire

### DIFF
--- a/.changeset/ratification-resolves-vote-record.md
+++ b/.changeset/ratification-resolves-vote-record.md
@@ -1,0 +1,22 @@
+---
+'nexus-agents': patch
+---
+
+fix(governance): make the authority-tier ratification gate able to fire
+
+The gate read `governance/authority-tier-transitions.jsonl` — a 0-byte file
+whose only writer, `IAuditLogger.logTierTransition`, is called from nothing but
+tests and a no-op stub. Empty file → no transitions → zero findings, always. So
+the #3842/#3894/#3927 path that resolves a `ratificationVoteRef` against the
+tamper-evident `vote-records.jsonl` could not emit a finding, and the only live
+guard on a promotion was a non-empty-string test — the cosmetic check #3842
+states it replaced. A manifest could be promoted to `enforce` citing a vote that
+does not exist.
+
+Authority tiers are not changed at runtime: they live in
+`governance/loop-tiers.yaml` and change by commit, so the runtime event the
+design waited for never occurs. The resolution machinery is now pointed at the
+promotion-evidence ledger, which does exist and does carry `ratificationVote`.
+The dead transitions file is removed.
+
+Remedy chosen by a 7-voter panel: Option C, 5 of 5 approvers, audit record #80.

--- a/scripts/check-authority-tier-drift.test.ts
+++ b/scripts/check-authority-tier-drift.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import { stringify as toYaml } from 'yaml';
 import {
+  ratificationGateFindings,
   analyzeTierDeclarations,
   analyzeLoopTierDeclarations,
   analyzeTierTransitionEvents,
@@ -324,6 +325,71 @@ function resolverOf(...records: VoteRecord[]): RatificationResolver {
 
 /** A resolver that resolves nothing (empty/absent ledger). */
 const emptyResolver: RatificationResolver = () => undefined;
+
+describe('ratificationGateFindings — the gate reads the evidence ledger (#5028)', () => {
+  const evidenceEntry = {
+    loopId: 'dev-pipeline',
+    fromTier: 'advisory' as const,
+    toTier: 'enforce' as const,
+    evalN: 120,
+    precision: 0.95,
+    recall: 0.9,
+    primaryMetric: { name: 'accuracy', value: 0.95, ci: [0.92, 0.97] as [number, number] },
+    soakDuration: 'P31D',
+    ratificationVote: '#9999',
+    evidenceUri: 'https://example.invalid/evidence',
+  };
+
+  it('fails a promotion whose ratificationVote resolves to nothing', () => {
+    // The wiring, not the machinery. `analyzeTierTransitionEvents` and
+    // `buildVoteRecordRatificationResolver` were already well tested — and the
+    // gate still could not fire, because it read
+    // `governance/authority-tier-transitions.jsonl`, a 0-byte file whose only
+    // writer is called from tests and a no-op stub. Tiers change by editing
+    // `loop-tiers.yaml`, so the runtime event never occurs.
+    const findings = ratificationGateFindings(
+      new Map([['dev-pipeline', evidenceEntry as never]]),
+      '' // no vote records at all
+    );
+
+    expect(findings.map((f) => f.code)).toContain('promotion-ratification-unresolved');
+  });
+
+  it('fails closed when the vote ledger itself cannot be verified', () => {
+    // The pair for the negative above, and the more important direction: a
+    // ledger that does not verify must reject every promotion rather than let
+    // one through. A hand-written record with a bogus hash is exactly what a
+    // forged ratification would look like.
+    const forged = JSON.stringify({
+      id: 'vote-1',
+      decision: 'approved',
+      strategy: 'higher_order',
+      ratifies: 'dev-pipeline',
+      proposal: 'promote dev-pipeline to enforce',
+      sequence: 1,
+      recordedAt: '2026-08-26T00:00:00.000Z',
+      proposalHash: 'x'.repeat(64),
+      approvalPercentage: 100,
+      voteCounts: { approve: 7, reject: 0, abstain: 0, total: 7 },
+      voters: [],
+      hash: 'y'.repeat(64),
+      version: '1.2',
+    });
+
+    const findings = ratificationGateFindings(
+      new Map([['dev-pipeline', { ...evidenceEntry, ratificationVote: 'vote-1' } as never]]),
+      forged
+    );
+
+    expect(findings.length).toBeGreaterThan(0);
+  });
+
+  it('reports nothing when no promotion has been claimed', () => {
+    // The empty case, named: no evidence entries is "no promotions yet", not a
+    // verdict about any promotion.
+    expect(ratificationGateFindings(new Map(), '')).toEqual([]);
+  });
+});
 
 describe('analyzeTierTransitionEvents — ratification gate (#3842, hardened #3894)', () => {
   it('FAILS a promotion event with NO ratificationVoteRef (breakage fixture)', () => {

--- a/scripts/check-authority-tier-drift.ts
+++ b/scripts/check-authority-tier-drift.ts
@@ -91,7 +91,6 @@ import {
 } from './vote-record-ratification.js';
 
 const EVIDENCE_LEDGER = join(ROOT, 'governance/authority-tier-evidence.yaml');
-const TRANSITION_LOG = join(ROOT, 'governance/authority-tier-transitions.jsonl');
 /**
  * The AUTHENTIC resolution source (#3927 item 1). The promotion gate resolves a
  * transition's `ratificationVoteRef` against this committed, tamper-evident
@@ -470,29 +469,50 @@ function enforceFloorShortfalls(e: PromotionEvidence): string[] {
  * structured errors. Returns true when every declaration is honest. Fails closed.
  */
 /**
- * #3842/#3894/#3927 ratification gate: read the hash-chained tier-transition log
- * (if any) and fail any PROMOTION event whose ratificationVoteRef does not RESOLVE
- * to an approved higher_order record in the AUTHENTIC, tamper-evident committed
- * ledger `governance/vote-records.jsonl` (#3927 item 1 — replaces the former
- * hand-committable `ratification-votes.yaml`). Fails closed on a tampered/malformed
- * ledger and on ambiguous (conflicting-decision) subjects. Returns no findings when
- * the transition log is absent (the no-promotions-yet happy path).
+ * #5028 ratification gate: resolve every promotion evidence entry's
+ * `ratificationVote` against the AUTHENTIC, tamper-evident committed ledger
+ * `governance/vote-records.jsonl`.
+ *
+ * This used to read `governance/authority-tier-transitions.jsonl` instead — a
+ * file that is 0 bytes and has no writer in the tree, because its only
+ * producer, `IAuditLogger.logTierTransition`, is called from nothing but tests
+ * and a no-op stub. Authority tiers are not changed at runtime; they live in
+ * `governance/loop-tiers.yaml` and change by commit, so the runtime event the
+ * design waited for never occurs. The gate therefore returned zero findings
+ * unconditionally, and the only live guard on a promotion was a non-empty
+ * string test — the cosmetic check #3842 says it replaced. A manifest could be
+ * promoted to `enforce` citing a vote that does not exist.
+ *
+ * The evidence ledger DOES exist and DOES carry `ratificationVote`, so the
+ * resolution machinery is now pointed at it. Fails closed on a tampered or
+ * malformed ledger and on ambiguous (conflicting-decision) subjects.
+ * Panel decision: Option C, 5 of 5 approvers, audit record #80.
  */
-function ratificationGateFindings(): TierDriftFinding[] {
-  if (!existsSync(TRANSITION_LOG)) return [];
-  const voteRecordsJsonl = existsSync(VOTE_RECORDS_LEDGER)
-    ? readFileSync(VOTE_RECORDS_LEDGER, 'utf-8')
-    : undefined;
+export function ratificationGateFindings(
+  evidence: ReadonlyMap<string, PromotionEvidence>,
+  voteRecordsJsonl: string | undefined
+): TierDriftFinding[] {
+  if (evidence.size === 0) return [];
   const { resolver, conflictSubjects, findings } =
     buildVoteRecordRatificationResolver(voteRecordsJsonl);
-  const { transitions, findings: logFindings } = recoverTransitions(
-    readFileSync(TRANSITION_LOG, 'utf-8')
-  );
-  return [
-    ...findings,
-    ...logFindings,
-    ...analyzeTierTransitionEvents(transitions, resolver, conflictSubjects),
-  ];
+
+  const out = [...findings];
+  for (const [loopId, e] of evidence) {
+    const finding = ratificationFindingFor(
+      {
+        kind: 'promotion',
+        subject: loopId,
+        fromTier: e.fromTier,
+        toTier: e.toTier,
+        evidenceRef: e.evidenceUri,
+        ratificationVoteRef: e.ratificationVote,
+      },
+      resolver,
+      conflictSubjects
+    );
+    if (finding !== null) out.push(finding);
+  }
+  return out;
 }
 
 export function checkAuthorityTierDeclarations(): boolean {
@@ -511,15 +531,21 @@ export function checkAuthorityTierDeclarations(): boolean {
   const loopYaml = existsSync(LOOP_TIER_REGISTRY_FILE)
     ? readFileSync(LOOP_TIER_REGISTRY_FILE, 'utf-8')
     : undefined;
+  const evidenceMap = buildEnforceEvidenceMap(evidenceYaml);
   findings.push(
     ...analyzeLoopTierDeclarations({
       loopYaml,
       embeddedLoops: LOOP_TIER_REGISTRY.loops,
-      enforceEvidenceById: buildEnforceEvidenceMap(evidenceYaml),
+      enforceEvidenceById: evidenceMap,
     })
   );
 
-  findings.push(...ratificationGateFindings());
+  findings.push(
+    ...ratificationGateFindings(
+      evidenceMap,
+      existsSync(VOTE_RECORDS_LEDGER) ? readFileSync(VOTE_RECORDS_LEDGER, 'utf-8') : undefined
+    )
+  );
 
   if (findings.length === 0) return true;
 


### PR DESCRIPTION
Closes finding 2 of #5028. Remedy chosen by a 7-voter panel: **Option C**, 5 of 5 approvers, 83.3%, audit record #80.

**Owner ratification required — touches `governance/`. I will not self-merge.**

## The gate had no input

`ratificationGateFindings()` read `governance/authority-tier-transitions.jsonl`: **0 bytes**, created 2026-06-16, never written. Its only writer, `IAuditLogger.logTierTransition`, is called from nothing but tests and a no-op stub. Empty file → no transitions → `analyzeTierTransitionEvents([])` → zero findings, unconditionally.

So the whole #3842/#3894/#3927 path that resolves a `ratificationVoteRef` against the tamper-evident `vote-records.jsonl` could not emit a finding. What actually guarded a promotion was `if (e.ratificationVote.trim() === '')` — a non-empty-string test, which is the cosmetic check #3842 states it replaced.

## Why no producer was ever written

**Authority tiers are not changed at runtime.** They live in `governance/loop-tiers.yaml`, a checked-in file, and the only commit that has ever changed one is `8ca02e8879`. A tier transition is a *commit*, not a runtime event — so `logTierTransition` was waiting for something that does not happen. That fact is what made the panel's three options genuinely different, and it is why the answer is not "go write the missing producer."

The evidence ledger, by contrast, exists and already carries `ratificationVote`. The resolution machinery is now pointed there.

## Verified end to end, not just in unit tests

With a promotion entry citing `ratificationVote: '#9999'`:

```
exit=1
[promotion-ratification-unresolved] tier-transition promotion of 'dev-pipeline'
(advisory → enforce) carries ratificationVoteRef='#9999' that does NOT resolve
to any authentic record in governance/vote-records.jsonl.
```

With the ledger restored: `exit=0`. That is the pair, and it is the scenario that previously exited 0.

| mutation | result |
| --- | --- |
| gate returns nothing | 2 failed |
| drop the collected findings | 1 failed |

51 tests pass.

## Two things I deliberately did not do

**`logTierTransition` stays.** It is in `api-surface.txt`, so removing it is a breaking API change needing its own unanimous vote — and #5003 showed that bar is real (a removal at 83.3% was rejected). It is now dead weight with a documented reason; removing it belongs in a separate, correctly-gated change.

**The positive unit test asserts fail-closed, not pass.** My first attempt hand-wrote a vote record to prove a valid ratification clears the gate; it failed, because the resolver runs tamper-evidence verification and a forged hash correctly fails the whole ledger closed. Rather than fabricate a valid hash chain to make a test go green, the unit test now pins that behaviour — an unverifiable ledger rejects every promotion — and the passing direction is covered by the end-to-end run above.