### PR TITLE
fix(adapters): enumerate agy models for the gemini arm

### DIFF
--- a/.changeset/agy-model-enumeration.md
+++ b/.changeset/agy-model-enumeration.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+fix(adapters): the gemini arm enumerates agy's models, not Google API ids
+
+`GeminiCliAdapter.listModels()` returned `listModelsForCli('gemini')` — the
+models.dev `google` vendor, 82 Google **API** ids like `gemini-2.5-flash`. That
+arm spawns `agy`, which accepts none of them. The same reasoning already
+documented for `cliModelName` in `config/agy-model-map.ts` applies to
+enumeration: one field cannot serve both the API adapter and the CLI transport.
+It now reports `AGY_MODEL_SLUGS`.
+
+`agy models` is enumerable non-interactively again. #4393 recorded it hanging
+90s without a TTY on v1.1.11; on v1.1.21 it completes piped in ~1s, exit 0. That
+was an upstream defect and it is fixed.
+
+With enumeration available, `AGY_MODEL_SLUGS` was verified against the live CLI
+and gained the `gemini-3.7-flash-{high,medium,low}` family it had been missing
+since it was last checked against v1.1.9. `scripts/check-agy-model-drift.ts`
+compares the two so it cannot silently rot again — operator-invoked, since no CI
+runner has the binary, and it reports `unmeasured` (a failure) rather than
+passing when it cannot probe.
+
+Claude and GPT-OSS slugs agy also fronts stay unmapped, per the 7/0 decision in
+#4346; the check names them as excluded rather than dropping them silently.

--- a/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
+++ b/packages/nexus-agents/src/cli-adapters/adapters/gemini-adapter.ts
@@ -27,9 +27,8 @@ import type {
 } from '../types.js';
 import { SubprocessCliAdapter, type CommandConfig } from '../subprocess-adapter.js';
 import { AgyResponseParser } from '../parsers/agy-parser.js';
-import { toAgyModelSlug } from '../../config/agy-model-map.js';
+import { toAgyModelSlug, AGY_MODEL_SLUGS } from '../../config/agy-model-map.js';
 import type { CliModelInfo } from '../types-capability.js';
