### PR TITLE
feat(mcp): stamp every tool result with the build that produced it

### DIFF
--- a/.changeset/tool-results-name-the-build.md
+++ b/.changeset/tool-results-name-the-build.md
@@ -11,8 +11,10 @@ to say which. `VERSION` reached only `serverInfo` at `initialize`, which a
 long-lived session sees once and a log reader never sees at all.
 
 Every tool result now carries `_meta['nexus-agents/build'] = { version }`,
-stamped in `toSdkCallback` — the single point every registered tool passes
-through, so a tool that builds its result by hand is stamped too.
+stamped in `runWithContexts` — the point both SDK adapters call, on the ordinary
+and the budget-mismatch path alike. Stamping the adapters instead would have
+missed `consensus_vote`, `orchestrate` and `run_workflow`, which go through
+`toSdkCallbackWithBudgetCheck`.
 
 It rides in `_meta` for the same reason the error envelope does (#2649):
 `structuredContent` is validated against the tool's `outputSchema` with

--- a/.changeset/tool-results-name-the-build.md
+++ b/.changeset/tool-results-name-the-build.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+feat(mcp): every tool result names the build that produced it
+
+The MCP server a client talks to is routinely a pinned global install rather
+than the working tree, so a tool result read as evidence about "the current
+code" could be answering from a months-old build with nothing in the response
+to say which. `VERSION` reached only `serverInfo` at `initialize`, which a
+long-lived session sees once and a log reader never sees at all.
+
+Every tool result now carries `_meta['nexus-agents/build'] = { version }`,
+stamped in `toSdkCallback` — the single point every registered tool passes
+through, so a tool that builds its result by hand is stamped too.
+
+It rides in `_meta` for the same reason the error envelope does (#2649):
+`structuredContent` is validated against the tool's `outputSchema` with
+`additionalProperties: false`, so an undeclared field there fails every call
+with `-32602`. `_meta` is the spec's out-of-band channel and is never
+schema-validated. The stamp extends `_meta` rather than replacing it, so a
+structured error envelope survives alongside it.
+
+Refs #5008 (build-identity half; the orphaned-process half stays open).

--- a/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
+++ b/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
@@ -44,6 +44,7 @@ import {
   registerListWorkflowsTool,
 } from './tools/index.js';
 import type { IWorkflowEngine } from '../core/index.js';
+import { VERSION } from '../version.js';
 
 // #4629: this test reached a real CLI binary through the CLI-detection layer.
 // The memory_query call below runs reflective retrieval, which asks the
@@ -231,6 +232,53 @@ describe('MCP Standalone Tools Integration', () => {
       compareFields: ['license'],
     },
   };
+
+  /**
+   * #5008: a tool result that does not name the build it came from cannot be
+   * used as evidence about a specific version. The MCP server is normally a
+   * pinned global install, so the build answering a call is routinely not the
+   * one in the working tree — and nothing in the response said which.
+   *
+   * The stamp rides in `_meta`, never `structuredContent`: the latter is
+   * validated against `outputSchema` with `additionalProperties: false`, so an
+   * undeclared field there breaks every call (#5044/#5045). `_meta` is the
+   * spec's out-of-band channel and is never schema-validated, which is why the
+   * error envelope already lives there (#2649).
+   */
+  it('every tool result names the build that produced it (#5008)', async () => {
+    const listed = await ctx.client.listTools();
+    const unstamped: string[] = [];
+
+    for (const tool of listed.tools) {
+      const args = ROUND_TRIP_ARGS[tool.name];
+      if (args === undefined) continue;
+      const result = await ctx.client.callTool({ name: tool.name, arguments: args });
+      const build = (result._meta as Record<string, unknown> | undefined)?.['nexus-agents/build'];
+      if ((build as { version?: unknown } | undefined)?.version !== VERSION) {
+        unstamped.push(tool.name);
+      }
+    }
+
+    expect(unstamped).toEqual([]);
+  }, 120_000);
+
+  it('keeps the error envelope alongside the build stamp (#5008)', async () => {
+    // The stamp is merged into `_meta`, which already carries the #2649 error
+    // envelope. Replacing `_meta` instead of extending it would silently strip
+    // every structured error — a regression no other test here would catch,
+    // since the envelope lives on the failure path.
+    const result = await ctx.client.callTool({
+      name: 'research_synthesize',
+      arguments: ROUND_TRIP_ARGS['research_synthesize'] ?? {},
+    });
+
+    const meta = result._meta as Record<string, unknown> | undefined;
+    expect(result.isError).toBe(true);
+    expect(meta?.['nexus-agents/error']).toBeDefined();
+    expect((meta?.['nexus-agents/build'] as { version?: string } | undefined)?.version).toBe(
+      VERSION
+    );
+  });
 
   /**
    * Tools whose round-trip call returns an error envelope rather than

--- a/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
@@ -17,6 +17,7 @@ import type { TimeoutConfig, SecurityConfig } from '../../config/schemas.js';
 import type { IPolicyFirewall, ExecutionMode } from './policy.js';
 import type { RateLimiterConfig } from './rate-limiter.js';
 import { RateLimiter } from './rate-limiter.js';
+import { VERSION } from '../../version.js';
 import {
   withMiddleware,
   createMiddlewareFactory,
@@ -294,10 +295,41 @@ function runWithContexts(
 export function toSdkCallback(
   handler: ToolHandler
 ): (args: unknown, extra: unknown) => Promise<SdkToolResult> {
-  return (args: unknown, extra: unknown) => {
+  return async (args: unknown, extra: unknown) => {
     const progressCtx = extractProgressContext(extra);
     const signal = (extra as SdkExtra | undefined)?.signal;
-    return runWithContexts(handler, args, progressCtx, signal);
+    const result = await runWithContexts(handler, args, progressCtx, signal);
+    return stampBuild(result);
+  };
+}
+
+/**
+ * `_meta` key naming the build that produced a tool result (#5008).
+ *
+ * The MCP server a client is talking to is routinely a pinned global install
+ * rather than the working tree, so a result read as evidence about "the
+ * current code" could be answering from a months-old build with nothing in the
+ * response to say so.
+ *
+ * It rides in `_meta` for the same reason the error envelope does (#2649):
+ * `structuredContent` is validated against the tool's `outputSchema` with
+ * `additionalProperties: false`, so an undeclared field there fails every call
+ * with -32602 (#5044/#5045). `_meta` is the spec's out-of-band channel and is
+ * never schema-validated.
+ */
+export const BUILD_META_KEY = 'nexus-agents/build';
+
+/**
+ * Attaches the build stamp, preserving any `_meta` the handler already set.
+ *
+ * Applied here rather than in the result factories because this is the single
+ * point every registered tool passes through — a tool that builds its result
+ * by hand is stamped too.
+ */
+function stampBuild(result: SdkToolResult): SdkToolResult {
+  return {
+    ...result,
+    _meta: { ...result._meta, [BUILD_META_KEY]: { version: VERSION } },
   };
 }
 

--- a/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
@@ -316,8 +316,11 @@ export function toSdkCallback(
  * `additionalProperties: false`, so an undeclared field there fails every call
  * with -32602 (#5044/#5045). `_meta` is the spec's out-of-band channel and is
  * never schema-validated.
+ *
+ * Kept module-private: the tests assert the literal wire name, which pins what
+ * a client actually sees rather than agreeing with the constant.
  */
-export const BUILD_META_KEY = 'nexus-agents/build';
+const BUILD_META_KEY = 'nexus-agents/build';
 
 /**
  * Attaches the build stamp, preserving any `_meta` the handler already set.

--- a/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
+++ b/packages/nexus-agents/src/mcp/middleware/tool-wrapper.ts
@@ -262,14 +262,21 @@ type SdkToolResult = {
   _meta?: Record<string, unknown>;
 };
 
-function runWithContexts(
+async function runWithContexts(
   handler: ToolHandler,
   args: unknown,
   progressCtx: ProgressContext | undefined,
   signal: AbortSignal | undefined
 ): Promise<SdkToolResult> {
   const run = (): Promise<SdkToolResult> => handler(args);
+  return stampBuild(await runInContexts(run, progressCtx, signal));
+}
 
+function runInContexts(
+  run: () => Promise<SdkToolResult>,
+  progressCtx: ProgressContext | undefined,
+  signal: AbortSignal | undefined
+): Promise<SdkToolResult> {
   // Nest contexts: abort signal outer, progress inner
   if (signal !== undefined && progressCtx !== undefined) {
     return abortSignalStorage.run(signal, () => progressContextStorage.run(progressCtx, run));
@@ -295,11 +302,10 @@ function runWithContexts(
 export function toSdkCallback(
   handler: ToolHandler
 ): (args: unknown, extra: unknown) => Promise<SdkToolResult> {
-  return async (args: unknown, extra: unknown) => {
+  return (args: unknown, extra: unknown) => {
     const progressCtx = extractProgressContext(extra);
     const signal = (extra as SdkExtra | undefined)?.signal;
-    const result = await runWithContexts(handler, args, progressCtx, signal);
-    return stampBuild(result);
+    return runWithContexts(handler, args, progressCtx, signal);
   };
 }
 
@@ -325,9 +331,13 @@ const BUILD_META_KEY = 'nexus-agents/build';
 /**
  * Attaches the build stamp, preserving any `_meta` the handler already set.
  *
- * Applied here rather than in the result factories because this is the single
- * point every registered tool passes through — a tool that builds its result
- * by hand is stamped too.
+ * Applied inside `runWithContexts` rather than in the result factories or in
+ * either SDK adapter. There are TWO adapters — `toSdkCallback` and
+ * `toSdkCallbackWithBudgetCheck`, the latter used by `consensus_vote`,
+ * `orchestrate` and `run_workflow` — and stamping in one of them left the other
+ * three tools unstamped. `runWithContexts` is what both call, on the ordinary
+ * and the budget-mismatch path alike, so it is the actual chokepoint. A tool
+ * that assembles its result by hand is stamped here too.
  */
 function stampBuild(result: SdkToolResult): SdkToolResult {
   return {


### PR DESCRIPTION
Refs #5008 — takes the build-identity half. The orphaned-process half stays open with reduced scope (see below).

## The gap

`VERSION` reached exactly one place under `src/mcp/`: `serverInfo` at `initialize` (`server.ts:92`). A long-lived session sees that once, a log reader never sees it, and no tool result carries it. Since the server is normally a **pinned global install** rather than the working tree, a result read as evidence about "the current code" could be answering from a months-old build with nothing in the response to say so.

That is directly load-bearing for this repo: every claim I verify by calling a tool is a claim about whichever build answered.

The existing mitigation (`version-check.ts`, #3283) logs a drift WARN to the *server's own stderr* at startup — invisible to the client holding the stale connection.

## The change

`toSdkCallback` (`middleware/tool-wrapper.ts`) now stamps every result:

```ts
_meta: { ...result._meta, [BUILD_META_KEY]: { version: VERSION } }
```

Two decisions worth stating:

**Where the stamp goes.** `runWithContexts`, which both SDK adapters call. The first version stamped `toSdkCallback` and described it as "the single point every registered tool passes through" — which was wrong. There is a second adapter, `toSdkCallbackWithBudgetCheck`, used by `consensus_vote`, `orchestrate` and `run_workflow`, and those three came back unstamped. The claim only became testable once #5057 registered `consensus_vote` in the round-trip suite; the test caught it on the rebase.

Stamping the result factories was the other option and is worse: a tool that assembles its result by hand bypasses them.

**Why `_meta` and not `structuredContent`.** `structuredContent` is validated against each tool's `outputSchema` with `additionalProperties: false`, so an undeclared field there fails **every call** with `-32602` — the exact failure #5044 shipped and #5045 built a gate for. `_meta` is the spec's out-of-band channel and is never schema-validated, which is why the #2649 error envelope already lives there.

## Verification

| mutation | result |
| --- | --- |
| stamp removed | 2 failed ✓ |
| stamp **replaces** `_meta` instead of extending it | 1 failed ✓ |

The second mutation initially **survived** — nothing pinned that the error envelope survives the stamp, and clobbering `_meta` would have silently stripped every structured error, a regression living only on the failure path. The test added for it drives `research_synthesize` (which errors in the test env) and asserts both keys are present.

The primary test walks the server's own `listTools()` and requires the stamp on every tool it can call, rather than sampling one.

4,224 tests pass across `src/mcp`; typecheck, lint, the API-surface gate, and the unused-export ratchet clean. `BUILD_META_KEY` is module-private — the tests assert the literal wire name, which pins what a client actually sees rather than agreeing with the constant.

## On the other half of #5008

Investigated and deliberately not attempted here. `StdinLifecycleMonitor` (#810, hardened #2905) already reaps on stdin `end`, stdin `close`, and a 30s ppid-change poll — all three detect **parent death**. The unreaped case is a *live* parent that abandoned the connection: same ppid, open stdin, no `transport.onclose` handler registered (`cli-server.ts:333`) and no idle timeout anywhere. The obvious fixes are speculative until someone reproduces a leak with a live parent, so #5008 should keep that half open at the narrower scope "live-parent abandonment is unreaped" rather than being closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk