### PR TITLE
feat(ops): surface issues whose blockers have all closed

### DIFF
--- a/.changeset/surface-unblocked-issues.md
+++ b/.changeset/surface-unblocked-issues.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+feat(ops): surface issues whose blockers have all closed
+
+`CLAUDE.md` requires two halves of dependency tracking. The filing half works —
+blocked issues genuinely record `blocked by #N` and an unblock trigger. The
+surfacing half ("a finished dependency should surface its dependents") was a
+rule addressed to whoever closes the blocker, with nothing behind it. #4440 sat
+ten days after its blocker closed.
+
+Measured before building, as #4617 required: of 136 open issues, **12 name a
+blocker and all 12 have every blocker closed.** Not one stale instance — the
+mechanism had never surfaced anything.
+
+`scripts/check-unblocked.ts` parses the blocker forms the repo actually uses,
+resolves each referenced issue's state, and reports the ones fully unblocked. A
+daily workflow files the result as a single tracking issue, and closes it when
+nothing is left to surface — a stale backlog report is worse than none, because
+a reader cannot tell it from a current one.
+
+Advisory throughout: it never fails a run and never blocks a merge. Failing CI
+because somebody finished a dependency would be hostile.
+
+Closes #4617.

--- a/.github/workflows/unblocked-check.yml
+++ b/.github/workflows/unblocked-check.yml
@@ -1,0 +1,108 @@
+name: Unblocked Backlog Check
+
+# Surfaces open issues whose named blockers have all closed (#4617).
+#
+# CLAUDE.md has two halves. The FILING half works: blocked issues genuinely
+# record "blocked by #N" and an unblock trigger. The SURFACING half — "a
+# finished dependency should surface its dependents" — was a rule addressed to
+# whoever closes the blocker, with nothing behind it. #4440 sat ten days after
+# its blocker closed.
+#
+# Measured before building, as #4617 required: of 136 open issues, 12 name a
+# blocker and ALL 12 have every blocker closed. The mechanism had never
+# surfaced anything.
+#
+# ADVISORY. This never fails a run and never blocks a merge — failing CI
+# because somebody finished a dependency would be hostile. The tracking issue
+# is the durable surface, same shape as the deploy staleness check (#4506).
+
+on:
+  schedule:
+    # Daily. The harm is a scheduling delay measured in days, not an outage,
+    # so a daily cadence bounds it well below the ten days that prompted this.
+    - cron: '15 13 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: unblocked-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Unblocked Backlog Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # Only to file/update the single tracking issue.
+      issues: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+
+      - uses: ./.github/actions/setup-node
+
+      # Two-phase on purpose: the script's decision is pure and unit-tested,
+      # and only the state resolution needs the network. A blocker whose state
+      # cannot be resolved stays absent from the map, and the script refuses to
+      # treat unknown as closed.
+      - name: Resolve blockers and report
+        id: report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ISSUES=$(gh issue list --state open --limit 400 --json number,title,body)
+
+          # Collect every blocker the script would parse, then resolve each once.
+          BLOCKERS=$(printf '%s' "$ISSUES" \
+            | grep -oiE '(blocked (by|on)|depends on|after|once) #[0-9]+' \
+            | grep -oE '[0-9]+' | sort -un || true)
+
+          STATES='{}'
+          for n in $BLOCKERS; do
+            state=$(gh issue view "$n" --json state --jq .state 2>/dev/null || echo '')
+            if [ -n "$state" ]; then
+              STATES=$(printf '%s' "$STATES" | jq --arg k "$n" --arg v "$state" '.[$k]=$v')
+            fi
+          done
+
+          # Issues go in on STDIN, not an env var: 136 bodies is ~700 KB and
+          # `execve` rejects that with E2BIG. The states map is small enough.
+          printf '%s' "$ISSUES" | BLOCKER_STATES_JSON="$STATES" \
+            npx tsx scripts/check-unblocked.ts | tee /tmp/unblocked.md
+
+      - name: File or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: 'ops(backlog): issues whose blockers have all closed'
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --state open --search "in:title $TITLE" --json number,title \
+            --jq "[.[] | select(.title == \"$TITLE\")] | .[0].number // empty")
+
+          {
+            cat /tmp/unblocked.md
+            echo
+            echo "_Regenerated daily by \`unblocked-check.yml\`. Advisory — this never blocks a merge._"
+            echo "_See #4617 for why the surfacing half needed a consumer to exist at all._"
+          } > /tmp/body.md
+
+          # Nothing to surface: close the tracking issue rather than leaving a
+          # stale list. An out-of-date backlog report is worse than none, since
+          # a reader cannot tell it from a current one.
+          if grep -q 'still have an open blocker' /tmp/unblocked.md; then
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --comment "Every blocked issue has an open blocker again. Closing; the daily run reopens this if that changes."
+            fi
+            exit 0
+          fi
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file /tmp/body.md
+          else
+            gh issue create --title "$TITLE" --body-file /tmp/body.md
+          fi