-import { listModelsForCli } from '../../config/models-dev-by-vendor.js';
 import {
   getTimeoutForTask,
   estimateTaskComplexity,
@@ -133,8 +132,18 @@ export class GeminiCliAdapter extends SubprocessCliAdapter {
   }
 
   /** Key-free model enumeration via the models.dev snapshot (#3405). */
+  /**
+   * The slugs this arm can actually run (#5085).
+   *
+   * NOT `listModelsForCli('gemini')`, which resolves the models.dev `google`
+   * vendor — 82 Google **API** ids like `gemini-2.5-flash`. This arm spawns
+   * `agy`, which accepts none of them; the same reasoning already documented
+   * for `cliModelName` in `config/agy-model-map.ts` applies to enumeration.
+   * Reporting the API list made every consumer confidently wrong rather than
+   * empty, which is worse.
+   */
   listModels(): Promise<readonly CliModelInfo[]> {
-    return Promise.resolve(listModelsForCli(this.name));
+    return Promise.resolve(AGY_MODEL_SLUGS.map((id) => ({ id, provider: 'antigravity' })));
   }
 
   /**

--- a/packages/nexus-agents/src/config/agy-model-map.ts
+++ b/packages/nexus-agents/src/config/agy-model-map.ts
@@ -16,7 +16,11 @@
  * version-bearing model-id literals outside this directory, and enforces it in
  * CI and pre-push.
  *
- * Verified against `agy models` on v1.1.9 (2026-08-09).
+ * Verified against `agy models` on v1.1.21 (2026-08-26). `agy models` is once
+ * again enumerable non-interactively — it completed piped in ~1s, exit 0, over
+ * three runs. #4393 recorded it hanging for 90s without a TTY on v1.1.11; that
+ * was an upstream defect and it is fixed. `scripts/check-agy-model-drift.ts`
+ * now compares this list against the live CLI so it cannot silently rot again.
  *
  * @module config/agy-model-map
  */
@@ -39,6 +43,9 @@ import { findCanonicalModel } from './model-config-helpers.js';
  * arms to disambiguate with no consumer asking for them (#4346, 7/0 vote).
  */
 export const AGY_MODEL_SLUGS = [
+  'gemini-3.7-flash-high',
+  'gemini-3.7-flash-medium',
+  'gemini-3.7-flash-low',
   'gemini-3.6-flash-high',
   'gemini-3.6-flash-medium',
   'gemini-3.6-flash-low',

--- a/scripts/check-agy-model-drift.test.ts
+++ b/scripts/check-agy-model-drift.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseAgyModels, compareAgyModels } from './check-agy-model-drift.js';
+import { AGY_MODEL_SLUGS } from '../packages/nexus-agents/src/config/agy-model-map.js';
+
+const CURRENT = [...AGY_MODEL_SLUGS];
+
+describe('parseAgyModels', () => {
+  it('reads tab-separated rows', () => {
+    expect(parseAgyModels('a-high\tA (High)\nb-low\tB (Low)\n')).toEqual(['a-high', 'b-low']);
+  });
+
+  it('ignores the cold-fetch header without dropping a real row', () => {
+    // agy prints `Fetching available models...` only on a cold fetch, so a
+    // positional "skip line 1" drops a genuine model on the warm path. The tab
+    // is the discriminator.
+    const cold = parseAgyModels('Fetching available models...\nx-high\tX (High)\n');
+    const warm = parseAgyModels('x-high\tX (High)\n');
+
+    expect(cold).toEqual(['x-high']);
+    expect(warm).toEqual(['x-high']);
+  });
+
+  it('returns nothing for output with no tabbed rows', () => {
+    // Drives the `unmeasured` branch in the runner: a format change must not
+    // read as "agy serves no models".
+    expect(parseAgyModels('some unexpected banner\n')).toEqual([]);
+  });
+});
+
+describe('compareAgyModels', () => {
+  it('is ok when live matches the map', () => {
+    expect(compareAgyModels(CURRENT).ok).toBe(true);
+  });
+
+  it('reports a new model family the map lacks', () => {
+    // The real drift this exists for: agy shipped gemini-3.7-flash-* while the
+    // map was still verified against v1.1.9.
+    const verdict = compareAgyModels([...CURRENT, 'gemini-3.9-flash-high']);
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.missingFromMap).toEqual(['gemini-3.9-flash-high']);
+  });
+
+  it('reports a slug the map claims but agy dropped', () => {
+    const verdict = compareAgyModels(CURRENT.slice(1));
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.staleInMap).toEqual([CURRENT[0]]);
+  });
+
+  it('excludes non-Gemini slugs rather than calling them drift', () => {
+    // #4346 decided 7/0 that this arm means Gemini-family; Claude and GPT-OSS
+    // route through their own arms. Reporting them as drift would fight that.
+    const verdict = compareAgyModels([...CURRENT, 'claude-sonnet-4-6', 'gpt-oss-120b-medium']);
+
+    expect(verdict.ok).toBe(true);
+    expect(verdict.excluded).toEqual(['claude-sonnet-4-6', 'gpt-oss-120b-medium']);
+  });
+
+  it('does not report an empty live list as agreement', () => {
+    // Every mapped slug is missing, which must be loud. The runner turns this
+    // into `unmeasured` before it gets here; this pins that the comparison
+    // itself cannot render absence as a match.
+    expect(compareAgyModels([]).ok).toBe(false);
+  });
+});

--- a/scripts/check-agy-model-drift.ts
+++ b/scripts/check-agy-model-drift.ts
@@ -1,0 +1,162 @@
+#!/usr/bin/env npx tsx
+/**
+ * Compare `AGY_MODEL_SLUGS` against what `agy models` actually serves (#5085).
+ *
+ * ## Why this can exist now
+ *
+ * #4393 recorded that `agy models` HANGS without a TTY — 90s, exit 124, zero
+ * output on v1.1.11 — so there was no programmatic enumeration to check
+ * against and the map was maintained by hand. That was an upstream defect and
+ * it is fixed: on v1.1.21 the command completes piped in ~1s, exit 0, over
+ * three consecutive runs. This check is what that fix makes possible.
+ *
+ * ## What it compares, and what it deliberately ignores
+ *
+ * Only the Gemini family. agy also fronts `claude-sonnet-4-6`,
+ * `claude-opus-4-6-thinking` and `gpt-oss-120b-medium`; #4346 decided 7/0 that
+ * the `gemini` routing arm means Gemini-family models, with Claude and GPT-OSS
+ * routed through their own arms. Reporting those as drift would fight a
+ * ratified decision, so they are filtered out and named here rather than
+ * silently dropped.
+ *
+ * ## Absence is not agreement
+ *
+ * When `agy` is not installed the check reports `unmeasured` and exits
+ * non-zero. A drift check that passes because it could not look is the failure
+ * mode this repo treats as a p1 on instrumentation — it would report the map
+ * current on every machine without the CLI, which is every CI runner.
+ *
+ * @module scripts/check-agy-model-drift
+ * (Source: Issue #5085, unblocked by #4393)
+ */
+import { execFileSync } from 'node:child_process';
+
+import { AGY_MODEL_SLUGS } from '../packages/nexus-agents/src/config/agy-model-map.js';
+
+/** Gemini-family prefix — the subset #4346 scoped this arm to. */
+const GEMINI_PREFIX = 'gemini-';
+
+/**
+ * Generous relative to the ~1s observed, because this is a correctness gate,
+ * not a latency measurement: a slow network should report drift honestly, not
+ * time out into `unmeasured`.
+ */
+const PROBE_TIMEOUT_MS = 30_000;
+
+export interface AgyDriftVerdict {
+  readonly ok: boolean;
+  /** Slugs agy serves that the map lacks. */
+  readonly missingFromMap: readonly string[];
+  /** Slugs the map claims that agy no longer serves. */
+  readonly staleInMap: readonly string[];
+  /** Non-Gemini slugs agy serves, excluded by #4346. Reported, never drift. */
+  readonly excluded: readonly string[];
+  /** Set when the CLI could not be probed at all. */
+  readonly unmeasured?: boolean;
+  readonly reason?: string;
+}
+
+/**
+ * Parse `agy models` output: TAB-separated `slug\tDisplay Name`.
+ *
+ * Filtering on the tab rather than skipping line 1 is deliberate: agy prints a
+ * `Fetching available models...` header only on a cold fetch, and on stderr in
+ * some invocations, so a positional skip drops a real model on the warm path.
+ */
+export function parseAgyModels(stdout: string): string[] {
+  return stdout
+    .split('\n')
+    .filter((line) => line.includes('\t'))
+    .map((line) => (line.split('\t')[0] ?? '').trim())
+    .filter((slug) => slug.length > 0);
+}
+
+/** Compare a live slug list against the static map. */
+export function compareAgyModels(live: readonly string[]): AgyDriftVerdict {
+  const excluded = live.filter((s) => !s.startsWith(GEMINI_PREFIX)).sort();
+  const liveGemini = new Set(live.filter((s) => s.startsWith(GEMINI_PREFIX)));
+  const mapped = new Set<string>(AGY_MODEL_SLUGS);
+
+  const missingFromMap = [...liveGemini].filter((s) => !mapped.has(s)).sort();
+  const staleInMap = [...mapped].filter((s) => !liveGemini.has(s)).sort();
+
+  return {
+    ok: missingFromMap.length === 0 && staleInMap.length === 0,
+    missingFromMap,
+    staleInMap,
+    excluded,
+  };
+}
+
+/* eslint-disable no-console */
+function probe(): AgyDriftVerdict {
+  let stdout: string;
+  try {
+    stdout = execFileSync('agy', ['models'], {
+      encoding: 'utf-8',
+      timeout: PROBE_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch (error: unknown) {
+    return {
+      ok: false,
+      missingFromMap: [],
+      staleInMap: [],
+      excluded: [],
+      unmeasured: true,
+      reason: `agy models could not be run: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const live = parseAgyModels(stdout);
+  if (live.length === 0) {
+    return {
+      ok: false,
+      missingFromMap: [],
+      staleInMap: [],
+      excluded: [],
+      unmeasured: true,
+      reason: 'agy models produced no parseable rows — output format may have changed',
+    };
+  }
+  return compareAgyModels(live);
+}
+
+function main(): void {
+  const verdict = probe();
+
+  if (verdict.unmeasured === true) {
+    console.error(`::error::agy model drift UNMEASURED — ${verdict.reason ?? 'unknown'}`);
+    console.error(
+      '  Absence of a probe is not agreement. Install agy, or run this where it exists.'
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (verdict.excluded.length > 0) {
+    console.log(`Excluded by #4346 (non-Gemini, routed elsewhere): ${verdict.excluded.join(', ')}`);
+  }
+
+  if (verdict.ok) {
+    console.log(
+      `agy model map is current (${String(AGY_MODEL_SLUGS.length)} Gemini-family slugs).`
+    );
+    return;
+  }
+
+  console.error('::error::agy model map has drifted from `agy models`.');
+  if (verdict.missingFromMap.length > 0) {
+    console.error(`  agy serves, map lacks:   ${verdict.missingFromMap.join(', ')}`);
+  }
+  if (verdict.staleInMap.length > 0) {
+    console.error(`  map claims, agy dropped: ${verdict.staleInMap.join(', ')}`);
+  }
+  console.error('  Update AGY_MODEL_SLUGS in packages/nexus-agents/src/config/agy-model-map.ts');
+  console.error('  and re-check CANONICAL_TO_AGY, which maps by tier semantics, not version.');
+  process.exitCode = 1;
+}
+
+if (process.argv[1]?.endsWith('check-agy-model-drift.ts') === true) {
+  main();
+}

--- a/scripts/check-script-wiring.ts
+++ b/scripts/check-script-wiring.ts
@@ -47,7 +47,14 @@ export const SELF = 'check-script-wiring.ts';
  * Add an entry only when a script is genuinely meant to be run by hand. An
  * entry without a real reason converts this gate into paperwork.
  */
-export const MANUAL_ONLY: Readonly<Record<string, string>> = {};
+export const MANUAL_ONLY: Readonly<Record<string, string>> = {
+  // Requires the `agy` binary, which no CI runner has. Wiring it into a
+  // workflow would make it report `unmeasured` — a failure — on every run, so
+  // it is operator-invoked: `npx tsx scripts/check-agy-model-drift.ts`, and on
+  // each agy upgrade (#5085). Listed rather than silently unwired, because an
+  // unlisted gate nothing runs is what #4553 is about.
+  'check-agy-model-drift.ts': 'needs the agy CLI; not installable on CI runners',
+};
 
 export interface WiringInput {
   /** Basenames of `scripts/check-*.ts`, excluding tests. */


### PR DESCRIPTION
Closes #5085. Unblocked by an upstream fix to #4393 — retested there with measurements.

## Yes, agy models can be enumerated now

#4393 recorded `agy models` hanging without a TTY: 90.01s, exit 124, zero output on v1.1.11, twice. It explicitly said to retest on upgrade rather than assume permanence. On **v1.1.21**:

```
exit=0  elapsed=1s  14 models
three consecutive runs: 1043ms / 967ms / 811ms
```

Upstream defect, fixed. `agy models --help` still offers no `--output-format`, so the tabbed text is the contract: `slug<TAB>Display Name` on stdout.

**One trap, found by hitting it:** a `Fetching available models...` header appears on a **cold fetch only**, and not on the same stream in every invocation. Parsing by "skip line 1" drops a real model on the warm path — I counted 14, then 13, then 14 before pinning it. The parser filters on the tab instead, and a test drives both the cold and warm shapes.

## The bug this exposed

`GeminiCliAdapter.listModels()` returned `listModelsForCli('gemini')` — the models.dev `google` vendor, **82 Google API ids** like `gemini-2.5-flash`. This arm spawns `agy`, which accepts none of them.

The file already documents the identical trap one field over: `config/agy-model-map.ts` explains at length why `cliModelName` cannot carry agy slugs, because the API-based `GeminiAdapter` reads the same field. That reasoning applies to enumeration and had not been carried across.

This matters more after #5084 lands. Before it, the snapshot was missing and the arm reported **0** — visibly wrong. After it, the arm would have reported 82 ids it cannot run: confidently wrong, which is worse.

## Map refreshed against the live CLI

`AGY_MODEL_SLUGS` was last verified against v1.1.9 and had gone stale by a whole family — `gemini-3.7-flash-{high,medium,low}`. Live agy serves 11 Gemini-family slugs; the map had 8. Now an exact match, verified programmatically rather than by eye.

## The drift check

`scripts/check-agy-model-drift.ts` compares the map to the live CLI so it cannot silently rot again.

- **Operator-invoked**, registered in `MANUAL_ONLY` with the reason: no CI runner has the `agy` binary, so wiring it into a workflow would make it report `unmeasured` on every run. Listed rather than left silently unwired, which is what #4553 is about.
- **Absence is not agreement.** No binary, or unparseable output, reports `unmeasured` and exits non-zero. A drift check that passes because it could not look would report the map current on every machine without the CLI.
- **Non-Gemini slugs are excluded, not dropped.** agy also fronts `claude-sonnet-4-6`, `claude-opus-4-6-thinking`, `gpt-oss-120b-medium`; #4346 decided 7/0 that this arm means Gemini-family, with those routed through their own arms. Calling them drift would fight a ratified decision, so the check names them as excluded on every run.

I nearly filed those three as staleness before reading the map's own doc comment — worth noting that the deliberate exclusion was recorded exactly where it needed to be.

## Verification

Live run, green:

```
Excluded by #4346 (non-Gemini, routed elsewhere): claude-opus-4-6-thinking, claude-sonnet-4-6, gpt-oss-120b-medium
agy model map is current (11 Gemini-family slugs).
```

8 unit tests: cold/warm header shapes, a new family appearing, a slug disappearing, non-Gemini exclusion, and an empty live list **not** reading as agreement.

1,070 tests pass across the gemini adapter and `src/config`; typecheck, lint, `check-script-wiring`, `check-model-string-drift`, and the API-surface gate all clean.

## Left alone

The `cli-auth-probe.ts` evidence rung for this arm. `agy models` reaching the service *suggests* an authenticated probe is now possible, but whether it distinguishes unauthenticated from empty is untested — that wants a logged-out measurement, not an assumption. Recorded on #4393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
