### PR TITLE
fix(config): honor NEXUS_SANDBOX_ROOT instead of defaulting to cwd

### DIFF
--- a/.changeset/sandbox-root-preempted.md
+++ b/.changeset/sandbox-root-preempted.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+fix(config): honor NEXUS_SANDBOX_ROOT instead of defaulting to cwd
+
+`NEXUS_SANDBOX` is itself one of `SANDBOX_ENV_VARS`, so setting it made the
+`container-env` heuristic fire and stamp `NEXUS_DATA_DIR = <cwd>/.nexus-agents`
+during CLI bootstrap. Every later `getNexusDataDir()` then took the
+`NEXUS_DATA_DIR` branch and returned before reaching its own sandbox branch —
+the one that resolves `NEXUS_SANDBOX_ROOT`.
+
+So the documented purpose of `NEXUS_SANDBOX_ROOT` ("default `NEXUS_DATA_DIR` to
+the multi-repo root") never happened from any entry point going through
+`cli.ts`, which is the CLI and `--mode=server`. In a multi-repo mount that
+silently fragmented audit-chain, vote-record and job state per working
+directory — the layout `doctor`'s `dataDirInsideRepo` check exists to detect and
+reports as operator misconfiguration.
+
+The heuristic now uses the declared root as the data-dir base when one is set,
+and falls back to cwd when it is not.

--- a/packages/nexus-agents/src/config/portable-mode.test.ts
+++ b/packages/nexus-agents/src/config/portable-mode.test.ts
@@ -17,6 +17,9 @@ const SANDBOX_VARS = [
   'ECS_CONTAINER_METADATA_URI_V4',
   'SANDBOX',
   'NEXUS_SANDBOX',
+  // #5026: the declared root now shapes the data dir, so it must be cleared
+  // between tests or one case's root leaks into the next one's expectation.
+  'NEXUS_SANDBOX_ROOT',
 ];
 
 function clearAllPortableEnv(): void {
@@ -78,6 +81,33 @@ describe('detectPortableMode (#2471)', () => {
     const result = detectPortableMode(tmp);
     expect(result.portable).toBe(true);
     expect(result.reason).toBe('container-env');
+  });
+
+  it('uses NEXUS_SANDBOX_ROOT as the data-dir base when declared (#5026)', () => {
+    // `NEXUS_SANDBOX` is itself one of SANDBOX_ENV_VARS, so setting it makes
+    // this heuristic fire and stamp `<cwd>/.nexus-agents` — which then
+    // short-circuits `getNexusDataDir`'s own sandbox branch before it can
+    // honour the declared root. The documented purpose of NEXUS_SANDBOX_ROOT
+    // ("default NEXUS_DATA_DIR to the multi-repo root") therefore never
+    // happened, and state fragmented per working directory.
+    process.env['NEXUS_SANDBOX'] = 'docker-opencode';
+    process.env['NEXUS_SANDBOX_ROOT'] = '/work';
+
+    const result = detectPortableMode(tmp);
+
+    expect(result.portable).toBe(true);
+    expect(result.reason).toBe('container-env');
+    expect(result.dataDir).toBe(join('/work', '.nexus-agents'));
+  });
+
+  it('falls back to cwd when the sandbox declares no root', () => {
+    // The pair: a container with no declared root must still get a working
+    // data dir rather than an empty base.
+    process.env['NEXUS_SANDBOX'] = 'docker-opencode';
+
+    const result = detectPortableMode(tmp);
+
+    expect(result.dataDir).toBe(join(tmp, '.nexus-agents'));
   });
 
   it('treats empty container env vars as not-set', () => {

--- a/packages/nexus-agents/src/config/portable-mode.ts
+++ b/packages/nexus-agents/src/config/portable-mode.ts
@@ -47,12 +47,7 @@ interface DetectionResult {
   readonly portable: boolean;
   readonly dataDir: string;
   readonly reason:
-    | 'env-data-dir'
-    | 'env-opt-out'
-    | 'env-opt-in'
-    | 'home-unwritable'
-    | 'container-env'
-    | 'default';
+    'env-data-dir' | 'env-opt-out' | 'env-opt-in' | 'home-unwritable' | 'container-env' | 'default';
 }
 
 function isHomeWritable(): boolean {
@@ -72,6 +67,18 @@ function inSandboxEnv(): boolean {
     if (val !== undefined && val !== '') return true;
   }
   return false;
+}
+
+/**
+ * The operator-declared sandbox root, when set (#5026).
+ *
+ * Read directly rather than through `detectSandbox()` to keep this module free
+ * of imports — it runs as a side effect of `cli-log-bootstrap` before anything
+ * else loads.
+ */
+function sandboxRootFromEnv(): string | undefined {
+  const raw = process.env['NEXUS_SANDBOX_ROOT']?.trim();
+  return raw !== undefined && raw !== '' ? resolve(raw) : undefined;
 }
 
 function checkExplicitEnv(cwd: string): DetectionResult | null {
@@ -94,7 +101,21 @@ function checkHeuristics(cwd: string): DetectionResult | null {
     return { portable: true, dataDir: join(cwd, '.nexus-agents'), reason: 'home-unwritable' };
   }
   if (inSandboxEnv()) {
-    return { portable: true, dataDir: join(cwd, '.nexus-agents'), reason: 'container-env' };
+    // #5026: prefer an explicitly declared sandbox root over cwd. `NEXUS_SANDBOX`
+    // is one of SANDBOX_ENV_VARS, so setting it makes this heuristic fire and
+    // stamp `NEXUS_DATA_DIR = <cwd>/.nexus-agents` — which then short-circuits
+    // `getNexusDataDir`'s own sandbox branch (`nexus-data-dir.ts:124-127`)
+    // before it can honour `NEXUS_SANDBOX_ROOT`. The documented purpose of that
+    // variable ("default NEXUS_DATA_DIR to the multi-repo root") therefore never
+    // happened, and state fragmented per working directory across a multi-repo
+    // mount. `doctor`'s dataDirInsideRepo check exists to detect exactly that
+    // layout and reports it as operator misconfiguration.
+    const declaredRoot = sandboxRootFromEnv();
+    return {
+      portable: true,
+      dataDir: join(declaredRoot ?? cwd, '.nexus-agents'),
+      reason: 'container-env',
+    };
   }
   return null;
 }


### PR DESCRIPTION
Closes finding 2 of #5026.

## The variable never took effect

`NEXUS_SANDBOX` is one of `SANDBOX_ENV_VARS` (`config/portable-mode.ts:41`), so setting it makes the `container-env` heuristic fire and stamp `NEXUS_DATA_DIR = <cwd>/.nexus-agents` (`:140`). That happens as a module-load side effect of `cli-log-bootstrap`, which `cli.ts:14` imports first.

Every later `getNexusDataDir()` then takes the `NEXUS_DATA_DIR` branch (`nexus-data-dir.ts:121-123`) and returns **before** reaching the sandbox branch at `:124-127` — the only code that resolves `NEXUS_SANDBOX_ROOT`.

So `resolve(sandbox.root ?? '/', '.nexus-agents')` was unreachable from the CLI and `--mode=server`, and the documented purpose of the variable — "default `NEXUS_DATA_DIR` to the multi-repo root" (`sandbox-detection.ts:8`) — never happened.

## Why it matters beyond tidiness

In a multi-repo mount, state lands in whatever `cwd` the process started in, so audit-chain, vote-record and job state fragment per working directory. The product already diagnoses this: `doctor`'s `dataDirInsideRepo` check (`cli/doctor.ts:738-745`) exists to detect the layout and advises "Set `NEXUS_DATA_DIR` at the multi-repo root" — reporting its own bootstrap as operator misconfiguration.

## Mutations

| mutation | result |
| --- | --- |
| ignore the declared root | 1 failed |
| use the root with no cwd fallback | 2 failed |

The second is the pair: a container that declares no root must still get a working data dir rather than `/.nexus-agents`.

## A test-isolation bug my own test surfaced

Adding the first test broke two existing ones: `SANDBOX_VARS` — the list the suite clears between cases — contained `NEXUS_SANDBOX` but not `NEXUS_SANDBOX_ROOT`. That was harmless while nothing read the root, and became a leak the moment something did. Added to the list, with a note saying why.

1,031 tests pass across `src/config`.

## Still open in #5026

The larger finding stands and is not addressed here: `NEXUS_SANDBOX` has **zero enforcement points** — no filesystem, network, subprocess or tool-availability restriction keys off it. This PR makes the data-dir behaviour match its documentation; it does not make the flag an isolation boundary. The `CLAUDE.md` row that lists it beside two real enforcement controls is a governance file and needs owner ratification to correct.