--- a/scripts/check-unblocked.test.ts
+++ b/scripts/check-unblocked.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseBlockers, selectUnblocked, formatReport } from './check-unblocked.js';
+
+const issue = (
+  number: number,
+  body: string,
+  title = `issue ${String(number)}`
+): { number: number; title: string; body: string } => ({ number, title, body });
+
+describe('parseBlockers', () => {
+  it('reads the forms this repo actually uses', () => {
+    // Survey of all 136 open issues: `blocked by` (4), `depends on` (3),
+    // `once #N` (1). The others cost nothing and are the same convention.
+    expect(parseBlockers('blocked by #4439')).toEqual([4439]);
+    expect(parseBlockers('blocked on #12')).toEqual([12]);
+    expect(parseBlockers('depends on #7')).toEqual([7]);
+    expect(parseBlockers('pick up once #99 lands')).toEqual([99]);
+    expect(parseBlockers('do this after #5 merges')).toEqual([5]);
+  });
+
+  it('ignores a bare cross-reference', () => {
+    // The common case by far, and almost never a dependency. Anchoring on the
+    // verb is what keeps this from reporting most of the backlog as blocked.
+    expect(parseBlockers('related: #4671, see also #4580')).toEqual([]);
+  });
+
+  it('deduplicates and sorts', () => {
+    expect(parseBlockers('blocked by #9, depends on #3, blocked by #9')).toEqual([3, 9]);
+  });
+
+  it('returns nothing for a body with no blockers', () => {
+    expect(parseBlockers('an ordinary issue body')).toEqual([]);
+  });
+});
+
+describe('selectUnblocked', () => {
+  const closed = (b: number): boolean => b < 100;
+
+  it('reports an issue whose every blocker closed', () => {
+    const verdict = selectUnblocked([issue(1, 'blocked by #10')], closed);
+
+    expect(verdict.unblocked).toEqual([{ number: 1, title: 'issue 1', blockers: [10] }]);
+    expect(verdict.tracked).toBe(1);
+  });
+
+  it('does not report an issue with one blocker still open', () => {
+    // The pair. Without it, "report everything" satisfies the test above.
+    const verdict = selectUnblocked([issue(1, 'blocked by #10 and depends on #200')], closed);
+
+    expect(verdict.unblocked).toEqual([]);
+    expect(verdict.tracked).toBe(1);
+  });
+
+  it('refuses to treat an unresolvable blocker as closed', () => {
+    // Unknown is not closed. Surfacing still-blocked work erodes trust in the
+    // report faster than missing an item would.
+    const verdict = selectUnblocked([issue(1, 'blocked by #10')], () => undefined);
+
+    expect(verdict.unblocked).toEqual([]);
+    expect(verdict.tracked).toBe(1);
+  });
+
+  it('does not count an issue that names no blocker', () => {
+    const verdict = selectUnblocked([issue(1, 'no dependency here')], closed);
+
+    expect(verdict.tracked).toBe(0);
+  });
+
+  it('reports unmeasured when no open issue names a blocker at all', () => {
+    // `unblocked: []` looks identical whether the backlog is current or the
+    // convention stopped being written. The second is the likelier
+    // explanation for a repo this size, so it is stated, not inferred.
+    const verdict = selectUnblocked([issue(1, 'ordinary'), issue(2, 'also ordinary')], closed);
+
+    expect(verdict.unmeasured).toBe(true);
+    expect(verdict.unblocked).toEqual([]);
+  });
+
+  it('is not unmeasured when blockers exist but none have cleared', () => {
+    const verdict = selectUnblocked([issue(1, 'blocked by #500')], closed);
+
+    expect(verdict.unmeasured).toBeUndefined();
+    expect(verdict.tracked).toBe(1);
+  });
+});
+
+describe('formatReport', () => {
+  it('names the unblocked issues and their blockers', () => {
+    const body = formatReport({
+      unblocked: [{ number: 4440, title: 'Reconcile TokenUsage', blockers: [4439] }],
+      tracked: 12,
+    });
+
+    expect(body).toContain('#4440');
+    expect(body).toContain('#4439');
+    expect(body).toContain('1 of 12');
+  });
+
+  it('says so plainly when everything is still blocked', () => {
+    expect(formatReport({ unblocked: [], tracked: 5 })).toContain('still have an open blocker');
+  });
+
+  it('reports the empty corpus as unmeasured, not clean', () => {
+    const body = formatReport({ unblocked: [], tracked: 0, unmeasured: true });
+
+    expect(body).toContain('unmeasured');
+    expect(body).not.toContain('Nothing to pick up');
+  });
+});

