### PR TITLE
feat(routing): make the capacity stage's opt-in reachable and its zero legible

### DIFF
--- a/.changeset/capacity-enforce-hard-limits-configurable.md
+++ b/.changeset/capacity-enforce-hard-limits-configurable.md
@@ -1,0 +1,31 @@
+---
+'nexus-agents': minor
+---
+
+feat(routing): make the capacity stage's documented opt-in actually settable
+
+`CapacityFilterStage` excludes an exhausted arm only when `enforceHardLimits` is
+true, and its doc said the flag "remains available for callers who have a real
+quota signal". No caller could set it: the sole production construction passed a
+hardcoded `{}`. So `outcome.excluded` was always empty, `excludedCount` could
+only ever report zero, and the fail-closed _"All routing candidates excluded —
+capacity_exhausted"_ branch was unreachable.
+
+The blocker that justified holding it — #4456's "no real quota signal exists
+yet" — has been overtaken. `CapacityTracker.recordProviderQuotaExhaustion` sets
+an exhaustion window from a durable provider `retry-after`, fired by
+`base-adapter` and `model-to-cli-adapter` on `RATE_LIMITED`, and `assessCapacity`
+maps it to `'exhausted'`. The evidence exists, so the opt-in is now real:
+`capacityStageConfig` on `CompositeRouterConfig` threads through to the stage.
+
+**The default is unchanged.** `enforceHardLimits` stays `false` and #4456's
+signal-only posture holds — it is a choice a caller can override rather than a
+hardcoding nobody could reach.
+
+`CompositeRouterStats` gains `capacityStats: { enforced, excludedCount }`.
+`enforced` is the load-bearing half: a zero `excludedCount` means one thing when
+enforcement is on and something else entirely when it is off, and the count
+alone could not say which. The field is absent when the stage is disabled — a
+third state, distinct from both zeros.
+
+Closes #4658.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -1777,6 +1777,7 @@ VariableDeclaration CompositeRouterConfigSchema
 InterfaceDeclaration CompositeRouterConfigWithPreference
   availableModelsCache?: import("src/config/available-models-cache").AvailableModelsCache | undefined
   capabilityMatchConfig?: Partial<CapabilityMatchConfig> | undefined
+  capacityStageConfig?: Partial<CapacityStageConfig> | undefined
   confidenceCascadeConfig?: Partial<ConfidenceCascadeConfig> | undefined
   distilledRuleStageConfig?: Partial<DistilledRuleStageConfig> | undefined
   latencyTrackerConfig?: Partial<{ decayFactor: number; maxSampleAgeMs: number; percentiles: number[]; windowSize: number; }> | undefined
@@ -1791,6 +1792,7 @@ InterfaceDeclaration CompositeRouterStats
   readonly avgDecisionTimeMs: number
   readonly banditStats: readonly { avgReward: number; name: string; pullCount: number; }[]
   readonly budgetRejectionRate: number
+  readonly capacityStats?: { readonly enforced: boolean; readonly excludedCount: number; } | undefined
   readonly decisionsPerCli: Readonly<Record<"claude" | "gemini" | "codex" | "opencode", number>>
   readonly latencyStats?: LatencyTrackerStats | undefined
   readonly preferenceStats?: { readonly dataPointCount: number; readonly enabled: boolean; readonly hasSufficientData: boolean; readonly strongModelPreferenceRate: number; } | undefined

--- a/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-types.ts
@@ -26,6 +26,7 @@ import type { CapabilityMatchConfig } from './routing/stages/capability-match-st
 import type { QualityConstraintConfig } from './routing/stages/quality-constraint-stage.js';
 import type { ResourceStrategyConfig } from './routing/stages/resource-strategy-stage.js';
 import type { DistilledRuleStageConfig } from './routing/stages/distilled-rule-stage.js';
+import type { CapacityStageConfig } from './routing/stages/capacity-stage.js';
 
 /**
  * Interface for routing metrics collection.
@@ -126,6 +127,18 @@ export interface CompositeRouterConfigWithPreference extends CompositeRouterConf
   resourceStrategyConfig?: Partial<ResourceStrategyConfig>;
   /** Distilled rule stage configuration (optional) (Issue #999) */
   distilledRuleStageConfig?: Partial<DistilledRuleStageConfig>;
