### PR TITLE
docs(ops): correct what actually fills the scratch tmpfs

### DIFF
--- a/docs/ops/tmpfs-exhaustion.md
+++ b/docs/ops/tmpfs-exhaustion.md
@@ -29,21 +29,42 @@ du -sh /tmp/claude-1000/*/* 2>/dev/null | sort -rh | head
 
 `/tmp` is commonly a **tmpfs** — memory-backed, fixed-size, and invisible in the ordinary "is the disk full" reflex, because the root volume can have hundreds of gigabytes free while `/tmp` sits at 100%.
 
-The dominant consumer is usually agent-session scratch: subagent and background-task JSONL transcripts, which are large and accumulate per session. During the 2026-08-18 incident, `/tmp/claude-1000` held **145 session directories**, and the bulk belonged to sessions from unrelated projects.
+The dominant consumer is agent-session scratch — but **not the transcripts**, which is worth stating because the obvious guess is wrong and sends you after the wrong files. Measured 2026-08-26:
+
+```
+.output transcripts (485 files, all sessions) :    9.1 MB
+scratchpad/ directories                       :    7.8 GB
+```
+
+The weight is in `scratchpad/`: files a session downloaded or generated to work on — archives, cloned repos, large JSON. A single three-day-old session held 6.2 GB of it, including the same 209 MB archive saved under four different names.
+
+Transcripts are ~2 KB each and will never be the problem. Sort by size and look at what is actually there rather than assuming.
 
 ## Recovery
 
-Delete the transcripts, which are the bulk and are not needed once a session has ended:
+Find the heavy directories first — the answer differs between incidents:
+
+```bash
+du -sm /tmp/claude-1000/*/*/ /tmp/claude-worktrees/*/ 2>/dev/null | sort -rn | head
+```
+
+Then remove whole session directories — **only ones you know are finished**:
+
+```bash
+# Flag anything untouched in the last two days before deleting it.
+for d in /tmp/claude-1000/*/*/ /tmp/claude-worktrees/*/; do
+  sz=$(du -sm "$d" 2>/dev/null | cut -f1)
+  [ "${sz:-0}" -ge 100 ] && printf '%6s MB  %s  %s\n' "$sz" \
+    "$(find "$d" -newermt '-2 days' -print -quit 2>/dev/null | grep -q . && echo ACTIVE || echo stale)" "$d"
+done | sort -rn
+
+rm -rf /tmp/claude-1000/<project>/<session-id>
+```
+
+Deleting `*.output` transcripts is also safe once a session has ended, but recovers single-digit megabytes — do not reach for it as the fix:
 
 ```bash
 find /tmp/claude-1000 -name '*.output' -type f -delete
-```
-
-Then re-check `df -h /tmp`. If that is not enough, remove whole session directories — **only ones you know are finished**:
-
-```bash
-ls -lt /tmp/claude-1000/*/ | head          # oldest last
-rm -rf /tmp/claude-1000/<project>/<session-id>
 ```
 
 Deleting another project's live session directory breaks that session. This is not something an agent should do on its own: it is a destructive operation outside any single session's blast radius, and it belongs on the human side of the hard-stop line. An agent may safely delete its **own** session's `*.output` files and nothing else.
@@ -60,6 +81,15 @@ system  /tmp                     10.7 GiB free of 31.3 GiB (66% used)    ok
 Both are measured deliberately. An earlier version of the check measured only the nexus scratch root, which on the reporting machine sits on a 900 GiB volume — it graded `ok` throughout the outage while the 32 GiB tmpfs it was not looking at was full. The roots are deduplicated by device id, so when both live on one filesystem it still prints one line, and the overall grade is the **worst** across filesystems so a roomy root cannot mask a starved one.
 
 Run `doctor` before a long autonomous session, not only when something breaks.
+
+## What nexus-agents already does
+
+Its own scratch is **not** on the tmpfs. `NEXUS_TMPDIR` defaults to
+`<dataDir>/tmp` inside the gitignored `.nexus-agents/` tree (#4412), which sits
+on the repo's volume. On the reporting machine that is 229 GiB free against the
+tmpfs's 11 GiB, and this repo's sessions account for well under 100 MB of the
+shared scratch. The harness scratchpad at `/tmp/claude-1000` is a different
+owner and cannot be redirected from here — for that, reaping is the only lever.
 
 ## Related
 


### PR DESCRIPTION
Corrects the runbook I merged in #5074 an hour ago. Refs #4488.

## What was wrong

Both #4488 and my runbook said the bulk was subagent/background-task JSONL transcripts. Measured on the reporting machine today:

```
.output transcripts (485 files, all sessions) :    9.1 MB
scratchpad/ directories                       :    7.8 GB
```

The recovery command I shipped — `find /tmp/claude-1000 -name '*.output' -delete` — frees **9 MB**. Someone following it during an outage would run it, see `df` barely move, and conclude the runbook was wrong about the whole diagnosis.

The weight is in `scratchpad/`: files a session downloaded or generated to work on. One three-day-old session held 6.2 GB, including the same 209 MB archive saved under four different names.

## Changes

- **Diagnostic leads with measurement, not assumption.** `du -sm .../*/*/ | sort -rn` first, because the answer differs between incidents. The numbers above are quoted so the next reader can see why the obvious guess is wrong.
- **Recovery is session directories**, with a snippet that flags anything touched in the last two days before you delete it. Transcript deletion stays, demoted, and explicitly labelled as recovering single-digit megabytes.
- **New section on what nexus-agents already does.** Its own scratch is not on the tmpfs — `NEXUS_TMPDIR` defaults to `<dataDir>/tmp` in the gitignored `.nexus-agents/` tree (#4412), on the repo's volume: 229 GiB free versus the tmpfs's 11 GiB. This repo's sessions are under 100 MB of the 7.8 GB. Stated because the natural next question is "why not just point it at the repo?" — for nexus-agents that is already the case, and the harness scratchpad is a different owner that cannot be redirected from here.

That last point matters for scope: the achievable fix for `/tmp/claude-1000` is reaping (#4631), not relocation.

markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
