### PR TITLE
test(mcp): round-trip async dispatch for every tool that advertises it

### DIFF
--- a/.changeset/async-mode-round-trip-coverage.md
+++ b/.changeset/async-mode-round-trip-coverage.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+test(mcp): round-trip async dispatch, not just each tool's ordinary response
+
+The output-schema round-trip suite calls each tool once, so it only ever sees
+one of a tool's response shapes. Async dispatch is a second one — `runAsJob`
+returns `{status:'pending', jobId}` rather than the tool's payload — and #5066
+was exactly that gap: `consensus_vote` declared an `outputSchema` its async
+envelope could not satisfy, and every `mode: 'async'` call failed with `-32602`
+while the suite stayed green.
+
+The async-capable set is derived from each tool's advertised input schema (a
+`mode` property accepting `'async'`) rather than hand-listed, so a tool gaining
+async dispatch later cannot go quietly uncovered. It has to be given arguments
+or the suite fails.
+
+The derivation earned that immediately: it found `run_workflow`, which
+advertises async mode and was absent from the hand-written list it replaced.
+Four tools are now covered, up from one.
+
+Tools without an `outputSchema` today are covered anyway — gaining one is
+precisely how the break would return.

--- a/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
+++ b/packages/nexus-agents/src/mcp/mcp-standalone-tools.test.ts
@@ -280,6 +280,64 @@ describe('MCP Standalone Tools Integration', () => {
     );
   });
 
+  /**
+   * Async dispatch is a SECOND response shape: `runAsJob` returns
+   * `{status:'pending', jobId}` rather than the tool's ordinary payload, and
+   * `ROUND_TRIP_ARGS` only ever exercises the first. #5066 was exactly that
+   * gap — `consensus_vote` declared an `outputSchema` its async envelope could
+   * not satisfy, so every `mode: 'async'` call failed with -32602.
+   *
+   * The set is DERIVED from each tool's advertised input schema rather than
+   * hand-listed: any tool offering `mode: 'async'` must appear here with
+   * arguments, so one gaining async dispatch later cannot quietly go
+   * uncovered. Tools without an `outputSchema` today are covered anyway —
+   * gaining one is precisely how the break would return.
+   */
+  const ASYNC_ARGS: Readonly<Record<string, Record<string, unknown>>> = {
+    consensus_vote: { proposal: 'round trip', quickMode: true },
+    // The spec parser needs a heading; without one the call fails as a
+    // business error and never reaches the async dispatch under test.
+    execute_spec: { spec: '# Round trip\n\nA spec used only to reach async dispatch.' },
+    run_graph_workflow: { workflow: 'round-trip' },
+    // Found by the derivation, not by me: it advertises async mode and was
+    // absent from the hand-written list this replaced.
+    run_workflow: { action: 'execute', template: 'round-trip', inputs: {} },
+  };
+
+  function offersAsyncMode(tool: { inputSchema?: unknown }): boolean {
+    const mode = (
+      tool.inputSchema as { properties?: Record<string, { enum?: unknown[] }> } | undefined
+    )?.properties?.['mode'];
+    return mode?.enum?.includes('async') === true;
+  }
+
+  it('async dispatch satisfies each tool outputSchema (#5066)', async () => {
+    const listed = await ctx.client.listTools();
+    const asyncTools = listed.tools.filter(offersAsyncMode).map((t) => t.name);
+    expect(asyncTools.length).toBeGreaterThan(0);
+    // A tool that advertises async mode and has no arguments here is not
+    // covered, and an uncovered tool is how #5066 shipped.
+    expect(asyncTools.filter((n) => ASYNC_ARGS[n] === undefined)).toEqual([]);
+
+    const violations: string[] = [];
+    for (const name of asyncTools) {
+      let result: unknown;
+      let thrown = '';
+      try {
+        result = await ctx.client.callTool({
+          name,
+          arguments: { ...ASYNC_ARGS[name], mode: 'async' },
+        });
+      } catch (error: unknown) {
+        thrown = error instanceof Error ? error.message : JSON.stringify(error);
+      }
+      const violation = schemaViolationIn(result, thrown);
+      if (violation !== '') violations.push(`${name}: ${violation}`);
+    }
+
+    expect(violations).toEqual([]);
+  }, 120_000);
+
   it('a second response shape also satisfies the outputSchema (#5066)', async () => {
     // The round-trip above calls each tool once with default arguments, so it
     // only ever sees ONE of a tool's response shapes. `consensus_vote` has two:


### PR DESCRIPTION
Follow-up to #5066, which I named in that PR rather than deferring.

## The gap

The output-schema round-trip suite calls each tool **once**, so it only ever sees one of a tool's response shapes. Async dispatch is a second one: `runAsJob` returns `{status:'pending', jobId}` instead of the tool's ordinary payload.

That is precisely how #5066 shipped. `consensus_vote` declared an `outputSchema` its async envelope could not satisfy, so **every** `mode: 'async'` call failed with `-32602` — and the round-trip suite, which only ever called it in sync mode, stayed green.

## The change

The async-capable set is **derived** from what each tool advertises — a `mode` property in its input schema whose enum accepts `'async'` — not hand-listed. A tool that gains async dispatch later must be given arguments here or the suite fails, so it cannot go quietly uncovered.

Tools without an `outputSchema` today are covered anyway. Gaining one is exactly how the break would return, and by then nobody would connect the two changes.

## The derivation paid for itself immediately

It found **`run_workflow`**, which advertises async mode and was absent from the hand-written list I wrote first. Four tools now covered — `consensus_vote`, `execute_spec`, `run_graph_workflow`, `run_workflow` — up from one.

Two argument details worth recording, both found by printing the actual response rather than assuming: `execute_spec`'s parser needs a heading (`# Title`) or the call fails as a business error before reaching async dispatch at all, and `run_workflow` requires `inputs` even when empty.

## Verification

| mutation | result |
| --- | --- |
| `consensus_vote` reverts to text-only async envelopes | 2 failed ✓ |
| a covered tool drops out of the argument table | 1 failed ✓ |
| the derivation finds nothing (`offersAsyncMode` → `false`) | 1 failed ✓ |

The second and third are what make this more than a snapshot: coverage shrinking, by either route, fails the suite rather than passing quietly.

4,232 tests pass across `src/mcp`; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
