### PR TITLE
fix(mcp): make consensus_vote async mode satisfy its own output schema

### DIFF
--- a/.changeset/consensus-vote-async-mode-works.md
+++ b/.changeset/consensus-vote-async-mode-works.md
@@ -1,0 +1,29 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): consensus_vote async mode no longer fails every call
+
+`consensus_vote` declares an `outputSchema`, so the SDK requires
+`structuredContent` on every non-error result. Its async branch dispatches
+through `runAsJob`, whose envelopes are text-only, so **every**
+`consensus_vote({ mode: 'async' })` call failed with
+`-32602: has an output schema but no structured content was provided` — the mode
+the tool's own description recommends for 7-voter higher-order panels.
+
+The dispatch now supplies structured envelopes via `runAsJob`'s `toEnvelope`
+hook, and the schema declares the `status` / `jobId` / `pollTool` / `note` /
+`retryAfterMs` fields they carry. The vote fields become optional, because a
+tool with two response shapes cannot express a discriminated union through
+`registerTool`'s `ZodRawShape`. `status` distinguishes them: present means an
+async-dispatch envelope, absent means a completed vote.
+
+What that gives up is requiredness. What it keeps is the guarantee that protects
+the protocol — `additionalProperties: false` still rejects an **undeclared**
+response field, which is the #5044 regression the schema exists to catch, and
+there is now a test pinning that specifically.
+
+Of the eleven tools using `runAsJob`, only `consensus_vote` declares an
+`outputSchema`, so the blast radius was exactly one tool.
+
+Closes #5066.

--- a/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
+++ b/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
@@ -280,6 +280,39 @@ describe('MCP Standalone Tools Integration', () => {
     );
   });
 