--- a/scripts/check-unblocked.ts
+++ b/scripts/check-unblocked.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env npx tsx
+/**
+ * Surface open issues whose named blockers have all closed (#4617).
+ *
+ * `CLAUDE.md` requires two halves. The FILING half works: blocked issues in
+ * this repo genuinely record "blocked by #N" and a named unblock trigger. The
+ * SURFACING half — "a finished dependency should surface its dependents" — is
+ * a rule addressed to whoever closes the blocker, with nothing behind it.
+ *
+ * Measured before building, as #4617 asked: of the 136 open issues,
+ * **12 name a blocker and all 12 have every blocker closed.** Not one stale
+ * instance — the mechanism had never surfaced anything. #4440 sat ten days
+ * after its blocker closed, which is what prompted the issue.
+ *
+ * ## Advisory, never blocking
+ *
+ * A gate that fails CI because somebody finished a dependency would be
+ * actively hostile. This reports; the scheduled workflow files the result as a
+ * tracking issue, which is the durable surface (same shape as #4506's deploy
+ * staleness check). Per #4562 a script with no consumer is the very thing this
+ * exists to fix, so the workflow is part of the change, not a follow-up.
+ *
+ * ## Why parse prose rather than use GitHub's own relationships
+ *
+ * #4617 asked this to be checked first. GitHub's sub-issue and Projects
+ * `blocked-by` fields would work, but nothing in this repo populates them —
+ * the convention in 136 open issues is prose in the body. A native-relationship
+ * check would report zero blocked issues today and be a gate that cannot fire.
+ * Reading what is actually written is what makes this measure anything.
+ *
+ * @module scripts/check-unblocked
+ * (Source: Issue #4617)
+ */
+
+/**
+ * Blocker references as they are actually written in this repo's issues.
+ *
+ * Derived from a survey of all 136 open issues rather than guessed: `blocked
+ * by` (4), `depends on` (3), `once #N` (1), plus `blocked on` / `after #N
+ * lands` which currently match nothing but are the same convention and cost
+ * nothing to accept. Anchored on the verb so a bare `#N` cross-reference —
+ * overwhelmingly the common case, and almost never a dependency — is ignored.
+ */
+const BLOCKER_PATTERN = /(?:blocked\s+(?:by|on)|depends\s+on|after|once)\s+#(\d+)/gi;
+
+export interface IssueSummary {
+  readonly number: number;
+  readonly title: string;
+  readonly body: string;
+}
+
+/** An open issue every one of whose named blockers has closed. */
+export interface UnblockedIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly blockers: readonly number[];
+}
+
+export interface UnblockedVerdict {
+  readonly unblocked: readonly UnblockedIssue[];
+  /** Open issues that name at least one blocker, closed or not. */
+  readonly tracked: number;
+  /**
+   * Set when NO open issue names a blocker at all (#4617).
+   *
+   * Zero unblocked issues means two very different things: the backlog is
+   * current, or the "blocked by #N" convention stopped being written and this
+   * check is reading an empty corpus. `unblocked: []` looks identical in both
+   * cases, so the second is stated rather than inferred — a check whose input
+   * vanished must not report the same clean result as one that ran.
+   */
+  readonly unmeasured?: boolean;
+}
+
+/** Blocker issue numbers named in an issue body. Deduplicated, ascending. */
+export function parseBlockers(body: string): number[] {
+  const found = new Set<number>();
+  for (const m of body.matchAll(BLOCKER_PATTERN)) {
+    const n = Number(m[1]);
+    if (Number.isSafeInteger(n) && n > 0) found.add(n);
+  }
+  return [...found].sort((a, b) => a - b);
+}
+
+/**
+ * Open issues whose every named blocker is closed.
+ *
+ * `isClosed` is injected so the decision is testable without the network —
+ * the resolution itself is the only part that needs `gh`.
+ *
+ * An issue naming a blocker whose state could not be resolved is NOT reported
+ * as unblocked. An unresolvable reference is unknown, and treating unknown as
+ * closed would surface work that is still blocked, which erodes trust in the
+ * report faster than missing one would.
+ */
+export function selectUnblocked(
+  issues: readonly IssueSummary[],
+  isClosed: (blocker: number) => boolean | undefined
+): UnblockedVerdict {
+  const unblocked: UnblockedIssue[] = [];
+  let tracked = 0;
+
+  for (const issue of issues) {
+    const blockers = parseBlockers(issue.body);
+    if (blockers.length === 0) continue;
+    tracked += 1;
+    if (blockers.every((b) => isClosed(b) === true)) {
+      unblocked.push({ number: issue.number, title: issue.title, blockers });
+    }
+  }
+
+  unblocked.sort((a, b) => a.number - b.number);
+  if (tracked === 0) return { unblocked, tracked, unmeasured: true };
+  return { unblocked, tracked };
+}
+
+/** Markdown body for the tracking issue. */
+export function formatReport(verdict: UnblockedVerdict): string {
+  if (verdict.unmeasured === true) {
+    return (
+      'No open issue names a blocker (`blocked by #N`, `depends on #N`, …).\n\n' +
+      'Reported as **unmeasured** rather than clean: an empty corpus and a current ' +
+      'backlog produce the same empty result, and the likelier explanation for a ' +
+      'repo this size is that the convention stopped being written. See #4617.\n'
+    );
+  }
+  if (verdict.unblocked.length === 0) {
+    return `All ${String(verdict.tracked)} blocked issue(s) still have an open blocker. Nothing to pick up.\n`;
+  }
+  const rows = verdict.unblocked
+    .map(
+      (u) =>
+        `| #${String(u.number)} | ${u.blockers.map((b) => `#${String(b)}`).join(', ')} | ${u.title} |`
+    )
+    .join('\n');
+  return (
+    `${String(verdict.unblocked.length)} of ${String(verdict.tracked)} blocked issue(s) ` +
+    'now have **every** named blocker closed:\n\n' +
+    '| issue | blockers (all closed) | title |\n| --- | --- | --- |\n' +
+    `${rows}\n\n` +
+    'Each records an unblock trigger in its body — that is the handoff. Pick them up ' +
+    'or re-prioritise them explicitly; leaving one here is how #4440 sat ten days ' +
+    'after its blocker closed (#4617).\n'
+  );
+}
+
+/* eslint-disable no-console */
+import { readFileSync } from 'node:fs';
+
+/**
+ * Open issues, read from STDIN.
+ *
+ * Not an env var, which is how this was first written: 136 issue bodies is
+ * roughly 700 KB and `execve` rejected it with `E2BIG` — the script and the
+ * workflow would both have died on the real backlog while passing every unit
+ * test. The sibling `check-stuck-runs.ts` uses `RUNS_JSON` safely because run
+ * summaries are tiny; issue bodies are not.
+ */
+function readIssues(): IssueSummary[] {
+  const raw = readFileSync(0, 'utf-8');
+  if (raw.trim() === '') return [];
+  const parsed = JSON.parse(raw) as Array<{ number: number; title: string; body?: string }>;
+  return parsed.map((i) => ({ number: i.number, title: i.title, body: i.body ?? '' }));
+}
+
+/**
+ * Blocker states from `BLOCKER_STATES_JSON`, a `{ "4439": "CLOSED" }` map the
+ * workflow resolves with `gh`. A number absent from the map resolves to
+ * `undefined` — unknown, which `selectUnblocked` refuses to treat as closed.
+ */
+function readBlockerStates(): (blocker: number) => boolean | undefined {
+  const raw = process.env['BLOCKER_STATES_JSON'];
+  if (raw === undefined || raw.trim() === '') return () => undefined;
+  const map = JSON.parse(raw) as Record<string, string>;
+  return (blocker) => {
+    const state = map[String(blocker)];
+    if (state === undefined) return undefined;
+    return state === 'CLOSED' || state === 'MERGED';
+  };
+}
+
+function main(): void {
+  const verdict = selectUnblocked(readIssues(), readBlockerStates());
+  console.log(formatReport(verdict));
+  // Advisory by design (#4617): a gate that fails CI because somebody finished
+  // a dependency would be hostile. The workflow reads stdout and files the
+  // tracking issue; the exit code stays 0 either way.
+}
+
+if (process.argv[1]?.endsWith('check-unblocked.ts') === true) {
+  main();
+}


