### PR TITLE
feat(routing): enforce the latency budget BudgetRouter has always accepted

### DIFF
--- a/.changeset/budget-router-enforces-latency.md
+++ b/.changeset/budget-router-enforces-latency.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': minor
+---
+
+feat(routing): BudgetRouter enforces the latency budget it has always accepted
+
+`BudgetRouter` declared a three-part budget — tokens, cost, latency — and
+enforced two. `maxLatencyMs` was Zod-validated on `BudgetConstraint`, given a
+`60000` default, and copied from routing YAML by the config adapter, and read by
+nothing: a grep across the router and its error/warning helpers found exactly one
+hit, the default assignment. `'latency'` was a declared member of both violation
+unions with no producer, so a consumer reporting "no latency violations" was
+reporting the absence of a check.
+
+`selectAdapterWithinBudget` now compares each candidate's profile latency against
+the budget, `BudgetRoutingResult` carries `estimatedLatencyMs` for the selected
+adapter, and `determineExceededConstraint` emits the `'latency'` violation.
+
+Behaviour change, bounded: the fastest cost-model profile is 1000ms and the
+slowest 2000ms, so the 60000ms default cannot exclude any current candidate. A
+deployment that explicitly set `maxLatencyMs` below 2000 will start seeing
+candidates filtered — which is what that setting always said it would do.
+
+A candidate with no cost-model profile is admitted rather than rejected: a
+latency budget must not silently exclude every model whose latency is unmeasured.
+`estimatedLatencyMs` is absent rather than `0` when no adapter was selected.
+
+Decided by consensus vote (higher_order, 5 approvers, 100% on option A —
+enforce — over remove and disclose-only). Closes #4907.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -965,6 +965,7 @@ InterfaceDeclaration BudgetRouterOptions
 InterfaceDeclaration BudgetRoutingResult
   readonly adapter: ICliAdapter | null
   readonly estimatedCostUsd: number
+  readonly estimatedLatencyMs?: number | undefined
   readonly estimatedTokens: number
   readonly projectedBudget: SessionBudget
   readonly warnings: readonly BudgetWarning[]

