### PR TITLE
fix(ci): report unmeasured when a gate's input was empty

### DIFF
--- a/.changeset/ci-gates-report-unmeasured.md
+++ b/.changeset/ci-gates-report-unmeasured.md
@@ -1,0 +1,25 @@
+---
+'nexus-agents': patch
+---
+
+fix(ci): two gates that reported clean because their input was empty
+
+`scripts/arch-lint.ts` graded `passed: errors.length === 0` over whatever the
+source globs matched — including zero files. A directory rename or a broken
+`collectLintTargets` made the architecture lint report PASSED having inspected
+nothing, with `filesScanned: 0` sitting unread in the same object.
+
+`scripts/check-registry-coverage.ts` graded `success: violations.length === 0`
+over `manifest.registries` — which an empty manifest satisfies trivially.
+`validateManifest`'s bitrot loop could not catch it either: no entries, no
+paths to check. Emptying the manifest made the gate green.
+
+Both now distinguish three states rather than two. An empty input reports
+`unmeasured` and exits non-zero, because absence of evidence is not evidence of
+compliance. The verdict logic is extracted into a pure function in each so the
+empty case is testable without a filesystem.
+
+Refs #4586. Two of the four non-governor sites that issue lists; the other two
+do not survive tracing — see the PR for why. The `inject-governance.ts` and
+`claims-verify.ts` sites are governor paths and need owner ratification, so they
+stay open.

--- a/scripts/arch-lint.test.ts
+++ b/scripts/arch-lint.test.ts
@@ -6,6 +6,8 @@ import {
   checkTempDirCleanup,
   checkTestHygiene,
   collectLintTargets,
+  lintVerdict,
+  type Violation,
 } from './arch-lint.js';
 import { SRC_ROOT } from './script-paths.js';
 
@@ -192,5 +194,39 @@ describe('checkTestHygiene', () => {
     expect(
       checkTestHygiene(srcFile('agents/experts/expert-prompts/testing-expert.ts'), content)
     ).toEqual([]);
+  });
+});
+
+describe('lintVerdict — zero files scanned is not a pass (#4586)', () => {
+  const noViolations: Violation[] = [];
+
+  it('reports unmeasured, not passed, when nothing was scanned', () => {
+    // `passed: errors.length === 0` is true over an empty file set, so a glob
+    // that stops matching — a directory rename, a moved package, a broken
+    // collectLintTargets — reported the architecture lint clean. Absence of
+    // evidence is not evidence of compliance.
+    const result = lintVerdict(noViolations, noViolations, 0);
+
+    expect(result.unmeasured).toBe(true);
+    expect(result.passed).toBe(false);
+  });
+
+  it('passes normally when files were scanned and none errored', () => {
+    // The pair: without it, "always unmeasured" would satisfy the test above.
+    const result = lintVerdict(noViolations, noViolations, 42);
+
+    expect(result.unmeasured).toBeUndefined();
+    expect(result.passed).toBe(true);
+  });
+
+  it('still fails on real errors over a non-empty scan', () => {
+    const errors: Violation[] = [
+      { file: 'a.ts', line: 1, category: 'test', rule: 'test', message: 'boom', severity: 'error' },
+    ];
+
+    const result = lintVerdict(errors, errors, 42);
+
+    expect(result.unmeasured).toBeUndefined();
+    expect(result.passed).toBe(false);
   });
 });

--- a/scripts/arch-lint.ts
+++ b/scripts/arch-lint.ts
@@ -19,7 +19,7 @@ import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { SRC_ROOT, DOCS_ROOT, ROOT } from './script-paths.js';
 
