### PR TITLE
fix(cli): distinguish a missing CLI binary from an unsupported version

### DIFF
--- a/.changeset/health-status-reports-reachability.md
+++ b/.changeset/health-status-reports-reachability.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': minor
+---
+
+fix(cli): the demo no longer lists an uninstalled CLI as available
+
+`getCliAvailability` wrote `available: true` unconditionally and read failure
+only from a `catch`. `healthCheck` does not throw — `BaseCliAdapter` catches and
+returns `{ healthy: false, version: 'unknown', versionStatus: 'unsupported' }`,
+and `ModelToCliAdapter.healthCheck` has no throw path at all. So a CLI whose
+binary is absent (`spawn ENOENT`) showed as installed-but-unauthenticated, and
+the demo told the user to run `auth login` for something they do not have.
+
+`HealthStatus` gains an optional `reachable`. `BaseCliAdapter` sets it `true`
+when the binary answered `--version` — whatever it said — and `false` when it
+could not be run; `ModelToCliAdapter` sets `true`, since an in-process API
+adapter has no binary to be missing. Absent means the producer predates the
+distinction, and consumers treat `reachable !== false` as present, so adding
+the field cannot silently reclassify an older adapter as uninstalled.
+
+This is what separates two states that were previously identical: a binary that
+is missing and one that is installed on an unsupported version are both
+`healthy: false` with `versionStatus: 'unsupported'`.
+
+Closes #5060.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -4177,6 +4177,7 @@ InterfaceDeclaration HealthStatus
   readonly healthy: boolean
   readonly lastChecked: Date
   readonly message?: string | undefined
+  readonly reachable?: boolean | undefined
   readonly version: string
   readonly versionStatus: VersionStatus
 InterfaceDeclaration HierarchicalOptions

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.test.ts
@@ -357,6 +357,39 @@ describe('BaseCliAdapter', () => {
       expect(status.message).toContain('not supported');
     });
 
