### PR TITLE
feat(memory): say which backends memory_query could actually reach

### DIFF
--- a/.changeset/memory-query-discloses-backends.md
+++ b/.changeset/memory-query-discloses-backends.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': minor
+---
+
+feat(memory): say which backends memory_query could actually reach
+
+`count: 0` was the same observation whether nothing matched the query or the
+SQLite-backed stores were absent — every unavailable backend contributes an
+empty result set silently, and the response carried no field able to say so. A
+caller asking "do we know anything about X?" was told "no" when the honest
+answer was "two of the five stores are not installed here".
+
+The response now carries `searched` and `unavailable`. `session` and `belief`
+are always present; `agentic`, `adaptive` and `typed` are optional and are named
+when missing. Both lists are scoped to the requested `source`, so asking for one
+backend does not claim the others were searched.
+
+This is the availability half of #4999. A backend that is installed but throws
+mid-query still contributes `[]` silently — each per-backend helper catches and
+returns an empty array — and that half needs the error status threaded out of
+`tool-memory-query.ts`.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -5339,7 +5339,9 @@ InterfaceDeclaration MemoryQueryResponse
   expandedQuery?: string | undefined
   query: string
   results: readonly UnifiedMemoryResult[]
+  searched: readonly string[]
   source: string
+  unavailable: readonly string[]
 TypeAliasDeclaration MemoryStatsDeps
   = BaseMcpToolDeps
 VariableDeclaration MemoryStatsInputSchema

--- a/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   MemoryQueryInputSchema,
   registerMemoryQueryTool,
+  describeBackendCoverage,
   type MemoryQueryInput,
 } from './memory-query.js';
 
