### PR TITLE
test(mcp): cover the three schema tools the round-trip suite could not reach

### DIFF
--- a/.changeset/roundtrip-remaining-schema-tools.md
+++ b/.changeset/roundtrip-remaining-schema-tools.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+test(mcp): cover the three schema-declaring tools the round-trip suite could not reach
+
+`consensus_vote`, `delegate_to_model`, and `list_workflows` declare an
+`outputSchema` and are registered on the production server, but were absent from
+the test server the round-trip suite builds. A response-field addition to any of
+them would have broken every call with `-32602` and left CI green — the exact
+regression #5045 exists to prevent, in the three tools it could not see.
+
+Also widens the failure filter: an earlier version counted a call as violating
+only if the thrown message contained `output schema` or `-32602`, silently
+crediting the tool for a timeout or transport fault. Any protocol-level throw
+now fails the suite.
+
+Fixes a latent bug in the test's own workflow-engine stub along the way.
+`IWorkflowEngine.listTemplates` is declared as `Promise<WorkflowTemplate[]>`, but
+the stub returned `{ ok, value }`; nothing called it until `list_workflows` did,
+and it crashed on `templates.map`.
+
+Refs #5045.

--- a/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
+++ b/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
@@ -39,6 +39,9 @@ import {
   registerSurveyOssLandscapeTool,
   registerVendorPublishingAuditTool,
   registerCompareDataFeedsTool,
+  registerConsensusVoteTool,
+  registerDelegateToModelTool,
+  registerListWorkflowsTool,
 } from './tools/index.js';
 import type { IWorkflowEngine } from '../core/index.js';
 
