### PR TITLE
test(mcp): gate registered-schema parity for dispatch tools

### DIFF
--- a/.changeset/schema-mirror-parity-gate.md
+++ b/.changeset/schema-mirror-parity-gate.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+test(mcp): every dispatch tool must advertise the fields its handler accepts
+
+Four tools maintain a hand-written object literal for `registerTool` rather
+than registering `SomeSchema.shape`, and a mirror is a second declaration of
+one contract. `run_workflow`'s omitted `idempotencyKey` was exactly that: the
+SDK stripped the field before the handler saw it, every async dispatch minted a
+fresh jobId, and the `replay` / `collision` envelopes could never fire — a
+whole feature unreachable with nothing red.
+
+The parity check runs at the protocol boundary, comparing what `listTools()`
+advertises against the schema each handler parses with, so it holds whether a
+tool mirrors or registers `.shape`.
+
+Keys only, deliberately. Replacing the mirrors with `.shape` was tried and
+measured: it degrades six caller-facing descriptions and newly advertises
+internal defaults. The mirrors carry better text than the internal schemas —
+descriptions should be free to differ, the field set must not.
+
+Refs #4972 finding 3. Finding 2 (`run_workflow`'s stripped `idempotencyKey`) is
+already fixed on main; finding 1 (AbortSignal adoption) stays open.