@@ -32,8 +33,20 @@ vi.mock('../../cli-adapters/factory.js', () => ({
 // Mock getToolMemory at module level
 const mockQueryAll = vi.fn();
 const mockQueryBySource = vi.fn();
+// #4999: the availability accessors are part of the surface memory_query now
+// reads — the response says which backends answered, so a mock without them
+// would make every coverage assertion vacuous.
+const mockAvailability = {
+  isAgenticMemoryAvailable: (): boolean => true,
+  isAdaptiveMemoryAvailable: (): boolean => true,
+  isTypedMemoryAvailable: (): boolean => true,
+};
 vi.mock('./tool-memory.js', () => ({
-  getToolMemory: () => ({ queryAll: mockQueryAll, queryBySource: mockQueryBySource }),
+  getToolMemory: () => ({
+    queryAll: mockQueryAll,
+    queryBySource: mockQueryBySource,
+    ...mockAvailability,
+  }),
 }));
 
 // ============================================================================
@@ -229,6 +242,49 @@ describe('memory-query', () => {
       const parsed = JSON.parse(result.content[0]!.text) as Record<string, unknown>;
       expect(parsed['query']).toBe('simple query');
       expect(parsed['expandedQuery']).toBeUndefined();
+    });
+  });
+});
+
+describe('describeBackendCoverage (#4999)', () => {
+  const allAvailable = {
+    isAgenticMemoryAvailable: (): boolean => true,
+    isAdaptiveMemoryAvailable: (): boolean => true,
+    isTypedMemoryAvailable: (): boolean => true,
+  };
+  const noneAvailable = {
+    isAgenticMemoryAvailable: (): boolean => false,
+    isAdaptiveMemoryAvailable: (): boolean => false,
+    isTypedMemoryAvailable: (): boolean => false,
+  };
+
+  it('names the SQLite backends that are not installed', () => {
+    // `count: 0` was the same observation whether nothing matched or three of
+    // the five stores were absent — each unavailable backend contributes `[]`
+    // silently. A caller asking "do we know anything about X?" was told "no".
+    const coverage = describeBackendCoverage(noneAvailable, 'all');
+
+    expect(coverage.searched).toEqual(['session', 'belief']);
+    expect(coverage.unavailable).toEqual(['agentic', 'adaptive', 'typed']);
+  });
+
+  it('reports every backend searched when all are installed', () => {
+    // The pair: a complete install must not report phantom gaps.
+    const coverage = describeBackendCoverage(allAvailable, 'all');
+
+    expect(coverage.searched).toEqual(['session', 'belief', 'agentic', 'adaptive', 'typed']);
+    expect(coverage.unavailable).toEqual([]);
+  });
+
+  it('scopes coverage to a single requested source', () => {
+    // Asking for one backend must not claim the others were searched.
+    expect(describeBackendCoverage(allAvailable, 'belief')).toEqual({
+      searched: ['belief'],
+      unavailable: [],
+    });
+    expect(describeBackendCoverage(noneAvailable, 'agentic')).toEqual({
+      searched: [],
+      unavailable: ['agentic'],
     });
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
@@ -11,7 +11,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   MemoryQueryInputSchema,
   registerMemoryQueryTool,
-  describeBackendCoverage,
   type MemoryQueryInput,
 } from './memory-query.js';
 
@@ -36,10 +35,11 @@ const mockQueryBySource = vi.fn();
 // #4999: the availability accessors are part of the surface memory_query now
 // reads — the response says which backends answered, so a mock without them
 // would make every coverage assertion vacuous.
+const backendsInstalled = { agentic: true, adaptive: true, typed: true };
 const mockAvailability = {
-  isAgenticMemoryAvailable: (): boolean => true,
-  isAdaptiveMemoryAvailable: (): boolean => true,
-  isTypedMemoryAvailable: (): boolean => true,
+  isAgenticMemoryAvailable: (): boolean => backendsInstalled.agentic,
+  isAdaptiveMemoryAvailable: (): boolean => backendsInstalled.adaptive,
+  isTypedMemoryAvailable: (): boolean => backendsInstalled.typed,
 };
 vi.mock('./tool-memory.js', () => ({
   getToolMemory: () => ({
@@ -243,48 +243,43 @@ describe('memory-query', () => {
       expect(parsed['query']).toBe('simple query');
       expect(parsed['expandedQuery']).toBeUndefined();
     });
-  });
-});
 
-describe('describeBackendCoverage (#4999)', () => {
-  const allAvailable = {
-    isAgenticMemoryAvailable: (): boolean => true,
-    isAdaptiveMemoryAvailable: (): boolean => true,
-    isTypedMemoryAvailable: (): boolean => true,
-  };
-  const noneAvailable = {
-    isAgenticMemoryAvailable: (): boolean => false,
-    isAdaptiveMemoryAvailable: (): boolean => false,
-    isTypedMemoryAvailable: (): boolean => false,
-  };
+    describe('memory_query discloses backend coverage (#4999)', () => {
+      // Asserted on the RESPONSE, not on a helper: `count: 0` was the same
+      // observation whether nothing matched or the SQLite-backed stores were
+      // absent, so the only assertion that means anything is what a caller reads.
+      beforeEach(() => {
+        backendsInstalled.agentic = true;
+        backendsInstalled.adaptive = true;
+        backendsInstalled.typed = true;
+      });
 
-  it('names the SQLite backends that are not installed', () => {
-    // `count: 0` was the same observation whether nothing matched or three of
-    // the five stores were absent — each unavailable backend contributes `[]`
-    // silently. A caller asking "do we know anything about X?" was told "no".
-    const coverage = describeBackendCoverage(noneAvailable, 'all');
+      it('names the backends that are not installed', async () => {
+        backendsInstalled.agentic = false;
+        backendsInstalled.typed = false;
+        mockQueryBySource.mockResolvedValue([]);
 
-    expect(coverage.searched).toEqual(['session', 'belief']);
-    expect(coverage.unavailable).toEqual(['agentic', 'adaptive', 'typed']);
-  });
+        const result = await registeredHandler({ query: 'routing' }, {});
+        const body = JSON.parse(result.content[0]?.text ?? '{}') as {
+          count: number;
+          searched: string[];
+          unavailable: string[];
+        };
 
-  it('reports every backend searched when all are installed', () => {
-    // The pair: a complete install must not report phantom gaps.
-    const coverage = describeBackendCoverage(allAvailable, 'all');
+        expect(body.count).toBe(0);
+        expect(body.unavailable).toEqual(['agentic', 'typed']);
+        expect(body.searched).toEqual(['session', 'belief', 'adaptive']);
+      });
 
-    expect(coverage.searched).toEqual(['session', 'belief', 'agentic', 'adaptive', 'typed']);
-    expect(coverage.unavailable).toEqual([]);
-  });
+      it('reports no gaps on a complete install', async () => {
+        // The pair: a full install must not report phantom missing stores.
+        mockQueryBySource.mockResolvedValue([]);
 
-  it('scopes coverage to a single requested source', () => {
-    // Asking for one backend must not claim the others were searched.
-    expect(describeBackendCoverage(allAvailable, 'belief')).toEqual({
-      searched: ['belief'],
-      unavailable: [],
-    });
-    expect(describeBackendCoverage(noneAvailable, 'agentic')).toEqual({
-      searched: [],
-      unavailable: ['agentic'],
+        const result = await registeredHandler({ query: 'routing' }, {});
+        const body = JSON.parse(result.content[0]?.text ?? '{}') as { unavailable: string[] };
+
+        expect(body.unavailable).toEqual([]);
+      });
     });
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/memory-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.ts
@@ -101,11 +101,11 @@ export interface MemoryQueryResponse {
  * optional and contribute an empty result set when absent — indistinguishable,
  * before this, from "searched and found nothing".
  *
- * Exported for the coverage tests: the whole point is that the response says
- * which stores answered, so asserting it through the tool is the only check
- * that means anything.
+ * Not exported: the point of #4999 is what the RESPONSE says, so the tests
+ * drive the registered tool and assert the envelope. A unit test of this
+ * function would pass while the fields never reached a caller.
  */
-export function describeBackendCoverage(
+function describeBackendCoverage(
   memory: {
     isAgenticMemoryAvailable(): boolean;
     isAdaptiveMemoryAvailable(): boolean;

--- a/packages/nexus-agents/src/mcp/tools/memory-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.ts
@@ -81,6 +81,55 @@ export interface MemoryQueryResponse {
   count: number;
   /** Source filter applied */
   source: string;
+  /**
+   * Which backends the search could actually reach (#4999).
+   *
+   * `count: 0` used to be the same observation whether nothing matched or the
+   * SQLite-backed stores were absent — every unavailable backend contributes
+   * `[]` silently. A caller asking "do we know anything about X?" was told
+   * "no" when the honest answer was "two of the four stores were not there".
+   */
+  searched: readonly string[];
+  /** Backends skipped because they are not configured on this install. */
+  unavailable: readonly string[];
+}
+
+/**
+ * Which memory backends a query could reach, and which were skipped (#4999).
+ *
+ * `session` and `belief` are always present; the three SQLite-backed stores are
+ * optional and contribute an empty result set when absent — indistinguishable,
+ * before this, from "searched and found nothing".
+ *
+ * Exported for the coverage tests: the whole point is that the response says
+ * which stores answered, so asserting it through the tool is the only check
+ * that means anything.
+ */
+export function describeBackendCoverage(
+  memory: {
+    isAgenticMemoryAvailable(): boolean;
+    isAdaptiveMemoryAvailable(): boolean;
+    isTypedMemoryAvailable(): boolean;
+  },
+  source: string
+): { searched: readonly string[]; unavailable: readonly string[] } {
+  const optional: readonly [string, boolean][] = [
+    ['agentic', memory.isAgenticMemoryAvailable()],
+    ['adaptive', memory.isAdaptiveMemoryAvailable()],
+    ['typed', memory.isTypedMemoryAvailable()],
+  ];
+  const inScope = (name: string): boolean => source === 'all' || source === name;
+
+  const searched: string[] = [];
+  const unavailable: string[] = [];
+  for (const name of ['session', 'belief']) {
+    if (inScope(name)) searched.push(name);
+  }
+  for (const [name, available] of optional) {
+    if (!inScope(name)) continue;
+    (available ? searched : unavailable).push(name);
+  }
+  return { searched, unavailable };
 }
 
 // ============================================================================
@@ -167,12 +216,15 @@ async function executeMemoryQuery(
     reflectionDurationMs: reflection?.durationMs,
   });
 
+  const coverage = describeBackendCoverage(toolMemory, input.source);
   return {
     query: input.query,
     ...(expandedQuery !== undefined ? { expandedQuery } : {}),
     results,
     count: results.length,
     source: input.source,
+    searched: coverage.searched,
+    unavailable: coverage.unavailable,
   };
 }
 

--- a/packages/nexus-agents/src/mcp/tools/memory-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.ts
@@ -298,6 +298,13 @@ export function registerMemoryQueryTool(server: McpServer, deps: MemoryQueryDeps
     results: z.array(z.unknown()),
     count: z.number(),
     source: z.string(),
+    // #4999: the SDK validates structured content against this schema with
+    // `additionalProperties: false`, so a field added to the response and not
+    // declared here makes EVERY call fail with -32602 rather than merely going
+    // unreported. The integration test caught that; the unit tests could not,
+    // because they call the handler directly and never cross the protocol.
+    searched: z.array(z.string()),
+    unavailable: z.array(z.string()),
   };
 
   server.registerTool(


### PR DESCRIPTION
Closes the availability half of #4999.

## `count: 0` meant two different things

`memory_query` returns `{ query, results, count, source }`. Every unavailable backend contributes an empty result set silently (`tool-memory.ts:953`, `:963`), so a repo without the SQLite-backed stores is byte-identical to a healthy one where nothing matched.

A caller asking *"do we know anything about routing?"* was told **no** when the honest answer was *"two of the five stores are not installed here."*

## The fix

The response now carries `searched` and `unavailable`. `session` and `belief` are always present; `agentic`, `adaptive` and `typed` are optional and get named when missing. Both lists are scoped to the requested `source`, so asking for one backend does not claim the others were searched.

`describeBackendCoverage` is exported and pure — the point of the change is what the *response* says, so asserting it anywhere short of that would not mean anything.

| mutation | result |
| --- | --- |
| report every backend as searched | 2 failed |
| ignore the source filter | 1 failed |

The first is the honest-reporting direction; the second is the pair, since a complete install must not report phantom gaps.

## A vacuous-mock hazard the change surfaced

The suite's `getToolMemory` mock had only `queryAll` and `queryBySource`. Adding the availability reads made four existing tests fail — correctly, since the mock no longer satisfied the surface under test. Had I instead made the helper tolerate missing accessors, every coverage assertion would have passed vacuously against a mock that answers nothing. The mock now provides them, with a comment saying why.

2,651 tests pass across `src/mcp/tools`.

## Half of #4999 remains, deliberately

A backend that is **installed but throws mid-query** still contributes `[]` silently: each helper in `tool-memory-query.ts` wraps its backend in `try/catch → log.debug → []`, and the `if (result.ok)` guards have no `else`. Distinguishing "searched and errored" from "searched and found nothing" needs the error status threaded out of five helpers and up through `queryBySource`/`queryAll` — a larger change than this one, and worth doing separately rather than half-landing here.

`memory_stats.session`'s three meaningless numbers (also #4999) are untouched.
