### PR TITLE
fix(routing): make the dead timePressure constant agree across builders

### DIFF
--- a/.changeset/time-pressure-constant-agrees.md
+++ b/.changeset/time-pressure-constant-agrees.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+fix(routing): the bandit's dead timePressure feature no longer disagrees with itself
+
+Nothing in the tree computes a time-pressure signal, so `BanditContext.timePressure`
+is a constant and its LinUCB coefficient is meaningless. That is known and
+documented (#4875), and inventing a producer is a design question rather than a
+wiring fix — so it stays constant.
+
+What was wrong is that it was **three** constants across five sites.
+`composite-router-helpers` and `task-profile-adapter` emitted `0.3`, while
+`LinUCBStage` — the other live builder feeding the same bandit — and the
+`warmStart`/`seedPriors` replay both used `0.5`.
+
+A constant feature carries no information. Two _different_ constants across live
+paths is worse than that: the value becomes learnable as a path indicator, so
+the bandit can fit accidental signal against a dimension nobody measures. All
+builders now use the neutral `0.5` the replay paths already assume, and a test
+pins that they cannot drift apart again.
+
+Two existing tests asserted the `0.3` as intended behaviour; both are updated
+with the reason rather than renumbered silently.

--- a/.changeset/time-pressure-constant-agrees.md
+++ b/.changeset/time-pressure-constant-agrees.md
@@ -22,3 +22,7 @@ pins that they cannot drift apart again.
 
 Two existing tests asserted the `0.3` as intended behaviour; both are updated
 with the reason rather than renumbered silently.
+
+`api-surface.txt` is regenerated for a formatting-only change: prettier collapsed
+the multi-line `ExpertTaskDomain` union onto one line when it reformatted the
+file this touches. Same seven members, different wrapping — no type change.

--- a/api-surface.txt
+++ b/api-surface.txt
@@ -3468,7 +3468,7 @@ InterfaceDeclaration ExpertResultSummary
   role: AgentRole
   success: boolean
 TypeAliasDeclaration ExpertTaskDomain
-  = | 'code' | 'security' | 'architecture' | 'documentation' | 'testing' | 'infrastructure' | 'general'
+  = 'code' | 'security' | 'architecture' | 'documentation' | 'testing' | 'infrastructure' | 'general'
 InterfaceDeclaration ExplorationEvent
   readonly details: Record<string, unknown>
   readonly eventType: ExplorationEventType

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.test.ts
@@ -163,9 +163,13 @@ describe('taskProfileToBanditContext', () => {
   });
 
   it('sets fixed budget and time values', () => {
+    // #4875: this live path emitted 0.3 while `LinUCBStage` — the other live
+    // builder feeding the same bandit — emitted 0.5. Both are constants, so
+    // neither carries information about time pressure; the disagreement was
+    // the defect, because a per-path constant is learnable as a path label.
     const ctx = taskProfileToBanditContext(makeTaskProfile());
     expect(ctx.budgetUtilization).toBe(0.5);
-    expect(ctx.timePressure).toBe(0.3);
+    expect(ctx.timePressure).toBe(0.5);
   });
 });
 

--- a/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
+++ b/packages/nexus-agents/src/cli-adapters/composite-router-helpers.ts
@@ -80,7 +80,14 @@ export function taskProfileToBanditContext(
     isCodeTask: profile.codeGeneration ? 1 : 0,
     isReasoningTask: profile.taskType === 'architecture' || profile.reasoningComplexity > 5 ? 1 : 0,
     budgetUtilization: budgetUtilization ?? NEUTRAL_FEATURE,
-    timePressure: 0.3,
+    // #4875: still a constant — nothing in the tree computes time pressure, and
+    // inventing a producer is a design question, not a wiring fix. What changed
+    // is WHICH constant: this path used 0.3 while `LinUCBStage` used 0.5 and
+    // `warmStart`/`seedPriors` replay at 0.5. A constant feature carries no
+    // information, but two DIFFERENT constants across live paths let the bandit
+    // use the value as a path indicator — accidental signal rather than none.
+    // Neutral, and equal to what the replay paths use, is the honest default.
+    timePressure: NEUTRAL_FEATURE,
   };
 }
 