+  it('a second response shape also satisfies the outputSchema (#5066)', async () => {
+    // The round-trip above calls each tool once with default arguments, so it
+    // only ever sees ONE of a tool's response shapes. `consensus_vote` has two:
+    // the vote result, and the `{status:'pending', jobId}` envelope from
+    // `runAsJob`. The async envelope carried no structured content at all, so
+    // every `mode: 'async'` call — the mode the tool's own description
+    // recommends for 7-voter panels — failed with -32602.
+    let result: unknown;
+    let thrown = '';
+    try {
+      result = await ctx.client.callTool({
+        name: 'consensus_vote',
+        arguments: { proposal: 'round trip', quickMode: true, mode: 'async' },
+      });
+    } catch (error: unknown) {
+      thrown = error instanceof Error ? error.message : JSON.stringify(error);
+    }
+
+    expect(schemaViolationIn(result, thrown)).toBe('');
+  }, 60_000);
+
+  /**
+   * A schema violation reaches the caller in one of two ways, and the first
+   * draft of this suite only knew about one of them (#5066): the SDK may
+   * throw, or it may hand back `isError: true` with the message in the text
+   * content. A test that only catches throws passes on the second form.
+   */
+  function schemaViolationIn(result: unknown, thrown: string): string {
+    const texts = (result as { content?: { text?: string }[] } | undefined)?.content ?? [];
+    const haystack = [thrown, ...texts.map((c) => c.text ?? '')].join(' ');
+    return /output schema|-32602/.test(haystack) ? haystack : '';
+  }
+
   /**
    * Tools whose round-trip call returns an error envelope rather than
    * structured content, so their `outputSchema` genuinely goes unchecked here:
@@ -335,16 +368,28 @@ describe('MCP Standalone Tools Integration', () => {
         missingArgs.push(tool.name);
         continue;
       }
+      let result: Awaited<ReturnType<typeof ctx.client.callTool>> | undefined;
+      let thrown = '';
       try {
-        const result = await ctx.client.callTool({ name: tool.name, arguments: args });
-        if (result.structuredContent === undefined) notExercised.push(tool.name);
+        result = await ctx.client.callTool({ name: tool.name, arguments: args });
       } catch (error: unknown) {
         // Every thrown error counts, not only the ones naming a schema. An
         // earlier version matched two substrings and silently credited the
         // tool for anything else — a timeout, a transport fault — which is the
         // same shape of hole this suite exists to close.
-        const message = error instanceof Error ? error.message : JSON.stringify(error);
-        callFailed.push(`${tool.name}: ${message}`);
+        thrown = error instanceof Error ? error.message : JSON.stringify(error);
+      }
+      // #5066: the SDK delivers a violation as an `isError` RESULT as often as
+      // it throws. Checked before the unstructured bucket, because a violation
+      // has no structured content either — and for a tool already in
+      // KNOWN_UNSTRUCTURED it would otherwise be credited as expected.
+      const violation = schemaViolationIn(result, thrown);
+      if (violation !== '') {
+        callFailed.push(`${tool.name}: ${violation}`);
+      } else if (thrown !== '') {
+        callFailed.push(`${tool.name}: ${thrown}`);
+      } else if (result?.structuredContent === undefined) {
+        notExercised.push(tool.name);
       }
     }
 

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.test.ts
@@ -1632,14 +1632,46 @@ describe('CONSENSUS_VOTE_OUTPUT_SCHEMA covers the full response (#4032)', () => 
     expect(() => z.object(CONSENSUS_VOTE_OUTPUT_SCHEMA).strict().parse(fullResponse)).not.toThrow();
   });
 
+  // #5066: the schema also covers the async-dispatch envelope, which is a
+  // second response shape with none of the vote fields. These five keys are
+  // the whole of that difference — named here so the drift guard below stays
+  // exact rather than being loosened to "superset".
+  const ASYNC_ENVELOPE_KEYS = ['status', 'jobId', 'pollTool', 'note', 'retryAfterMs'];
+
   it('declares exactly the response keys (no schema/response key drift)', () => {
     // Key-level guard: catches a response field absent from the schema (the
     // panelWarning/costSummary failure mode). It does NOT police value
     // constraints — the `decision` enum is kept aligned structurally instead,
     // by reusing VoteDecisionStatusSchema (see the enum test below).
     expect(Object.keys(CONSENSUS_VOTE_OUTPUT_SCHEMA).sort()).toEqual(
-      Object.keys(fullResponse).sort()
+      [...Object.keys(fullResponse), ...ASYNC_ENVELOPE_KEYS].sort()
     );
+  });
+
+  it('strictly accepts the async-dispatch envelope (#5066)', () => {
+    // The shape that used to fail every `mode: 'async'` call with -32602,
+    // because `runAsJob`'s default envelopes carry no structured content and
+    // the schema had no field they could satisfy.
+    expect(() =>
+      z.object(CONSENSUS_VOTE_OUTPUT_SCHEMA).strict().parse({
+        status: 'pending',
+        jobId: 'job-vote-1',
+        pollTool: 'get_job_result',
+        note: 'Poll via get_job_result({ jobId }) until status !== "pending".',
+      })
+    ).not.toThrow();
+  });
+
+  it('still rejects a response field the schema does not declare (#5066)', () => {
+    // The guarantee the widening had to preserve. Requiredness is gone;
+    // `additionalProperties: false` is what actually catches a #5044-shaped
+    // regression, and it still fires.
+    expect(() =>
+      z
+        .object(CONSENSUS_VOTE_OUTPUT_SCHEMA)
+        .strict()
+        .parse({ ...fullResponse, undeclaredField: 1 })
+    ).toThrow();
   });
 
   it.each(['approved', 'rejected', 'pending', 'timeout', 'no_quorum'] as const)(

--- a/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
+++ b/packages/nexus-agents/src/mcp/tools/consensus-vote.ts
@@ -25,6 +25,7 @@ import { createSecureHandler, type HandlerContext } from '../middleware/secure-h
 import {
   toolStructuredError,
   toolSuccess,
+  toolSuccessStructured,
   type ToolResult,
   type BaseMcpToolDeps,
 } from './tool-result.js';
@@ -72,7 +73,11 @@ import { getToolAnnotations } from '../tool-annotations.js';
 // #3045 / epic #2631 Stage 4 — async-mode dispatch + concurrency cap.
 // #3045 / epic #2631 Stage 4 — async-mode dispatch via the shared `runAsJob`
 // helper (#3729).
-import { runAsJob } from '../jobs/run-as-job.js';
+import {
+  runAsJob,
+  defaultCollisionEnvelope,
+  type JobEnvelopeBuilders,
+} from '../jobs/run-as-job.js';
 import { randomUUID } from 'node:crypto';
 import type {
   VotingStrategy,
@@ -969,6 +974,9 @@ function dispatchAsyncConsensusVote(
     input: args,
     idempotencyKey: args.idempotencyKey,
     freshJobId: () => `job-vote-${randomUUID()}`,
+    // #5066: structured envelopes — this tool declares an outputSchema, and
+    // the SDK rejects a non-error result that carries no structured content.
+    toEnvelope: ASYNC_ENVELOPES,
     // #4362: `handleConsensusVote`'s `{ ok: false }` used to flow into the job
     // record verbatim, and `runAsJob` records `complete` for anything its `run`
     // callback RESOLVES — so a dead voter panel produced a job a caller polling
@@ -1057,48 +1065,102 @@ function createConsensusVoteHandler(deps: ConsensusVoteDeps) {
   };
 }
 
-/** Output schema for consensus_vote tool (Issue #1117, #1246). */
+/**
+ * Async-dispatch envelopes carrying `structuredContent` (#5066).
+ *
+ * `runAsJob`'s defaults are text-only. Because this tool declares an
+ * `outputSchema`, the SDK requires structured content on every non-error
+ * result, so every `mode: 'async'` call failed with -32602 — the mode the
+ * tool's own description recommends for 7-voter panels.
+ */
+const ASYNC_ENVELOPES: JobEnvelopeBuilders<ToolResult> = {
+  pending: (jobId) =>
+    toolSuccessStructured({
+      status: 'pending',
+      jobId,
+      pollTool: 'get_job_result',
+      note: 'Poll via get_job_result({ jobId }) until status !== "pending".',
+    }),
+  busy: (retryAfterMs, toolName) =>
+    toolSuccessStructured({
+      status: 'busy',
+      retryAfterMs,
+      note: `Async-mode concurrency cap reached for ${toolName}. Retry later or use mode: "sync".`,
+    }),
+  replay: (jobId) =>
+    toolSuccessStructured({
+      status: 'replay',
+      jobId,
+      pollTool: 'get_job_result',
+      note: 'Poll via get_job_result({ jobId }) until status !== "pending".',
+    }),
+  collision: defaultCollisionEnvelope,
+};
+
+/**
+ * Output schema for consensus_vote tool (Issue #1117, #1246).
+ *
+ * Every vote field is optional because this tool has TWO response shapes and
+ * `registerTool` takes a `ZodRawShape`, which cannot express a discriminated
+ * union (#5066). `status` tells them apart: present means an async-dispatch
+ * envelope, absent means a completed vote.
+ *
+ * What that gives up is requiredness. What it keeps is the guarantee that
+ * actually protects the protocol: the SDK validates with
+ * `additionalProperties: false`, so an UNDECLARED response field still fails
+ * every call — the #5044 regression this schema exists to catch.
+ */
 export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
