### PR TITLE
fix(mcp): report backends that threw during a memory query

### DIFF
--- a/.changeset/memory-query-reports-errored-backends.md
+++ b/.changeset/memory-query-reports-errored-backends.md
@@ -1,8 +1,8 @@
 ---
-'nexus-agents': patch
+'nexus-agents': minor
 ---
 
-fix(mcp): `memory_query` says when a backend threw instead of reporting an empty result
+feat(mcp): `memory_query` says when a backend threw instead of reporting an empty result
 
 Each per-backend query helper catches its own error, logs at debug, and returns
 `[]`. The empty array is right — partial results beat none — but it left a

--- a/.changeset/memory-query-reports-errored-backends.md
+++ b/.changeset/memory-query-reports-errored-backends.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): `memory_query` says when a backend threw instead of reporting an empty result
+
+Each per-backend query helper catches its own error, logs at debug, and returns
+`[]`. The empty array is right — partial results beat none — but it left a
+corrupted SQLite file indistinguishable from a store that simply matched
+nothing, and the response reported both as a successful search.
+
+The helpers now take a `MemoryQueryContext` carrying an optional `onFailure`
+reporter alongside the logger, `queryBySource`/`queryAll` thread a per-source
+reporter through it, and the new `ToolMemoryManager.queryWithStatus` returns the
+failing source names next to the results. `memory_query` surfaces them as
+`errored` — on the single-source path as much as on `'all'`, so the field always
+means "observed to throw", never "not checked".
+
+Completes the second half of #4999; the first half (`searched`/`unavailable`,
+which backends were installed at all) shipped in #5044.

--- a/.changeset/memory-query-reports-errored-backends.md
+++ b/.changeset/memory-query-reports-errored-backends.md
@@ -10,7 +10,11 @@ corrupted SQLite file indistinguishable from a store that simply matched
 nothing, and the response reported both as a successful search.
 
 The helpers now take a `MemoryQueryContext` carrying an optional `onFailure`
-reporter alongside the logger, `queryBySource`/`queryAll` thread a per-source
+reporter alongside the logger, fired on an `err` Result as well as on a thrown
+exception — every real backend catches internally and resolves with `err(...)`,
+so reporting only from `catch` would have left the disclosure unreachable for
+the corrupt store it exists for. `ok([])` stays silent: that is a miss, not a
+failure. From there `queryBySource`/`queryAll` thread a per-source
 reporter through it, and the new `ToolMemoryManager.queryWithStatus` returns the
 failing source names next to the results. `memory_query` surfaces them as
 `errored` — on the single-source path as much as on `'all'`, so the field always

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -5336,6 +5336,7 @@ VariableDeclaration MemoryQueryInputSchema
   : z.ZodObject<{ limit: z.ZodDefault<z.ZodOptional<z.ZodNumber>>; query: z.ZodString; source: z.ZodDefault<z.ZodOptional<z.ZodEnum<{ adaptive: "adaptive"; agentic: "agentic"; all: "all"; belief: "belief"; session: "session"; typed: "typed"; }>>>; }, z.core.$strip>
 InterfaceDeclaration MemoryQueryResponse
   count: number
+  errored: readonly string[]
   expandedQuery?: string | undefined
   query: string
   results: readonly UnifiedMemoryResult[]

--- a/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
@@ -36,6 +36,7 @@ const mockQueryBySource = vi.fn();
 // reads — the response says which backends answered, so a mock without them
 // would make every coverage assertion vacuous.
 const backendsInstalled = { agentic: true, adaptive: true, typed: true };