+  /**
+   * Capacity filter stage configuration (optional) (#4658).
+   *
+   * `enforceHardLimits` was documented as "available for callers who have a
+   * real quota signal" while the sole production construction passed a
+   * hardcoded `{}`, so no caller could set it. The signal exists now —
+   * `CapacityTracker.recordProviderQuotaExhaustion` fires from two adapters on
+   * a durable `RATE_LIMITED` — so the opt-in is real. The default stays
+   * `false`: #4456's signal-only posture is unchanged, it is a choice now
+   * rather than a hardcoding.
+   */
+  capacityStageConfig?: Partial<CapacityStageConfig>;
   /** Preference router configuration (optional, uses defaults if not provided) */
   preferenceRouterConfig?: Partial<PreferenceRouterConfig>;
   /** ZeroRouter configuration (optional, uses defaults if not provided) */
@@ -242,6 +255,17 @@ export interface CompositeRouterStats {
   readonly avgDecisionTimeMs: number;
   /** Budget filter rejection rate */
   readonly budgetRejectionRate: number;
+  /**
+   * Capacity filter statistics (#4658), present when the stage is enabled.
+   *
+   * `enforced` is load-bearing: `excludedCount` can only be zero while
+   * enforcement is off, so reporting the count alone presents a default as a
+   * measurement. `enforced: false` says which of the two a zero is.
+   */
+  readonly capacityStats?: {
+    readonly enforced: boolean;
+    readonly excludedCount: number;
+  };
   /** Preference routing statistics */
   readonly preferenceStats?: {
     /** Whether preference routing is enabled */

--- a/packages/nexus-agents/src/cli-adapters/composite-router.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router.ts
@@ -76,6 +76,7 @@ import {
   type ConfidenceCascadeConfig,
   type CapabilityMatchConfig,
   type QualityConstraintConfig,
+  type CapacityStageConfig,
   type ResourceStrategyConfig,
   type DistilledRuleStageConfig,
 } from './routing/stages/index.js';
@@ -265,6 +266,7 @@ export class CompositeRouter implements ICompositeRouter {
       qualityConstraintConfig,
       resourceStrategyConfig,
       distilledRuleStageConfig,
+      capacityStageConfig,
       metricsCollector,
       orchestrationObserver,
       availableModelsCache,
@@ -274,16 +276,9 @@ export class CompositeRouter implements ICompositeRouter {
     this.logger = logger ?? createLogger({ component: 'CompositeRouter' });
     this.adapters = adapters;
     this.cliNames = Array.from(adapters.keys());
-    // Only assign metricsCollector if provided (Issue #559)
-    if (metricsCollector !== undefined) {
-      this.metricsCollector = metricsCollector;
-    }
-    // Only assign orchestrationObserver if provided (Issue #587)
-    if (orchestrationObserver !== undefined) {
-      this.orchestrationObserver = orchestrationObserver;
-      this.logger.debug('OrchestrationObserver wired to CompositeRouter');
-    }
-    // (#2540 PR 7) Wire optional availability cache.
+    this.assignOptionalCollaborators(metricsCollector, orchestrationObserver);
+    // (#2540 PR 7) Wire optional availability cache. Stays here: the field is
+    // readonly, so it can only be assigned in the constructor.
     if (availableModelsCache !== undefined) {
       this.availableModelsCache = availableModelsCache;
       this.logger.debug('AvailableModelsCache wired to CompositeRouter');
@@ -300,8 +295,29 @@ export class CompositeRouter implements ICompositeRouter {
       qualityConstraint: qualityConstraintConfig,
       resourceStrategy: resourceStrategyConfig,
       distilledRule: distilledRuleStageConfig,
+      capacity: capacityStageConfig,
     });
     this.logInitialization(adapters.size);
+  }
+
+  /**
+   * Optional collaborators, assigned only when supplied so an absent one stays
+   * `undefined` rather than being stored as a null-ish value. Extracted from
+   * the constructor to keep it under the function-length bar (#4658).
+   */
+  private assignOptionalCollaborators(
+    metricsCollector: CompositeRouterConfigWithPreference['metricsCollector'],
+    orchestrationObserver: CompositeRouterConfigWithPreference['orchestrationObserver']
+  ): void {
+    // Only assign metricsCollector if provided (Issue #559)
+    if (metricsCollector !== undefined) {
+      this.metricsCollector = metricsCollector;
+    }
+    // Only assign orchestrationObserver if provided (Issue #587)
+    if (orchestrationObserver !== undefined) {
+      this.orchestrationObserver = orchestrationObserver;
+      this.logger.debug('OrchestrationObserver wired to CompositeRouter');
+    }
   }
 
   private initializeCoreRouters(
@@ -345,6 +361,7 @@ export class CompositeRouter implements ICompositeRouter {
       qualityConstraint?: Partial<QualityConstraintConfig> | undefined;
       resourceStrategy?: Partial<ResourceStrategyConfig> | undefined;
       distilledRule?: Partial<DistilledRuleStageConfig> | undefined;
+      capacity?: Partial<CapacityStageConfig> | undefined;
     }
   ): void {
     if (this.config.enableRoutingMemory) {
@@ -366,6 +383,7 @@ export class CompositeRouter implements ICompositeRouter {
       qualityConstraint?: Partial<QualityConstraintConfig> | undefined;
       resourceStrategy?: Partial<ResourceStrategyConfig> | undefined;
       distilledRule?: Partial<DistilledRuleStageConfig> | undefined;
+      capacity?: Partial<CapacityStageConfig> | undefined;
     } = {}
   ): void {
     if (this.config.enableConfidenceCascade) {
@@ -381,7 +399,17 @@ export class CompositeRouter implements ICompositeRouter {
       this.resourceStrategyStage = new ResourceStrategyStage(stageConfigs.resourceStrategy);
     }
     if (this.config.enableCapacityBalancing) {
-      this.capacityFilterStage = new CapacityFilterStage(this.adapters, {}, this.logger);
+      // #4658: was a hardcoded `{}`, so `enforceHardLimits` — documented as
+      // "available for callers who have a real quota signal" — could not be set
+      // by any caller. The signal now exists (`recordProviderQuotaExhaustion`
+      // fires from two adapters on a durable RATE_LIMITED), so the opt-in is
+      // threaded. The default stays `false`: #4456's signal-only posture is
+      // unchanged, it is now a choice rather than a hardcoding.
+      this.capacityFilterStage = new CapacityFilterStage(
+        this.adapters,
+        stageConfigs.capacity ?? {},
+        this.logger
+      );
     }
     if (this.config.enableStrategyDistillation) {
       this.strategyDistiller = isPersistenceEnabled()
@@ -1041,6 +1069,7 @@ export class CompositeRouter implements ICompositeRouter {
       banditStats: this.linucbBandit?.getStats() ?? [],
       latencyStats,
       routingMemoryStats,
+      ...capacityStatsOf(this.capacityFilterStage),
     };
 
     if (preferenceStats !== undefined) {
@@ -1074,4 +1103,25 @@ export function createCompositeRouter(
     resolved = { ...config, availableModelsCache: cache };
   }
   return new CompositeRouter(adapters, resolved, logger);
+}
+
+/**
+ * Capacity stats for {@link CompositeRouter.getStats}, absent when the stage is
+ * disabled (#4658).
+ *
+ * Absent means "not running", which is a different thing from "running and
+ * excluded nothing" — and both are different from "running, enforcing, and
+ * excluded nothing". `enforced` separates the last two.
+ */
+function capacityStatsOf(stage: CapacityFilterStage | undefined): {
+  capacityStats?: { enforced: boolean; excludedCount: number };
+} {
+  if (stage === undefined) return {};
+  const stats = stage.getStats();
+  return {
+    capacityStats: {
+      enforced: stats['enforced'] === true,
+      excludedCount: typeof stats['excludedCount'] === 'number' ? stats['excludedCount'] : 0,
+    },
+  };
 }

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.test.ts
@@ -469,19 +469,62 @@ describe('capacity stage wiring claims (#4658)', () => {
     expect(DEFAULT_COMPOSITE_CONFIG.enableCapacityBalancing).toBe(true);
   });
 
-  it('assesses but cannot exclude, because enforceHardLimits is not settable in production', async () => {
-    // The production construction passes a hardcoded `{}`, so the default
-    // stands. If a caller ever supplies real config, this test should fail and
-    // be replaced by one that exercises the opt-in.
+  it('still does not exclude by default — the posture is unchanged', async () => {
+    // #4456 chose signal-only deliberately, and that default stands.
     const stage = new CapacityFilterStage(adapters({ claude: capacity({ quotaExhausted: true }) }));
 
     const outcome = await stage.filterArms(['claude'] as RoutingArmId[]);
 
-    // Exhaustion IS observed...
     expect(outcome.eligible).toEqual(['claude']);
-    // ...and deliberately not acted on. `excludedCount` stays 0 while the
-    // exclusion is held pending a real quota signal (#4456).
     expect(outcome.excluded.size).toBe(0);
     expect(stage.getStats().excludedCount).toBe(0);
+  });
+
+  it('a caller CAN now opt in, and the exclusion fires (#4658)', async () => {
+    // This replaces the test that pinned "enforceHardLimits is not settable in
+    // production" — which said in its own comment that it should be replaced by
+    // one exercising the opt-in as soon as a caller could supply real config.
+    // A caller can now, so this is that test.
+    const stage = new CapacityFilterStage(
+      adapters({ claude: capacity({ quotaExhausted: true }) }),
+      { enforceHardLimits: true }
+    );
+
+    const outcome = await stage.filterArms(['claude'] as RoutingArmId[]);
+
+    expect(outcome.eligible).toEqual([]);
+    expect(outcome.excluded.size).toBe(1);
+    expect(stage.getStats().excludedCount).toBe(1);
+  });
+
+  it('threads capacity config from CompositeRouter, so the opt-in is reachable', async () => {
+    // The gap was never the stage — it was that the sole production
+    // construction passed a hardcoded `{}`, so `enforceHardLimits` could not be
+    // set by any caller and `excludedCount` could only ever report zero.
+    const { CompositeRouter } = await import('../../composite-router.js');
+
+    const signalOnly = new CompositeRouter(adapters({ claude: capacity({}) }), {
+      enableCapacityBalancing: true,
+    });
+    const enforcing = new CompositeRouter(adapters({ claude: capacity({}) }), {
+      enableCapacityBalancing: true,
+      capacityStageConfig: { enforceHardLimits: true },
+    });
+
+    // Both report zero exclusions. Only `enforced` says whether that zero is a
+    // measurement or a default — which is the half `excludedCount` alone
+    // could never carry.
+    expect(signalOnly.getStats().capacityStats).toEqual({ enforced: false, excludedCount: 0 });
+    expect(enforcing.getStats().capacityStats).toEqual({ enforced: true, excludedCount: 0 });
+  });
+
+  it('omits capacityStats entirely when the stage is off', async () => {
+    // Absent means "not running" — a third state, distinct from both zeros.
+    const { CompositeRouter } = await import('../../composite-router.js');
+    const router = new CompositeRouter(adapters({ claude: capacity({}) }), {
+      enableCapacityBalancing: false,
+    });
+
+    expect(router.getStats().capacityStats).toBeUndefined();
   });
 });

--- a/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
+++ b/packages/nexus-agents/src/cli-adapters/routing/stages/capacity-stage.ts
@@ -92,15 +92,27 @@ export interface CapacityStageConfig {
  *   pipeline. Each arm is assessed and logged.
  * - The EXCLUSION does not run. `filterArms` only drops an arm when
  *   `enforceHardLimits` is true, and the sole production construction passes a
- *   hardcoded `{}`, leaving the `false` default. So `excludedCount` is
- *   structurally 0 and `outcome.excluded` is always empty.
+ *   hardcoded `{}`, leaving the `false` default. So `excludedCount` was
+ *   structurally 0 and `outcome.excluded` always empty.
  * - `createCapacityStage` — the FACTORY — has no non-test caller. That is a
  *   fact about the factory, not about the stage, and conflating the two is what
  *   produced the previous error.
  *
- * So: a passing capacity check is a real assessment, but it can never exclude.
- * Making the flag settable without a real quota producer would only relocate
- * the hole #4456 deliberately left open.
+ * THIRD CORRECTION (#4658, resolved). The paragraph above was accurate when
+ * written and is now history. The blocker it named — "making the flag settable
+ * without a real quota producer would only relocate the hole #4456 left open" —
+ * has been overtaken: the producer exists.
+ * `CapacityTracker.recordProviderQuotaExhaustion` sets `quotaExhaustedUntil`
+ * from a durable provider `retry-after`, fired by `base-adapter.ts` and
+ * `model-to-cli-adapter.ts` on `RATE_LIMITED`, and `assessCapacity` maps
+ * `quotaExhausted` to `'exhausted'`. So exclusion now has real evidence to act
+ * on, and `capacityStageConfig` on `CompositeRouterConfig` makes the opt-in
+ * reachable.
+ *
+ * The DEFAULT is unchanged: `enforceHardLimits` stays `false`, so #4456's
+ * signal-only posture still holds. It is a choice a caller can override now
+ * rather than a hardcoding nobody could reach — and `getStats().enforced`
+ * reports which, so a zero `excludedCount` is no longer ambiguous.
  *
  * (`BudgetStageConfig.enforceHardLimits` is a different setting on a different
  * router and IS enforced — see `budget-router.ts`. The mirrored name here is
@@ -234,6 +246,10 @@ export class CapacityFilterStage implements IRouterStage {
 
   getStats(): Record<string, unknown> {
     return {
+      // #4658: `excludedCount` can only be zero while enforcement is off, so
+      // reporting it alone presents a default as a measurement. `enforced`
+      // says which of the two a zero is.
+      enforced: this.config.enforceHardLimits,
       excludedCount: this.excludedCount,
       unmeasuredCount: this.unmeasuredCount,
       throttledCount: this.throttledCount,


### PR DESCRIPTION
Closes #4658.

## The defect

`CapacityFilterStage` excludes an arm only under `assessment === 'exhausted' && this.config.enforceHardLimits`. The flag's doc said it *"remains available for callers who have a real quota signal"*. **No caller could set it** — the sole production construction was:

```ts
// composite-router.ts:384
this.capacityFilterStage = new CapacityFilterStage(this.adapters, {}, this.logger);
```

A hardcoded `{}`. Downstream: `outcome.excluded` always empty, `excludedCount` (surfaced by `getStats`) permanently `0`, and the fail-closed *"All routing candidates excluded — capacity_exhausted"* branch (`composite-router-stages.ts:211`) unreachable — a safety net for a state that could not occur.

## Why now: the stated blocker has been overtaken

The issue and the file's own comment held enforcement pending #4456's *"a real quota signal exists"*. It does now, and I verified the whole chain rather than taking the comment's word:

- `CapacityTracker.recordProviderQuotaExhaustion` (`capacity-tracker.ts:242`) sets `quotaExhaustedUntil` from a durable provider `retry-after`, and sets `hasObserved` so the reading is not discarded as unmeasured.
- Two production adapters fire it on `RATE_LIMITED`: `base-adapter.ts:245` and `model-to-cli-adapter.ts:196`.
- `assessCapacity` maps `quotaExhausted` to `'exhausted'` (`capacity-stage.ts:155`).

So exclusion has real evidence to act on. That is what makes this a wiring fix rather than "enabling a dead escape path" — the producer is named and live.

## The change

`capacityStageConfig` on `CompositeRouterConfig`, threaded to the stage. **The default is unchanged**: `enforceHardLimits` stays `false`, so #4456's signal-only posture holds. It becomes a choice a caller can override rather than a hardcoding nobody could reach.

`CompositeRouterStats` gains `capacityStats: { enforced, excludedCount }`. `enforced` is the load-bearing half — a zero `excludedCount` means one thing with enforcement on and something else entirely with it off, and the count alone could not say which. The field is **absent** when the stage is disabled: a third state, distinct from both zeros.

## The test that invited this

`capacity-stage.test.ts:472` pinned the old behaviour and said so in its own comment: *"If a caller ever supplies real config, this test should fail and be replaced by one that exercises the opt-in."* A caller can now, so it is replaced — the signal-only default keeps its own test, and the opt-in gets one that shows the exclusion firing.

## Verification

| mutation | result |
| --- | --- |
| stage construction reverts to hardcoded `{}` | 1 failed ✓ |
| `capacity` dropped at the `initializeMemoryAndStages` call site | 1 failed ✓ |
| `enforced` hardcoded `false` | 1 failed ✓ |
| absent stage renders as `{enforced: false, excludedCount: 0}` | 1 failed ✓ |

The last two matter as much as the first: they pin that the disclosure distinguishes all three states rather than collapsing them.

The stage's long wiring comment — corrected twice before — is corrected a third time, marking the #4456 blocker resolved and naming the producer, so the next reader does not re-derive it.

2,729 tests pass across `src/cli-adapters`; typecheck, lint, the unused-export ratchet, and the API-surface gate clean. `minor` — two additive optional fields on published interfaces.

## Note for review

The constructor crossed the function-length bar with the sixth stage config, so the optional-collaborator assignment is extracted. `availableModelsCache` stays inline: the field is `readonly` and can only be assigned in the constructor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