-interface Violation {
+export interface Violation {
   readonly file: string;
   readonly line: number;
   readonly rule: string;
@@ -28,10 +28,20 @@ interface Violation {
   readonly severity: 'error' | 'warning';
 }
 
-interface LintResult {
+export interface LintResult {
   readonly violations: Violation[];
   readonly filesScanned: number;
   readonly passed: boolean;
+  /**
+   * Set when the lint ran over ZERO files (#4586).
+   *
+   * `passed: errors.length === 0` is true over an empty file set, so a glob
+   * that stops matching — a directory rename, a moved package, a broken
+   * `collectLintTargets` — reported the architecture lint clean. `filesScanned`
+   * sat in the same object, unread. Absence of evidence is not evidence of
+   * compliance: this reports `unmeasured` and exits non-zero.
+   */
+  readonly unmeasured?: boolean;
 }
 
 // Note: Layer definitions are documented in wiring-graph.json
@@ -518,11 +528,26 @@ function lint(): LintResult {
   // Filter to only errors for pass/fail
   const errors = violations.filter((v) => v.severity === 'error');
 
-  return {
-    violations,
-    filesScanned: srcFiles.length + scriptFiles.length,
-    passed: errors.length === 0,
-  };
+  return lintVerdict(violations, errors, srcFiles.length + scriptFiles.length);
+}
+
+/**
+ * The pass/fail/unmeasured verdict, separated from the scan so the empty-input
+ * case is testable without a filesystem (#4586).
+ *
+ * Three states, not two. `passed: errors.length === 0` is true over an empty
+ * file set, so a glob that stops matching reported the architecture lint clean
+ * with `filesScanned: 0` sitting unread beside it.
+ */
+export function lintVerdict(
+  violations: Violation[],
+  errors: readonly Violation[],
+  filesScanned: number
+): LintResult {
+  if (filesScanned === 0) {
+    return { violations, filesScanned, passed: false, unmeasured: true };
+  }
+  return { violations, filesScanned, passed: errors.length === 0 };
 }
 
 /**
@@ -572,7 +597,11 @@ function printResults(result: LintResult): void {
     console.log('');
   }
 
-  if (result.passed) {
+  if (result.unmeasured === true) {
+    console.log('✗ Architectural lint UNMEASURED — zero files scanned');
+    console.log('  Nothing was inspected, so nothing can be said to have passed.');
+    console.log('  Check the source globs in collectLintTargets/collectScriptTargets.');
+  } else if (result.passed) {
     console.log('✓ Architectural lint PASSED');
   } else {
     console.log('✗ Architectural lint FAILED');

--- a/scripts/check-registry-coverage.test.ts
+++ b/scripts/check-registry-coverage.test.ts
@@ -19,6 +19,7 @@ import {
   findMissingPeers,
   getChangedFiles,
   extractMarkerEntries,
+  isUnmeasurableManifest,
 } from './check-registry-coverage.js';
 
 // ============================================================================
@@ -275,5 +276,20 @@ describe('getChangedFiles', () => {
 
     const changed = getChangedFiles(ctx.dir);
     expect(changed).toContain('note.txt');
+  });
+});
+
+describe('an empty manifest is unmeasured, not clean (#4586)', () => {
+  it('treats zero declared registries as unmeasurable', () => {
+    // `success: violations.length === 0` is satisfied by an empty manifest, so
+    // emptying `registries` made the gate green while inspecting nothing — and
+    // `validateManifest`'s bitrot loop had no entries to catch it either.
+    expect(isUnmeasurableManifest(0)).toBe(true);
+  });
+
+  it('treats a populated manifest as measurable', () => {
+    // The pair: without it, "always unmeasurable" would satisfy the test above.
+    expect(isUnmeasurableManifest(1)).toBe(false);
+    expect(isUnmeasurableManifest(12)).toBe(false);
   });
 });

--- a/scripts/check-registry-coverage.ts
+++ b/scripts/check-registry-coverage.ts
@@ -342,12 +342,39 @@ interface CheckResult {
   readonly success: boolean;
   readonly violations: readonly Violation[];
   readonly bitrot_errors: readonly string[];
+  /**
+   * Set when the manifest declared ZERO registries (#4586).
+   *
+   * The verdict is `violations.length === 0`, which an empty manifest
+   * satisfies: emptying `registries` made the gate green while inspecting
+   * nothing. `validateManifest` cannot catch it either — its bitrot loop has
+   * no entries to check. Absence of evidence is not evidence of coverage, so
+   * this reports `unmeasured` and fails.
+   */
+  readonly unmeasured?: boolean;
+}
+
+/**
+ * Whether a manifest declaring this many registries can support a verdict
+ * (#4586).
+ *
+ * Extracted so the empty case is testable without a repo on disk. Zero
+ * registries means nothing was inspected: `violations.length === 0` is
+ * satisfied trivially, and `validateManifest`'s bitrot loop has no entries to
+ * catch it, so emptying the manifest made the gate green.
+ */
+export function isUnmeasurableManifest(registryCount: number): boolean {
+  return registryCount === 0;
 }
 
 export function performCheck(verbose: boolean): CheckResult {
   const manifest = loadManifest();
   if (manifest === null) {
     return { success: false, violations: [], bitrot_errors: [] };
+  }
+
+  if (isUnmeasurableManifest(manifest.registries.length)) {
+    return { success: false, violations: [], bitrot_errors: [], unmeasured: true };
   }
 
   const bitrotErrors = validateManifest(manifest);
@@ -375,6 +402,14 @@ function checkRegistryCoverage(verbose: boolean): boolean {
   console.log('================================\n');
 
   const result = performCheck(verbose);
+
+  if (result.unmeasured === true) {
+    console.error('✗ Registry-coverage UNMEASURED — the manifest declares zero registries.\n');
+    console.error('  Nothing was inspected, so nothing can be said to be covered. Emptying');
+    console.error('  `registries` used to make this gate green (#4586).');
+    console.error('  Restore docs/ops/registry-coverage-manifest.json.');
+    return false;
+  }
 
   if (result.bitrot_errors.length > 0) {
     console.error('✗ Manifest bitrot detected (paths in manifest do not exist on disk):\n');


### PR DESCRIPTION
Refs #4586. Takes the two non-governor sites that survive tracing; reports on the two that do not.

## The class

Not "a check that cannot fail" — these *can* fail. The inversion is that **deleting the thing under inspection makes the gate green**:

- `arch-lint.ts:524` — `passed: errors.length === 0` over whatever the globs matched, including nothing. A directory rename or a broken `collectLintTargets` reports the architecture lint PASSED having inspected zero files, with `filesScanned: 0` sitting unread in the same object literal.
- `check-registry-coverage.ts:370` — `success: violations.length === 0` over `manifest.registries`, which an empty manifest satisfies trivially. `validateManifest`'s bitrot loop cannot catch it either: no entries means no paths to check. Emptying `docs/ops/registry-coverage-manifest.json` makes the gate green.

Both now distinguish **pass / fail / unmeasured**. An empty input reports `unmeasured` and exits non-zero.

The verdict logic is extracted into a pure function in each — `lintVerdict`, `isUnmeasurableManifest` — so the empty case is testable without a filesystem. Testing it any other way would have meant running the whole lint over a repo that always has files.

## Two of the four listed sites do not survive tracing

Reporting these rather than fixing them, because filing or "fixing" a non-defect is its own kind of noise:

**`check-registry-coverage.ts:290` (`arraysEqual` over two empty extractions) — not a defect.** The issue's scenario is "a marker section that stopped matching on both sides reads as in-sync". But `extractMarkerEntries` returns `null` when the marker is missing, and the call site guards it: `if (before === null || after === null) return false`. The only surviving case is a marker present with zero entries on both sides — which genuinely *is* in sync.

**`check-strategy-manifest-drift.ts:163` (zero findings from an empty parse) — not a defect.** `analyzeManifestDrift` does not loop over a possibly-empty collection to reach its verdict; it deep-compares the parsed YAML against the embedded `STRATEGY_MANIFEST_REGISTRY` constant. An emptied YAML either fails `StrategyManifestRegistrySchema.parse` (which throws, and the caller returns `false`) or differs from the non-empty embedded constant and raises `yaml-ts-drift`. Either way it is caught.

## Verification

| mutation | result |
| --- | --- |
| arch-lint treats zero files as a pass again | 1 failed ✓ |
| an empty manifest is measurable again | 1 failed ✓ |

Each fix has its pair — a populated input still passing — without which "always unmeasured" would satisfy the empty-case test. And both gates were run against the real repo: `arch-lint` exits 0 with `✓ Architectural lint PASSED`, `check-registry-coverage` exits 0 with `✓ No registry-coverage violations`. The change does not disturb the working case.

42 tests pass across the two suites; typecheck, lint, and the unused-export ratchet clean.

## Still open on #4586

The `inject-governance.ts` sites (eight of them) and `src/governance/claims-verify.ts` are **governor paths** under CODEOWNERS — owner ratification, never auto-merged. They need their own PR and stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