+let mockErroredBackends: readonly string[] = [];
 const mockAvailability = {
   isAgenticMemoryAvailable: (): boolean => backendsInstalled.agentic,
   isAdaptiveMemoryAvailable: (): boolean => backendsInstalled.adaptive,
@@ -45,6 +46,17 @@ vi.mock('./tool-memory.js', () => ({
   getToolMemory: () => ({
     queryAll: mockQueryAll,
     queryBySource: mockQueryBySource,
+    // #4999: the search reports which backends threw. A mock without this
+    // makes every coverage assertion below vacuous — the third time this mock
+    // has had to grow with the surface, which is itself a seam worth watching.
+    queryWithStatus: async (
+      source: string,
+      query: string,
+      limit?: number
+    ): Promise<{ results: unknown; errored: readonly string[] }> => ({
+      results: await mockQueryBySource(source, query, limit),
+      errored: mockErroredBackends,
+    }),
     ...mockAvailability,
   }),
 }));
@@ -269,6 +281,37 @@ describe('memory-query', () => {
         expect(body.count).toBe(0);
         expect(body.unavailable).toEqual(['agentic', 'typed']);
         expect(body.searched).toEqual(['session', 'belief', 'adaptive']);
+      });
+
+      it('names a backend that was installed but threw (#4999)', async () => {
+        // Distinct from `unavailable`: the store is here, it just could not
+        // answer. Each helper swallows its failure into an empty result set, so
+        // a corrupted SQLite file read exactly like a store with no matches.
+        mockErroredBackends = ['agentic', 'typed'];
+        mockQueryBySource.mockResolvedValue([]);
+
+        const result = await registeredHandler({ query: 'routing' }, {});
+        const body = JSON.parse(result.content[0]?.text ?? '{}') as {
+          count: number;
+          errored: string[];
+          unavailable: string[];
+        };
+
+        expect(body.count).toBe(0);
+        expect(body.errored).toEqual(['agentic', 'typed']);
+        // The stores are installed — this is not the unavailable case.
+        expect(body.unavailable).toEqual([]);
+      });
+
+      it('reports no errors when every backend answered', async () => {
+        // The pair: a healthy search must not imply failures.
+        mockErroredBackends = [];
+        mockQueryBySource.mockResolvedValue([]);
+
+        const result = await registeredHandler({ query: 'routing' }, {});
+        const body = JSON.parse(result.content[0]?.text ?? '{}') as { errored: string[] };
+
+        expect(body.errored).toEqual([]);
       });
 
       it('reports no gaps on a complete install', async () => {

--- a/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.test.ts
@@ -264,6 +264,9 @@ describe('memory-query', () => {
         backendsInstalled.agentic = true;
         backendsInstalled.adaptive = true;
         backendsInstalled.typed = true;
+        // Reset alongside the install flags: a test that sets this and does
+        // not clear it makes every later assertion order-dependent.
+        mockErroredBackends = [];
       });
 
       it('names the backends that are not installed', async () => {

--- a/packages/nexus-agents/src/mcp/tools/memory-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/memory-query.ts
@@ -92,6 +92,14 @@ export interface MemoryQueryResponse {
   searched: readonly string[];
   /** Backends skipped because they are not configured on this install. */
   unavailable: readonly string[];
+  /**
+   * Backends that were installed and threw while answering (#4999).
+   *
+   * Distinct from `unavailable`: the store is here, it just could not answer.
+   * Each helper swallows its own failure into an empty result set, so without
+   * this a corrupted SQLite file read exactly like a store with no matches.
+   */
+  errored: readonly string[];
 }
 
 /**
@@ -205,7 +213,11 @@ async function executeMemoryQuery(
     logger
   );
 
-  const results = await toolMemory.queryBySource(input.source, effectiveQuery, input.limit);
+  // #4999: the same search, with the failures each backend swallows collected
+  // instead of discarded. `errored` therefore always means "observed to throw",
+  // never "not checked" — on the single-source path as much as on 'all'.
+  const searchResult = await toolMemory.queryWithStatus(input.source, effectiveQuery, input.limit);
+  const results = searchResult.results;
 
   logger.debug('Memory query executed', {
     query: input.query,
@@ -225,6 +237,7 @@ async function executeMemoryQuery(
     source: input.source,
     searched: coverage.searched,
     unavailable: coverage.unavailable,
+    errored: searchResult.errored,
   };
 }
 
@@ -305,6 +318,7 @@ export function registerMemoryQueryTool(server: McpServer, deps: MemoryQueryDeps
     // because they call the handler directly and never cross the protocol.
     searched: z.array(z.string()),
     unavailable: z.array(z.string()),
+    errored: z.array(z.string()),
   };
 
   server.registerTool(

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-query.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-query.test.ts
@@ -71,7 +71,12 @@ vi.mock('./memory-decay.js', () => ({
   })),
 }));
 
-import { queryBeliefMemory } from './tool-memory-query.js';
+import {
+  queryBeliefMemory,
+  queryAgenticMemory,
+  queryTypedMemory,
+  queryAdaptiveMemory,
+} from './tool-memory-query.js';
 import { ToolMemoryManager } from './tool-memory.js';
 
 function createMockLogger(): ILogger {
@@ -328,6 +333,122 @@ describe('query helpers report a swallowed failure (#4999)', () => {
     expect(onFailure).toHaveBeenCalledTimes(1);
   });
 
+  it('calls onFailure when the backend returns an error Result', async () => {
+    // This, not the throw above, is what production actually does. Every real
+    // backend catches its own exception and returns `err(...)`:
+    // HybridMemoryBackend.search, searchAgentic and the belief recall path all
+    // resolve rather than reject. Reporting only from `catch` made the whole
+    // disclosure unreachable for the corrupt-store case it exists for.
+    const erroringBeliefs = {
+      recallBySubject: (): Promise<{ ok: false; error: Error }> =>
+        Promise.resolve({ ok: false, error: new Error('db is corrupt') }),
+      query: (): Promise<{ ok: false; error: Error }> =>
+        Promise.resolve({ ok: false, error: new Error('db is corrupt') }),
+    };
+    const onFailure = vi.fn();
+
+    const results = await queryBeliefMemory(erroringBeliefs as never, 'routing', ['routing'], 5, {
+      log: createMockLogger(),
+      onFailure,
+    });
+
+    expect(results).toEqual([]);
+    expect(onFailure).toHaveBeenCalled();
+  });
+
+  // One case per helper: the belief tests above cover only one of the four
+  // `err` reports, and a solo mutation of any other line survived without
+  // these. Each backend is stubbed to resolve `err` — the shape a corrupt
+  // SQLite file actually produces.
+  const ERR = { ok: false as const, error: new Error('db is corrupt') };
+
+  it('reports an agentic backend that could not answer', async () => {
+    const onFailure = vi.fn();
+
+    const results = await queryAgenticMemory(
+      { searchAgentic: () => Promise.resolve(ERR) } as never,
+      'routing',
+      ['routing'],
+      5,
+      { log: createMockLogger(), onFailure }
+    );
+
+    expect(results).toEqual([]);
+    expect(onFailure).toHaveBeenCalled();
+  });
+
+  it('reports a typed backend that could not answer', async () => {
+    const onFailure = vi.fn();
+
+    const results = await queryTypedMemory(
+      { queryByType: () => Promise.resolve(ERR) } as never,
+      'routing',
+      ['routing'],
+      5,
+      { log: createMockLogger(), onFailure }
+    );
+
+    expect(results).toEqual([]);
+    expect(onFailure).toHaveBeenCalled();
+  });
+
+  it('reports an adaptive backend that could not answer', async () => {
+    const onFailure = vi.fn();
+
+    const results = await queryAdaptiveMemory(
+      { search: () => Promise.resolve(ERR) } as never,
+      'routing',
+      ['routing'],
+      5,
+      { log: createMockLogger(), onFailure }
+    );
+
+    expect(results).toEqual([]);
+    expect(onFailure).toHaveBeenCalled();
+  });
+
+  it('reports a failed subject recall with no keywords to fall back on', async () => {
+    // Pins the FIRST belief report specifically. With keywords present the
+    // fallback also fails and fires the second report, so a solo mutation of
+    // this line survived until the no-keyword case existed.
+    const onFailure = vi.fn();
+
+    const results = await queryBeliefMemory(
+      {
+        recallBySubject: () => Promise.resolve(ERR),
+        query: () => Promise.resolve({ ok: true as const, value: [] }),
+      } as never,
+      'routing',
+      [],
+      5,
+      { log: createMockLogger(), onFailure }
+    );
+
+    expect(results).toEqual([]);
+    expect(onFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a belief keyword scan that could not answer', async () => {
+    // The second belief call: `recallBySubject` succeeds with no match, so the
+    // keyword fallback runs and it is the one that fails. Without this, the
+    // two belief reports mask each other under solo mutation.
+    const onFailure = vi.fn();
+
+    const results = await queryBeliefMemory(
+      {
+        recallBySubject: () => Promise.resolve({ ok: true as const, value: [] }),
+        query: () => Promise.resolve(ERR),
+      } as never,
+      'routing',
+      ['routing'],
+      5,
+      { log: createMockLogger(), onFailure }
+    );
+
+    expect(results).toEqual([]);
+    expect(onFailure).toHaveBeenCalled();
+  });
+
   it('does not call onFailure when the backend answers', async () => {
     // The pair: a healthy empty result must not be reported as a failure.
     const emptyBeliefs = {
@@ -353,9 +474,14 @@ describe('queryWithStatus names the backends that threw (#4999)', () => {
   // backend is injected into a real manager rather than stubbed at the top.
   function managerWithThrowingBeliefs(): ToolMemoryManager {
     const manager = new ToolMemoryManager(createMockLogger());
+    // An error Result, not a rejection: that is the shape every real backend
+    // produces for a corrupt store, and the shape the first draft of this
+    // disclosure could not see.
     (manager as unknown as { beliefs: unknown }).beliefs = {
-      recallBySubject: (): Promise<never> => Promise.reject(new Error('db is corrupt')),
-      query: (): Promise<never> => Promise.reject(new Error('db is corrupt')),
+      recallBySubject: (): Promise<{ ok: false; error: Error }> =>
+        Promise.resolve({ ok: false, error: new Error('db is corrupt') }),
+      query: (): Promise<{ ok: false; error: Error }> =>
+        Promise.resolve({ ok: false, error: new Error('db is corrupt') }),
     };
     return manager;
   }

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-query.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-query.test.ts
@@ -71,6 +71,7 @@ vi.mock('./memory-decay.js', () => ({
   })),
 }));
 
+import { queryBeliefMemory } from './tool-memory-query.js';
 import { ToolMemoryManager } from './tool-memory.js';
 
 function createMockLogger(): ILogger {
@@ -303,5 +304,85 @@ describe('tool-memory cross-query', () => {
         expect(results[i - 1]!.relevance).toBeGreaterThanOrEqual(results[i]!.relevance);
       }
     });
+  });
+});
+
+describe('query helpers report a swallowed failure (#4999)', () => {
+  it('calls onFailure when the backend throws', async () => {
+    // Each helper catches its backend's error and returns `[]`, so a store
+    // that threw was indistinguishable from one that matched nothing. The
+    // empty array is still returned — partial results beat none — but the
+    // caller now learns the store could not answer.
+    const throwingBeliefs = {
+      recallBySubject: (): Promise<never> => Promise.reject(new Error('db is corrupt')),
+      query: (): Promise<never> => Promise.reject(new Error('db is corrupt')),
+    };
+    const onFailure = vi.fn();
+
+    const results = await queryBeliefMemory(throwingBeliefs as never, 'routing', ['routing'], 5, {
+      log: createMockLogger(),
+      onFailure,
+    });
+
+    expect(results).toEqual([]);
+    expect(onFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onFailure when the backend answers', async () => {
+    // The pair: a healthy empty result must not be reported as a failure.
+    const emptyBeliefs = {
+      recallBySubject: (): Promise<{ ok: true; value: never[] }> =>
+        Promise.resolve({ ok: true, value: [] }),
+      query: (): Promise<{ ok: true; value: never[] }> => Promise.resolve({ ok: true, value: [] }),
+    };
+    const onFailure = vi.fn();
+
+    const results = await queryBeliefMemory(emptyBeliefs as never, 'routing', ['routing'], 5, {
+      log: createMockLogger(),
+      onFailure,
+    });
+
+    expect(results).toEqual([]);
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+});
+
+describe('queryWithStatus names the backends that threw (#4999)', () => {
+  // The seam: helper `onFailure` -> queryAll's `errored` reporter -> the
+  // caller's list. Mutating either link must fail a test here, so the failing
+  // backend is injected into a real manager rather than stubbed at the top.
+  function managerWithThrowingBeliefs(): ToolMemoryManager {
+    const manager = new ToolMemoryManager(createMockLogger());
+    (manager as unknown as { beliefs: unknown }).beliefs = {
+      recallBySubject: (): Promise<never> => Promise.reject(new Error('db is corrupt')),
+      query: (): Promise<never> => Promise.reject(new Error('db is corrupt')),
+    };
+    return manager;
+  }
+
+  it('reports the failing source instead of an innocuous empty result', async () => {
+    const { results, errored } = await managerWithThrowingBeliefs().queryWithStatus(
+      'all',
+      'routing'
+    );
+
+    expect(results).toEqual([]);
+    expect(errored).toContain('belief');
+  });
+
+  it('reports the failing source on a single-source query too', async () => {
+    // The single-source path used to hardcode `errored: []` — a corrupt store
+    // read as an empty one whenever the caller named it directly.
+    const { errored } = await managerWithThrowingBeliefs().queryWithStatus('belief', 'routing');
+
+    expect(errored).toEqual(['belief']);
+  });
+
+  it('reports nothing when every backend answers', async () => {
+    const manager = new ToolMemoryManager(createMockLogger());
+
+    const { errored } = await manager.queryWithStatus('all', 'routing');
+
+    expect(errored).toEqual([]);
   });
 });

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-query.ts
@@ -67,7 +67,7 @@ export function querySessionMemory(
  * returns `[]` (#4999): partial results beat none, but the caller must still
  * be able to tell "this store threw" from "this store matched nothing".
  */
-export interface MemoryQueryContext {
+interface MemoryQueryContext {
   readonly log: ILogger;
   readonly onFailure?: (() => void) | undefined;
 }

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-query.ts
@@ -65,11 +65,43 @@ export function querySessionMemory(
  *
  * `onFailure` exists because each helper swallows its backend's error and
  * returns `[]` (#4999): partial results beat none, but the caller must still
- * be able to tell "this store threw" from "this store matched nothing".
+ * be able to tell "this store failed" from "this store matched nothing".
+ *
+ * It must fire on an `err` Result as well as on a thrown exception. Every real
+ * backend catches internally and resolves with `err(...)` —
+ * `HybridMemoryBackend.search`, `searchAgentic` and the belief recall path all
+ * do — so a version that reported only from `catch` could not see the corrupt
+ * store it was written for. `ok([])` is a miss and stays silent; `err` is a
+ * failure and is always reported.
  */
 interface MemoryQueryContext {
   readonly log: ILogger;
   readonly onFailure?: (() => void) | undefined;
+}
+
+/**
+ * Keyword fallback for a subject recall that matched nothing (#1225).
+ *
+ * Extracted so `queryBeliefMemory` stays within the complexity bar; it reports
+ * its own `err` Result because a failed scan is a store that could not answer,
+ * not a store with no matches.
+ */
+async function keywordScanBeliefs(
+  beliefs: HindsightBeliefMemory,
+  keywords: readonly string[],
+  onFailure: (() => void) | undefined
+): Promise<readonly Belief[]> {
+  if (keywords.length === 0) return [];
+  const KEYWORD_SCAN_LIMIT = 1000;
+  const allResult = await beliefs.query({ includeSuperseded: false, limit: KEYWORD_SCAN_LIMIT });
+  if (!allResult.ok) {
+    onFailure?.();
+    return [];
+  }
+  return allResult.value.filter((b) => {
+    const text = (b.subject + ' ' + b.predicate + ' ' + b.object).toLowerCase();
+    return keywords.some((k) => text.includes(k));
+  });
 }
 
 /** Query BeliefMemory. Falls back to keyword search when exact match misses (#1225). */
@@ -84,22 +116,11 @@ export async function queryBeliefMemory(
   const results: UnifiedMemoryResult[] = [];
   try {
     const beliefResult = await beliefs.recallBySubject(query, limit);
-    let matched: readonly Belief[] = [];
-    if (beliefResult.ok && beliefResult.value.length > 0) {
-      matched = beliefResult.value;
-    } else if (keywords.length > 0) {
-      const KEYWORD_SCAN_LIMIT = 1000;
-      const allResult = await beliefs.query({
-        includeSuperseded: false,
-        limit: KEYWORD_SCAN_LIMIT,
-      });
-      if (allResult.ok) {
-        matched = allResult.value.filter((b) => {
-          const text = (b.subject + ' ' + b.predicate + ' ' + b.object).toLowerCase();
-          return keywords.some((k) => text.includes(k));
-        });
-      }
-    }
+    if (!beliefResult.ok) onFailure?.();
+    const matched =
+      beliefResult.ok && beliefResult.value.length > 0
+        ? beliefResult.value
+        : await keywordScanBeliefs(beliefs, keywords, onFailure);
     for (const b of matched.filter((x) => !x.superseded)) {
       results.push({
         source: 'belief',
@@ -132,6 +153,7 @@ export async function queryAgenticMemory(
   const results: UnifiedMemoryResult[] = [];
   try {
     const agResult = await agentic.searchAgentic(query, limit);
+    if (!agResult.ok) onFailure?.();
     if (agResult.ok) {
       for (const e of agResult.value) {
         results.push({
@@ -167,6 +189,7 @@ export async function queryTypedMemory(
       typed.queryByType('episodic', query, limitPerType),
     ]);
     for (const r of [semanticResult, episodicResult]) {
+      if (!r.ok) onFailure?.();
       if (r.ok) {
         for (const e of r.value) {
           results.push({
@@ -198,6 +221,7 @@ export async function queryAdaptiveMemory(
   const results: UnifiedMemoryResult[] = [];
   try {
     const searchResult = await adaptive.search(query, limit);
+    if (!searchResult.ok) onFailure?.();
     if (searchResult.ok) {
       for (const e of searchResult.value) {
         results.push({

--- a/packages/nexus-agents/src/mcp/tools/tool-memory-query.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory-query.ts
@@ -60,14 +60,27 @@ export function querySessionMemory(
   }));
 }
 
+/**
+ * Logging + failure-reporting context shared by the per-backend query helpers.
+ *
+ * `onFailure` exists because each helper swallows its backend's error and
+ * returns `[]` (#4999): partial results beat none, but the caller must still
+ * be able to tell "this store threw" from "this store matched nothing".
+ */
+export interface MemoryQueryContext {
+  readonly log: ILogger;
+  readonly onFailure?: (() => void) | undefined;
+}
+
 /** Query BeliefMemory. Falls back to keyword search when exact match misses (#1225). */
 export async function queryBeliefMemory(
   beliefs: HindsightBeliefMemory,
   query: string,
   keywords: readonly string[],
   limit: number,
-  log: ILogger
+  ctx: MemoryQueryContext
 ): Promise<UnifiedMemoryResult[]> {
+  const { log, onFailure } = ctx;
   const results: UnifiedMemoryResult[] = [];
   try {
     const beliefResult = await beliefs.recallBySubject(query, limit);
@@ -98,7 +111,11 @@ export async function queryBeliefMemory(
       });
     }
   } catch (e: unknown) {
+    // #4999: a swallowed failure used to be indistinguishable from an empty
+    // result set. The caller still gets `[]` — partial results are better than
+    // none — but it now learns the store could not answer.
     log.debug('Belief memory query failed', { error: String(e) });
+    onFailure?.();
   }
   return results;
 }
@@ -109,8 +126,9 @@ export async function queryAgenticMemory(
   query: string,
   keywords: readonly string[],
   limit: number,
-  log: ILogger
+  ctx: MemoryQueryContext
 ): Promise<UnifiedMemoryResult[]> {
+  const { log, onFailure } = ctx;
   const results: UnifiedMemoryResult[] = [];
   try {
     const agResult = await agentic.searchAgentic(query, limit);
@@ -128,6 +146,7 @@ export async function queryAgenticMemory(
     }
   } catch (e: unknown) {
     log.debug('Agentic memory query failed', { error: String(e) });
+    onFailure?.();
   }
   return results;
 }
@@ -138,8 +157,9 @@ export async function queryTypedMemory(
   query: string,
   keywords: readonly string[],
   limitPerType: number,
-  log: ILogger
+  ctx: MemoryQueryContext
 ): Promise<UnifiedMemoryResult[]> {
+  const { log, onFailure } = ctx;
   const results: UnifiedMemoryResult[] = [];
   try {
     const [semanticResult, episodicResult] = await Promise.all([
@@ -161,6 +181,7 @@ export async function queryTypedMemory(
     }
   } catch (e: unknown) {
     log.debug('Typed memory query failed', { error: String(e) });
+    onFailure?.();
   }
   return results;
 }
@@ -171,8 +192,9 @@ export async function queryAdaptiveMemory(
   query: string,
   keywords: readonly string[],
   limit: number,
-  log: ILogger
+  ctx: MemoryQueryContext
 ): Promise<UnifiedMemoryResult[]> {
+  const { log, onFailure } = ctx;
   const results: UnifiedMemoryResult[] = [];
   try {
     const searchResult = await adaptive.search(query, limit);
@@ -190,6 +212,7 @@ export async function queryAdaptiveMemory(
     }
   } catch (e: unknown) {
     log.debug('Adaptive memory query failed', { error: String(e) });
+    onFailure?.();
   }
   return results;
 }

--- a/packages/nexus-agents/src/mcp/tools/tool-memory.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-memory.ts
@@ -898,7 +898,11 @@ export class ToolMemoryManager {
    * Returns results from SessionMemory, BeliefMemory, AgenticMemory, and TypedMemory
    * with source attribution and relevance scoring.
    */
-  async queryAll(query: string, limit = 10): Promise<readonly UnifiedMemoryResult[]> {
+  async queryAll(
+    query: string,
+    limit = 10,
+    errored?: (source: string) => void
+  ): Promise<readonly UnifiedMemoryResult[]> {
     // Wait for SQLite backends to finish initializing before querying (#794 pattern)
     if (this.initPromise !== null) {
       await this.initPromise;
@@ -912,12 +916,34 @@ export class ToolMemoryManager {
     const perSource = Math.ceil(limit / sourceCount);
     const results = [
       ...this.querySessionMemory(query, keywords, perSource),
-      ...(await this.queryBeliefMemory(query, keywords, perSource)),
-      ...(await this.queryAgenticMemory(query, keywords, perSource)),
-      ...(await this.queryTypedMemory(query, keywords, Math.ceil(perSource / 2))),
-      ...(await this.queryAdaptiveMemory(query, keywords, perSource)),
+      ...(await this.queryBeliefMemory(query, keywords, perSource, () => errored?.('belief'))),
+      ...(await this.queryAgenticMemory(query, keywords, perSource, () => errored?.('agentic'))),
+      ...(await this.queryTypedMemory(query, keywords, Math.ceil(perSource / 2), () =>
+        errored?.('typed')
+      )),
+      ...(await this.queryAdaptiveMemory(query, keywords, perSource, () => errored?.('adaptive'))),
     ];
     return results.sort((a, b) => b.relevance - a.relevance).slice(0, limit);
+  }
+
+  /**
+   * `queryBySource`, plus the names of the backends that threw while answering (#4999).
+   *
+   * Each per-backend helper swallows its error and contributes `[]`, so a store
+   * that failed is invisible in the merged result set — indistinguishable from
+   * one that simply matched nothing. Callers that report coverage need the
+   * difference, and only this variant can tell them. Single-source queries get
+   * the same treatment as `'all'` — a corrupt store must not read as an empty
+   * one whichever way it was asked.
+   */
+  async queryWithStatus(
+    source: 'session' | 'belief' | 'agentic' | 'typed' | 'adaptive' | 'all',
+    query: string,
+    limit = 10
+  ): Promise<{ results: readonly UnifiedMemoryResult[]; errored: readonly string[] }> {
+    const failures = new Set<string>();
+    const results = await this.queryBySource(source, query, limit, (name) => failures.add(name));
+    return { results, errored: [...failures] };
   }
 
   /**
@@ -928,10 +954,11 @@ export class ToolMemoryManager {
   async queryBySource(
     source: 'session' | 'belief' | 'agentic' | 'typed' | 'adaptive' | 'all',
     query: string,
-    limit = 10
+    limit = 10,
+    errored?: (source: string) => void
   ): Promise<readonly UnifiedMemoryResult[]> {
     if (source === 'all') {
-      return this.queryAll(query, limit);
+      return this.queryAll(query, limit, errored);
     }
     // Wait for SQLite backends to finish initializing
     if (this.initPromise !== null) {
@@ -948,16 +975,18 @@ export class ToolMemoryManager {
         results = this.querySessionMemory(query, keywords, limit);
         break;
       case 'belief':
-        results = await this.queryBeliefMemory(query, keywords, limit);
+        results = await this.queryBeliefMemory(query, keywords, limit, () => errored?.('belief'));
         break;
       case 'agentic':
-        results = await this.queryAgenticMemory(query, keywords, limit);
+        results = await this.queryAgenticMemory(query, keywords, limit, () => errored?.('agentic'));
         break;
       case 'typed':
-        results = await this.queryTypedMemory(query, keywords, limit);
+        results = await this.queryTypedMemory(query, keywords, limit, () => errored?.('typed'));
         break;
       case 'adaptive':
-        results = await this.queryAdaptiveMemory(query, keywords, limit);
+        results = await this.queryAdaptiveMemory(query, keywords, limit, () =>
+          errored?.('adaptive')
+        );
         break;
     }
     return results.sort((a, b) => b.relevance - a.relevance).slice(0, limit);
@@ -977,39 +1006,55 @@ export class ToolMemoryManager {
   private async queryBeliefMemory(
     query: string,
     keywords: readonly string[],
-    limit: number
+    limit: number,
+    onFailure?: () => void
   ): Promise<UnifiedMemoryResult[]> {
-    return queryBeliefMemoryHelper(this.beliefs, query, keywords, limit, this.log);
+    return queryBeliefMemoryHelper(this.beliefs, query, keywords, limit, {
+      log: this.log,
+      onFailure,
+    });
   }
 
   private async queryAgenticMemory(
     query: string,
     keywords: readonly string[],
-    limit: number
+    limit: number,
+    onFailure?: () => void
   ): Promise<UnifiedMemoryResult[]> {
     if (this.agentic === null) return [];
 
-    return queryAgenticMemoryHelper(this.agentic, query, keywords, limit, this.log);
+    return queryAgenticMemoryHelper(this.agentic, query, keywords, limit, {
+      log: this.log,
+      onFailure,
+    });
   }
 
   private async queryTypedMemory(
     query: string,
     keywords: readonly string[],
-    limitPerType: number
+    limitPerType: number,
+    onFailure?: () => void
   ): Promise<UnifiedMemoryResult[]> {
     if (this.typed === null) return [];
 
-    return queryTypedMemoryHelper(this.typed, query, keywords, limitPerType, this.log);
+    return queryTypedMemoryHelper(this.typed, query, keywords, limitPerType, {
+      log: this.log,
+      onFailure,
+    });
   }
 
   private async queryAdaptiveMemory(
     query: string,
     keywords: readonly string[],
-    limit: number
+    limit: number,
+    onFailure?: () => void
   ): Promise<UnifiedMemoryResult[]> {
     if (this.adaptive === null) return [];
 
-    return queryAdaptiveMemoryHelper(this.adaptive, query, keywords, limit, this.log);
+    return queryAdaptiveMemoryHelper(this.adaptive, query, keywords, limit, {
+      log: this.log,
+      onFailure,
+    });
   }
 
   // ==========================================================================


### PR DESCRIPTION
Closes #4999. Second half of the pair — the first half (`searched` / `unavailable`, i.e. which backends were installed at all) shipped in #5044.

## The defect

Each per-backend query helper in `tool-memory-query.ts` swallows its backend's failure and returns `[]`. The empty array is the right call — partial results beat none — but nothing above it ever learned the failure happened. A corrupted SQLite file and a store with no matches produced byte-identical responses, and `memory_query` reported both as a clean search across every backend it listed in `searched`.

## The change

- `MemoryQueryContext` (`{ log, onFailure? }`) replaces the trailing `log` param on the four async helpers. Collapsing the two into one object also keeps them under the `max-params` bar.
- `queryAll` and `queryBySource` take an optional `errored(source)` reporter and pass a per-source closure down.
- New `ToolMemoryManager.queryWithStatus(source, query, limit)` returns `{ results, errored }`.
- `MemoryQueryResponse` gains `errored: string[]`, declared in `outputSchema` — an undeclared response field makes *every* call fail `-32602` (#5044/#5045).

`errored` is populated on the single-source path as well as `'all'`, so the field always means "observed to fail" and never "not checked". The first draft hardcoded `errored: []` for single-source queries with a comment explaining the gap; that is the same vacuous-check class the issue is about, so `queryWithStatus` dispatches through `queryBySource` and covers both.

## The correction that matters most

An adversarial review of this PR found that the original version **could not fire for the case it was written for.** It reported only from `catch`, but no production backend throws — `HybridMemoryBackend.search`, `searchAgentic`, and the belief recall path all catch internally and resolve with `err(...)`. The corrupt SQLite file, the motivating example in the issue, took the `if (result.ok)` branch and was silently skipped.

Every report site now fires on `!result.ok` as well as on a thrown exception. `ok([])` stays silent — that is a miss, not a failure.

The seam test had the same blind spot: it injected a *rejecting* stub, so it proved the unreachable path. It now injects an `err`-resolving stub, which is the shape production actually produces.

## Verification

Six mutations, each applied alone (a redundant report masks its partner otherwise):

| mutation | result |
| --- | --- |
| belief subject-recall stops reporting `err` | 1 failed ✓ |
| belief keyword-scan stops reporting `err` | 1 failed ✓ |
| agentic stops reporting `err` | 1 failed ✓ |
| typed stops reporting `err` | 1 failed ✓ |
| adaptive stops reporting `err` | 1 failed ✓ |
| handler hardcodes `errored: []` | 1 failed ✓ |

The first belief mutation initially survived: with keywords present the fallback also fails and fires the *other* report. It is pinned by a no-keyword case that leaves only one report reachable. Each of the other three needed its own direct helper test, because all three SQLite backends are `null` in the shared harness and their lines were never executed.

Two smaller review findings also fixed: `mockErroredBackends` is reset in `beforeEach` alongside the install flags, and the keyword scan is extracted so `queryBeliefMemory` stays under the complexity bar.

4,225 tests pass across `src/mcp`; typecheck, lint, the unused-export ratchet, and the API-surface gate are clean. `minor`, matching #5044 — a required field added to a published response interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk