### PR TITLE
fix(mcp): stop recording a verified panel when voters were missing

### DIFF
--- a/.changeset/pr-review-verified-panel-completeness.md
+++ b/.changeset/pr-review-verified-panel-completeness.md
@@ -1,0 +1,28 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): pr_review stops recording a verified panel when voters were missing
+
+Under the default `errorPolicy: 'standard'`, `aggregatePrDecisions` dropped
+errored voters from the denominator and then recorded
+`{ decision: 'approve', verified: true }`. One approve plus four errors was
+written into the governance record as a unanimous, verified approval —
+unanimity measured over a denominator that excluded everyone who could have
+disagreed. Inducing errors manufactured a verified approve, which is the exact
+attack `absolute_quorum` was added to prevent.
+
+Two neighbouring paths made the same claim: an all-errored panel
+(`valid.length === 0`) returned `verified: true`, asserting a complete panel for
+a vote in which nobody spoke, and the Tier-4 ambiguous abstain did the same
+regardless of how many voters were missing.
+
+The **decision** is unchanged — dropping the errored voter is what `standard`
+means, and #4132 kept it deliberately. What changes is the separate claim about
+the panel: `verified` is now `false` with a `reason` naming the counts whenever
+fewer voters responded than were asked. A complete, error-free panel still
+verifies.
+
+Decided by consensus vote (higher_order, 6 approvers, 5 selecting this option
+over flipping the default to `absolute_quorum` and over documenting the gap).
+Closes #5017.

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.test.ts
@@ -234,7 +234,13 @@ describe('pr_review tool', () => {
         }),
         makeReview('architect', 'approve'),
       ];
-      expect(aggregatePrDecisions(reviews)).toEqual({ decision: 'approve', verified: true });
+      // The DECISION still ignores the error vote's findings (#2233). The
+      // panel-completeness claim now reflects that a voter was missing (#5017).
+      expect(aggregatePrDecisions(reviews)).toEqual({
+        decision: 'approve',
+        verified: false,
+        reason: 'incomplete panel: 1 of 2 voters responded',
+      });
     });
 
     it('soft-block ignores error votes too', () => {
@@ -246,7 +252,13 @@ describe('pr_review tool', () => {
         makeReview('catfish', 'approve'),
         makeReview('scope_steward', 'approve'),
       ];
-      expect(aggregatePrDecisions(reviews)).toEqual({ decision: 'abstain', verified: true });
+      // Soft-block still needs 3 VALID dissenters, so this stays an abstain
+      // (#2233) — but the panel was not complete, so it is not verified (#5017).
+      expect(aggregatePrDecisions(reviews)).toEqual({
+        decision: 'abstain',
+        verified: false,
+        reason: 'incomplete panel: 4 of 5 voters responded',
+      });
     });
 
     it('returns abstain when all voters errored', () => {
@@ -254,7 +266,11 @@ describe('pr_review tool', () => {
         makeReview('architect', 'approve', { source: 'error' }),
         makeReview('security', 'approve', { source: 'error' }),
       ];
-      expect(aggregatePrDecisions(reviews)).toEqual({ decision: 'abstain', verified: true });
+      expect(aggregatePrDecisions(reviews)).toEqual({
+        decision: 'abstain',
+        verified: false,
+        reason: 'incomplete panel: 0 of 2 voters responded',
+      });
     });
 
     it('returns abstain on mixed approve/abstain (no clear approval)', () => {
@@ -326,10 +342,65 @@ describe('pr_review tool', () => {
         });
       });
 
-      it('DEFAULT (standard) is unchanged: an errored voter is dropped → verified approve', () => {
+      it('DEFAULT (standard) keeps the approve but stops claiming a verified panel (#5017)', () => {
+        // This test previously pinned `verified: true` on purpose, to hold the
+        // pre-#4132 line that `standard` drops errors. The DECISION still does
+        // — that is what the policy means, and it is unchanged. What changed is
+        // that `verified` is a claim ABOUT THE PANEL, and unanimity measured
+        // over a denominator that excludes everyone who could have disagreed
+        // cannot support it. Decided by consensus vote (5 of 6 approvers).
         const reviews = fullPanel({ scope_steward: { source: 'error' } });
-        // No policy arg → standard: the pre-#4132 behavior (drop the error).
-        expect(aggregatePrDecisions(reviews)).toEqual({ decision: 'approve', verified: true });
+
+        expect(aggregatePrDecisions(reviews)).toEqual({
+          decision: 'approve',
+          verified: false,
+          reason: 'incomplete panel: 4 of 5 voters responded',
+        });
+      });
+
+      it('DEFAULT (standard) still verifies a complete, error-free panel', () => {
+        // The pair. Without it the change above is indistinguishable from
+        // "always report verified:false".
+        expect(aggregatePrDecisions(fullPanel())).toEqual({
+          decision: 'approve',
+          verified: true,
+        });
+      });
+
+      it('an all-errored panel does not record a verified abstain (#5017)', () => {
+        // The empty case: `valid.length === 0` returned `verified: true`,
+        // asserting a complete panel for a vote in which nobody spoke.
+        const reviews = fullPanel({
+          architect: { source: 'error' },
+          security: { source: 'error' },
+          devex: { source: 'error' },
+          catfish: { source: 'error' },
+          scope_steward: { source: 'error' },
+        });
+
+        expect(aggregatePrDecisions(reviews)).toEqual({
+          decision: 'abstain',
+          verified: false,
+          reason: 'incomplete panel: 0 of 5 voters responded',
+        });
+      });
+
+      it('an ambiguous outcome on an incomplete panel is not verified (#5017)', () => {
+        // Tier 4 made the same claim: `abstain, verified: true` regardless of
+        // how many voters were missing.
+        const reviews: PrReviewVote[] = [
+          makeReview('architect', 'approve'),
+          makeReview('security', 'approve'),
+          makeReview('devex', 'approve'),
+          makeReview('catfish', 'request_changes'),
+          makeReview('scope_steward', 'approve', { source: 'error' }),
+        ];
+
+        expect(aggregatePrDecisions(reviews)).toEqual({
+          decision: 'abstain',
+          verified: false,
+          reason: 'incomplete panel: 4 of 5 voters responded',
+        });
       });
     });
   });

