### PR TITLE
feat(research): say how many findings a cluster actually had

### DIFF
--- a/.changeset/synthesis-discloses-truncation.md
+++ b/.changeset/synthesis-discloses-truncation.md
@@ -1,0 +1,16 @@
+---
+'nexus-agents': minor
+---
+
+feat(research): say how many findings a cluster actually had
+
+`keyInsights` is capped at ten, and the cap bites: against the live registry six
+of eleven clusters exceed it, `orchestration` with 55 distinct findings. A
+caller saw `paperCount: 40` beside ten insights and could not tell "these are
+the cluster's insights" from "these are ten of fifty-five".
+
+`ClusterSynthesis` now carries `totalInsights`, and the CLI renderer says
+`Key insights (5 of 55)` instead of `Key insights:` — three nested truncations
+(55 → 10 → 5), none of which was visible before.
+
+A bounded read is legitimate; a bounded read reported as complete is not.

--- a/packages/nexus-agents/src/cli/research-command.ts
+++ b/packages/nexus-agents/src/cli/research-command.ts
@@ -400,8 +400,11 @@ function formatCluster(cluster: SynthesisResult['clusters'][number], lines: stri
   lines.push(`Papers: ${cluster.papers.map((p) => p.title).join(', ')}`);
   if (cluster.commonThemes.length > 0) lines.push(`Themes: ${cluster.commonThemes.join(', ')}`);
   if (cluster.keyInsights.length > 0) {
-    lines.push('Key insights:');
-    // #2663 — each insight carries its source paper ids.
+    // #5001: say what portion this is. The renderer shows 5 of a list already
+    // capped at 10, over a cluster that may have had 55 — three nested
+    // truncations, none of which used to be visible.
+    const shown = Math.min(5, cluster.keyInsights.length);
+    lines.push(`Key insights (${String(shown)} of ${String(cluster.totalInsights)}):`);
     for (const insight of cluster.keyInsights.slice(0, 5)) {
       lines.push(`  - ${insight.insight} [${insight.sourcePaperIds.join(', ')}]`);
     }

--- a/packages/nexus-agents/src/cli/research-helpers-synthesize.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-synthesize.test.ts
@@ -362,3 +362,43 @@ describe('synthesizeResearch', () => {
     expect(first.paperCount).toBe(3);
   });
 });
+
+describe('cluster insight truncation is disclosed (#5001)', () => {
+  function registryWithFindings(count: number): Record<string, unknown> {
+    const papers: Record<string, Record<string, unknown>> = {};
+    for (let i = 0; i < count; i++) {
+      papers[`p${String(i)}`] = makePaper(String(i), `Paper ${String(i)}`, ['memory'], ['x'], {
+        key_findings: [`distinct finding number ${String(i)}`],
+      });
+    }
+    return makeRegistry(papers);
+  }
+
+  it('reports the full finding count when the cap bites', async () => {
+    // `keyInsights` is capped at 10 and the cap bites in practice: against the
+    // live registry six of eleven clusters exceed it, `orchestration` with 55.
+    // Ten insights beside `paperCount` were indistinguishable from a cluster
+    // that had exactly ten.
+    mockLoadPapersRegistry.mockResolvedValue({ ok: true, value: registryWithFindings(12) });
+
+    const result = await synthesizeResearch('memory');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const cluster = result.value.clusters[0];
+    expect(cluster?.keyInsights.length).toBe(10);
+    expect(cluster?.totalInsights).toBe(12);
+  });
+
+  it('reports an honest count when nothing was dropped', async () => {
+    // The pair: a cluster inside the cap must not imply hidden findings.
+    mockLoadPapersRegistry.mockResolvedValue({ ok: true, value: registryWithFindings(3) });
+
+    const result = await synthesizeResearch('memory');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const cluster = result.value.clusters[0];
+    expect(cluster?.totalInsights).toBe(cluster?.keyInsights.length);
+  });
+});

