### PR TITLE
test(pipeline): pin that the delegate policy gate cannot deny today

### DIFF
--- a/.changeset/policy-gate-deny-capability-pin.md
+++ b/.changeset/policy-gate-deny-capability-pin.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+test(pipeline): pin whether the delegate policy gate can actually deny
+
+The V2 delegate pipeline's only policy gate cannot deny anything, for any input,
+in any mode: `trustTierRule` requires `stageType === 'execute'`, `ENTRY_GATE`
+guards a `route` stage, and no production stage is execute-typed (#4657).
+
+Existing coverage checks the pieces — that the mechanism halts on an injected
+always-denying engine, that the guarded stage is route-typed, that no stage is
+execute-typed. None of it runs the _real_ rule at the _real_ gate. This adds
+that: the actual `trustTierRule`, the actual `ENTRY_GATE`, an explicitly
+tier-4 task, block mode — and pins that nothing is denied.
+
+Pinning a negative is the point. Widening the rule to cover `route`, or
+retyping the route stage to `execute` — the two remedies on the #4657 ballot —
+each make this test fail, so whichever the project chooses has to be chosen
+deliberately rather than drifting in.
+
+No behaviour change. The #4657 remedy remains undecided: the consensus panel
+approved 6 of 7 but split 3/2/1 across the options, so no option cleared the
+supermajority bar. A test proving deny-capability was the one thing every voter
+agreed on regardless of which remedy they preferred.

--- a/packages/nexus-agents/src/pipeline/v2-delegate.test.ts
+++ b/packages/nexus-agents/src/pipeline/v2-delegate.test.ts
@@ -435,6 +435,48 @@ describe('the entry gate guards a stage that does not execute (#4657)', () => {
     expect(plan.stages.filter((s) => s.type === 'execute')).toEqual([]);
   });
 
+  it('the REAL rule at the REAL gate cannot deny, even at tier 4 in block mode (#4657)', async () => {
+    // The end-to-end version of the two shape checks above, and the durable
+    // fix every voter on the #4657 panel agreed on regardless of which remedy
+    // they preferred.
+    //
+    // The sibling tests inject an always-denying engine, which proves the gate
+    // MECHANISM works. This one runs the actual `trustTierRule` against the
+    // actual `ENTRY_GATE` with the most untrusted input there is, in the
+    // strictest mode, and pins that nothing is denied — because the rule
+    // requires `stageType === 'execute'` and the only gate guards a `route`
+    // stage.
+    //
+    // Pinning a negative is the point. The day someone adds an execute-typed
+    // stage, widens the rule, or moves the gate, this test fails and forces the
+    // #4657 decision to be made deliberately instead of drifting.
+    const { compilePlan } = await import('./plan-compiler.js');
+    const { executeGraph } = await import('../orchestration/graph/graph-executor.js');
+    const { createDefaultPolicyEngine } = await import('./policy-engine.js');
+    const { buildDelegatePlan } = await import('./v2-delegate.js');
+
+    const compiled = compilePlan(buildDelegatePlan(makeTask()), {
+      policyEnforcement: {
+        engine: createDefaultPolicyEngine(),
+        mode: 'block',
+        // Untrusted, and explicitly so: the rule's own fail-closed default is
+        // also 4, so this must not pass merely by omission.
+        pipelineState: { trustTier: '4' },
+      },
+    });
+
+    expect(compiled.ok).toBe(true);
+    if (!compiled.ok) return;
+    const result = await executeGraph(compiled.value, {}, { timeout: 5000 });
+
+    // No PolicyBlockedError, and the guarded stage ran.
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.nodeResults.find((r) => r.nodeId === 'route-model')?.status).toBe(
+      'success'
+    );
+  });
+
   it('the plan is backed by a skeleton plugin, which is why route is honest', async () => {
     const { MODEL_ROUTER_PLUGIN } = await import('./core-plugins.js');
     const { buildDelegatePlan } = await import('./v2-delegate.js');


### PR DESCRIPTION
Refs #4657. The durable fix every voter on that panel agreed on, independent of which remedy they preferred. **No behaviour change.**

## Why a test and not a fix

The consensus panel on #4657 approved 6 of 7 but split **3 / 2 / 1** across widen-the-rule / document-and-stop-advertising / move-the-gate. The leading option held 50% of approvers, below the supermajority bar this security change requires, so it records as no-decision. Full outcome and the five new facts the panel surfaced are in [the issue comment](https://github.com/nexus-substrate/nexus-agents/issues/4657#issuecomment-5425235784).

What was unanimous: **a test proving whether the gate can deny.** That needs no decision between the options and changes nothing.

## What was already covered, and what was not

The existing tests check the pieces:

- the gate mechanism halts when an always-denying engine is injected
- the guarded stage is `route`-typed
- no stage in the delegate plan is `execute`-typed

None of them runs the **real rule at the real gate**. So the composite fact — that `trustTierRule` + `ENTRY_GATE` together cannot deny — was true of the code and asserted by nothing.

This test runs the actual `createDefaultPolicyEngine()`, the actual compiled `ENTRY_GATE`, an explicitly `trustTier: '4'` task (explicit rather than omitted, since the rule's fail-closed default is also 4 and I did not want it passing by omission), in `block` mode — and pins that nothing is denied and the guarded stage runs.

## Verification

Pinning a negative only earns its place if it fails when the negative stops holding. Both #4657 remedies were applied as mutations:

| mutation | result |
| --- | --- |
| widen `trustTierRule` to cover `route` (option B) | 4 failed ✓ |
| retype the route stage to `execute` (option A) | 4 failed ✓ |

So whichever remedy the project picks, this fails and forces the decision to be made deliberately rather than drifting in. Four tests fire rather than one, because the shape assertions catch it too — that redundancy is fine here; it is the end-to-end one that would survive a refactor of the others.

697 tests pass across `src/pipeline`; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
