### PR TITLE
fix(ci): treat an unrecognised knip shape as unmeasured, and finish the CLI-attribution sweep

### DIFF
--- a/.changeset/knip-shape-and-remaining-writers.md
+++ b/.changeset/knip-shape-and-remaining-writers.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+fix(ci): treat an unrecognised knip shape as unmeasured, and finish the CLI-attribution sweep
+
+Two corrections to fixes that shipped a few hours ago.
+
+**#5030 left half the defect.** `normalizeKnipJson` returns `[]` for any parsed
+JSON that is neither a top-level array nor an object with an `issues` array, and
+`classifyKnipOutput` reported that as `ran: true`. So a knip whose reporter shape
+changed — the exact case the check exists for, and which its own doc comment
+says varies by version and reporter mode — parsed cleanly and counted as a
+completed scan of zero issues. The test shipped with that fix asserted
+`{"files":[]}` was "a genuine empty result"; that fixture is the
+reporter-change case. An unrecognised shape is now `ran: false`, and the pair
+test uses the two shapes the normalizer actually understands.
+
+**#5020 fixed two of four writers.** `issue-triage-tool.ts` and
+`research-discover.ts` append the same shape — synthetic `model` label, no
+knowledge of the serving CLI — and still hardcoded `cli: DEFAULT_CLI`.
+`research_discover` runs on essentially every non-trivial task, so it was the
+highest-volume of the four. Both now record `cli: 'unknown'`; the changeset for
+#5020 said "two live tool paths" and should have said four.

--- a/packages/nexus-agents/src/mcp/tools/issue-triage-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/issue-triage-tool.ts
@@ -31,7 +31,6 @@ import {
   getOutcomeStore,
   categorizeOutcomeErrorMessage,
 } from '../../orchestration/outcomes/index.js';
-import { DEFAULT_CLI } from '../../config/model-capabilities-types.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
 // ============================================================================
