### PR TITLE
fix(config): let a model probe failure reach the cache that handles it

### DIFF
--- a/.changeset/model-source-reports-probe-failure.md
+++ b/.changeset/model-source-reports-probe-failure.md
@@ -1,0 +1,30 @@
+---
+'nexus-agents': patch
+---
+
+fix(config): a failed model probe no longer overwrites a good catalog with an empty one
+
+`AvailableModelsCache.fetchSource` has always had the right handling for a
+failed probe — keep the stale value, do not restamp `fetchedAt`. It never ran.
+Both real sources caught their own failures and returned `[]`, which the cache
+reads as a **successful empty probe**: the good catalog was discarded and the
+empty one marked fresh for the whole TTL, with the stale-refresh path
+re-poisoning it on the next tick. No warning was ever logged.
+
+The fail-open behaviour moves up one level, to the cache, which is the layer
+that can tell a failed probe from an empty one:
+
+- `createOpenRouterModelsSource().listModels()` now rejects on network, timeout,
+  non-OK status, and byte-cap refusal. `fetchOpenRouterCatalog` keeps the
+  documented fail-open contract the #4121 drift job depends on.
+- The adapter wrapper in `register-model-sources` lets its probe failure
+  propagate. One bad source still cannot poison the union — that isolation is
+  the cache's, one level up.
+
+Knock-on: `list_available_models` can now answer `ok: false`. Its handling was
+already correct and already tested against a rejecting source; nothing could
+make a real source reject, so `ok` was `true` for a dead transport reporting
+zero models.
+
+Closes #5059. Addresses the `list_available_models` half of #5060; the `demo`
+half is separate and stays open.

--- a/packages/nexus-agents/src/config/available-models-cache.test.ts
+++ b/packages/nexus-agents/src/config/available-models-cache.test.ts
@@ -165,3 +165,66 @@ describe('AvailableModelsCache (#2540)', () => {
     });
   });
 });
+
+describe('a failed probe must not overwrite a good catalog (#5059)', () => {
+  function sourceThatFailsAfterFirstCall(): {
+    source: AvailableModelsSource;
+    fail: () => void;
+  } {
+    let failing = false;
+    return {
+      source: {
+        name: 'flaky',
+        listModels: () =>
+          failing
+            ? Promise.reject(new Error('network down'))
+            : Promise.resolve([{ id: 'model-a' }, { id: 'model-b' }]),
+      },
+      fail: () => {
+        failing = true;
+      },
+    };
+  }
+
+  it('keeps the cached catalog when the next probe fails', async () => {
+    // The cache already has the right handling — it just never ran, because
+    // both real sources caught internally and returned `[]`, which takes the
+    // SUCCESS path: the empty list is stored and stamped fresh, discarding a
+    // good catalog for the whole TTL.
+    let clock = 0;
+    const { source, fail } = sourceThatFailsAfterFirstCall();
+    const cache = new AvailableModelsCache({
+      sources: [source],
+      ttlMs: 100,
+      now: () => clock,
+    });
+
+    expect(await cache.getAll()).toHaveLength(2);
+
+    fail();
+    clock = 1000; // past the TTL, so the next call re-probes
+
+    expect(await cache.getAll()).toHaveLength(2);
+  });
+
+  it('does not mark a failed probe as freshly fetched', async () => {
+    // Stamping `fetchedAt` on failure is what makes the damage last a full
+    // TTL: the bad state looks current, so nothing retries.
+    let clock = 0;
+    const { source, fail } = sourceThatFailsAfterFirstCall();
+    const cache = new AvailableModelsCache({
+      sources: [source],
+      ttlMs: 100,
+      now: () => clock,
+    });
+    await cache.getAll();
+
+    fail();
+    clock = 1000;
+    await cache.getAll();
+
+    // Recovery on the very next probe, not after another full TTL.
+    clock = 1001;
+    expect(await cache.getAll()).toHaveLength(2);
+  });
+});

--- a/packages/nexus-agents/src/config/openrouter-models-source.test.ts
+++ b/packages/nexus-agents/src/config/openrouter-models-source.test.ts
@@ -3,7 +3,11 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 
-import { createOpenRouterModelsSource, parseCatalog } from './openrouter-models-source.js';
+import {
+  fetchOpenRouterCatalog,
+  createOpenRouterModelsSource,
+  parseCatalog,
+} from './openrouter-models-source.js';
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
@@ -32,18 +36,22 @@ describe('createOpenRouterModelsSource (#3404)', () => {
     ]);
   });
 
