### PR TITLE
test(mcp): round-trip four more tools against their declared output schemas

### DIFF
--- a/.changeset/output-schema-round-trip.md
+++ b/.changeset/output-schema-round-trip.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+test(mcp): round-trip four more tools against their declared output schemas
+
+A response field missing from a tool's `outputSchema` does not merely go
+unreported: the SDK validates structured content with
+`additionalProperties: false`, so every call fails with `-32602` and the tool
+becomes unusable. That shipped once and was caught only because `memory_query`
+happens to be round-tripped in the integration suite.
+
+A tool's own tests cannot see it — they call the registered handler directly and
+never cross the protocol — so the guard has to be a real client call.
+`memory_write`, `research_synthesize`, `run_workflow` and `research_add` now
+make one, asserting narrowly: a business failure is fine, an output-schema
+violation is not.
+
+Partial coverage of #5045, which remains open for the tools this harness does
+not register.

--- a/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
+++ b/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
@@ -148,6 +148,45 @@ describe('MCP Standalone Tools Integration', () => {
   });
 
   // --------------------------------------------------------------------------
+  // Output-schema round-trip (#5045)
+  // --------------------------------------------------------------------------
+
+  /**
+   * A response field missing from a tool's declared `outputSchema` does not go
+   * unreported — the SDK validates structured content with
+   * `additionalProperties: false`, so EVERY call fails with -32602 and the tool
+   * becomes unusable. #5044 shipped exactly that and was caught only because
+   * `memory_query` happens to be round-tripped here.
+   *
+   * The tool's own tests cannot see it: they call the registered handler
+   * directly and never cross the protocol. So the guard has to be a real client
+   * call, and the assertion is narrow on purpose — a business failure is fine,
+   * an output-schema violation is not.
+   */
+  const SCHEMA_ROUND_TRIP: readonly { name: string; args: Record<string, unknown> }[] = [
+    { name: 'memory_write', args: { key: 'rt-key', content: 'round-trip', backend: 'session' } },
+    { name: 'research_synthesize', args: {} },
+    { name: 'run_workflow', args: { action: 'list' } },
+    { name: 'research_add', args: { title: 'rt', url: 'https://example.invalid/rt' } },
+  ];
+
+  for (const { name, args } of SCHEMA_ROUND_TRIP) {
+    it(`${name} response satisfies its declared outputSchema`, async () => {
+      let failure = '';
+      try {
+        await ctx.client.callTool({ name, arguments: args });
+      } catch (error: unknown) {
+        failure = error instanceof Error ? error.message : JSON.stringify(error);
+      }
+
+      // A tool may legitimately refuse these arguments; what it may not do is
+      // return structured content its own schema rejects.
+      expect(failure).not.toContain('output schema');
+      expect(failure).not.toContain('-32602');
+    });
+  }
+
+  // --------------------------------------------------------------------------
   // registry_import
   // --------------------------------------------------------------------------
 


### PR DESCRIPTION
Partial coverage of #5045.

## The class

A response field missing from a tool's `outputSchema` does not go unreported — the SDK validates structured content with `additionalProperties: false`, so **every call fails with `-32602`** and the tool becomes unusable. #5044 shipped exactly that, and was caught only because `memory_query` happens to be one of the six tools round-tripped here.

A tool's own tests cannot see it: they call the registered handler directly and never cross the protocol. The guard has to be a real client call.

`memory_write`, `research_synthesize`, `run_workflow` and `research_add` now make one. The assertion is deliberately narrow — a business failure is fine, an output-schema violation is not — so the test does not become a de-facto behaviour test of four unrelated tools.

## The mutation, and the first one that was wrong

Injecting an undeclared field into `writeToAgentic` **survived** — because the test calls `memory_write` with `backend: 'session'`, which never reaches that path. Moving the injection to `writeToSession`, the path the test actually drives, fails it.

Worth recording: a mutation that misses the exercised code path proves nothing, and reads exactly like a passing guard. That is the same shape as the three surviving mutations found earlier tonight, arriving from the fixture side instead of the code side.

| mutation | result |
| --- | --- |
| undeclared field on the agentic path (not exercised) | survived — wrong mutation |
| undeclared field on the session path (exercised) | 1 failed |

15 tests pass.

## Scope

This harness registers 15 tools; #5045 counts 23 files declaring an `outputSchema`. The rest are registered elsewhere, so the issue stays open rather than being marked done by a partial guard. I also did not add the static response-vs-schema comparison it mentions as an alternative — a regex version would be the kind of check that cannot fail, which is the class #5028 is about.
