### PR TITLE
fix(mcp): report a returned error envelope as a failed tool call

### DIFF
--- a/.changeset/observability-proxy-reports-failures.md
+++ b/.changeset/observability-proxy-reports-failures.md
@@ -1,0 +1,19 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): the tool observability proxy reported every failed call as a success
+
+`createToolObservabilityProxy` emitted `tool.completed { success: true }` from
+the `try` path with the value hardcoded, and read failure only from its `catch`.
+Nexus tools do not throw — `toolStructuredError` returns `{ isError: true }` —
+so no real tool failure ever reached the `catch`, and every EventBus consumer
+saw a 100% tool success rate. A tool returning a validation or internal error
+envelope was indistinguishable from one that worked.
+
+`success` is now derived from `result.isError`, matching what the sibling
+middleware `tool-metrics.ts` has always recorded, and a returned envelope
+carries its text as `errorMessage` the way the throw path already did.
+
+The existing failure test used a _throwing_ handler, which is why the gap
+survived: it exercised the one path production never takes.

--- a/packages/nexus-agents/src/mcp/tools/tool-observability-proxy.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-observability-proxy.test.ts
@@ -114,6 +114,32 @@ describe('createToolObservabilityProxy', () => {
     expect(completed.errorMessage).toBe('test failure');
   });
 