--- a/packages/nexus-agents/src/cli/research-helpers-synthesize.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-synthesize.ts
@@ -101,6 +101,16 @@ export interface ClusterSynthesis {
   readonly papers: readonly SynthesisPaperRef[];
   readonly commonThemes: readonly string[];
   readonly keyInsights: readonly AttributedInsight[];
+  /**
+   * How many attributed findings this cluster actually had (#5001).
+   *
+   * `keyInsights` is capped, and the cap bites: against the live registry six
+   * of eleven clusters exceed it, `orchestration` with 55. A caller seeing
+   * `paperCount: 40` beside ten insights could not tell "these are the
+   * cluster's insights" from "these are ten of fifty-five". A bounded read is
+   * fine; a bounded read reported as complete is not.
+   */
+  readonly totalInsights: number;
   readonly techniques: readonly string[];
   readonly implementationOpportunities: readonly string[];
   readonly gaps: readonly string[];
@@ -352,17 +362,34 @@ function synthesizeCluster(cluster: PaperCluster): ClusterSynthesis {
   }
 
   return {
+    ...insightFields(cluster.papers),
     topic: cluster.topic,
     paperCount: cluster.paperCount,
     papers: cluster.papers.map(toPaperRef),
     commonThemes,
-    keyInsights: attributeFindings(cluster.papers).slice(0, 10),
     techniques,
     implementationOpportunities: uniqueOpportunities,
     gaps,
     alignedTechniques,
     qualityDistribution,
   };
+}
+
+/** Insights carried per cluster. The count dropped is disclosed, not silent. */
+const MAX_CLUSTER_INSIGHTS = 10;
+
+/**
+ * The capped insight list plus the count it was capped from (#5001).
+ *
+ * Returned together so the two can never drift: a `keyInsights` without its
+ * `totalInsights` is the silent truncation this replaced.
+ */
+function insightFields(papers: readonly SynthesisPaper[]): {
+  keyInsights: readonly AttributedInsight[];
+  totalInsights: number;
+} {
+  const all = attributeFindings(papers);
+  return { keyInsights: all.slice(0, MAX_CLUSTER_INSIGHTS), totalInsights: all.length };
 }
 
 /** Find themes that span multiple topic clusters. */


### PR DESCRIPTION
Closes finding 1 of #5001.

## A cap that bites, reported as complete

`keyInsights: attributeFindings(cluster.papers).slice(0, 10)` dropped findings with no count, flag, or gap entry. Against the live registry the cap is the common case, not an edge: `orchestration` has 55 distinct normalised findings, `code-generation` 47, `memory` 43, `routing` 42 — **six of eleven clusters exceed it.**

A caller saw `paperCount: 40` beside ten insights and could not tell "these are the cluster's insights" from "these are ten of fifty-five".

`ClusterSynthesis` now carries `totalInsights`, and the CLI renderer says `Key insights (5 of 55)` rather than `Key insights:` — three nested truncations (55 → 10 → 5), none of which was visible.

A bounded read is legitimate; a bounded read reported as complete is not.

## Kept together on purpose

`insightFields()` returns the capped list and its source count as one value, so `keyInsights` cannot be produced without `totalInsights` beside it. That is also what got the function back under the 50-line limit, but the reason to do it that way is the coupling: a later edit that recomputes one and not the other reintroduces exactly this defect.

| mutation | result |
| --- | --- |
| report the truncated length as the total | 1 failed |
| report the cap constant as the total | 2 failed |
| stop truncating entirely | 1 failed |

The third is the pair — the cap exists for a reason and removing it is not the fix.

6,884 tests pass across `src/cli`.

## Not in this PR

#5001's second finding stands: `AttributedInsightSchema` cannot fail at its only call site, because the input is non-empty by construction. `.rules/research.md` credits that schema with enforcing the provenance invariant — "a validated guarantee, not a hope" — when what actually holds it is the `Set` in `attributeFindings`. Correcting that claim touches a governance file, and adding the test that would make the schema a real check is a separate change.