-  proposal: z.string(),
-  strategy: VotingStrategySchema,
+  /** Async-dispatch envelope discriminator — absent on a completed vote. */
+  status: z.enum(['pending', 'busy', 'replay']).optional(),
+  jobId: z.string().max(200).optional(),
+  pollTool: z.literal('get_job_result').optional(),
+  note: z.string().max(500).optional(),
+  retryAfterMs: z.number().optional(),
+  proposal: z.string().optional(),
+  strategy: VotingStrategySchema.optional(),
   // Reuses the canonical VoteDecisionStatusSchema (single source) — a hand-listed
   // subset here (was ['approved','rejected','no_quorum']) omitted the reachable
   // 'timeout'/'pending' outcomes and made strict clients reject those votes (#4032).
-  decision: VoteDecisionStatusSchema,
-  approvalPercentage: z.number(),
-  voteCounts: z.object({
-    approve: z.number(),
-    reject: z.number(),
-    abstain: z.number(),
-    error: z.number(),
-  }),
-  votes: z.array(
-    z.object({
-      role: z.string().max(100),
-      decision: z.enum(['approve', 'reject', 'abstain']),
-      confidence: z.number(),
-      reasoning: z.string().max(4000),
-      simulated: z.boolean(),
-      error: z.boolean(),
-      modelUsed: z.string().max(100).optional(),
-      rejectionCategories: z
-        .array(
-          z.enum([
-            'YAGNI',
-            'DRY_VIOLATION',
-            'OVER_ENGINEERING',
-            'SCOPE_CREEP',
-            'SECURITY_RISK',
-            'MISALIGNED',
-            'INSUFFICIENT_EVIDENCE',
-          ])
-        )
-        .optional(),
+  decision: VoteDecisionStatusSchema.optional(),
+  approvalPercentage: z.number().optional(),
+  voteCounts: z
+    .object({
+      approve: z.number(),
+      reject: z.number(),
+      abstain: z.number(),
+      error: z.number(),
     })
-  ),
+    .optional(),
+  votes: z
+    .array(
+      z.object({
+        role: z.string().max(100),
+        decision: z.enum(['approve', 'reject', 'abstain']),
+        confidence: z.number(),
+        reasoning: z.string().max(4000),
+        simulated: z.boolean(),
+        error: z.boolean(),
+        modelUsed: z.string().max(100).optional(),
+        rejectionCategories: z
+          .array(
+            z.enum([
+              'YAGNI',
+              'DRY_VIOLATION',
+              'OVER_ENGINEERING',
+              'SCOPE_CREEP',
+              'SECURITY_RISK',
+              'MISALIGNED',
+              'INSUFFICIENT_EVIDENCE',
+            ])
+          )
+          .optional(),
+      })
+    )
+    .optional(),
   threshold: VoteThresholdSchema.optional(),
-  durationMs: z.number(),
-  simulateVotes: z.boolean(),
+  durationMs: z.number().optional(),
+  simulateVotes: z.boolean().optional(),
   higherOrderMetadata: z
     .object({
       posteriorApproval: z.number(),
@@ -1119,7 +1181,7 @@ export const CONSENSUS_VOTE_OUTPUT_SCHEMA = {
   // normal case; false means all-simulated (skipped by design) or write-failed
   // (data dir unwritable) — voteRecordNote carries the actionable reason. Makes
   // a previously WARN-only skip visible to MCP callers.
-  voteRecordPersisted: z.boolean(),
+  voteRecordPersisted: z.boolean().optional(),
   voteRecordNote: z.string().max(500).optional(),
   // #3587: set when the panel DEGRADED (some voters errored), so the decision
   // rests on fewer voters than requested. Part of the response since #3587 but


### PR DESCRIPTION
Closes #5066. Found by calling the tool, not by reading it.

## The failure

```
consensus_vote({ proposal: "...", strategy: "higher_order", mode: "async" })
→ MCP error -32602: Output validation error: Tool consensus_vote has an
  output schema but no structured content was provided
```

Not intermittent, not input-dependent. `consensus_vote` declares `outputSchema` (`consensus-vote.ts:1209`), so the SDK requires `structuredContent` on every non-error result. The async branch dispatches through `runAsJob`, whose envelopes are text-only — `defaultPendingEnvelope` and friends call `toolSuccess`, never `toolSuccessStructured` (`run-as-job.ts:118,130,141`).

The two features were mutually exclusive as built, and the tool shipped with both on. The tool description steers callers straight at it: *"Use `async` for higher-order strategies with 7 voters."*

Blast radius is exactly one tool: eleven use `runAsJob`, and only this one declares an `outputSchema`.

## The fix

Structured envelopes via `runAsJob`'s existing `toEnvelope` hook, and the schema declares the five fields they carry (`status`, `jobId`, `pollTool`, `note`, `retryAfterMs`).

The vote fields become **optional**. `registerTool` takes a `ZodRawShape`, which cannot express a discriminated union, so a tool with two response shapes has no way to require either set. `status` tells them apart: present means an async-dispatch envelope, absent means a completed vote.

Being explicit about the trade, since it weakens a governance-path schema: **requiredness is gone; `additionalProperties: false` is not.** The half that catches a #5044-shaped regression — an undeclared response field breaking every call — still fires, and there is now a test pinning exactly that. Requiredness was never what protected the protocol.

## The test that could not fail

My first attempt wrapped the async call in `try/catch` and asserted nothing was thrown. It passed against the broken code. The SDK delivers a validation failure as an `isError` **result** at least as often as it throws, so a catch-only assertion sees a clean run.

That is the same hole in the #5045 round-trip gate I merged earlier tonight, and it is fixed here too: the gate now inspects the returned result's text as well as the thrown message. It mattered — a violation carries no structured content either, so for a tool already in `KNOWN_UNSTRUCTURED` (which `consensus_vote` is, having no adapters in the test env) a schema break would have been silently credited as expected.

## Verification

| mutation | result |
| --- | --- |
| revert to `runAsJob`'s text-only envelopes | 1 failed ✓ |
| leave one vote field required | 1 failed ✓ |

Plus three schema-level tests: the async envelope parses strictly, an undeclared field still throws, and the key-drift guard is updated to name the five async keys explicitly rather than being loosened to a superset check — so a new *sync* response field missing from the schema still fails it.

4,228 tests pass across `src/mcp`; typecheck, lint, the unused-export ratchet, and the API-surface gate clean.

## Follow-up worth doing

The round-trip suite calls each tool once, so it only ever sees one of a tool's response shapes. This PR adds a second-shape case for `consensus_vote`; the general version — exercise `mode: 'async'` for every `runAsJob` tool, whether or not it declares a schema today — is noted in #5066 and not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
