### PR TITLE
docs(architecture): correct the policy-gate aggregation rule for recordKind

### DIFF
--- a/docs/architecture/EVENT_BUS_BOUNDARIES.md
+++ b/docs/architecture/EVENT_BUS_BOUNDARIES.md
@@ -104,11 +104,29 @@ The durable `policy_gate` record carries `mode` (`warn`=soak vs `block`=enforce)
 loop needs to distinguish soak evidence from enforced denials. The bus
 `policy.evaluated` event does **not** carry these and is per-run.
 
-**Aggregation rule:** sum durable `policy_gate` records **only**. The two
-records are intentional (back-compat for existing TraceWriter consumers + a
-durable sink that survives process exit) — **never sum `trace.jsonl` together
+**Aggregation rule:** sum durable records **only**, and count by `recordKind`.
+The two sinks are intentional (back-compat for existing TraceWriter consumers +
+a durable sink that survives process exit) — **never sum `trace.jsonl` together
 with the durable log**, or every decision is double-counted. The durable log is
 authoritative; `trace.jsonl` is for single-run observability.
+
+Since #3727 the durable log carries **two record kinds** under the same
+`action: 'security.policy_gate'`, so counting raw records over-counts:
+
+| `recordKind` | Emitted                                  | Count it for                        |
+| ------------ | ---------------------------------------- | ----------------------------------- |
+| `summary`    | once per **evaluation**, including clean | the denominator (evaluations)       |
+| `violation`  | once per **violation** in an evaluation  | per-rule breakdowns, never the rate |
+
+An evaluation with two violations writes **three** durable records. The
+would-block rate is therefore
+`count(recordKind === 'summary' && violationCount > 0) / count(recordKind === 'summary')`
+— which is exactly what `computePolicyWouldBlockRate`
+(`security/audit-trail.ts:427-439`) implements. Read the rate from that helper
+rather than aggregating by hand.
+
+Note the durable record's `action` is `security.policy_gate`; the bare
+`policy_gate` is the in-memory `AuditEvent.type`.
 
 The durable sink is wired only when the MCP server threads its single startup
 `auditLogger` (one `AuditTrail` built per run wrapping it, so all runs share the


### PR DESCRIPTION
Closes finding 5 of #5039 — the one correction that is a matter of fact rather than a design decision.

## The rule went stale two days after it was written

`EVENT_BUS_BOUNDARIES.md` said: *"sum durable `policy_gate` records **only** … never sum `trace.jsonl` together with the durable log, or every decision is double-counted."* That was accurate for #3710 (doc last touched `3facbd76b1`, 2026-06-07).

#3727 landed two days later (`2bdda5deba`) and added a **third** record: `emitDurablePolicyEvaluationSummary` (`pipeline/policy-evaluator.ts:258`) appends one `recordKind: 'summary'` per *evaluation*, alongside the per-violation records. Both land under the same `action: 'security.policy_gate'`.

**An evaluation with two violations writes three durable records.** A reader following the documented rule literally over-counts.

## Why this one matters more than a typical doc drift

The same section names that log as the **canonical source for soak-vs-enforce readiness evidence (#3653)** — the input to deciding whether to flip the policy gate from `warn` to `block`. The doc that tells you how to read the evidence told you to read it wrong.

That is adjacent to #4988, where I had already found the soak's evidence base hollow for two other reasons. This is a third: even a correctly-populated log was documented as being counted incorrectly.

## The correction

The section now names both record kinds, says which one is the denominator, and points at `computePolicyWouldBlockRate` (`security/audit-trail.ts:427-439`) — which already implements the right arithmetic — rather than inviting a hand-rolled aggregation. Also corrects `policy_gate` → `security.policy_gate` for the durable `action`; the bare name is the in-memory `AuditEvent.type`.

Docs only; markdownlint clean.

## Not in this PR

The other four findings in #5039 each need a decision rather than an edit — authentication and Byzantine detection are both fully implemented and referenced by nothing, so the choice is wire the control or stop advertising it. I am not making that call in a docs PR.