--- a/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
+++ b/packages/nexus-agents/src/mcp/tools/pr-review-tool.ts
@@ -329,7 +329,19 @@ export function aggregatePrDecisions(
   errorPolicy: 'standard' | 'absolute_quorum' = 'standard'
 ): PrReviewAggregate {
   const valid = reviews.filter((r) => r.source !== 'error');
-  if (valid.length === 0) return { decision: 'abstain', verified: true };
+  // #5017: `verified` is a claim about the PANEL, not about the decision, and
+  // it is the field a reader of a governance record trusts. An outcome reached
+  // over a denominator that excludes voters who could have disagreed cannot
+  // support it — including the empty case below, which asserted a complete
+  // panel for a vote in which nobody spoke. Decided by consensus vote.
+  const complete = (): PrReviewAggregate['verified'] => valid.length === reviews.length;
+  const incompleteReason = `incomplete panel: ${String(valid.length)} of ${String(reviews.length)} voters responded`;
+  const panelVerdict = (decision: PrReviewAggregate['decision']): PrReviewAggregate =>
+    complete()
+      ? { decision, verified: true }
+      : { decision, verified: false, reason: incompleteReason };
+
+  if (valid.length === 0) return panelVerdict('abstain');
 
   // Tier 1: verified blocker — ≥1 voter has a verified finding. A genuine
   // request_changes blocker still wins under BOTH policies (runs before the
@@ -355,11 +367,13 @@ export function aggregatePrDecisions(
     if (errorPolicy === 'absolute_quorum') {
       return absoluteQuorumApprove(reviews, valid);
     }
-    return { decision: 'approve', verified: true };
+    // The DECISION still drops the errored voter — that is what `standard`
+    // means and #4132 kept it deliberately. Only the completeness claim moves.
+    return panelVerdict('approve');
   }
 
   // Tier 4: ambiguous — abstain.
-  return { decision: 'abstain', verified: true };
+  return panelVerdict('abstain');
 }
 
 /**


### PR DESCRIPTION
Closes #5017.

## The defect

Under the default `errorPolicy: 'standard'`, `aggregatePrDecisions` filters errored voters out of `valid` and then:

```ts
if (valid.every((r) => r.decision === 'approve')) {
  if (errorPolicy === 'absolute_quorum') return absoluteQuorumApprove(reviews, valid);
  return { decision: 'approve', verified: true };
}
```

**1 approve + 4 errors → `{ decision: 'approve', verified: true }`**, written into the governance record. Unanimity over a denominator that excludes everyone who could have disagreed. The comment directly above names the hazard — *"would silently drop the errored voter from the denominator and rubber-stamp the merge"* — and this branch does it. Inducing errors manufactures a verified approve, the exact attack `absolute_quorum` (#4132) exists to prevent.

Two neighbours made the same claim, and the vote's architect voter flagged the first:

- `valid.length === 0` returned `{ decision: 'abstain', verified: true }` — a complete panel asserted for a vote in which **nobody spoke**.
- Tier 4's ambiguous abstain returned `verified: true` regardless of how many voters were missing.

## The decision

Genuine three-way fork on the governor path, so it went to a live `consensus_vote` (`higher_order`, alternatives declared as `options`).

**Approved 6-1; 5 of 6 approvers selected option A** (make `verified` honest, leave the decision alone) over B (flip the default to `absolute_quorum`) and C (document the gap). The security voter chose B; the contrarian rejected.

## The change

The **decision is unchanged**. Dropping the errored voter is what `standard` means and #4132 kept it deliberately. What changes is the separate claim about the panel: `verified: false` with a `reason` naming the counts whenever fewer voters responded than were asked. A complete, error-free panel still verifies.

## Answering the contrarian with the audit

The rejection argued the split is either ineffective (if consumers only read `decision`) or breaking (if they enforce `verified`), and that the blast radius was unknown. Two voters asked for that audit; here it is. Every consumer of `aggregate.verified`:

| site | reads | effect of an `approve` + `verified: false` |
| --- | --- | --- |
| `pr-review-diff-budget.ts:377` | `decision === 'approve' && verified` | skips the partial-coverage degrade — the aggregate already makes no verification claim to degrade |
| `.github/workflows/pr-review.yml:194` | `summary === 'request_changes' && verified === false` | unaffected; keyed on `request_changes` only |
| `pr-review-record-store.ts:108`, `pr-review-record.ts:245` | persists it | records the truth instead of the claim |
| `self-eval/aggregation-helpers.ts:56` | renders `[v]` / `[ ]` | shows unverified |

**No CI path halts, and no gate loosens.** The audit-record writers are the consumers that change, which is the point.

## Verification

Four mutations, each alone:

| mutation | result |
| --- | --- |
| Tier-3 approve claims `verified: true` again | 2 failed ✓ |
| empty panel claims `verified: true` | 2 failed ✓ |
| Tier-4 abstain claims `verified: true` | 2 failed ✓ |
| `complete()` hardcoded `true` | 6 failed ✓ |

`pr-review-tool.test.ts:329` pinned the old behaviour on purpose. It is rewritten rather than deleted, with the rationale in the comment: the decision it was defending is still there, the panel claim is not. Its pair — a complete error-free panel still verifying — is added, without which the change is indistinguishable from "always report `verified: false`".

Three existing tests also asserted `verified: true` on incomplete panels; each is updated with a comment separating what #2233 was defending (the decision) from what #5017 changes (the claim).

## Worth naming for a future reader

`verified` is overloaded. Tier 1 uses it to mean "a verified finding exists" — evidence-based, and correctly independent of panel completeness. Tiers 3 and 4 use it to mean "the panel was complete". Both survive here because Tier 1's meaning is sound, but the two senses in one field are how this drifted, and splitting them is a separate change.

4,528 tests pass across `src/mcp` and `src/audit`; typecheck, lint, the unused-export ratchet, and the API-surface gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