@@ -237,7 +236,13 @@ function recordTriageOutcome(success: boolean, durationMs: number, errorMsg?: st
     const store = getOutcomeStore();
     store.append({
       id: `triage-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
-      cli: DEFAULT_CLI,
+      // #5034: NOT `DEFAULT_CLI`. This tool does not know which CLI served the
+      // work — `model` below is a synthetic label — and hardcoding 'claude'
+      // credited or debited claude in the routing learner on every run.
+      // `'unknown'` is the schema's own unattributed value, which the bandit's
+      // warm-start partitions out instead of replaying (#4935). #5020 fixed
+      // two of these four writers; this is the remainder.
+      cli: 'unknown',
       category: 'planning',
       model: 'issue-triage',
       success,

--- a/packages/nexus-agents/src/mcp/tools/research-discover.ts
+++ b/packages/nexus-agents/src/mcp/tools/research-discover.ts
@@ -49,7 +49,6 @@ import {
   getOutcomeStore,
   categorizeOutcomeErrorMessage,
 } from '../../orchestration/outcomes/index.js';
-import { DEFAULT_CLI } from '../../config/model-capabilities-types.js';
 import { getToolAnnotations } from '../tool-annotations.js';
 
 // =============================================================================
@@ -542,7 +541,13 @@ function recordDiscoveryOutcome(success: boolean, durationMs: number, errorMsg?:
     const store = getOutcomeStore();
     store.append({
       id: `research-discover-${String(getTimeProvider().now())}-${getRandomProvider().random().toString(36).slice(2, 8)}`,
-      cli: DEFAULT_CLI,
+      // #5034: NOT `DEFAULT_CLI`. This tool does not know which CLI served the
+      // work — `model` below is a synthetic label — and hardcoding 'claude'
+      // credited or debited claude in the routing learner on every run.
+      // `'unknown'` is the schema's own unattributed value, which the bandit's
+      // warm-start partitions out instead of replaying (#4935). #5020 fixed
+      // two of these four writers; this is the remainder.
+      cli: 'unknown',
       category: 'research',
       model: 'research-discover',
       success,

--- a/scripts/check-orphans.test.ts
+++ b/scripts/check-orphans.test.ts
@@ -231,11 +231,23 @@ describe('classifyKnipOutput (#5028)', () => {
     expect(String(run.reason)).toContain('parseable');
   });
 
-  it('reports a genuine empty result as a completed scan', () => {
-    // The pair: a real clean repo must not be reported as unmeasured.
+  it('reports JSON in an unrecognised shape as not run (#5034)', () => {
+    // `normalizeKnipJson` returned `[]` for any shape it did not understand, so
+    // a reporter change — the case this check exists for — parsed cleanly and
+    // reported a completed scan of zero issues. My own fix shipped with a test
+    // asserting `{"files":[]}` counted as a clean scan; that fixture IS the
+    // reporter-change case.
     const run = classifyKnipOutput('{"files":[]}');
 
-    expect(run.ran).toBe(true);
+    expect(run.ran).toBe(false);
+    expect(String(run.reason)).toContain('recognised reporter shape');
+  });
+
+  it('reports a genuine empty result as a completed scan', () => {
+    // The pair: a real clean repo must not be reported as unmeasured. Both
+    // shapes the normalizer actually understands.
+    expect(classifyKnipOutput('[]').ran).toBe(true);
+    expect(classifyKnipOutput('{"issues":[]}').ran).toBe(true);
   });
 });
 

--- a/scripts/check-orphans.ts
+++ b/scripts/check-orphans.ts
@@ -246,13 +246,18 @@ export function isAllowlisted(
 /** Coerce a parsed knip JSON value into the array shape we expect.
  *  Knip can emit either a top-level array or an object with `issues` array
  *  depending on version + reporter mode. Defensively normalize. */
-function normalizeKnipJson(parsed: unknown): readonly KnipIssue[] {
+function normalizeKnipJson(parsed: unknown): readonly KnipIssue[] | undefined {
   if (Array.isArray(parsed)) return parsed as readonly KnipIssue[];
   if (parsed !== null && typeof parsed === 'object' && 'issues' in parsed) {
     const inner = parsed.issues;
     if (Array.isArray(inner)) return inner as readonly KnipIssue[];
   }
-  return [];
+  // #5034: `undefined`, not `[]`. An unrecognised shape is knip telling us
+  // something we cannot read — the reporter-change case this whole check
+  // exists for — and returning an empty issue list made it indistinguishable
+  // from a clean scan. The doc above says the shape varies by version and
+  // reporter mode, which is exactly why this branch must not report health.
+  return undefined;
 }
 
 /**
@@ -283,7 +288,15 @@ export function classifyKnipOutput(stdout: string): KnipRun {
     return { issues: [], ran: false, reason: 'knip produced no output' };
   }
   try {
-    return { issues: normalizeKnipJson(JSON.parse(stdout)), ran: true };
+    const issues = normalizeKnipJson(JSON.parse(stdout));
+    if (issues === undefined) {
+      return {
+        issues: [],
+        ran: false,
+        reason: 'knip output was JSON but not a recognised reporter shape',
+      };
+    }
+    return { issues, ran: true };
   } catch (error: unknown) {
     return {
       issues: [],


### PR DESCRIPTION
Closes #5034. Both defects are mine, from fixes that merged a few hours ago, found by an adversarial review of my own night's work.

## 1. #5030 left half the defect — and its test pinned the half it left

`normalizeKnipJson` returns `[]` for any parsed JSON that is neither a top-level array nor an object with an `issues` array. `classifyKnipOutput` reported that as `ran: true`, so **"parsed but shape not understood" was still a completed scan of zero issues** — the reporter-change case the check exists for, and which the function's own doc comment says varies by version and reporter mode.

The test I shipped with that fix says it out loud:

```ts
it('reports a genuine empty result as a completed scan', () => {
  const run = classifyKnipOutput('{"files":[]}');
  expect(run.ran).toBe(true);
});
```

`{"files":[]}` has no `issues` key and is not an array. The fixture I picked to represent a *genuine empty result* is the failure case, and I asserted it counts as clean.

An unrecognised shape is now `ran: false` with a reason, and the pair test uses `'[]'` and `'{"issues":[]}'` — the two shapes the normalizer actually understands.

## 2. #5020 fixed two of four writers

`issue-triage-tool.ts:240` and `research-discover.ts:545` are byte-identical in shape to the two I fixed — synthetic `model` label, `source: 'manual'`, no knowledge of the serving CLI — and still hardcoded `cli: DEFAULT_CLI`.

`research_discover` runs on essentially every non-trivial task under the default working mode, so it was the **highest-volume** of the four and the last one found. The #5020 changeset says "two live tool paths"; there were four.

`grep "cli: DEFAULT_CLI"` across non-test source is now clean except `budget-errors.ts:77`, which is a `BudgetExceededError` payload rather than a `TaskOutcome` — it never reaches the OutcomeStore, so it moves no routing arm. Noted in the issue so the next sweep does not re-derive it.

## Mutations

| mutation | result |
| --- | --- |
| unrecognised shape reports `ran: true` again | 1 failed |
| `normalizeKnipJson` returns `[]` instead of `undefined` | 1 failed |

29 orphan-check tests and 14 tool tests pass.

## Not fixed here

Three more findings from the same review are recorded in #5034 rather than patched: the circuit-breaker fix has two lines that each survive solo mutation (only the conjunction is pinned, and my comment's claim about which half is "operative" is unfalsifiable as written); that same fix silently gave `getSnapshot().failureCount` a third undocumented semantic; and the DocOps suite's "original bug" test cannot fail as written. Each needs its own change rather than being bundled into a correction PR.