### PR TITLE
fix(mcp): thread the audit logger to every tool, not just run_dev_pipeline

### DIFF
--- a/.changeset/audit-logger-reaches-all-tools.md
+++ b/.changeset/audit-logger-reaches-all-tools.md
@@ -1,0 +1,23 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): the policy audit emit was unreachable for 38 of 44 tools
+
+`secure-handler.ts:261` records a policy decision only when
+`config.auditLogger` is present. `buildStandardDeps` gated that logger on
+`toolName === 'run_dev_pipeline'`, which was correct when #3710 wrote it — that
+was then the only tool consuming a durable audit logger.
+
+#4987 changed the premise: the MCP `PolicyFirewall` now evaluates rules on
+**every** tool. The gate was never revisited, so for the 38 tools registered
+through `standardHandler`, a policy denial could not reach the audit chain — in
+enforce mode or in warn. Five tools with bespoke registration (`execute_expert`,
+`consensus_vote`, `pr_review`, `run`, `orchestrate`) already received it.
+
+The logger is now threaded whenever the server has one. This emits nothing on
+its own; it makes an existing emit reachable.
+
+Prerequisite for #4991 and therefore for #4988 — the warn-mode soak that
+decision rests on could not produce durable evidence while the emit was
+unreachable for most of the surface.

--- a/packages/nexus-agents/src/cli-server-tools.test.ts
+++ b/packages/nexus-agents/src/cli-server-tools.test.ts
@@ -598,6 +598,37 @@ describe('registerMcpTools - tool allowlisting', () => {
     expect(mockRegisterMemoryQueryTool).toHaveBeenCalled();
   });
 
+  it('threads the audit logger to a standardHandler tool, not just run_dev_pipeline (#4991)', () => {
+    // #4987 made the MCP PolicyFirewall evaluate rules on EVERY tool, and
+    // `secure-handler.ts:261` emits the decision only `if (pResult &&
+    // config.auditLogger)`. `buildStandardDeps` withheld the logger from every
+    // tool except `run_dev_pipeline`, so a policy denial on any of the 38 tools
+    // registered through `standardHandler` could never reach the chain — in
+    // enforce mode or in warn. The warn-mode soak #4988 depends on therefore
+    // produced no durable evidence at all.
+    //
+    // memory_query is a plain standardHandler tool: if IT gets the logger, the
+    // generic path does.
+    const auditLogger = { logPolicyDecision: vi.fn() };
+    registerMcpTools(makeDefaultOptions({ auditLogger }));
+
+    expect(mockRegisterMemoryQueryTool).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ auditLogger })
+    );
+  });
+
+  it('omits the audit logger when the server has none', () => {
+    // The pair: threading must stay conditional. An always-present key would
+    // put `undefined` on the deps object and defeat the `config.auditLogger`
+    // guard's ability to mean "no durable chain configured".
+    registerMcpTools(makeDefaultOptions());
+
+    const deps = mockRegisterMemoryQueryTool.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+    expect(deps).toBeDefined();
+    expect(deps).not.toHaveProperty('auditLogger');
+  });
+
   it('should skip categories when allowlist excludes them', () => {
     const options = makeDefaultOptions({
       securityConfig: {

--- a/packages/nexus-agents/src/cli-server-tools.ts
+++ b/packages/nexus-agents/src/cli-server-tools.ts
@@ -632,11 +632,16 @@ function buildStandardDeps(
     logger: ctx.logger,
     rateLimiter: ctx.rateLimiterFactory.getForTool(toolName),
     ...(ctx.securityConfig !== undefined && { security: ctx.securityConfig }),
-    // #3710: only run_dev_pipeline consumes the durable auditLogger — thread it
-    // so its consensus→execute policy gate persists decisions to the shared chain.
-    ...(toolName === 'run_dev_pipeline' && ctx.auditLogger !== undefined
-      ? { auditLogger: ctx.auditLogger }
-      : {}),
+    // #3710 threaded this for `run_dev_pipeline` alone, because it was then the
+    // only tool consuming a durable auditLogger. #4987 changed that: the MCP
+    // `PolicyFirewall` now evaluates rules on EVERY tool, and
+    // `secure-handler.ts:261` emits the policy decision only `if (pResult &&
+    // config.auditLogger)`. Withholding the logger left that emit unreachable
+    // for the 38 tools registered through `standardHandler` — a policy denial
+    // on any of them could never reach the chain, in enforce mode or warn
+    // (#4991). Threading it does not emit anything on its own; it makes the
+    // existing emit reachable.
+    ...(ctx.auditLogger !== undefined ? { auditLogger: ctx.auditLogger } : {}),
   };
 }
 


### PR DESCRIPTION
Refs #4991 — its stated prerequisite, done first. Prerequisite in turn for #4988.

## #4991 said to confirm before building, so I did

> "the audit path for policy decisions is unreachable for almost every tool regardless of mode. Worth confirming before building the warn-mode emitter, or the emitter lands as another guard that cannot fire."

Confirmed, and the count in that issue is now outdated. It says *"threads `auditLogger` only for `run_dev_pipeline`"*. Measured on main:

- **38 tools** go through `standardHandler` → `buildStandardDeps`, which gated the logger on `toolName === 'run_dev_pipeline'`
- **5 tools** already received it via bespoke registration — `execute_expert`, `consensus_vote`, `pr_review`, `run`, `orchestrate`
- so it was 6 of 44, not 1

The gate was correct when #3710 wrote it: `run_dev_pipeline` was then the only consumer of a durable audit logger. **#4987 changed the premise** by making the `PolicyFirewall` evaluate rules on every tool, and the gate was never revisited.

`secure-handler.ts:261`:

```ts
if (pResult && config.auditLogger) {
  emitPolicyAudit(config.auditLogger, config.toolName, requestContext, 'policy denied');
}
```

With `config.auditLogger` undefined, that emit cannot fire — so a policy denial on 38 of 44 tools could never reach the chain, **in enforce mode or in warn**. Building #4991's warn-mode emitter on top of that would have produced exactly the "guard that cannot fire" the issue warned about.

## The change

Thread the logger whenever the server has one. It emits nothing by itself; it makes an existing emit reachable.

Deliberately still conditional. An unconditional `auditLogger: ctx.auditLogger` would put an `undefined` key on the deps object, and `config.auditLogger` would stop meaning "no durable chain configured" — the second test pins that.

## Verification

| mutation | result |
| --- | --- |
| revert to `run_dev_pipeline` only | 1 failed ✓ |
| thread unconditionally (`undefined` key) | 1 failed ✓ |

`memory_query` is the observation point — a plain `standardHandler` tool, so if it receives the logger the generic path does.

4,273 tests pass across `src/mcp` and the server-tools suite; typecheck, lint and the API-surface gate clean.

## What this does not do

It does not make warn-mode denials durable — that is #4991's actual body, and it needs an emit on the *would-have-denied* path, which currently produces one ephemeral `logger.warn`. This PR only removes the reason that emitter could not have worked. #4990 (audit logging off by default, unannounced) remains a separate compounding factor named in the same issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