-  it('fails open (empty) on a non-OK status', async () => {
+  // #5059: these previously asserted `[]`. Swallowing a probe failure into an
+  // empty list reached AvailableModelsCache on the SUCCESS path, overwriting a
+  // good catalog and stamping it fresh for the whole TTL. The source now
+  // rejects; `fetchOpenRouterCatalog` keeps fail-open for the #4121 drift job.
+  it('reports a non-OK status as a probe failure', async () => {
     const fetchImpl = vi.fn(() =>
       Promise.resolve(jsonResponse({}, false, 503))
     ) as unknown as typeof fetch;
     const src = createOpenRouterModelsSource({ fetchImpl });
-    expect(await src.listModels()).toEqual([]);
+    await expect(src.listModels()).rejects.toThrow(/503/);
   });
 
-  it('fails open (empty) on a network/timeout error', async () => {
+  it('reports a network/timeout error as a probe failure', async () => {
     const fetchImpl = vi.fn(() => Promise.reject(new Error('aborted'))) as unknown as typeof fetch;
     const src = createOpenRouterModelsSource({ fetchImpl });
-    expect(await src.listModels()).toEqual([]);
+    await expect(src.listModels()).rejects.toThrow('aborted');
   });
 
   it('fails open (empty) on a schema-invalid payload (untrusted input)', async () => {
@@ -68,7 +76,10 @@ describe('createOpenRouterModelsSource (#3404)', () => {
     expect(await src.listModels()).toEqual([]);
   });
 
-  it('rejects (empty) before buffering when Content-Length exceeds the cap', async () => {
+  it('rejects before buffering when Content-Length exceeds the cap', async () => {
+    // Still refuses to buffer — `text()` rejects if it is ever called. What
+    // changed (#5059) is that the refusal is now reported rather than
+    // flattened into an empty catalog.
     const fetchImpl = vi.fn(() =>
       Promise.resolve({
         ok: true,
@@ -78,7 +89,7 @@ describe('createOpenRouterModelsSource (#3404)', () => {
       } as unknown as Response)
     ) as unknown as typeof fetch;
     const src = createOpenRouterModelsSource({ fetchImpl });
-    expect(await src.listModels()).toEqual([]);
+    await expect(src.listModels()).rejects.toThrow(/byte cap/);
   });
 
   it('caps the number of returned ids', async () => {
@@ -121,5 +132,36 @@ describe('parseCatalog supported_parameters widening (#4121)', () => {
         JSON.stringify({ data: [{ id: 'vendor/model-c', supported_parameters: [1, 2] }] })
       )
     ).toEqual([]);
+  });
+});
+
+describe('probe failure reaches the caller (#5059)', () => {
+  it('rejects when the fetch fails, rather than reporting an empty catalog', async () => {
+    // The source caught network/timeout/parse failures and returned `[]`. That
+    // takes AvailableModelsCache's SUCCESS path, so a good cached catalog was
+    // overwritten with nothing and stamped fresh for the whole TTL — and
+    // `list_available_models` reported the dead transport as `ok: true`.
+    const source = createOpenRouterModelsSource({
+      fetchImpl: () => Promise.reject(new Error('network down')),
+    });
+
+    await expect(source.listModels()).rejects.toThrow('network down');
+  });
+
+  it('rejects on a non-OK response', async () => {
+    const source = createOpenRouterModelsSource({
+      fetchImpl: () => Promise.resolve(new Response('nope', { status: 503 })),
+    });
+
+    await expect(source.listModels()).rejects.toThrow(/503/);
+  });
+
+  it('still resolves empty for the drift job, which documents fail-open', async () => {
+    // `fetchOpenRouterCatalog` has a deliberate fail-open contract (#4121):
+    // the reconciliation job treats `[]` as a LOUD skip. Only the cache-source
+    // path changes.
+    await expect(
+      fetchOpenRouterCatalog({ fetchImpl: () => Promise.reject(new Error('network down')) })
+    ).resolves.toEqual([]);
   });
 });

--- a/packages/nexus-agents/src/config/openrouter-models-source.ts
+++ b/packages/nexus-agents/src/config/openrouter-models-source.ts
@@ -97,7 +97,19 @@ export function parseCatalog(text: string): readonly OpenRouterCatalogModel[] {
 }
 
 /** Fetch + validate the catalog. Fail-OPEN: any failure returns `[]`. */
-async function fetchCatalog(
+/**
+ * Fetch the catalog, THROWING on any probe failure (#5059).
+ *
+ * The cache source uses this variant. It used to swallow failures into `[]`,
+ * which reached `AvailableModelsCache` on the success path: the empty list
+ * overwrote a good catalog and was stamped fresh for the whole TTL, and
+ * `list_available_models` reported the dead transport as `ok: true`. An empty
+ * result must mean "the catalog is empty", never "the probe did not run".
+ *
+ * {@link fetchOpenRouterCatalog} keeps the fail-open behaviour for the #4121
+ * drift job, which documents `[]` as a loud skip.
+ */
+async function fetchCatalogOrThrow(
   url: string,
   timeoutMs: number,
   doFetch: typeof fetch
@@ -112,32 +124,36 @@ async function fetchCatalog(
       headers: { accept: 'application/json' },
     });
     if (!res.ok) {
-      logger.warn('OpenRouter catalog fetch returned non-OK; treating as empty', {
-        status: res.status,
-      });
-      return [];
+      throw new Error(`OpenRouter catalog fetch returned HTTP ${String(res.status)}`);
     }
     // Pre-check Content-Length so a hostile/huge body is rejected BEFORE it is
     // buffered. The text().length check is a backstop for servers that omit or
     // lie about Content-Length.
     const declaredLen = res.headers.get('content-length');
     if (declaredLen !== null && Number(declaredLen) > MAX_BYTES) {
-      logger.warn('OpenRouter catalog Content-Length exceeds byte cap; ignoring', {
-        bytes: declaredLen,
-      });
-      return [];
+      throw new Error(`OpenRouter catalog Content-Length ${declaredLen} exceeds the byte cap`);
     }
     const ids = parseCatalog(await res.text());
     logger.debug('OpenRouter catalog loaded', { count: ids.length });
     return ids;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Fail-open wrapper: any probe failure yields `[]`. */
+async function fetchCatalog(
+  url: string,
+  timeoutMs: number,
+  doFetch: typeof fetch
+): Promise<readonly OpenRouterCatalogModel[]> {
+  try {
+    return await fetchCatalogOrThrow(url, timeoutMs, doFetch);
   } catch (error: unknown) {
-    // Fail-open: probe failure (network/timeout/parse) → empty list.
     logger.warn('OpenRouter catalog fetch failed; treating as empty', {
       error: error instanceof Error ? error.message : String(error),
     });
     return [];
-  } finally {
-    clearTimeout(timer);
   }
 }
 
@@ -151,7 +167,9 @@ export function createOpenRouterModelsSource(
   return {
     name: 'openrouter',
     providerHint: 'openrouter',
-    listModels: () => fetchCatalog(url, timeoutMs, doFetch),
+    // Throws on probe failure so the cache can tell it apart from an empty
+    // catalog (#5059).
+    listModels: () => fetchCatalogOrThrow(url, timeoutMs, doFetch),
   };
 }
 

--- a/packages/nexus-agents/src/config/register-model-sources.test.ts
+++ b/packages/nexus-agents/src/config/register-model-sources.test.ts
@@ -41,6 +41,9 @@ describe('registerDefaultModelSources (#3404)', () => {
   });
 
   it('is fail-open: one adapter throwing does not poison the others', async () => {
+    // The isolation is unchanged — it just lives in the cache now rather than
+    // in the source wrapper (#5059), which is what lets a failed probe be told
+    // apart from an empty one.
     const cache = new AvailableModelsCache({ sources: [] });
     const adapters = new Map<string, unknown>([
       ['opencode', { listModels: () => Promise.reject(new Error('cli down')) }],
@@ -50,6 +53,24 @@ describe('registerDefaultModelSources (#3404)', () => {
 
     const all = await cache.getAll();
     expect(all.map((m) => m.id)).toContain('gemini-3-pro');
+  });
+
+  it('lets an adapter probe failure reach the cache (#5059)', async () => {
+    // The wrapper used to catch and return `[]`, which the cache reads as a
+    // SUCCESSFUL empty probe: a good catalog is overwritten and stamped fresh
+    // for the whole TTL. Asserted at the source, because at the cache boundary
+    // the two are — by construction — indistinguishable.
+    const cache = new AvailableModelsCache({ sources: [] });
+    const adapters = new Map<string, unknown>([
+      ['opencode', { listModels: () => Promise.reject(new Error('cli down')) }],
+    ]);
+    registerDefaultModelSources(cache, adapters, { includeOpenRouter: false });
+
+    const source = buildDefaultModelSources(adapters, { includeOpenRouter: false }).find(
+      (x) => x.name === 'opencode'
+    );
+    expect(source).toBeDefined();
+    await expect(source?.listModels()).rejects.toThrow('cli down');
   });
 
   it('skips adapters without a listModels method', async () => {

--- a/packages/nexus-agents/src/config/register-model-sources.ts
+++ b/packages/nexus-agents/src/config/register-model-sources.ts
@@ -18,15 +18,12 @@
  *
  * @module config/register-model-sources
  */
-import { createLogger } from '../core/index.js';
 
 import { createOpenRouterModelsSource } from './openrouter-models-source.js';
 import { routingArmDisplaySlot } from '../cli-adapters/types.js';
 import type { RoutingArmId } from '../cli-adapters/types.js';
 
 import type { AvailableModelsCache, AvailableModelsSource } from './available-models-cache.js';
-
-const logger = createLogger({ component: 'register-model-sources' });
 
 /** Whether dynamic model discovery is enabled (opt-in; default OFF). */
 export function isDynamicModelsEnabled(): boolean {
@@ -47,23 +44,21 @@ function hasListModels(adapter: unknown): adapter is ListsModels {
 }
 
 /**
- * Wrap an adapter's `listModels()` as a fail-open cache source named for its CLI
- * (so `getCandidateCliNames` filters on it). Probe failures → `[]`.
+ * Wrap an adapter's `listModels()` as a cache source named for its CLI (so
+ * `getCandidateCliNames` filters on it).
+ *
+ * Probe failures propagate (#5059). Catching them here returned `[]`, which
+ * reached `AvailableModelsCache` on the SUCCESS path: the empty list replaced
+ * a good catalog and was stamped fresh for the whole TTL. The cache has always
+ * had the right handling for a rejection — keep the stale value, do not
+ * restamp — it just never ran. One bad source still cannot poison the union;
+ * that isolation lives in the cache, one level up, where it can tell a failed
+ * probe from an empty one.
  */
 function adapterSource(cliName: string, adapter: ListsModels): AvailableModelsSource {
   return {
     name: cliName,
-    listModels: () =>
-      adapter
-        .listModels()
-        .then((models) => models.map((m) => ({ id: m.id })))
-        .catch((error: unknown) => {
-          logger.debug('adapter listModels failed; treating as empty', {
-            cli: cliName,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return [];
-        }),
+    listModels: () => adapter.listModels().then((models) => models.map((m) => ({ id: m.id }))),
   };
 }
 


### PR DESCRIPTION
Closes #5059. Addresses the `list_available_models` half of #5060.

## The defect

`AvailableModelsCache.fetchSource` has always handled a failed probe correctly — keep the stale value, do **not** restamp `fetchedAt`:

```ts
} catch (e: unknown) {
  logger.warn('AvailableModelsCache source probe failed', { ... });
  // Keep the stale value if we have one; otherwise empty.
  return state.value ?? [];
}
```

It has never run. Both real sources catch internally and return `[]`:

- `openrouter-models-source.ts:133` — network, timeout, parse → `[]`
- `register-model-sources.ts:60` — `.catch(… return [])` on adapter sources

An empty array takes the **success** path. `state.value = []`, `state.fetchedAt = now`. A good catalog is discarded, the empty one is stamped fresh for the whole TTL, and the stale-refresh path re-poisons it on the next tick. No warning is ever logged, because the `catch` the warning lives in cannot be reached.

Third instance of the same shape tonight, after #5050 (memory backends) and #5058 (tool observability proxy): **a `catch`-only handler guarding producers that return rather than throw.**

## The change

Fail-open moves up one level — to the cache, which is the layer that can tell a failed probe from an empty one.

- `createOpenRouterModelsSource().listModels()` rejects on network, timeout, non-OK status, and byte-cap refusal. `fetchCatalog` is retained as an explicit fail-open wrapper for `fetchOpenRouterCatalog`, whose `[]`-means-loud-skip contract the #4121 drift job depends on — that behaviour is unchanged.
- The adapter wrapper in `register-model-sources` lets its failure propagate. **One bad source still cannot poison the union**; that isolation was never the wrapper's job, it is the cache's.

## Three existing tests asserted the defect

`openrouter-models-source.test.ts` had three `fails open (empty) on …` cases pinning `listModels()` returning `[]` for a probe failure. They were the reason the gap survived a review — the behaviour looked deliberate because a test said so. Rewritten to assert rejection, each with a comment saying what changed and why.

## Verification

| mutation | result |
| --- | --- |
| OpenRouter source swallows failures again | 5 failed ✓ |
| adapter wrapper swallows failures again | 1 failed ✓ |
| non-OK status returns `[]` instead of throwing | 2 failed ✓ |

The adapter mutation initially **survived** — nothing pinned that wrapper, and the existing "fail-open" test passes either way because the cache provides the isolation regardless. It needed an assertion at the source itself, since at the cache boundary the two outcomes are by construction indistinguishable. That is the whole defect in miniature.

New cache tests cover the recovery path end-to-end. Being precise about what they are: **the cache code did not change** — those tests are regression coverage for handling that was already correct and never exercised, not evidence of a fix.

3,700 tests pass across `src/config` and `src/mcp/tools`; typecheck, lint, and the API-surface gate clean.

## Scope

Two paths still flatten to `[]` rather than rejecting: a schema-invalid payload and an over-cap body detected after buffering. Both go through `parseCatalog`, which is exported and has its own untrusted-input contract, so changing it belongs in its own change. Saying so rather than implying full coverage.

The `demo` half of #5060 (`available: true` written unconditionally against a non-throwing `healthCheck`) is untouched and stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