@@ -117,11 +120,23 @@ async function setupServer(): Promise<TestContext> {
   registerVendorPublishingAuditTool(server, deps);
   registerCompareDataFeedsTool(server, deps);
 
-  // run_workflow needs a stub workflow engine
+  // run_workflow and list_workflows need a stub workflow engine
+  // `IWorkflowEngine.listTemplates` is declared as `Promise<WorkflowTemplate[]>`
+  // (core/types/workflow.ts:219) — a bare array, not a Result. The previous
+  // `{ ok, value }` stub passed only because nothing in this suite called it;
+  // list_workflows does, and crashed on `templates.map`.
   const stubEngine = {
-    listTemplates: () => Promise.resolve({ ok: true, value: [] }),
+    listTemplates: () => Promise.resolve([]),
   } as unknown as IWorkflowEngine;
   registerRunWorkflowTool(server, { ...deps, workflowEngine: stubEngine });
+  registerListWorkflowsTool(server, { ...deps, workflowEngine: stubEngine });
+  // #5052 follow-up: these three declare an `outputSchema` and are registered
+  // on the production server, so a response-field addition to any of them
+  // would have broken every call with the round-trip suite still green. Their
+  // optional deps (notifier, gateway adapters, feedback integration) are not
+  // needed to exercise the protocol boundary.
+  registerConsensusVoteTool(server, deps);
+  registerDelegateToModelTool(server, deps);
 
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const connectResult = await connectTransport(server, serverTransport, logger);
@@ -206,6 +221,9 @@ describe('MCP Standalone Tools Integration', () => {
     list_experts: { format: 'names' },
     survey_oss_landscape: { query: 'round trip' },
     vendor_publishing_audit: { vendor: 'anthropic' },
+    list_workflows: { format: 'names' },
+    consensus_vote: { proposal: 'round trip', quick: true },
+    delegate_to_model: { task: 'round trip', model: 'claude-haiku' },
     compare_data_feeds: {
       feedAPath: join(feedDir, 'a.json'),
       feedBPath: join(feedDir, 'b.json'),
@@ -220,13 +238,16 @@ describe('MCP Standalone Tools Integration', () => {
    *
    * - `research_synthesize` — the paper registry is empty in the test env, so
    *   it answers "No papers found in registry" as an error envelope.
+   * - `consensus_vote` — the CLI factory is stubbed to find no adapters, so
+   *   all seven voters fail. Running it for real would mean live model calls;
+   *   `simulateVotes` is not an option (#2319) and would prove nothing anyway.
    *
    * Naming them is the point. Counting an unstructured response as a pass
    * would make this a check that cannot fail, which is the same shape of hole
    * #5045 exists to close. Four tools sat here in the first draft; three were
    * my own bad arguments, found only because the list was printed.
    */
-  const KNOWN_UNSTRUCTURED: readonly string[] = ['research_synthesize'];
+  const KNOWN_UNSTRUCTURED: readonly string[] = ['consensus_vote', 'research_synthesize'];
 
   /**
    * A response field missing from a tool's declared `outputSchema` does not go
@@ -257,7 +278,7 @@ describe('MCP Standalone Tools Integration', () => {
     expect(Object.keys(ROUND_TRIP_ARGS).filter((n) => !schemaNames.has(n))).toEqual([]);
 
     const missingArgs: string[] = [];
-    const violations: string[] = [];
+    const callFailed: string[] = [];
     const notExercised: string[] = [];
 
     for (const tool of schemaTools) {
@@ -270,14 +291,19 @@ describe('MCP Standalone Tools Integration', () => {
         const result = await ctx.client.callTool({ name: tool.name, arguments: args });
         if (result.structuredContent === undefined) notExercised.push(tool.name);
       } catch (error: unknown) {
+        // Every thrown error counts, not only the ones naming a schema. An
+        // earlier version matched two substrings and silently credited the
+        // tool for anything else — a timeout, a transport fault — which is the
+        // same shape of hole this suite exists to close.
         const message = error instanceof Error ? error.message : JSON.stringify(error);
-        if (message.includes('output schema') || message.includes('-32602')) {
-          violations.push(`${tool.name}: ${message}`);
-        }
+        callFailed.push(`${tool.name}: ${message}`);
       }
     }
 
-    expect(violations).toEqual([]);
+    // A protocol-level throw means the call did not complete: a schema
+    // violation (-32602), a transport fault, a timeout. A tool answering
+    // `isError` in its content is fine and does not land here.
+    expect(callFailed).toEqual([]);
     // A new schema-declaring tool must be given arguments here, or it is not
     // covered — and an uncovered tool is exactly how #5044 shipped.
     expect(missingArgs).toEqual([]);


### PR DESCRIPTION
Refs #5045. Follow-up to #5052, from an adversarial review of that PR.

## The gap #5052 left

The round-trip list is derived from `listTools()` — but of a server this test file assembles by hand. Three tools declare an `outputSchema` and are registered on the **production** server yet were never registered here, so they were outside the derived set:

- `consensus_vote` (`cli-server-tools.ts:390`)
- `delegate_to_model` (`cli-server-tools.ts:424`)
- `list_workflows` (`cli-server-tools.ts:376`)

A #5044-shaped regression in any of the three would break every call with `-32602` and leave the suite green. The reverse assertion did not catch it either: it checks that everything in the argument table still declares a schema, not that every schema-declaring tool is in the table.

That also makes #5052's headline count wrong — it was 13 of 14 registered schema tools, not "14 of 15".

## Changes

**Three tools registered.** Their optional deps (notifier, gateway adapters, feedback integration) are not needed to exercise the protocol boundary. `list_workflows` and `delegate_to_model` now return structured content and are genuinely validated. `consensus_vote` cannot be: the CLI factory is stubbed to find no adapters, so all seven voters fail. It joins `KNOWN_UNSTRUCTURED` with that reason stated — `simulateVotes` is not an option (#2319) and would prove nothing about the real response shape.

**The failure filter no longer drops what it does not recognise.** It matched two substrings and silently credited the tool for anything else — a timeout, a transport fault. Any protocol-level throw now fails the suite. A tool answering `isError` in its content is unaffected; that is a business failure, not a broken call.

## A real bug in the test's own stub

`IWorkflowEngine.listTemplates` is declared `Promise<WorkflowTemplate[]>` (`core/types/workflow.ts:219`) — a bare array. The suite's stub returned `{ ok: true, value: [] }`. Nothing called it until `list_workflows` did, and it died on `templates.map is not a function`. Fixed to match the interface.

Worth noting: `orchestration/orchestrator-factory.test.ts:57` has the same wrong shape (`mockResolvedValue(ok([]))`). Out of scope here, but it is the second instance of a stub contradicting a declared contract with nothing to catch it.

## Verification

| mutation | result |
| --- | --- |
| `list_workflows` returns an undeclared field | 1 failed ✓ |
| `delegate_to_model` returns an undeclared field | 1 failed ✓ |

The `delegate_to_model` mutation first went into `delegate-to-model.ts` and **survived** — that file declares the schema but the response is built in `delegate-to-model-helpers.ts:401`. Mutating the file that actually produces the result kills it.

4,209 tests pass across `src/mcp`; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
