### PR TITLE
fix(research): disclose the alignment-summary truncation and test the attribution schema

### DIFF
--- a/.changeset/synthesis-opportunity-truncation.md
+++ b/.changeset/synthesis-opportunity-truncation.md
@@ -1,0 +1,20 @@
+---
+'nexus-agents': patch
+---
+
+fix(research): say how many improvement opportunities synthesis found, not just the ten it lists
+
+`buildAlignmentSummary` capped `topOpportunities` at ten with no count beside it,
+so a caller could not tell a repo with exactly ten improvable techniques from one
+with fifty. The alignment map holds twelve `partial` techniques carrying a hint,
+so the cap bites in practice. `AlignmentSummary` now carries `totalOpportunities`,
+capped and counted in one place so the two cannot drift — the same shape
+`ClusterSynthesis.totalInsights` took in #5048.
+
+Also adds the first tests for `AttributedInsightSchema`. `.rules/research.md`
+credits it with structurally enforcing that every synthesized insight names a
+source, but its only call site builds the id list non-empty by construction, so
+`.min(1)` had never had the opportunity to reject anything and no test imported
+it. The schema is correct; nothing had checked that it was.
+
+Refs #5001.

--- a/packages/nexus-agents/src/cli/research-helpers-synthesize.test.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-synthesize.test.ts
@@ -5,7 +5,7 @@
  * (Source: Issue #1386 — Research Synthesis Pipeline)
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { synthesizeResearch } from './research-helpers-synthesize.js';
+import { synthesizeResearch, AttributedInsightSchema } from './research-helpers-synthesize.js';
 
 // ============================================================================
 // Mocks
@@ -400,5 +400,93 @@ describe('cluster insight truncation is disclosed (#5001)', () => {
     if (!result.ok) return;
     const cluster = result.value.clusters[0];
     expect(cluster?.totalInsights).toBe(cluster?.keyInsights.length);
+  });
+});
+
+describe('alignment summary truncation (#5001)', () => {
+  beforeEach(() => {
+    mockLoadPapersRegistry.mockReset();
+  });
+
+  /**
+   * The map holds twelve `partial` techniques carrying an improvement hint, so
+   * one paper per technique overruns the ten-item cap on `topOpportunities`
+   * using only real keys — no synthetic inflation.
+   */
+  const PARTIAL_WITH_HINT = [
+    'capability-instruction-tuning',
+    'aegean-consensus',
+    'cp-wbft-consensus',
+    'mem0-memory-architecture',
+    'graph-based-memory',
+    'history-encoding',
+    'aflow-mcts-workflows',
+    'temporal-graph-orchestration',
+    'model-based-coordination',
+    'trinity-roles',
+    'sew-self-evolving-workflows',
+    'scaling-coordination-predictor',
+  ];
+
+  it('says how many improvement opportunities it found, not just the ten it lists', async () => {
+    // `topOpportunities` is capped, and a caller seeing ten entries cannot
+    // tell a repo with exactly ten improvable techniques from one with
+    // twelve. Same shape as `totalInsights` (#5001) one level up.
+    const papers: Record<string, Record<string, unknown>> = {};
+    PARTIAL_WITH_HINT.forEach((technique, i) => {
+      papers[`p${String(i)}`] = makePaper(String(i), `Paper ${String(i)}`, ['memory'], ['llm'], {
+        techniques_extracted: [technique],
+      });
+    });
+    mockLoadPapersRegistry.mockResolvedValue({ ok: true, value: makeRegistry(papers) });
+
+    const result = await synthesizeResearch('memory');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(`synthesis failed: ${result.error.message}`);
+    const summary = result.value.alignmentSummary;
+    // The cap still applies — this discloses the truncation, it does not lift it.
+    expect(summary.topOpportunities.length).toBe(10);
+    expect(summary.totalOpportunities).toBe(PARTIAL_WITH_HINT.length);
+  });
+
+  it('reports an untruncated list as complete', async () => {
+    // The pair: with fewer opportunities than the cap the two agree, so a
+    // consumer comparing them learns nothing was dropped.
+    const papers: Record<string, Record<string, unknown>> = {};
+    PARTIAL_WITH_HINT.slice(0, 3).forEach((technique, i) => {
+      papers[`p${String(i)}`] = makePaper(String(i), `Paper ${String(i)}`, ['memory'], ['llm'], {
+        techniques_extracted: [technique],
+      });
+    });
+    mockLoadPapersRegistry.mockResolvedValue({ ok: true, value: makeRegistry(papers) });
+
+    const result = await synthesizeResearch('memory');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(`synthesis failed: ${result.error.message}`);
+    expect(result.value.alignmentSummary.totalOpportunities).toBe(3);
+    expect(result.value.alignmentSummary.topOpportunities.length).toBe(3);
+  });
+});
+
+describe('AttributedInsightSchema (#5001)', () => {
+  /**
+   * `.rules/research.md` credits this schema with structurally enforcing that
+   * every synthesized insight carries a source. At its only call site the
+   * input is built as `[...new Set([paper.id])]` — non-empty by construction —
+   * so `.min(1)` has never had the chance to reject anything, and no test
+   * imported it. The invariant held because of the caller, not the schema.
+   */
+  it('rejects an insight with no source paper ids', () => {
+    expect(() =>
+      AttributedInsightSchema.parse({ insight: 'unattributed claim', sourcePaperIds: [] })
+    ).toThrow();
+  });
+
+  it('accepts an insight that names its source', () => {
+    expect(() =>
+      AttributedInsightSchema.parse({ insight: 'attributed claim', sourcePaperIds: ['p1'] })
+    ).not.toThrow();
   });
 });