### PR DESCRIPTION
Closes #4617.

## Measured first, as the issue required

#4617 explicitly gated the build: *"count how many open issues currently have all their named blockers closed. If the answer is one, this is not worth a script."*

**12 of 12.** Every open issue that names a blocker has all of them closed:

```
#3069 ← #3090 #3091    #4464 ← #4452    #4875 ← #4869
#3831 ← #3830          #4495 ← #4494    #4972 ← #4494
#3849 ← #3847          #4617 ← #4439    #4988 ← #4888
#4440 ← #4439          #4754 ← #4673    #4991 ← #4888
```

Not one stale instance — the surfacing half had never surfaced anything, which is why #4440 sat ten days. (#4617 itself is on the list, blocked by the same #4439.)

The issue also asked whether GitHub's own tooling covers this. Sub-issues and the Projects `blocked-by` field would, but **nothing in this repo populates them** — the convention across 136 open issues is prose in the body. A native-relationship check would report zero blocked issues today: a gate that cannot fire. Parsing what is actually written is what makes this measure anything.

## The script

`scripts/check-unblocked.ts`, following the ~30 existing `check-*.ts` gates.

- **Patterns derived from a survey, not guessed**: `blocked by` (4 uses), `depends on` (3), `once #N` (1), plus `blocked on` / `after #N lands` which match nothing today but are the same convention. Anchored on the verb, so a bare `#N` cross-reference — overwhelmingly the common case and almost never a dependency — is ignored.
- **Unknown is not closed.** A blocker whose state cannot be resolved keeps its issue out of the report. Surfacing still-blocked work erodes trust faster than missing an item would.
- **`unmeasured` when no issue names a blocker at all.** An empty corpus and a current backlog produce identical empty results; for a repo this size the likelier explanation is that the convention stopped being written, so it is stated rather than inferred.