--- a/packages/nexus-agents/src/cli-adapters/budget-errors.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-errors.test.ts
@@ -50,6 +50,47 @@ function makeConstraint(overrides: Partial<BudgetConstraint> = {}): BudgetConstr
 // ============================================================================
 
 describe('determineExceededConstraint', () => {
+  describe('latency constraint exceeded (maxLatencyMs) — #4907', () => {
+    it('names latency when no candidate met the latency budget', () => {
+      // `'latency'` was a declared member of the constraint union that no
+      // producer emitted, so a consumer switching on it had a dead arm and
+      // "no latency violations" meant "never checked".
+      const budget = makeConstraint({ maxLatencyMs: 500 });
+      const result = makeResult({ adapter: null, estimatedLatencyMs: undefined });
+      const session = makeBudget();
+
+      const exceeded = determineExceededConstraint(budget, result, session);
+
+      expect(exceeded.constraint).toBe('latency');
+      expect(exceeded.limit).toBe(500);
+      // The fastest model in the cost table — the best any candidate offered.
+      expect(exceeded.current).toBe(1000);
+    });
+
+    it('does not blame latency when an adapter was selected', () => {
+      // A selected adapter met the latency budget, so a rejection here is
+      // about the session totals and must not be misattributed.
+      const budget = makeConstraint({ maxLatencyMs: 5000 });
+      const result = makeResult({ estimatedLatencyMs: 1500, estimatedTokens: 500 });
+      const session = makeBudget({ tokensRemaining: 10 });
+
+      const exceeded = determineExceededConstraint(budget, result, session);
+
+      expect(exceeded.constraint).toBe('tokens');
+    });
+
+    it('does not blame latency when no latency budget was set', () => {
+      // Absent constraint means unchecked, not violated.
+      const budget = makeConstraint({});
+      const result = makeResult({ adapter: null, estimatedTokens: 500 });
+      const session = makeBudget({ tokensRemaining: 10 });
+
+      const exceeded = determineExceededConstraint(budget, result, session);
+
+      expect(exceeded.constraint).toBe('tokens');
+    });
+  });
+
   describe('token constraint exceeded (maxTokens)', () => {
     it('detects when estimated tokens exceed maxTokens', () => {
       const budget = makeConstraint({ maxTokens: 1000 });

--- a/packages/nexus-agents/src/cli-adapters/budget-errors.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-errors.ts
@@ -12,6 +12,41 @@ import type {
   BudgetRoutingResult,
 } from './types.js';
 import { DEFAULT_CLI } from '../config/model-capabilities-types.js';
+import { DEFAULT_COST_MODELS } from './budget-router-types.js';
+
+/**
+ * Latency of the fastest model in the cost table, reported as `current` on a
+ * latency violation (#4907) — the best any candidate could have done.
+ */
+function fastestCandidateLatencyMs(): number {
+  const values = Object.values(DEFAULT_COST_MODELS).map((m) => m.avgLatencyMs);
+  // Named empty case: an empty cost table means nothing to compare, and
+  // `Math.min()` of nothing is `Infinity`, which would read as "unboundedly
+  // slow" rather than "unknown".
+  return values.length === 0 ? 0 : Math.min(...values);
+}
+
+/**
+ * The latency arm of {@link determineExceededConstraint} (#4907).
+ *
+ * `'latency'` was a declared member of the constraint union with no producer,
+ * so a consumer switching on it had an arm that could never run. It fires only
+ * when a latency budget was set AND no adapter was selectable, which is the
+ * one state where latency — rather than the session totals — is the reason.
+ */
+function latencyExceeded(
+  budget: BudgetConstraint,
+  result: BudgetRoutingResult
+): { constraint: 'latency'; limit: number; current: number; suggestion: string } | undefined {
+  if (budget.maxLatencyMs === undefined) return undefined;
+  if (result.adapter !== null || result.estimatedLatencyMs !== undefined) return undefined;
+  return {
+    constraint: 'latency',
+    limit: budget.maxLatencyMs,
+    current: fastestCandidateLatencyMs(),
+    suggestion: 'Raise the latency budget or add a faster model',
+  };
+}
 
 /**
  * Determine which constraint was exceeded.
@@ -42,6 +77,12 @@ export function determineExceededConstraint(
       suggestion: 'Use a cheaper model or increase cost budget',
     };
   }
+  // #4907: `'latency'` was a declared member of this union with no producer,
+  // so a consumer switching on `constraint` had an arm that could never run.
+  // Reported before the session-budget arms because a latency rejection means
+  // no adapter was selectable at all — the session totals are not why.
+  const latencyViolation = latencyExceeded(budget, result);
+  if (latencyViolation !== undefined) return latencyViolation;
   if (currentBudget.tokensRemaining < result.estimatedTokens) {
     return {
       constraint: 'tokens',

--- a/packages/nexus-agents/src/cli-adapters/budget-router.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-router.test.ts
@@ -196,6 +196,40 @@ describe('BudgetRouter', () => {
       expect(result.withinBudget).toBe(false);
     });
 
+    it('rejects a task whose fastest candidate exceeds maxLatencyMs (#4907)', () => {
+      // `maxLatencyMs` was Zod-validated, defaulted, and copied from routing
+      // YAML — and read by nothing. No input could make it bind, so a consumer
+      // reporting "no latency violations" reported the absence of a check.
+      // The fastest entry in DEFAULT_COST_MODELS is codex at 1000ms.
+      const task: CliTask = { content: 'Test task' };
+
+      const result = router.checkBudget(task, { maxLatencyMs: 500 });
+
+      expect(result.withinBudget).toBe(false);
+      expect(result.adapter).toBeNull();
+    });
+
+    it('admits a task whose candidate meets maxLatencyMs (#4907)', () => {
+      // The pair: 5000ms clears every profile in the table, so the constraint
+      // is being evaluated rather than always failing.
+      const task: CliTask = { content: 'Test task' };
+
+      const result = router.checkBudget(task, { maxLatencyMs: 5000 });
+
+      expect(result.withinBudget).toBe(true);
+      expect(result.adapter).not.toBeNull();
+    });
+
+    it('reports estimatedLatencyMs as unmeasured when no candidate fits', () => {
+      // Naming the empty case: with no adapter selected there is no latency to
+      // report, and 0 would read as instantaneous.
+      const task: CliTask = { content: 'Test task' };
+
+      const result = router.checkBudget(task, { maxLatencyMs: 1 });
+
+      expect(result.estimatedLatencyMs).toBeUndefined();
+    });
+
     it('should project budget after task', () => {
       const task: CliTask = { content: 'Test task' };
 

--- a/packages/nexus-agents/src/cli-adapters/budget-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/budget-router.ts
@@ -29,6 +29,7 @@ import type {
 import { DEFAULT_CAPABILITIES, routingArmDisplaySlot } from './types.js';
 import type { CliName } from './types.js';
 import { estimateTokens, estimateCost } from './budget-utils.js';
+import { DEFAULT_COST_MODELS } from './budget-router-types.js';
 import { generateBudgetWarnings } from './budget-warnings.js';
 import { createBudgetExceededError } from './budget-errors.js';
 import { detectTaskCategory } from '../config/task-specialization.js';
@@ -86,6 +87,18 @@ export function estimateRegistryCostUsd(
  * Budget-constrained task router.
  * Implements budget-aware routing with session tracking and enforcement.
  */
+/**
+ * Profile latency for a routing slot, or `undefined` when the slot has no cost
+ * model (#4907).
+ *
+ * `undefined` means unmeasured, and an unmeasured candidate is admitted rather
+ * than rejected: a latency budget must not silently exclude every model whose
+ * profile happens to be missing.
+ */
+function latencyOf(slot: CliName): number | undefined {
+  return DEFAULT_COST_MODELS[slot]?.avgLatencyMs;
+}
+
 export class BudgetRouter implements IBudgetRouter {
   private readonly adapters: Map<RoutingArmId, ICliAdapter>;
   private readonly options: Required<BudgetRouterOptions>;
@@ -192,9 +205,13 @@ export class BudgetRouter implements IBudgetRouter {
       ? estimateCost(adapter.name, estimatedInputTokens, estimatedOutputTokens)
       : 0;
 
+    const estimatedLatencyMs =
+      adapter === null ? undefined : latencyOf(routingArmDisplaySlot(adapter.name));
+
     // Check budget constraints
     const currentBudget = this.getSessionBudget();
-    const withinBudget = this.checkConstraints(budget, estimatedTokens, estimatedCostUsd);
+    const withinBudget =
+      adapter !== null && this.checkConstraints(budget, estimatedTokens, estimatedCostUsd);
 
     // Generate warnings
     const warnings = generateBudgetWarnings(
@@ -212,6 +229,7 @@ export class BudgetRouter implements IBudgetRouter {
       withinBudget,
       estimatedCostUsd,
       estimatedTokens,
+      ...(estimatedLatencyMs !== undefined ? { estimatedLatencyMs } : {}),
       warnings,
       projectedBudget,
     };
@@ -415,8 +433,16 @@ export class BudgetRouter implements IBudgetRouter {
       const withinCostBudget =
         budget.maxCostUsd === undefined || estimatedCost <= budget.maxCostUsd;
       const withinContextWindow = estimatedTokens <= caps.contextWindow;
+      // #4907: the third declared budget. `maxLatencyMs` was validated,
+      // defaulted and plumbed from routing YAML, but read by nothing, so the
+      // `'latency'` violation kind had no producer and no input could make the
+      // constraint bind.
+      const withinLatencyBudget =
+        budget.maxLatencyMs === undefined ||
+        latencyOf(slot) === undefined ||
+        (latencyOf(slot) as number) <= budget.maxLatencyMs;
 
-      if (withinTokenBudget && withinCostBudget && withinContextWindow) {
+      if (withinTokenBudget && withinCostBudget && withinContextWindow && withinLatencyBudget) {
         return adapter;
       }
     }

--- a/packages/nexus-agents/src/cli-adapters/types-routing.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-routing.ts
@@ -153,6 +153,15 @@ export interface BudgetRoutingResult {
   readonly estimatedCostUsd: number;
   /** Estimated tokens for this task */
   readonly estimatedTokens: number;
+  /**
+   * Expected latency of the selected adapter, in ms (#4907).
+   *
+   * Absent when no adapter was selected — there is then no latency to report,
+   * and `0` would read as instantaneous. Present only when `adapter` is
+   * non-null, so it is the profile latency of the model that would actually
+   * run, not an aggregate over candidates.
+   */
+  readonly estimatedLatencyMs?: number | undefined;
   /** Any budget warnings */
   readonly warnings: readonly BudgetWarning[];
   /** Budget after this task (if executed) */


### PR DESCRIPTION
Closes #4907.

## The defect

`BudgetRouter` presented a three-part budget and enforced two. `maxLatencyMs` was fully plumbed and read by nobody:

- `budget-router-types.ts:21,30` — on `BudgetConstraint`, Zod `z.number().positive().optional()`, so a bad value is rejected and a good one accepted.
- `budget-router.ts:46` — `defaultConstraints.maxLatencyMs = 60000`.
- `config/routing-config-adapter.ts` — copied from routing YAML.
- A grep across `budget-router.ts`, `budget-errors.ts`, `budget-warnings.ts` returned exactly one hit: the default assignment.

`'latency'` was a declared member of both violation unions (`budget-errors.ts:24`, `types-routing.ts:119,137`) that no producer emitted. So a consumer switching on `constraint` had a dead arm, and one reporting "no latency violations" was reporting the absence of a check. Setting `budget.maxLatencyMs: 1` bound nothing.

## The decision

Genuine three-way fork — enforce / remove / disclose-only — so it went to a live `consensus_vote` (`higher_order`, with the alternatives declared as `options` so the tally measures which one won, per #4472).

**Approved, 5 approvers, 100% on option A (enforce).** The architect, security, devex, ai_ml, and pm roles all selected A. The contrarian rejected — not preferring another option on the merits, but arguing that either A or B needs a shadow/deprecation phase to measure blast radius before flipping. One voter (scope_steward) timed out; the panel-degraded warning is in the record.

The contrarian's objection is the right one to answer with evidence rather than process, and the evidence closes it: **the entire cost-model table runs 1000–2000ms** (`budget-router-types.ts:105-124`, codex 1000 / gemini 1500 / opencode 1500 / claude 2000). The 60000ms default cannot exclude any current candidate, so there is no silent blast radius to shadow-measure. The only deployments whose behaviour changes are those that explicitly set `maxLatencyMs` below 2000 — and for them the change is the setting doing what it documents.

## The change

- `selectAdapterWithinBudget` compares each candidate's profile latency against the budget.
- `BudgetRoutingResult` gains `estimatedLatencyMs` — the selected adapter's profile latency, **absent** when no adapter was selected, because there is then no latency to report and `0` would read as instantaneous.
- `determineExceededConstraint` emits `'latency'`, extracted into `latencyExceeded` to stay under the function-length bar. It fires only when a latency budget was set *and* no adapter was selectable — the one state where latency, rather than the session totals, is the reason.
- A candidate with no cost-model profile is **admitted**, not rejected: a latency budget must not silently exclude every model whose latency is unmeasured.

## Verification

Red first — `expected true to be false` on `checkBudget(task, { maxLatencyMs: 500 })` before the change.

| mutation | result |
| --- | --- |
| latency dropped from the selection predicate | 2 failed ✓ |
| `estimatedLatencyMs` reported even with no adapter | 17 failed ✓ |
| latency violation relabelled `'cost'` | 1 failed ✓ |
| latency arm of `determineExceededConstraint` disabled | 1 failed ✓ |

Paired tests throughout: 500ms rejects and 5000ms admits, so the constraint is evaluated rather than always failing; and two cases confirm a rejection is *not* blamed on latency when an adapter was selected or when no latency budget was set.

3,754 tests pass across `src/cli-adapters` and `src/config`; typecheck, lint, the unused-export ratchet, and the API-surface gate clean. `minor` — an added optional field on a published interface.

## Not touched

`QualityConstraintStage` has its own `maxLatencyMs` on a different type and genuinely enforces it. Its separate weakness — no caller ever supplies `stageConfigs.qualityConstraint.maxLatencyMs`, so it is permanently the `10000` default — is unrelated and stays out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