--- a/packages/nexus-agents/src/mcp/tools/schema-mirror-parity.test.ts
+++ b/packages/nexus-agents/src/mcp/tools/schema-mirror-parity.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Every field a dispatch tool's handler accepts must be advertised in the
+ * schema it registers (#4972 finding 3).
+ *
+ * Six tools register `SomeSchema.shape` and cannot drift. Four maintain a
+ * separate object literal for `registerTool`, and a mirror is a second
+ * declaration of one contract. `run_workflow`'s omitted `idempotencyKey` was
+ * exactly that: the SDK stripped the field before the handler saw it, every
+ * async dispatch minted a fresh jobId, and its `replay` / `collision`
+ * envelopes could never fire — a whole feature unreachable, nothing red.
+ *
+ * ## Asserted at the protocol boundary, on KEYS only
+ *
+ * The comparison runs against what `listTools()` actually advertises, not
+ * against a module-private constant. That is the surface the SDK filters
+ * against, and it works whether a tool mirrors its schema or registers
+ * `.shape`.
+ *
+ * Keys only, deliberately. The mirrors are not pure duplication — that is why
+ * replacing them with `.shape` is not the fix. They carry richer caller-facing
+ * text: the graph mirror says `Workflow name: echo, pipeline, code-review,
+ * security-scan. Use "list" for available workflows.` where the internal
+ * schema says `Name of the predefined graph workflow to execute`. Swapping in
+ * `.shape` was tried and measured — it degrades six descriptions and newly
+ * advertises internal defaults. Descriptions should be free to differ; the
+ * field set must not.
+ *
+ * @module mcp/tools/schema-mirror-parity.test
+ * (Source: Issue #4972)
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+import { createServer, connectTransport } from '../server.js';
+import {
+  registerTools,
+  registerExecuteSpecTool,
+  registerRunGraphWorkflowTool,
+  registerRunWorkflowTool,
+} from './index.js';
+import { ExecuteSpecInputSchema } from './execute-spec-tool.js';
+import { RunGraphWorkflowInputSchema } from './run-graph-workflow.js';
+import { RunWorkflowInputSchema } from './run-workflow-types.js';
+import type { IWorkflowEngine } from '../../core/index.js';
+
+vi.mock('../../cli-adapters/factory.js', () => ({
+  createCliAdapter: vi.fn(),
+  createAllAdapters: vi.fn(() => new Map()),
+  isCliAvailable: vi.fn().mockResolvedValue(false),
+  getAvailableClis: vi.fn().mockResolvedValue([]),
+}));
+
+/** Internal schema each dispatch tool's handler parses its input with. */
+const EXPECTED: Readonly<Record<string, Record<string, unknown>>> = {
+  execute_spec: ExecuteSpecInputSchema.shape,
+  run_graph_workflow: RunGraphWorkflowInputSchema.shape,
+  run_workflow: RunWorkflowInputSchema.shape,
+};
+
+let advertised: Record<string, readonly string[]>;
+let cleanup: () => Promise<void>;
+
+beforeAll(async () => {
+  const sr = createServer();
+  if (!sr.ok) throw new Error(sr.error.message);
+  const { server, logger } = sr.value;
+  const infra = registerTools(server, { logger });
+  const deps = { logger: infra.logger, rateLimiter: infra.rateLimiter };
+  registerExecuteSpecTool(server, deps);
+  registerRunGraphWorkflowTool(server, deps);
+  registerRunWorkflowTool(server, {
+    ...deps,
+    workflowEngine: { listTemplates: () => Promise.resolve([]) } as unknown as IWorkflowEngine,
+  });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const connected = await connectTransport(server, serverTransport, logger);
+  if (!connected.ok) throw new Error(connected.error.message);
+  const client = new Client({ name: 'schema-parity', version: '1.0.0' });
+  await client.connect(clientTransport);
+
+  const listed = await client.listTools();
+  advertised = Object.fromEntries(
+    listed.tools.map((t) => [
+      t.name,
+      Object.keys(
+        (t.inputSchema as { properties?: Record<string, unknown> }).properties ?? {}
+      ).sort(),
+    ])
+  );
+  cleanup = async () => {
+    await client.close();
+    await server.close();
+  };
+});
+
+afterAll(async () => {
+  await cleanup();
+});
+
+describe('registered schemas advertise every field the handler accepts (#4972)', () => {
+  it.each(Object.keys(EXPECTED))('%s', (tool) => {
+    // A field present internally but absent from the registration is stripped
+    // by the SDK before the handler runs — the `idempotencyKey` case.
+    expect(advertised[tool]).toEqual(Object.keys(EXPECTED[tool] ?? {}).sort());
+  });
+
+  it('actually inspected each tool, rather than comparing two absent entries', () => {
+    // `undefined === undefined` would pass every row above if a tool failed to
+    // register. Naming the empty case is what makes those assertions mean
+    // something.
+    for (const tool of Object.keys(EXPECTED)) {
+      expect(advertised[tool], `${tool} did not register`).toBeDefined();
+      expect((advertised[tool] ?? []).length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
Refs #4972, finding 3. Picked up because the unblocked-backlog check I shipped in #5079 surfaced it — first use of that tool.

## Verified state of the issue first

Finding 2 — `run_workflow`'s `idempotencyKey` stripped by the SDK — is **already fixed on main**. `run-workflow.ts:276` now reads `const toolInputSchema = RunWorkflowInputSchema.shape;` with a comment naming #4972. Nothing to do there.

Finding 1 (zero of ten `runAsJob` adopters accept the `AbortSignal`) is an unfinished rollout, as the issue says, and stays open.

That leaves finding 3, which is the one that prevents recurrence.

## The gate

Four tools maintain a hand-written literal for `registerTool` rather than registering `.shape`. A mirror is a second declaration of one contract, and `run_workflow`'s omission was the consequence: the SDK stripped `idempotencyKey` before the handler ran, every async dispatch minted a fresh jobId, and the `replay` / `collision` envelopes could never fire. A whole feature unreachable, nothing red.

The check runs at the **protocol boundary** — comparing what `listTools()` advertises against the schema each handler parses with. Two reasons that beats comparing constants: two of the four mirrors are module-private and would need exporting (which the unused-export ratchet would then flag), and the advertised schema is the surface the SDK actually filters against.

## Why not just delete the mirrors — I tried it and measured

The obvious fix is replacing all four with `.shape`. I did that, captured `listTools()` before and after, and diffed:

```
- "description": "Workflow name: echo, pipeline, code-review, security-scan. Use \"list\" for available workflows."
+ "description": "Name of the predefined graph workflow to execute"
- "description": "Markdown specification to execute. Must contain \"## Requirements\" and \"## Acceptance Criteria\" sections."
+ "description": "Markdown specification to execute"
+ "default": true          # internal defaults newly advertised
```

**The mirrors are not pure duplication.** They carry materially better caller-facing text than the internal schemas — six descriptions degrade, and internal defaults leak into the advertised contract. So the swap was reverted and the gate asserts **keys only**: descriptions should be free to differ, the field set must not.

Worth stating because "just use `.shape`" is the reflex, and the reflex is wrong here for a reason that is invisible until you diff the output.

## Verification

| mutation | result |
| --- | --- |
| graph mirror drops `dispatch` | 1 failed ✓ |
| `run_workflow` reverts to a partial mirror | 1 failed ✓ |

The second reproduces the original defect shape exactly. There is also an explicit empty-case test: `advertised[tool]` being `undefined` on both sides would satisfy every row above, so the suite asserts each tool actually registered and advertises a non-empty property set.

4,236 tests pass across `src/mcp`; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