## It has a consumer, because that was the whole point

#4617 warns that a script with no consumer *"becomes the very thing it is meant to fix"*. A daily workflow files the report as one tracking issue, deduped on title — the same shape as the deploy staleness check (#4506).

It also **closes** that issue when nothing is left to surface. A stale backlog report is worse than none: a reader cannot distinguish it from a current one.

**Advisory throughout.** Never fails a run, never blocks a merge. Failing CI because somebody finished a dependency would be hostile.

## Running it caught a design flaw the unit tests could not

The first version took issues through an `ISSUES_JSON` env var, copying `check-stuck-runs.ts`. Against the real backlog:

```
/bin/bash: .../npx: Argument list too long
```

136 issue bodies is ~700 KB and `execve` rejects it with `E2BIG`. Every unit test passed; the script and the workflow would both have died on first contact. `check-stuck-runs.ts` gets away with the pattern because run summaries are tiny. Issues now arrive on **stdin**; only the small states map stays an env var.

## Verification

| mutation | result |
| --- | --- |
| unknown blocker treated as closed | 1 failed ✓ |
| empty corpus reports clean instead of unmeasured | 1 failed ✓ |
| pattern widened to bare `#N` cross-references | 1 failed ✓ |

13 tests, each positive case paired with its negative. Lint, typecheck, and `check-script-wiring` (30 scripts reachable from CI) clean; workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
