### PR TITLE
fix(routing): bound the total distilled-rule adjustment per candidate

### DIFF
--- a/.changeset/distilled-rule-aggregate-cap.md
+++ b/.changeset/distilled-rule-aggregate-cap.md
@@ -1,0 +1,21 @@
+---
+'nexus-agents': patch
+---
+
+fix(routing): bound the total distilled-rule adjustment per candidate
+
+`findMatchingRules` treats an undefined task category as match-all, and each
+matched rule was applied to the score separately with no bound on the sum. Since
+`detectTaskCategory` returns null for any content without a specialization
+keyword, an unscoped task could stack six penalties at confidence 0.88 into
+**-26.4** against a candidate at 0 — an order of magnitude past `avoidDelta`,
+the largest documented single-rule bound, driven entirely by rules learned for
+categories that were not this task's.
+
+Every documented bound was per-rule (`ACTION_DELTAS`); nothing bounded the
+aggregate. The matched deltas are now summed and clamped to the single-rule
+range, and a `distilled-rule:capped=<cli>` signal says when the clamp bit — a
+bounded score is not the same as one the rules produced, and the trace should
+not imply otherwise.
+
+Remedy chosen by a 7-voter panel: Option A, 4 of 6 approvers, audit record #81.

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/distilled-rule-stage.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/distilled-rule-stage.test.ts
@@ -117,6 +117,56 @@ describe('DistilledRuleStage', () => {
       }
     });
 
+    it('caps the aggregate when an unscoped task matches every rule (#5004)', async () => {
+      // `detectTaskCategory` returns null for content with no specialization
+      // keyword, and an undefined category matches ALL of a CLI's rules. Six
+      // penalties at confidence 0.88 stacked to -26.4 against a candidate at 0
+      // — an order of magnitude past `avoidDelta`, the largest documented
+      // single-rule bound, driven by rules learned for six unrelated
+      // categories.
+      const categories = [
+        'code_generation',
+        'code_review',
+        'documentation',
+        'testing',
+        'debugging',
+        'refactoring',
+      ];
+      const rules = categories.map((category) =>
+        makeRule({ id: `failure-rate:claude:${category}`, category, confidence: 1.0 })
+      );
+      const stage = new DistilledRuleStage(createMockDistiller(rules));
+      // No `task-category:` signal → the stage's category-unknown branch.
+      const ctx = createContext('an unscoped task', ['claude', 'gemini']);
+
+      const result = await stage.route(ctx);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const claudeScore = result.value.context.scores.get('claude') ?? 0;
+      expect(claudeScore).toBeGreaterThanOrEqual(-10);
+      expect(result.value.context.signals).toContain('distilled-rule:capped=claude');
+    });
+
+    it('leaves an in-bounds aggregate untouched', async () => {
+      // The pair: the cap must clamp, not flatten. A single penalty is well
+      // inside the bound and must still be applied at its full value.
+      const rules = [makeRule({ action: 'penalize', confidence: 1.0 })];
+      const stage = new DistilledRuleStage(createMockDistiller(rules));
+      const ctx = createContext(
+        'test task',
+        ['claude', 'gemini'],
+        ['task-category:code_generation']
+      );
+
+      const result = await stage.route(ctx);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.context.scores.get('claude')).toBe(-5);
+      expect(result.value.context.signals).not.toContain('distilled-rule:capped=claude');
+    });
+
     it('applies penalize action to matching CLI', async () => {
       const rules = [makeRule({ action: 'penalize', confidence: 1.0 })];
       const stage = new DistilledRuleStage(createMockDistiller(rules));

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/distilled-rule-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/distilled-rule-stage.ts
@@ -125,14 +125,32 @@ export class DistilledRuleStage implements IRouterStage {
 
     for (const cli of candidates) {
       const matchingRules = this.findMatchingRules(activeRules, cli, category);
+      if (matchingRules.length === 0) continue;
+
+      // #5004: sum first, then clamp. Each rule was applied separately with no
+      // bound on the total, so an unscoped task — `detectTaskCategory` returns
+      // null for any content without a specialization keyword, and an undefined
+      // category matches ALL of a CLI's rules — could stack six penalties into
+      // -26.4 against a candidate at 0. Every documented bound is per-rule
+      // (`ACTION_DELTAS`), and nothing bounded the sum. Panel decision:
+      // Option A, 4 of 6 approvers, audit record #81.
+      const raw = matchingRules.reduce((sum, rule) => sum + this.computeDelta(rule), 0);
+      const capped = Math.min(this.config.boostDelta, Math.max(this.config.avoidDelta, raw));
+      updated = updateScore(updated, cli, capped);
       for (const rule of matchingRules) {
-        const delta = this.computeDelta(rule);
-        updated = updateScore(updated, cli, delta);
         updated = {
           ...updated,
           signals: [...updated.signals, `distilled-rule:applied=${rule.id}`],
         };
         applied++;
+      }
+      if (capped !== raw) {
+        // Disclose the clamp: a score that was bounded is not the same as one
+        // the rules produced, and the trace should not imply otherwise.
+        updated = {
+          ...updated,
+          signals: [...updated.signals, `distilled-rule:capped=${cli}`],
+        };
       }
     }
 


### PR DESCRIPTION
Closes finding 2 of #5004. Remedy chosen by a 7-voter panel: **Option A**, 85.7% supermajority, 4 of 6 approvers (B took 2), audit record #81.

## An unbounded sum of per-rule bounds

`findMatchingRules` treats an undefined category as match-all:

```ts
rules.filter((r) => r.cli === cli && (category === undefined || r.category === category))
```

and each match was applied to the score separately. `detectTaskCategory` returns null for any content without a specialization keyword, so an unscoped task matches **every** rule a CLI has. Six penalties at confidence 0.88 stack to **-26.4** against a candidate at 0 — an order of magnitude past `avoidDelta`, the largest documented single-rule bound, driven entirely by rules learned for six categories that were not this task's.

`ACTION_DELTAS` documents bounds per rule. Nothing bounded the sum. That is why this went to a vote rather than being fixed as a bug: capping the aggregate introduces a ceiling the code never claimed, and the alternatives — dropping unscoped rules entirely, or documenting the behaviour — each discard something real.

## The clamp discloses itself

A `distilled-rule:capped=<cli>` signal fires when the bound bites. A bounded score is not the same as one the rules produced, and after a night of finding records that quietly rounded off what actually happened, adding a clamp without saying when it applies would have been the same mistake in a new place.

The per-rule `distilled-rule:applied=` signals are unchanged, so the trace still names every rule that contributed.

| mutation | result |
| --- | --- |
| remove the cap | 1 failed |
| always clamp to the floor | 3 failed |
| hide the cap signal | 1 failed |

The second is the pair: the cap must clamp, not flatten — a single in-bounds penalty still applies at its full -5.

2,717 tests pass across `src/cli-adapters`.

## Margin worth noting

The leading option took 4 of 6 approver selections — 66.7%, which clears the bar but not comfortably. The two B votes wanted no distilled adjustment at all on an unscoped task. If the cap turns out to under-correct in practice, B is the documented fallback rather than a new question.

## Remaining in #5004

`confidence` is a sample-count sigmoid that ignores the metric it is named for yet scales the penalty, and `promote()` writes a latency ratio into `successRate` while having no production caller — which also makes the documented `promotionConfidence: 0.7` gate dead. Both are separate decisions.
