### PR TITLE
test(adapters): pin the load-bearing half of the circuit-breaker recovery fix

### DIFF
--- a/.changeset/circuit-breaker-pin-early-return.md
+++ b/.changeset/circuit-breaker-pin-early-return.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+test(adapters): pin the load-bearing half of the circuit-breaker recovery fix
+
+The #5011 fix changed two lines and the test pinned only their conjunction:
+each half is individually sufficient, so reverting either alone left the suite
+green. The code comment asserted one half was "the operative fix" and the other
+"redundant" — a ranking no test could falsify.
+
+Two assertions now pin the early return directly: a failure recorded while the
+circuit is open must not restamp `lastFailureTime`, and must not increment
+`failureCount`. Dropping that return alone now fails both.
+
+Reverting the `lastStateChange` change alone still fails nothing, and that is
+the honest result rather than a gap: with `lastFailureTime` frozen, the two
+fields are set microseconds apart at the open transition and never diverge. The
+comment now says which half is pinned and admits the other cannot be.

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.test.ts
@@ -154,6 +154,31 @@ describe('CliCircuitBreaker', () => {
       expect(breaker.getState()).toBe('half-open');
     });
 
+    it('does not restamp lastFailureTime for a failure recorded while open (#5034)', () => {
+      // Pins the early return specifically. The two halves of the #5011 fix are
+      // individually sufficient — with `lastFailureTime` frozen the window
+      // reads the same from either field — so the recovery test above passes
+      // with EITHER half reverted. This assertion fails only if the early
+      // return goes, which is what makes the pair separable.
+      const before = breaker.getSnapshot().lastFailureTime;
+
+      vi.advanceTimersByTime(1_000);
+      breaker.recordFailure('unknown');
+
+      expect(breaker.getSnapshot().lastFailureTime).toBe(before);
+    });
+
+    it('does not count a failure recorded while open (#5034)', () => {
+      // `failureCount` drives the closed-state threshold and is reset on the
+      // transition back to closed, so counting failures during the open window
+      // measures nothing — and `getSnapshot()` exposes the field.
+      const before = breaker.getSnapshot().failureCount;
+
+      breaker.recordFailure('unknown');
+
+      expect(breaker.getSnapshot().failureCount).toBe(before);
+    });
+
     it('does not re-probe before the window has elapsed', () => {
       // The pair: fixing the restart must not make the circuit probe early.
       expect(breaker.getState()).toBe('open');

--- a/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
+++ b/packages/nexus-agents/src/cli-adapters/circuit-breaker.ts
@@ -211,12 +211,20 @@ export class CliCircuitBreaker implements ICircuitBreaker {
   private onFailure(category: FailureCategory): void {
     // #5011: a failure recorded while the circuit is already open carries no
     // information — the circuit is open, that is the verdict — and updating
-    // `lastFailureTime` here is what delayed recovery. This is the operative
-    // half of the fix; the `lastStateChange` change in `checkStateTransition`
-    // is redundant with it (nothing else advances `lastFailureTime` while
-    // open) and is kept because measuring recovery from the transition is what
-    // the window actually means. `failureCount` stays put too: it drives the
-    // closed-state threshold and is reset on the transition back to closed.
+    // `lastFailureTime` here is what delayed recovery.
+    //
+    // #5034: this line is the LOAD-BEARING half, and the tests now say so:
+    // dropping it alone fails two assertions. The `lastStateChange` change in
+    // `checkStateTransition` is genuinely redundant given this return —
+    // reverting THAT alone fails nothing, because with `lastFailureTime`
+    // frozen the two fields are set microseconds apart at the open transition
+    // and never diverge. It is kept because measuring recovery from the
+    // transition is what the window means, not because any behaviour
+    // distinguishes it. Saying which half is pinned, and admitting the other
+    // cannot be, beats a mutation table that implies two clean kills.
+    //
+    // `failureCount` stays put too: it drives the closed-state threshold and
+    // is reset on the transition back to closed.
     if (this.state === 'open') return;
 
     this.failureCount++;


### PR DESCRIPTION
Closes the circuit-breaker finding in #5034.

## The gap

The #5011 fix changed two lines, and the test pinned only their conjunction. Each half is individually sufficient, so reverting either alone left the suite green — and my code comment asserted a ranking ("this is the operative half; the other is redundant") that no test could falsify.

## Now falsifiable, and the answer is not symmetric

Two assertions pin the early return directly: a failure recorded while the circuit is open must not restamp `lastFailureTime`, and must not increment `failureCount`. Both read through `getSnapshot()`, which is the surface an operator dashboard uses.

| mutation | before | after |
| --- | --- | --- |
| drop the early return alone | survived | **2 failed** |
| revert the timer to `lastFailureTime` alone | survived | still survives |

The second row is the honest result, not a remaining gap. With `lastFailureTime` frozen by the early return, the two fields are set microseconds apart at the open transition and never diverge — so no behaviour distinguishes the timer change, and contriving a test to make it look pinned would be theatre. The comment now states which half is load-bearing and admits the other cannot be pinned while the first exists.

That is the claim-vs-code correction: the original comment was right in substance and unfalsifiable in form.

2,715 tests pass across `src/cli-adapters`.

## Still open in #5034

`getSnapshot()` now freezes `failureCount` for the whole open window, giving that field a third semantic the `#3026` comment does not describe. No non-test consumer reads it outside `getSnapshot`, so it is reporting fidelity rather than breakage — but the comment should be corrected or the field should carry the distinction explicitly. Left separate because it is a documentation decision, not a test gap.