+    it('marks a reachable binary as reachable (#5060)', async () => {
+      adapter.setCachedVersion('2.1.0');
+      const status = await adapter.healthCheck();
+      expect(status.reachable).toBe(true);
+    });
+
+    it('marks an unrunnable binary as unreachable, not merely unhealthy (#5060)', async () => {
+      // `healthCheck` catches and returns rather than throwing, so a consumer
+      // reading only `healthy` cannot tell "binary absent" from "present but
+      // on an unsupported version" — `demo` told users to run `auth login`
+      // for a CLI they did not have installed.
+      const failing = new TestCliAdapter();
+      vi.spyOn(failing, 'getVersion').mockRejectedValue(new Error('spawn ENOENT'));
+
+      const status = await failing.healthCheck();
+
+      expect(status.healthy).toBe(false);
+      expect(status.reachable).toBe(false);
+      expect(status.message).toContain('ENOENT');
+    });
+
+    it('distinguishes unreachable from an unsupported installed version (#5060)', () => {
+      // The pair that makes `reachable` load-bearing: both are `healthy:
+      // false` with `versionStatus: 'unsupported'`, so only `reachable`
+      // separates them.
+      adapter.setCachedVersion('0.0.1');
+      return adapter.healthCheck().then((status) => {
+        expect(status.healthy).toBe(false);
+        expect(status.versionStatus).toBe('unsupported');
+        expect(status.reachable).toBe(true);
+      });
+    });
+
     it('should handle outdated version in health check', async () => {
       adapter.setCachedVersion('2.0.1');
       const status = await adapter.healthCheck();

--- a/packages/nexus-agents/src/cli-adapters/base-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/base-adapter.ts
@@ -264,6 +264,8 @@ export abstract class BaseCliAdapter implements ICliAdapter {
         healthy: versionStatus !== 'unsupported' && versionStatus !== 'breaking',
         version,
         versionStatus,
+        // The binary answered `--version`, whatever it said (#5060).
+        reachable: true,
         lastChecked: new Date(getTimeProvider().now()),
         ...(message !== undefined && { message }),
       };
@@ -274,6 +276,8 @@ export abstract class BaseCliAdapter implements ICliAdapter {
         healthy: false,
         version: 'unknown',
         versionStatus: 'unsupported',
+        // `getVersion` could not run the binary — absent, not merely outdated.
+        reachable: false,
         message: error instanceof Error ? error.message : 'Health check failed',
         lastChecked: new Date(getTimeProvider().now()),
       };

--- a/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/model-to-cli-adapter.ts
@@ -217,6 +217,9 @@ export class ModelToCliAdapter implements ICliAdapter {
       healthy: valid.ok,
       version: 'api',
       versionStatus: 'supported',
+      // In-process API adapter: there is no binary to be missing, so it is
+      // always reachable and only its config can be wrong (#5060).
+      reachable: true,
       lastChecked: new Date(0),
       ...(valid.ok ? {} : { message: valid.error.message }),
     });

--- a/packages/nexus-agents/src/cli-adapters/types-core.ts
+++ b/packages/nexus-agents/src/cli-adapters/types-core.ts
@@ -179,6 +179,20 @@ export interface HealthStatus {
   readonly versionStatus: VersionStatus;
   /** Optional message (e.g., upgrade recommendation) */
   readonly message?: string;
+  /**
+   * Whether the underlying CLI could be reached at all (#5060).
+   *
+   * `healthCheck` catches its own failures and returns rather than throwing, so
+   * a `healthy: false` result covers two very different states: the binary ran
+   * and reported an unsupported version, or the binary could not be run at all
+   * (`spawn ENOENT`). Both arrive as `versionStatus: 'unsupported'`, and a
+   * consumer reading only `healthy` told users to authenticate a CLI they had
+   * not installed.
+   *
+   * Absent means the producer predates the distinction — unknown, not
+   * unreachable. Consumers should treat `reachable !== false` as "present".
+   */
+  readonly reachable?: boolean;
   /** Last successful health check */
   readonly lastChecked: Date;
 }

--- a/packages/nexus-agents/src/cli/demo-command.test.ts
+++ b/packages/nexus-agents/src/cli/demo-command.test.ts
@@ -7,9 +7,76 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Mock CLI adapter factory to avoid real subprocess spawns (perf: saves ~7s)
+// Mock CLI adapter factory to avoid real subprocess spawns (perf: saves ~7s).
+// #5060: `gemini` reports an UNREACHABLE binary — `healthCheck` resolves with
+// `reachable: false` rather than throwing, which is what production does when
+// `getVersion` hits `spawn ENOENT`. `claude` reports a reachable binary on an
+// unsupported version. Both are `healthy: false`; only `reachable` separates
+// them, and the demo used to call both "available".
 vi.mock('../cli-adapters/factory.js', () => ({
-  createAllAdapters: vi.fn(() => new Map()),
+  createAllAdapters: vi.fn(
+    () =>
+      new Map([
+        [
+          'gemini',
+          {
+            healthCheck: () =>
+              Promise.resolve({
+                healthy: false,
+                version: 'unknown',
+                versionStatus: 'unsupported',
+                reachable: false,
+                message: 'spawn ENOENT',
+                lastChecked: new Date(0),
+              }),
+          },
+        ],
+        [
+          'claude',
+          {
+            healthCheck: () =>
+              Promise.resolve({
+                healthy: false,
+                version: '0.0.1',
+                versionStatus: 'unsupported',
+                reachable: true,
+                lastChecked: new Date(0),
+              }),
+          },
+        ],
+        // One healthy CLI, so the live path renders the availability list at
+        // all — it is only shown when something is authenticated.
+        [
+          'codex',
+          {
+            healthCheck: () =>
+              Promise.resolve({
+                healthy: true,
+                version: '2.0.0',
+                versionStatus: 'supported',
+                reachable: true,
+                lastChecked: new Date(0),
+              }),
+            execute: () => Promise.resolve({ ok: true, value: { text: 'demo output' } }),
+          },
+        ],
+        // A producer that predates `reachable` and cannot say. Absent must mean
+        // unknown-so-assume-present, never absent — otherwise adding the field
+        // silently reclassifies every older adapter as uninstalled.
+        [
+          'opencode',
+          {
+            healthCheck: () =>
+              Promise.resolve({
+                healthy: false,
+                version: '1.0.0',
+                versionStatus: 'unsupported',
+                lastChecked: new Date(0),
+              }),
+          },
+        ],
+      ])
+  ),
 }));
 
 import {
@@ -78,6 +145,18 @@ describe('demo-command', () => {
       const result = await runRoutingDemo('Explain how closures work', false);
 
       expect(result).toContain('Reasoning:       yes');
+    });
+
+    it('does not list an unreachable CLI as available (#5060)', async () => {
+      // A missing binary was shown as installed-but-unauthenticated, so the
+      // demo told the user to run `auth login` for a CLI they do not have.
+      const result = await runRoutingDemo('Implement a sorting function', true);
+
+      expect(result).toMatch(/gemini\s+- not available/);
+      // The pair: an installed CLI on an unsupported version is still present.
+      expect(result).toMatch(/claude\s+- available \(not authenticated\)/);
+      // And a producer that cannot say is treated as present, not absent.
+      expect(result).toMatch(/opencode\s+- available \(not authenticated\)/);
     });
 
     it('should show mock disclaimer', async () => {

--- a/packages/nexus-agents/src/cli/demo-command.ts
+++ b/packages/nexus-agents/src/cli/demo-command.ts
@@ -58,16 +58,18 @@ async function getCliAvailability(): Promise<readonly CliAvailability[]> {
       continue;
     }
 
-    try {
-      const health = await adapter.healthCheck();
-      results.push({
-        name,
-        available: true,
-        authenticated: health.healthy,
-      });
-    } catch {
-      results.push({ name, available: false, authenticated: false });
-    }
+    // #5060: `available: true` used to be written unconditionally, and
+    // `healthCheck` does not throw — it catches and returns. So a CLI whose
+    // binary is absent showed as installed-but-unauthenticated, and the demo
+    // told the user to run `auth login` for something they did not have.
+    // `reachable` absent means an older producer that cannot say; treat that
+    // as present rather than inventing an absence.
+    const health = await adapter.healthCheck();
+    results.push({
+      name,
+      available: health.reachable !== false,
+      authenticated: health.healthy,
+    });
   }
 
   cliAvailabilityCache = results;


### PR DESCRIPTION
Closes #5060. The `list_available_models` half of that issue is fixed by #5063; this is the `demo` half.

## The defect

`demo-command.ts:61-70`:

```ts
try {
  const health = await adapter.healthCheck();
  results.push({ name, available: true, authenticated: health.healthy });
} catch {
  results.push({ name, available: false, authenticated: false });
}
```

`available: true` is written unconditionally, and the `catch` never runs. `BaseCliAdapter.healthCheck` (`base-adapter.ts:272`) catches and **returns** `{ healthy: false, version: 'unknown', versionStatus: 'unsupported' }`; `ModelToCliAdapter.healthCheck` has no throw path at all.

**Observable:** a CLI whose binary is absent (`spawn ENOENT` from `getVersion`) is shown as installed-but-unauthenticated, so the demo tells the user to run `auth login` for something they do not have.

Fourth instance tonight of the same shape — a `catch`-only failure branch guarding producers that return rather than throw — after #5050, #5058, and #5063.

## Why a new field rather than inference

A missing binary and an installed binary on an unsupported version are **identical** in the existing payload: both `healthy: false`, `versionStatus: 'unsupported'`. `version: 'unknown'` looks like a tell, but it is an artifact of the error branch rather than a stated contract, and inferring off it would be exactly the kind of guess this repo treats as unsafe.

`HealthStatus` gains an optional `reachable`:

- `BaseCliAdapter` — `true` when the binary answered `--version`, whatever it said; `false` when it could not be run.
- `ModelToCliAdapter` — `true`. An in-process API adapter has no binary to be missing; only its config can be wrong.
- **Absent** means the producer predates the distinction. Consumers treat `reachable !== false` as present, so adding the field cannot silently reclassify an older adapter as uninstalled.

Same shape as `confidenceMeasured` (#4831), `tokensMeasured` (#4734), and `conflictsDetected` (#4854).

## Verification

| mutation | result |
| --- | --- |
| error path claims `reachable: true` | 1 failed ✓ |
| success path claims `reachable: false` | 2 failed ✓ |
| demo ignores `reachable` and writes `available: true` | 1 failed ✓ |
| demo treats absent `reachable` as absent | 1 failed ✓ |

The last two both survived a first pass. The demo consumer had no coverage at all — the test file mocked `createAllAdapters` to return an empty map, so `getCliAvailability` never reached the branch. The mock now carries four adapters covering every case: unreachable, reachable-but-unsupported, healthy, and one that omits the field entirely. The availability list only renders on the live path, which needs something authenticated, which is why the healthy adapter is there.

Three explicit producer tests too, including the pair that makes the field load-bearing: unreachable and installed-but-unsupported are both `healthy: false, versionStatus: 'unsupported'`, and only `reachable` separates them.

2,794 tests pass across `src/cli-adapters` and the demo/doctor suites; typecheck, lint, the unused-export ratchet, and the API-surface gate clean. `minor` — an added optional field on a published interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
