### PR TITLE
test(ci): replace a DocOps escape-hatch test that could not fail

### DIFF
--- a/.changeset/docops-merge-commit-real-case.md
+++ b/.changeset/docops-merge-commit-real-case.md
@@ -1,0 +1,15 @@
+---
+'nexus-agents': patch
+---
+
+test(ci): replace a DocOps escape-hatch test that could not fail
+
+`does NOT see [skip-docops] when only the merge-commit message has it (the
+original bug)` created a branch with no bypass token anywhere and asserted the
+token was absent. That passes for any implementation that does not invent the
+token — including the `git log -1` version #2411 fixed — so it pinned nothing
+while reading as coverage of the merge-ref case.
+
+It now exercises the actual #2411 bug: the token sits in an earlier branch
+commit with an unrelated commit on top, which is precisely what `git log -1`
+missed under a PR merge ref. Narrowing the range to `HEAD~1..HEAD` fails it.

--- a/scripts/check-docops-skill.test.ts
+++ b/scripts/check-docops-skill.test.ts
@@ -112,17 +112,27 @@ describe('getCommitMessagesForEscapeHatch (#2411)', () => {
     expect(out).toContain('feat: an honest change');
   });
 
-  it('does NOT see [skip-docops] when only the merge-commit message has it (the original bug)', () => {
+  it('sees [skip-docops] in a branch commit that is not HEAD (#2411, the original bug)', () => {
+    // #5034: this test used to create a branch with no bypass token anywhere
+    // and assert the token was absent — which passes for any implementation
+    // that does not invent it, including the `git log -1` version #2411 fixed.
+    // It read as coverage of the merge-ref case and pinned nothing.
+    //
+    // The actual #2411 bug: under a PR merge ref, `git log -1` returns the
+    // generated merge-commit subject, so a token in the developer's own commit
+    // was never seen. That is what this now exercises — the token is in an
+    // EARLIER branch commit, with an unrelated commit on top.
     git(ctx.dir, 'checkout -q -b feature');
-    git(ctx.dir, 'commit --allow-empty -q -m "feat: real change without bypass token"');
+    git(ctx.dir, 'commit --allow-empty -q -m "docs: intentional bypass [skip-docops]"');
+    git(ctx.dir, 'commit --allow-empty -q -m "chore: follow-up with no token"');
 
     git(ctx.dir, 'update-ref refs/remotes/origin/main main');
     process.env['GITHUB_BASE_REF'] = 'main';
 
     const out = getCommitMessagesForEscapeHatch(ctx.dir);
 
-    expect(out).not.toContain('[skip-docops]');
-    expect(out).toContain('feat: real change without bypass token');
+    expect(out).toContain('[skip-docops]');
+    expect(out).toContain('chore: follow-up with no token');
   });
 
   it('falls back to HEAD-only when GITHUB_BASE_REF points at a non-existent ref', () => {


### PR DESCRIPTION
Closes the DocOps test finding in #5034.

## A test that could not fail

```ts
it('does NOT see [skip-docops] when only the merge-commit message has it (the original bug)', () => {
  git(ctx.dir, 'checkout -q -b feature');
  git(ctx.dir, 'commit --allow-empty -q -m "feat: real change without bypass token"');
  …
  expect(out).not.toContain('[skip-docops]');
});
```

The fixture never creates a merge commit and never writes `[skip-docops]` anywhere. The assertion passes for any implementation that does not *invent* the token — including the `git log -1` version #2411 fixed. It sat directly beneath the two tests I added in #5029 and read as coverage of the merge-ref case, which was in fact unpinned.

## What #2411 actually was

Under a PR merge ref, `git log -1` returns the generated merge-commit subject, so a token in the developer's own commit was never seen. The test now exercises that: the token is in an **earlier** branch commit with an unrelated commit on top.

| mutation | result |
| --- | --- |
| narrow the range to `HEAD~1..HEAD` (the #2411 bug) | 2 failed |
| restore the symmetric `...` range (#5029's bug) | 1 failed |

Both regressions this file guards are now pinned by distinct tests.

## What I did not do

I considered asserting that a token in the merge commit's *own* message is ignored — which is what the old test's name implied. That assertion would be false: under `actions/checkout`'s PR merge ref, `origin/main..HEAD` legitimately includes the merge commit itself. It is harmless in practice because GitHub generates that subject, but writing a test that asserts otherwise would have replaced a vacuous test with a wrong one.

10 tests pass.