--- a/packages/nexus-agents/src/cli-adapters/time-pressure-agreement.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/time-pressure-agreement.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Every builder of `BanditContext.timePressure` must use the same constant
+ * until something computes one (#4875).
+ *
+ * Nothing in the tree produces a time-pressure measurement, so the feature is
+ * a constant and its LinUCB coefficient is meaningless. That is documented and
+ * accepted. What is NOT acceptable is different constants on different paths:
+ * `composite-router-helpers` used 0.3 while `LinUCBStage` and the
+ * `warmStart`/`seedPriors` replay used 0.5. A constant carries no information;
+ * two constants let the bandit use the value as a PATH INDICATOR, which is
+ * accidental signal fitted against a dimension nobody measures.
+ *
+ * This test is why the constant cannot drift apart again. When a real producer
+ * lands, it replaces the constant everywhere and this test should be rewritten
+ * to assert the producer is wired, not deleted.
+ *
+ * @module cli-adapters/time-pressure-agreement.test
+ * (Source: Issue #4875)
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { taskAnalysisResultToBanditContext } from '../core/task-analysis/task-profile-adapter.js';
+import type { TaskAnalysisResult } from '../core/task-analysis/shared-task-analyzer.js';
+
+/** The value every replay path uses, and therefore the only honest default. */
+const NEUTRAL = 0.5;
+
+const analysis = {
+  complexityScore: 0.5,
+  estimatedTokens: 1000,
+  capabilities: { codeGeneration: true },
+  reasoningType: 'reasoning',
+} as unknown as TaskAnalysisResult;
+
+describe('timePressure constant agreement (#4875)', () => {
+  it('the task-analysis builder defaults to the neutral value', () => {
+    expect(taskAnalysisResultToBanditContext(analysis).timePressure).toBe(NEUTRAL);
+  });
+
+  it('still honours an explicitly supplied value', () => {
+    // The pair: the default changing must not mean the option is ignored. No
+    // caller supplies it today, which is exactly why the default matters.
+    expect(taskAnalysisResultToBanditContext(analysis, { timePressure: 0.9 }).timePressure).toBe(
+      0.9
+    );
+  });
+
+  it('no production builder still hardcodes the old 0.3', () => {
+    // Source-level because the builders live in separate modules with
+    // different inputs; a value-level test would need each one's context
+    // fixture and would miss a sixth site added later.
+    const roots = [
+      'cli-adapters/composite-router-helpers.ts',
+      'cli-adapters/routing/stages/linucb-stage.ts',
+      'core/task-analysis/task-profile-adapter.ts',
+      'cli-adapters/linucb-bandit.ts',
+    ];
+    const offenders: string[] = [];
+    for (const rel of roots) {
+      const src = readFileSync(join(__dirname, '..', rel), 'utf-8');
+      for (const line of src.split('\n')) {
+        // Skip comments — they discuss the old value deliberately.
+        if (line.trim().startsWith('//') || line.trim().startsWith('*')) continue;
+        if (/timePressure:\s*0\.3\b/.test(line)) offenders.push(`${rel}: ${line.trim()}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/cli-adapters/time-pressure-agreement.test.ts
+++ b/packages/nexus-agents/src/cli-adapters/time-pressure-agreement.test.ts
@@ -56,6 +56,10 @@ describe('timePressure constant agreement (#4875)', () => {
       'cli-adapters/routing/stages/linucb-stage.ts',
       'core/task-analysis/task-profile-adapter.ts',
       'cli-adapters/linucb-bandit.ts',
+      // Re-exports `taskProfileToBanditContext` rather than duplicating it, so
+      // it carries no literal — listed because #4875 describes it as a
+      // parallel builder, and a future edit could make that true.
+      'cli/routing-audit-logic.ts',
     ];
     const offenders: string[] = [];
     for (const rel of roots) {

--- a/packages/nexus-agents/src/cli/routing-audit-logic.test.ts
+++ b/packages/nexus-agents/src/cli/routing-audit-logic.test.ts
@@ -144,10 +144,15 @@ describe('routing-audit-logic', () => {
     });
 
     it('should set default time pressure', () => {
+      // #4875: was 0.3. Nothing computes a time-pressure signal, so this stays
+      // a constant — but it must be the SAME constant every builder and replay
+      // path uses, or the bandit can learn the value as a path label. This
+      // module re-exports `taskProfileToBanditContext`, so the offline audit
+      // and the live router are the same function and cannot diverge.
       const profile = analyzeTaskString('Any task');
       const context = taskProfileToBanditContextFromProfile(profile);
 
-      expect(context.timePressure).toBe(0.3);
+      expect(context.timePressure).toBe(0.5);
     });
 
     it('should cap context length at 1.0', () => {

--- a/packages/nexus-agents/src/core/task-analysis/task-profile-adapter.test.ts
+++ b/packages/nexus-agents/src/core/task-analysis/task-profile-adapter.test.ts
@@ -268,9 +268,14 @@ describe('taskAnalysisResultToBanditContext', () => {
   });
 
   it('uses default budget and time pressure when not provided', () => {
+    // #4875: `timePressure` was 0.3 here while every replay path
+    // (`warmStart`/`seedPriors`) and `LinUCBStage` used 0.5. Nothing computes
+    // a time-pressure signal, so the feature is a constant either way — but
+    // two DIFFERENT constants let the bandit use the value as a path
+    // indicator. Neutral, matching the replay paths, is the honest default.
     const ctx = taskAnalysisResultToBanditContext(makeAnalysis());
     expect(ctx.budgetUtilization).toBe(0.5);
-    expect(ctx.timePressure).toBe(0.3);
+    expect(ctx.timePressure).toBe(0.5);
   });
 
   it('uses provided budget and time pressure', () => {

--- a/packages/nexus-agents/src/core/task-analysis/task-profile-adapter.ts
+++ b/packages/nexus-agents/src/core/task-analysis/task-profile-adapter.ts
@@ -142,9 +142,12 @@ export function taskAnalysisResultToBanditContext(
     isReasoningTask:
       analysis.reasoningType === 'reasoning' ? 1 : analysis.complexityScore > 0.5 ? 0.5 : 0,
 
-    // External context (default mid-range if not provided)
+    // External context (default mid-range if not provided).
+    // #4875: `timePressure` defaulted to 0.3 here while every replay path uses
+    // 0.5, so the same dead feature entered the model at two values depending
+    // on which builder ran. No caller supplies the option today.
     budgetUtilization: options.budgetUtilization ?? 0.5,
-    timePressure: options.timePressure ?? 0.3,
+    timePressure: options.timePressure ?? 0.5,
   };
 }
 
@@ -157,13 +160,7 @@ export function taskAnalysisResultToBanditContext(
  * Maps to domain values used by expert definitions.
  */
 export type ExpertTaskDomain =
-  | 'code'
-  | 'security'
-  | 'architecture'
-  | 'documentation'
-  | 'testing'
-  | 'infrastructure'
-  | 'general';
+  'code' | 'security' | 'architecture' | 'documentation' | 'testing' | 'infrastructure' | 'general';
 
 /**
  * Legacy TaskComplexity type for expert-selector compatibility.


### PR DESCRIPTION
Refs #4875. Does **not** invent a producer — that issue explicitly says threading one is a design question, and the measurement below says the candidates it named are not usable.

## Measured the trigger before building — it has not fired

#4875's pickup condition: *"when `maxLatencyMs` is confirmed to be a usable producer"*. I fixed `BudgetRouter` to actually enforce `maxLatencyMs` earlier today (#5061), which looks like the trigger. It is not:

- **No config anywhere sets `maxLatencyMs`.** `routing-config-adapter.ts:55` reads it from routing YAML; no YAML in the tree supplies it. The only value that ever reaches `BudgetConstraint` is the `60000` default.
- So `estimatedLatencyMs / maxLatencyMs` would be `1000–2000 / 60000` → four discrete values in `[0.017, 0.033]`, derived entirely from **which arm was picked** — which the bandit already knows from the arm identity. Not a deadline signal.
- The other candidate, `CliTask.timeoutMs`, is set at exactly one production site (`cli-commands-handlers.ts:334`) from an explicit CLI flag. Absent for effectively all traffic.

So the honest state remains "documented constant", and #4875 stays open.

## What *is* fixable, and is a real defect

The issue records the constant as `0.3` vs `0.5`. It is **three** values across five sites:

| site | value | path |
| --- | --- | --- |
| `composite-router-helpers.ts:83` | **0.3** | live routing |
| `task-profile-adapter.ts:147` | **0.3** | default when caller omits |
| `linucb-stage.ts:211` | 0.5 | live routing |
| `linucb-stage.ts:227` | 0.5 | outcome replay |
| `linucb-bandit.ts:277` | 0.5 | `warmStart` / `seedPriors` |

**Two live builders feed the same bandit at different constants.** A constant feature carries no information — that is accepted. Two constants is worse: the value becomes learnable as a *path indicator*, so the bandit can fit accidental signal against a dimension nobody measures. The issue noted the live/replay mismatch but not that the two live paths disagree with each other.

All builders now use `0.5`, the value every replay path already assumes.

## Left alone deliberately

`meta-shadow-selector.ts:165` uses `0`, and also `budgetUtilization: 0`, with its own comment — *"No budget/urgency signal is available at selection time; left neutral."* That is internally consistent within a separate selector (#3593) with its own feature contract. Changing it would be a different decision, so I did not fold it in.

## Verification

| mutation | result |
| --- | --- |
| router-helper reverts to `0.3` | 1 failed ✓ |
| adapter default reverts to `0.3` | 1 failed ✓ |

Three tests: the default is neutral, an explicitly supplied value is still honoured (so the default change did not silently ignore the option), and a source-level scan asserts no production builder still hardcodes `0.3`. The last is source-level on purpose — the builders take different inputs, so a value-level test would need a fixture per builder and would miss a sixth site added later.

**Three existing tests asserted the `0.3` as intended behaviour** — `task-profile-adapter.test.ts:273`, `composite-router-helpers.test.ts:168`, and `routing-audit-logic.test.ts:150`. All updated with the reason in a comment rather than renumbered silently.

The third was caught by CI, not by me: my source-scan test listed four files and omitted `cli/routing-audit-logic.ts`, which #4875 explicitly names. It is now in the scan.

Worth correcting the issue on that point: it describes `routing-audit-logic.ts:75` as *"the identical constant in its parallel builder"*. It is not a parallel builder any more — line 81 **re-exports** `taskProfileToBanditContext`. So fixing the shared function covered the audit path automatically, and only its test needed updating. The two paths cannot diverge because they are the same function.

7,134 tests pass across `src/cli`, `src/cli-adapters` and `src/core/task-analysis`; typecheck, lint, the API-surface gate and the unused-export ratchet clean.

## One more thing in the diff

`api-surface.txt` is regenerated for a **formatting-only** change. `ExpertTaskDomain` happens to be declared in `task-profile-adapter.ts`, and prettier collapsed its multi-line union onto one line when it reformatted the file. Same seven members, different wrapping — I verified the generator is deterministic across runs before concluding that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk