### PR TITLE
fix(build): ship the models.dev snapshot to dist

### DIFF
--- a/.changeset/ship-models-dev-snapshot.md
+++ b/.changeset/ship-models-dev-snapshot.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+fix(build): ship the models.dev snapshot — installed copies enumerated zero models
+
+`models-dev-snapshot-loader.ts` reads `models-dev-snapshot.json` as a sibling of
+its own compiled module, so the file has to land in `dist/`. It was never in
+tsup's copy list, and `package.json#files` ships only `dist/` — so **no
+installed copy has ever contained it.**
+
+The loader catches the failure and returns `[]`, so nothing was red. The effect:
+every `claude` / `codex` / `gemini` model enumeration returned zero from the
+published package, while dev — running from `src/config/` via tsx — returned
+13 / 47 / 82. `opencode` (native probe) and OpenRouter (network) do not use the
+snapshot and kept working, which masked it in every health report.
+
+A second, latent defect surfaced while fixing it: `cp -r src/workflows/templates
+dist/workflows/` nests when `dist/workflows/` already exists and copies the
+source _as_ `dist/workflows` when it does not, so a clean build laid the
+templates out flat and `template-loader.ts` — which looks for
+`dist/workflows/templates` — found nothing. The target is now named explicitly.
+
+`scripts/check-dist-assets.ts` fails the build when a runtime-read asset is
+missing or truncated, and the `|| true` suffixes that let a failed copy pass
+silently are gone.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,15 @@ jobs:
       - name: Build
         run: pnpm build
 
+      # Runtime data assets are copied by tsup's `onSuccess`, not bundled, so a
+      # missing copy ships a package whose loaders silently fall back to empty.
+      # `models-dev-snapshot.json` was never in the copy list, and every
+      # installed copy enumerated zero models for claude/codex/gemini (#5083).
+      # `pnpm build` already runs this; the explicit step names the failure
+      # instead of burying it in tsup output.
+      - name: Verify runtime assets reached dist
+        run: npx tsx scripts/check-dist-assets.ts
+
       - name: Upload build output
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/packages/nexus-agents/package.json
+++ b/packages/nexus-agents/package.json
@@ -60,7 +60,7 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && npx tsx ../../scripts/check-dist-assets.ts",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.config.e2e.ts",

--- a/packages/nexus-agents/tsup.config.ts
+++ b/packages/nexus-agents/tsup.config.ts
@@ -37,11 +37,23 @@ export default defineConfig({
     __NEXUS_VERSION__: JSON.stringify(pkg.version),
   },
   onSuccess: [
-    'cp -r src/workflows/templates dist/workflows/ 2>/dev/null || true',
+    // `cp -r src dest/` is state-dependent: it NESTS when `dist/workflows/`
+    // already exists and copies src AS `dist/workflows` when it does not, so a
+    // clean build laid the templates out flat and `template-loader.ts` — which
+    // looks for `dist/workflows/templates` — found nothing. Naming the target
+    // explicitly makes it the same either way (#5083).
+    'mkdir -p dist/workflows/templates && cp -r src/workflows/templates/. dist/workflows/templates/',
     // T2 bundled model registry (#2174 / #2175) — runtime reads from dist
-    'cp src/config/model-registry.generated.json dist/model-registry.generated.json 2>/dev/null || true',
+    'cp src/config/model-registry.generated.json dist/model-registry.generated.json',
+    // models.dev snapshot — `models-dev-snapshot-loader.ts` reads it as a
+    // SIBLING of the compiled module, so it must land in dist. It never did,
+    // and `package.json#files` ships only `dist`, so no installed copy has
+    // ever had it: every `claude`/`codex`/`gemini` model enumeration returned
+    // `[]` while dev (reading `src/config/`) returned 13/47/82. `opencode`
+    // (native probe) and OpenRouter (network) masked it by still working.
+    'cp src/config/models-dev-snapshot.json dist/models-dev-snapshot.json',
     // Polyglot QA/security ast-grep rules (#4249 child C) — YAML, tsup won't bundle
     // it. Only the *.yml rules ship to dist; fixtures/ are test-only.
-    'mkdir -p dist/security/ast-rules && cp src/security/ast-rules/*.yml dist/security/ast-rules/ 2>/dev/null || true',
+    'mkdir -p dist/security/ast-rules && cp src/security/ast-rules/*.yml dist/security/ast-rules/',
   ].join(' && '),
 });

--- a/scripts/check-dist-assets.test.ts
+++ b/scripts/check-dist-assets.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { missingDistAssets, REQUIRED_DIST_ASSETS } from './check-dist-assets.js';
+
+function box(): string {
+  return mkdtempSync(join(tmpdir(), 'dist-assets-'));
+}
+
+describe('missingDistAssets (#5083)', () => {
+  it('reports an asset absent from dist', () => {
+    // The real defect: `models-dev-snapshot.json` was never copied, so every
+    // installed copy enumerated zero models for claude/codex/gemini while the
+    // loader caught the failure and returned `[]`.
+    const dir = box();
+    try {
+      expect(missingDistAssets(dir)).not.toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a present-but-truncated asset', () => {
+    // `existsSync` accepts a half-written file, and an empty JSON array parses
+    // fine and enumerates to nothing — the same silent-empty outcome one step
+    // further along.
+    const dir = box();
+    try {
+      for (const { file } of REQUIRED_DIST_ASSETS) {
+        const path = join(dir, file);
+        mkdirSync(join(path, '..'), { recursive: true });
+        writeFileSync(path, '[]');
+      }
+      const missing = missingDistAssets(dir);
+
+      expect(missing.some((m) => m.includes('below the'))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('passes when every asset is present and full-size', () => {
+    // The pair. Without it, "always report missing" satisfies both tests above.
+    const dir = box();
+    try {
+      for (const { file, minBytes } of REQUIRED_DIST_ASSETS) {
+        const path = join(dir, file);
+        mkdirSync(join(path, '..'), { recursive: true });
+        writeFileSync(path, 'x'.repeat(minBytes + 1));
+      }
+
+      expect(missingDistAssets(dir)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts a directory asset regardless of size', () => {
+    // `workflows/templates` and `security/ast-rules` are directories; a size
+    // floor is meaningless for them and must not fail them.
+    const dir = box();
+    try {
+      for (const { file, minBytes } of REQUIRED_DIST_ASSETS) {
+        const path = join(dir, file);
+        if (minBytes > 1) {
+          mkdirSync(join(path, '..'), { recursive: true });
+          writeFileSync(path, 'x'.repeat(minBytes + 1));
+        } else {
+          mkdirSync(path, { recursive: true });
+        }
+      }
+
+      expect(missingDistAssets(dir)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/check-dist-assets.ts
+++ b/scripts/check-dist-assets.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env npx tsx
+/**
+ * Verify every runtime-read data asset actually reached `dist/` (#5083).
+ *
+ * Some loaders read a data file as a SIBLING of their own compiled module —
+ * `join(dirname(fileURLToPath(import.meta.url)), 'x.json')`. tsup bundles code,
+ * not data, so those files are copied in `onSuccess`. A copy that is missing,
+ * or silently swallowed with `|| true`, ships a package whose loader falls back
+ * to empty.
+ *
+ * `models-dev-snapshot.json` was never in the copy list at all. Because
+ * `package.json#files` ships only `dist`, no installed copy has ever contained
+ * it: every `claude` / `codex` / `gemini` model enumeration returned `[]`,
+ * while dev — running from `src/config/` via tsx — returned 13 / 47 / 82. The
+ * two transports that do not use the snapshot (`opencode`, native probe; and
+ * OpenRouter, network) kept working and masked it.
+ *
+ * The loaders all catch and fall back to `[]`, so nothing was ever red. This
+ * check is what makes the omission fail the build instead.
+ *
+ * @module scripts/check-dist-assets
+ * (Source: Issue #5083)
+ */
+import { existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { ROOT } from './script-paths.js';
+
+const DIST = join(ROOT, 'packages/nexus-agents/dist');
+
+/**
+ * Assets a runtime loader reads from `dist/`, with the smallest size that
+ * indicates real content.
+ *
+ * The size floor matters: `cp` of a truncated or half-written file leaves a
+ * path that `existsSync` accepts, and an empty JSON array parses fine and
+ * enumerates to nothing — which is the failure this check exists to catch,
+ * one step further along.
+ */
+export const REQUIRED_DIST_ASSETS: ReadonlyArray<{
+  readonly file: string;
+  readonly minBytes: number;
+}> = [
+  { file: 'models-dev-snapshot.json', minBytes: 50_000 },
+  { file: 'model-registry.generated.json', minBytes: 1_000 },
+  { file: 'workflows/templates', minBytes: 1 },
+  { file: 'security/ast-rules', minBytes: 1 },
+];
+
+/**
+ * Assets missing or truncated under `distDir`. Pure and directory-injected so
+ * the empty and truncated cases are testable without a build.
+ */
+export function missingDistAssets(distDir: string): string[] {
+  const problems: string[] = [];
+  for (const { file, minBytes } of REQUIRED_DIST_ASSETS) {
+    const path = join(distDir, file);
+    if (!existsSync(path)) {
+      problems.push(`${file}: MISSING from dist/`);
+      continue;
+    }
+    const stat = statSync(path);
+    if (stat.isDirectory()) continue;
+    if (stat.size < minBytes) {
+      problems.push(`${file}: ${String(stat.size)} bytes, below the ${String(minBytes)} floor`);
+    }
+  }
+  return problems;
+}
+
+/* eslint-disable no-console */
+function main(): void {
+  if (!existsSync(DIST)) {
+    console.error(`::error::dist/ not found at ${DIST} — run the build first.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const problems = missingDistAssets(DIST);
+
+  if (problems.length > 0) {
+    console.error('::error::Runtime assets missing from dist/ — the published package would ship');
+    console.error('a loader that silently falls back to empty. Check tsup.config.ts `onSuccess`.');
+    for (const p of problems) console.error(`  - ${p}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`dist assets OK (${String(REQUIRED_DIST_ASSETS.length)} checked).`);
+}
+
+if (process.argv[1]?.endsWith('check-dist-assets.ts') === true) {
+  main();
+}


### PR DESCRIPTION
Closes #5083. Found by investigating why a freshly restarted MCP server reported `modelCount: 0` for claude, codex and gemini while both CLIs were logged in with models present.

## The defect

`models-dev-snapshot-loader.ts` resolves its data file as a **sibling of its own compiled module** (`join(dirname(fileURLToPath(import.meta.url)), 'models-dev-snapshot.json')`). tsup bundles code, not data, so files like this are copied in `onSuccess`. `model-registry.generated.json` is on that list; **`models-dev-snapshot.json` never was.** `package.json#files` ships only `dist/`, so `src/config/` does not travel either.

**No installed copy has ever contained it.** The loader catches, logs at `debug`, and caches `[]` for the process lifetime, so nothing was ever red.

| transport | dev (tsx, reads `src/config/`) | installed (`dist/`) |
| --- | --- | --- |
| claude → anthropic | 13 | **0** |
| codex → openai | 47 | **0** |
| gemini → google | 82 | **0** |
| opencode | 361 (native probe) | 363 |
| openrouter | — | 416 (network) |

The two transports that do not use the snapshot kept working and masked it in every health report. Worse, after #5063 `ok: true, modelCount: 0` correctly means *"the probe succeeded and this transport has no models"* — so the honest reading of a healthy-looking report was still wrong.

Confirmed by copying the file into the installed `dist/` and loading it in a fresh process: `entries: 353`, `openai: 47, anthropic: 13, google: 82`.

## A second defect the gate found on its first run

```
cp -r src/workflows/templates dist/workflows/
```

`cp -r src dest/` **nests** when `dist/workflows/` exists and copies the source **as** `dist/workflows` when it does not. On a clean build the templates land flat and `template-loader.ts` — which looks for `dist/workflows/templates` — finds nothing. Incremental builds happened to produce the right layout, which is why the published package is correct today; a fresh CI checkout is the case that breaks. The target is now named explicitly so both paths agree.

Both copies also carried `2>/dev/null || true`, so a failed copy could never fail the build. Those are gone.

## The gate

`scripts/check-dist-assets.ts` fails the build when a runtime-read asset is missing **or truncated**. The size floor is load-bearing: `existsSync` accepts a half-written file, and an empty JSON array parses fine and enumerates to nothing — the same silent-empty outcome one step further along.

Wired into `pnpm build`, plus an explicit CI step. `check-script-wiring` (#4562) correctly rejected the transitive-only invocation, and the explicit step names the failure instead of burying it in tsup output.

## Verification

- **Against the real pre-fix `dist`:** exits 1, naming `models-dev-snapshot.json: MISSING from dist/`. This is the actual defect, not a synthetic one.
- **Clean rebuild** (`rm -rf dist && pnpm build`): exits 0, `dist assets OK (4 checked)` — 245,780-byte snapshot, 694,330-byte registry, 3 ast-rules, 11 templates nested correctly.
- **Enumeration from the built `dist`:** 353 entries, 47/13/82.

| mutation | result |
| --- | --- |
| size floor disabled | 1 failed ✓ |

Four unit tests on the extracted `missingDistAssets` predicate cover missing, truncated, all-present, and directory assets — the last because a size floor is meaningless for `workflows/templates` and must not fail it.

## Not in scope

`gemini` maps to the models.dev `google` vendor, but that arm now runs **agy** (Antigravity) since Google retired the gemini CLI, so those 82 ids describe Google's API models rather than what agy serves. #4393 tracks the underlying constraint — `agy models` hangs without a TTY, so there is no programmatic discovery to substitute. Left for that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