+  it('reports a returned error envelope as a failure, not a success', async () => {
+    // Nexus tools signal failure by RETURNING `{ isError: true }` from
+    // `toolStructuredError` — they do not throw. The proxy read only the
+    // `catch`, so every EventBus consumer saw a 100% tool success rate and a
+    // validation failure was indistinguishable from a working call. The
+    // sibling middleware already gets this right: tool-metrics.ts records
+    // `success: result.isError !== true`.
+    const mock = createMockServer();
+    const proxy = createToolObservabilityProxy(mock as never, eventBus);
+
+    proxy.registerTool(
+      'erroring_tool',
+      {},
+      mockHandler({
+        content: [{ type: 'text', text: 'Validation error: bad input' }],
+        isError: true,
+      }) as never
+    );
+
+    await mock.registered.get('erroring_tool')!.cb({}, {});
+
+    const completed = events[1] as PipelineEvent & { type: 'tool.completed' };
+    expect(completed.type).toBe('tool.completed');
+    expect(completed.success).toBe(false);
+  });
+
   it('increments invocation IDs across tools (#1186)', async () => {
     const mock = createMockServer();
     const proxy = createToolObservabilityProxy(mock as never, eventBus);

--- a/packages/nexus-agents/src/mcp/tools/tool-observability-proxy.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-observability-proxy.ts
@@ -45,7 +45,7 @@ interface ToolConfig {
  */
 /**
  * First text block of a tool result, for the `errorMessage` on a returned
- * error envelope. The structured envelope itself lives in `_meta` (#2649) and
+ * error result. The structured envelope itself lives in `_meta` (#2649) and
  * is not repeated here — this is the human-readable line the throw path
  * already puts on the event.
  */
@@ -91,10 +91,11 @@ function wrapWithObservability(
       const result = await cb(args, extra);
       const durationMs = getTimeProvider().now() - startTime;
 
-      // A nexus tool signals failure by RETURNING `{ isError: true }` from
-      // `toolStructuredError`, not by throwing, so reading only the `catch`
-      // below reported a 100% success rate to every EventBus consumer. Matches
-      // `tool-metrics.ts`, which has always recorded `result.isError !== true`.
+      // A nexus tool signals failure by RETURNING an error result from
+      // `toolStructuredError` — with the error flag set — not by throwing. So
+      // reading only the `catch` below reported a 100% success rate to every
+      // EventBus consumer. Matches `tool-metrics.ts`, which has always
+      // recorded `result.isError !== true`.
       const failed = (result as { isError?: boolean } | undefined)?.isError === true;
 
       eventBus.emit({

--- a/packages/nexus-agents/src/mcp/tools/tool-observability-proxy.ts
+++ b/packages/nexus-agents/src/mcp/tools/tool-observability-proxy.ts
@@ -43,6 +43,18 @@ interface ToolConfig {
  * - `tool.invoked` — when a tool handler starts executing
  * - `tool.completed` — when a tool handler finishes (success or error)
  */
+/**
+ * First text block of a tool result, for the `errorMessage` on a returned
+ * error envelope. The structured envelope itself lives in `_meta` (#2649) and
+ * is not repeated here — this is the human-readable line the throw path
+ * already puts on the event.
+ */
+function firstTextOf(result: unknown): string {
+  const content = (result as { content?: { type?: string; text?: string }[] } | undefined)?.content;
+  const text = content?.find((c) => c.type === 'text')?.text;
+  return text ?? 'Tool returned an error result with no text content';
+}
+
 export function createToolObservabilityProxy(server: McpServer, eventBus: IEventBus): McpServer {
   return new Proxy(server, {
     get(target: McpServer, prop: string | symbol, receiver: unknown): unknown {
@@ -79,13 +91,20 @@ function wrapWithObservability(
       const result = await cb(args, extra);
       const durationMs = getTimeProvider().now() - startTime;
 
+      // A nexus tool signals failure by RETURNING `{ isError: true }` from
+      // `toolStructuredError`, not by throwing, so reading only the `catch`
+      // below reported a 100% success rate to every EventBus consumer. Matches
+      // `tool-metrics.ts`, which has always recorded `result.isError !== true`.
+      const failed = (result as { isError?: boolean } | undefined)?.isError === true;
+
       eventBus.emit({
         type: 'tool.completed',
         timestamp: getTimeProvider().now(),
         toolName,
         invocationId,
         durationMs,
-        success: true,
+        success: !failed,
+        ...(failed ? { errorMessage: firstTextOf(result) } : {}),
       });
 
       return result;


### PR DESCRIPTION
Found by a sweep for the defect shape I shipped twice tonight in #5050: **failure reporting that lives only in a `catch`, guarding producers that return a `Result` rather than throwing.**

## The defect

`tool-observability-proxy.ts:82-89` emitted the completion event from the `try` path with the verdict written in:

```ts
eventBus.emit({
  type: 'tool.completed',
  ...
  success: true,          // hardcoded; `result` is not consulted
});
```

Failure was read only from the `catch` below. But nexus tools do not throw — `toolStructuredError` (`tool-result.ts:141`) **returns** `{ isError: true }`. So no real tool failure ever reached that `catch`, and every `tool.completed` subscriber has seen a 100% tool success rate. A tool returning a validation or internal error envelope was indistinguishable from one that worked.

The convention is not in doubt: the sibling middleware has always recorded it correctly — `tool-metrics.ts:109`, `success: result.isError !== true`. The two instruments watching the same calls disagreed, and the one feeding the EventBus was the wrong one.

## Why it survived

The existing failure test (`tool-observability-proxy.test.ts:99`) drives a **throwing** handler and asserts `success: false`. It passes, and it exercises the one path production never takes. That is the same blind spot as the seam test in #5050 — the test agreed with the code about a world neither had checked.

## The change

`success` is derived from `result.isError`; a returned envelope contributes its first text block as `errorMessage`, matching what the throw path already put on the event.

## Verification

Red first: the new test asserts `success: false` for a handler returning `{ isError: true }` and failed with `expected true to be false` before the fix.

| mutation | result |
| --- | --- |
| `success` hardcoded `true` again | 1 failed ✓ |
| `isError` comparison inverted | 1 failed ✓ |

4,223 tests pass across `src/mcp`; typecheck and lint clean.

## Note for review

`src/mcp/` is `@williamzujkowski` under CODEOWNERS — review-requested, not merge-blocked by the governor gate. Flagging rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