--- a/packages/nexus-agents/src/cli/research-helpers-synthesize.ts
+++ b/packages/nexus-agents/src/cli/research-helpers-synthesize.ts
@@ -125,6 +125,17 @@ export interface AlignmentSummary {
   readonly notStarted: number;
   readonly total: number;
   readonly topOpportunities: readonly string[];
+  /**
+   * How many improvement opportunities existed before `topOpportunities` was
+   * capped (#5001).
+   *
+   * The alignment map holds twelve `partial` techniques carrying a hint, so
+   * the cap bites on any repo whose research touches most of them. Ten listed
+   * entries look identical whether ten or fifty were found; a bounded read is
+   * fine, a bounded read reported as complete is not. Mirrors
+   * `ClusterSynthesis.totalInsights`.
+   */
+  readonly totalOpportunities: number;
 }
 
 /** Summary of a single feature gate for synthesis output. */
@@ -378,6 +389,9 @@ function synthesizeCluster(cluster: PaperCluster): ClusterSynthesis {
 /** Insights carried per cluster. The count dropped is disclosed, not silent. */
 const MAX_CLUSTER_INSIGHTS = 10;
 
+/** Cap on the improvement opportunities listed in the alignment summary (#5001). */
+const MAX_TOP_OPPORTUNITIES = 10;
+
 /**
  * The capped insight list plus the count it was capped from (#5001).
  *
@@ -453,15 +467,18 @@ function buildAlignmentSummary(clusters: readonly ClusterSynthesis[]): Alignment
   // Top opportunities: partial implementations with hints (most improvable)
   const opportunities = allAlignments
     .filter((a) => a.status === 'partial' && a.improvementHint !== undefined)
-    .map((a) => `${a.technique}: ${a.improvementHint ?? ''}`)
-    .slice(0, 10);
+    .map((a) => `${a.technique}: ${a.improvementHint ?? ''}`);
 
   return {
     implemented,
     partial,
     notStarted,
     total: allAlignments.length,
-    topOpportunities: opportunities,
+    // Capped and counted together so the two cannot drift — a
+    // `topOpportunities` without its total is the silent truncation this
+    // replaced (#5001).
+    topOpportunities: opportunities.slice(0, MAX_TOP_OPPORTUNITIES),
+    totalOpportunities: opportunities.length,
   };
 }
 


### PR DESCRIPTION
Refs #5001. Takes the two non-governance items; the rule-wording change in `.rules/research.md` needs owner ratification and is deliberately left out.

## 1. `topOpportunities` truncated silently

`research-helpers-synthesize.ts:455` capped the list at ten and reported nothing about it:

```ts
const opportunities = allAlignments
  .filter((a) => a.status === 'partial' && a.improvementHint !== undefined)
  .map((a) => `${a.technique}: ${a.improvementHint ?? ''}`)
  .slice(0, 10);
```

Ten listed entries look identical whether ten or fifty were found. This is not hypothetical: `research-alignment-map.ts` holds **twelve** `partial` techniques carrying a hint, so any synthesis touching most of the map overruns the cap.

`AlignmentSummary` now carries `totalOpportunities`, and the cap and the count are applied in one place so they cannot drift — the same shape `ClusterSynthesis.totalInsights` took in #5048. The cap stays; this discloses it rather than lifting it.

The test uses the twelve real map keys rather than synthetic ones, so it fails for the reason it claims. Its companion feeds three and asserts the two agree, which is what tells a consumer nothing was dropped.

## 2. `AttributedInsightSchema` had no test

`.rules/research.md:18-20` calls the provenance invariant "enforced structurally by `AttributedInsightSchema` … a validated guarantee, not a hope." At its only call site the input is `[...new Set([paper.id])]` — non-empty by construction — so `.min(1)` has never had the chance to reject anything, and `grep` showed no test importing it.

Being precise about what this fixes: **the schema is correct and the invariant does hold today.** What was missing was any check that it does. Two tests now pin both directions, and removing `.min(1)` fails one of them. That converts the rule's claim from an assertion about the code into something the code has to keep earning — but it does not change behavior, and the changeset says so.

## Verification

| mutation | result |
| --- | --- |
| `totalOpportunities` reports the post-cap count | 1 failed ✓ |
| `AttributedInsightSchema` drops `.min(1)` | 1 failed ✓ |

6,890 tests pass across `src/cli`; typecheck, lint, and the API-surface gate clean (`AlignmentSummary` is not on the published surface, so this is a `patch`).

## Deliberately not in this PR

- **`research-command.ts:461` prints five of the ten unlabelled** — a third truncation of the same class. The formatter is private and the command-level test harness does not mock `synthesizeResearch`, so covering it properly is a larger change than the fix; making it untested in a PR about honest instrumentation would be the wrong trade. #5001 stays open for it.
- **The `.rules/research.md` wording.** The rule credits the schema with an enforcement it was not performing. That is a governance file — owner ratification, not a self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
