### PR TITLE
fix(security): report an empty ClawGuard allowlist as unmeasured, not as a deny

### DIFF
--- a/.changeset/clawguard-unmeasured-intersection.md
+++ b/.changeset/clawguard-unmeasured-intersection.md
@@ -1,0 +1,36 @@
+---
+'nexus-agents': patch
+---
+
+security(clawguard): make the empty allowlist say `unmeasured`, delete the dead parallel adapter, and pin the reachability gap
+
+The ClawGuard access-policy check decides on one field, `allowedTools`, and no
+production producer ever writes a tool name into it — the LLM deriver is asked
+for tool categories and pins `[]`, the keyword fallback hardcodes `[]`, and the
+derivation-failure paths choose between `[]` and `'*'`. So `[].includes(name)`
+was false for every call and the verdict was a constant function of
+`(mode, isRiskyTool(name))`, independent of the objective, the LLM output and
+the trust tier.
+
+`checkAccess` now returns a new `unmeasured` decision for an empty allowlist
+instead of falling through to a deny. The allowlist arm did not run; saying so
+is not the same as saying the call was examined and refused. The middleware
+allows the call, logs it, and deliberately does **not** record it as a
+violation — recording it would give the #2077 enforce-flip denominator a
+definitionally 100% violation rate that carries no information about precision.
+The unbypassable denylist still runs first and still denies.
+
+Also removed `guardMcpToolCall` and `createAccessPolicyMiddleware`, a second
+copy of the enforcement adapter with no production caller and no entry in
+`api-surface.txt`, and corrected three module headers that described behaviour
+the code does not have: that `off` is the default mode (it has been `audit`
+since v2.50), and that the denylist protects `~/.ssh/**`, `~/.aws/**` and
+`/etc/shadow` "even in `off` mode" (it is reachable only from `checkAccess`,
+which an absent policy short-circuits before). A denial now logs at `warn`
+rather than `info`, so the blocking mode no longer logs below the observing one.
+
+No behaviour change at runtime: the guard remains a pass-through at inbound MCP
+dispatch. Which boundary it should guard is open in #5022 — a 7-voter panel
+split 2-2-1-1 without clearing the bar — and the new
+`access-policy-reachability.test.ts` pins the current behaviour so that question
+cannot be answered silently by a change elsewhere.

--- a/packages/nexus-agents/src/security/access-constraint-deriver/access-policy-reachability.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/access-policy-reachability.test.ts
@@ -116,3 +116,75 @@ describe('ClawGuard reachability at inbound MCP dispatch (#5022)', () => {
     expect(result.isError).toBeUndefined();
   });
 });
+
+/**
+ * The `unmeasured` verdict is keyed on `allowedTools.length === 0`, which is
+ * sound only while NO producer ever intends a real allowlist. That makes it
+ * fail-OPEN by construction: a future deriver that genuinely computes an
+ * allowlist and returns `[]` on a parse failure would silently degrade to
+ * allow-all instead of denying.
+ *
+ * Rather than build speculative machinery for a producer that does not exist
+ * (YAGNI), this ratchets the premise. The day a producer emits a real tool
+ * name, this test fails and whoever wrote it has to revisit the branch in
+ * `enforcer.ts` and distinguish "no producer attempted" from "a producer
+ * attempted and came back empty".
+ */
+describe('producer contract: nothing intends a real allowlist yet (#5022)', () => {
+  it('has no production site assigning a non-empty allowedTools to a TaskAccessPolicy', async () => {
+    const { readFile, readdir } = await import('node:fs/promises');
+    const { join, dirname } = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
+
+    const srcRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+    async function walk(dir: string): Promise<string[]> {
+      const entries = await readdir(dir, { withFileTypes: true });
+      const out = await Promise.all(
+        entries.map(async (e) => {
+          const full = join(dir, e.name);
+          if (e.isDirectory()) return e.name === 'node_modules' ? [] : walk(full);
+          return e.isFile() && e.name.endsWith('.ts') && !e.name.includes('.test.') ? [full] : [];
+        })
+      );
+      return out.flat();
+    }
+
+    const offenders: string[] = [];
+    for (const file of await walk(srcRoot)) {
+      const text = await readFile(file, 'utf8');
+      // Only files that actually build a ClawGuard policy. Other types in the
+      // tree carry an unrelated `allowedTools` (role capabilities, expert
+      // config, the Claude CLI --allowedTools flag) that never reaches
+      // checkAccess.
+      if (!text.includes('TaskAccessPolicy')) continue;
+      for (const [i, line] of text.split('\n').entries()) {
+        const m = /^\s*allowedTools:\s*(.+?),?\s*$/.exec(line);
+        if (m === null) continue;
+        const value = m[1] ?? '';
+        const isEmptyOrWildcard = /^(\[\]|'\*')/.test(value);
+        // Type positions and spreads are declarations, not assignments.
+        const isDeclaration = value.startsWith('z.') || value.includes('|');
+        if (!isEmptyOrWildcard && !isDeclaration) {
+          offenders.push(`${file.slice(srcRoot.length + 1)}:${String(i + 1)}: ${line.trim()}`);
+        }
+      }
+    }
+
+    // Guard against the scan silently matching nothing: the known producers
+    // must be found, or this assertion would pass because the walk broke.
+    expect(offenders).toEqual([]);
+  });
+
+  it('finds the known empty-allowlist producers, so the scan above is not vacuous', async () => {
+    const { deriveFallbackPolicy } = await import('./fallback-regex.js');
+
+    const policy = deriveFallbackPolicy(
+      'read the repository and summarise it',
+      'audit',
+      'reachability-hash'
+    );
+
+    expect(policy.allowedTools).toEqual([]);
+  });
+});

--- a/packages/nexus-agents/src/security/access-constraint-deriver/access-policy-reachability.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/access-policy-reachability.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ClawGuard reachability contract (#5022).
+ *
+ * Every other test in this directory establishes the access policy itself,
+ * with `withAccessPolicy(...)`, and then asserts what the enforcer decides.
+ * That is the one input production never supplies: `withAccessPolicy` has
+ * exactly two production callers, both wrapping in-process orchestrator /
+ * expert execution, and an inbound MCP request is a SIBLING async context
+ * rather than a descendant of either. So 124 tests passed over a subsystem
+ * that was a pass-through for every real dispatch.
+ *
+ * These tests therefore assert REACHABILITY rather than verdicts: they run a
+ * handler through the real middleware stack the way the server does, with no
+ * policy in scope, and record what the guard actually does.
+ *
+ * WHY THIS PINS THE CURRENT (BROKEN) BEHAVIOUR ON PURPOSE. #5022 asks which
+ * boundary ClawGuard should guard, and a 7-voter panel split 2-2-1-1 without
+ * reaching the supermajority bar, so the question is open. Until it is
+ * answered, the failure mode to prevent is a SILENT change: someone
+ * establishing a policy at dispatch without deciding the boundary would flip
+ * enforcement on for every registered tool. If a change here turns these red,
+ * that is the signal — resolve #5022 and rewrite this file to state the new
+ * contract. Do not relax an assertion to make it green.
+ *
+ * @module security/access-constraint-deriver/access-policy-reachability.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { withMiddleware } from '../../mcp/middleware/middleware-chain.js';
+import { getActivePolicy, withAccessPolicy } from './mcp-guard.js';
+import type { TaskAccessPolicy } from './types.js';
+
+function policy(overrides: Partial<TaskAccessPolicy> = {}): TaskAccessPolicy {
+  return {
+    allowedTools: [],
+    allowedPathPatterns: [],
+    allowedOperations: '*',
+    objectiveHash: 'reachability-fixture',
+    derivedAt: '2026-08-27T00:00:00.000-04:00',
+    source: 'llm',
+    mode: 'enforce',
+    ...overrides,
+  };
+}
+
+function okResult(): { content: Array<{ type: 'text'; text: string }> } {
+  return { content: [{ type: 'text' as const, text: 'handler-ran' }] };
+}
+
+describe('ClawGuard reachability at inbound MCP dispatch (#5022)', () => {
+  it('observes no policy in scope when a wrapped tool is dispatched normally', async () => {
+    const seen: Array<TaskAccessPolicy | undefined> = [];
+    const wrapped = withMiddleware('exec_shell', () => {
+      seen.push(getActivePolicy());
+      return Promise.resolve(okResult());
+    });
+
+    await wrapped({});
+
+    // This is the whole defect in one assertion. When it starts failing,
+    // a policy reaches dispatch — which is a #5022 decision, not a refactor.
+    expect(seen).toEqual([undefined]);
+  });
+
+  it('runs the handler for a tool that `enforce` would deny, because the guard never evaluates', async () => {
+    const handler = vi.fn(() => Promise.resolve(okResult()));
+    const wrapped = withMiddleware('exec_shell', handler);
+
+    const result = (await wrapped({})) as { isError?: boolean };
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('does not gate an unbypassable denylisted tool at this boundary', async () => {
+    const handler = vi.fn(() => Promise.resolve(okResult()));
+    const wrapped = withMiddleware('git_push_force', handler);
+
+    const result = (await wrapped({})) as { isError?: boolean };
+
+    // `denylist.ts` calls these patterns unbypassable and `mcp-guard.ts` once
+    // claimed even `off` mode denied them. Neither holds here: the denylist
+    // lives inside `checkAccess`, which a missing policy short-circuits before.
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('DOES gate that same tool once a policy is in scope — so the stack itself is wired', async () => {
+    const handler = vi.fn(() => Promise.resolve(okResult()));
+    const wrapped = withMiddleware('git_push_force', handler);
+
+    const result = (await withAccessPolicy(policy(), () => wrapped({}))) as {
+      isError?: boolean;
+    };
+
+    // The contrast with the previous test is the point: the middleware is
+    // genuinely mounted and the enforcer genuinely works. Only the scope is
+    // wrong. This also keeps the three tests above from passing for a boring
+    // reason, such as the mount having been removed.
+    expect(result.isError).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('an empty allowlist is unmeasured, so a policy in scope does not deny everything', async () => {
+    const handler = vi.fn(() => Promise.resolve(okResult()));
+    const wrapped = withMiddleware('exec_shell', handler);
+
+    const result = (await withAccessPolicy(policy({ mode: 'enforce' }), () => wrapped({}))) as {
+      isError?: boolean;
+    };
+
+    // Before #5022, establishing a policy at dispatch would have denied every
+    // guarded call under `enforce`, since no producer emits tool names. This
+    // is the assertion that makes fixing the scope safe rather than an outage.
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/security/access-constraint-deriver/access-policy-reachability.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/access-policy-reachability.test.ts
@@ -130,61 +130,110 @@ describe('ClawGuard reachability at inbound MCP dispatch (#5022)', () => {
  * `enforcer.ts` and distinguish "no producer attempted" from "a producer
  * attempted and came back empty".
  */
+/** A site that WRITES `allowedTools`, and whether the value is a bare literal. */
+interface WriteSite {
+  readonly where: string;
+  readonly text: string;
+  readonly literal: boolean;
+}
+
+/**
+ * Classifies one source line. Returns undefined when the line is not a write
+ * to `allowedTools` — a mention inside a message template, a
+ * `matchedRule: 'allowedTools'` string, a read such as
+ * `policy.allowedTools === '*'`, or a Zod/type declaration.
+ */
+function classifyAllowedToolsLine(trimmed: string): { literal: boolean } | undefined {
+  const colon = /^allowedTools:\s*(.+?),?$/.exec(trimmed);
+  const shorthand = /^allowedTools,$/.test(trimmed) || /[{,]\s*allowedTools\s*[,}]/.test(trimmed);
+  const memberAssign = /\.allowedTools\s*=[^=]/.test(trimmed);
+  if (colon === null && !shorthand && !memberAssign) return undefined;
+
+  const value = (colon?.[1] ?? '').trim();
+  // Type positions and Zod schema fields declare the field, not a value.
+  if (colon !== null && /^(z\.|.*\|)/.test(value)) return undefined;
+
+  // A literal `[]` or `'*'` is the only shape meaning "no producer intends an
+  // allowlist". Shorthand (`{ allowedTools, ...rest }`) and post-hoc
+  // assignment (`policy.allowedTools = names`) are deliberately NOT literals:
+  // they are the shapes a real producer would take, and their arrival is
+  // exactly the trigger to revisit the `unmeasured` branch in enforcer.ts.
+  return { literal: colon !== null && /^(\[\]|'\*')$/.test(value) };
+}
+
+async function listSourceFiles(dir: string): Promise<string[]> {
+  const { readdir } = await import('node:fs/promises');
+  const { join } = await import('node:path');
+  const entries = await readdir(dir, { withFileTypes: true });
+  const out = await Promise.all(
+    entries.map(async (e) => {
+      const full = join(dir, e.name);
+      if (e.isDirectory()) return e.name === 'node_modules' ? [] : listSourceFiles(full);
+      return e.isFile() && e.name.endsWith('.ts') && !e.name.includes('.test.') ? [full] : [];
+    })
+  );
+  return out.flat();
+}
+
+/** Every site that writes `allowedTools`, in files that build a ClawGuard policy. */
+async function scanProducers(): Promise<{ filesScanned: number; sites: WriteSite[] }> {
+  const { readFile } = await import('node:fs/promises');
+  const { join, dirname } = await import('node:path');
+  const { fileURLToPath } = await import('node:url');
+
+  const srcRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+  const sites: WriteSite[] = [];
+  let filesScanned = 0;
+
+  for (const file of await listSourceFiles(srcRoot)) {
+    const text = await readFile(file, 'utf8');
+    // Elsewhere in the tree `allowedTools` belongs to unrelated types — role
+    // capabilities, expert config, the Claude CLI flag — that never reach
+    // checkAccess.
+    if (!text.includes('TaskAccessPolicy')) continue;
+    filesScanned += 1;
+
+    for (const [i, line] of text.split('\n').entries()) {
+      if (!line.includes('allowedTools')) continue;
+      const trimmed = line.trim();
+      const verdict = classifyAllowedToolsLine(trimmed);
+      if (verdict === undefined) continue;
+      sites.push({
+        where: `${file.slice(srcRoot.length + 1)}:${String(i + 1)}`,
+        text: trimmed,
+        literal: verdict.literal,
+      });
+    }
+  }
+  return { filesScanned, sites };
+}
+
 describe('producer contract: nothing intends a real allowlist yet (#5022)', () => {
-  it('has no production site assigning a non-empty allowedTools to a TaskAccessPolicy', async () => {
-    const { readFile, readdir } = await import('node:fs/promises');
-    const { join, dirname } = await import('node:path');
-    const { fileURLToPath } = await import('node:url');
+  it('finds the known producers, so the scan cannot pass by finding nothing', async () => {
+    const { filesScanned, sites } = await scanProducers();
 
-    const srcRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    // Without these the offender check below is vacuous: rename
+    // TaskAccessPolicy, or let srcRoot resolve one level off, and the filter
+    // matches zero files while the test stays green.
+    expect(filesScanned).toBeGreaterThan(0);
+    expect(sites.length).toBeGreaterThan(0);
 
-    async function walk(dir: string): Promise<string[]> {
-      const entries = await readdir(dir, { withFileTypes: true });
-      const out = await Promise.all(
-        entries.map(async (e) => {
-          const full = join(dir, e.name);
-          if (e.isDirectory()) return e.name === 'node_modules' ? [] : walk(full);
-          return e.isFile() && e.name.endsWith('.ts') && !e.name.includes('.test.') ? [full] : [];
-        })
-      );
-      return out.flat();
+    for (const producer of ['deriver.ts', 'llm-deriver.ts', 'fallback-regex.ts']) {
+      expect(sites.some((site) => site.where.includes(producer))).toBe(true);
     }
-
-    const offenders: string[] = [];
-    for (const file of await walk(srcRoot)) {
-      const text = await readFile(file, 'utf8');
-      // Only files that actually build a ClawGuard policy. Other types in the
-      // tree carry an unrelated `allowedTools` (role capabilities, expert
-      // config, the Claude CLI --allowedTools flag) that never reaches
-      // checkAccess.
-      if (!text.includes('TaskAccessPolicy')) continue;
-      for (const [i, line] of text.split('\n').entries()) {
-        const m = /^\s*allowedTools:\s*(.+?),?\s*$/.exec(line);
-        if (m === null) continue;
-        const value = m[1] ?? '';
-        const isEmptyOrWildcard = /^(\[\]|'\*')/.test(value);
-        // Type positions and spreads are declarations, not assignments.
-        const isDeclaration = value.startsWith('z.') || value.includes('|');
-        if (!isEmptyOrWildcard && !isDeclaration) {
-          offenders.push(`${file.slice(srcRoot.length + 1)}:${String(i + 1)}: ${line.trim()}`);
-        }
-      }
-    }
-
-    // Guard against the scan silently matching nothing: the known producers
-    // must be found, or this assertion would pass because the walk broke.
-    expect(offenders).toEqual([]);
   });
 
-  it('finds the known empty-allowlist producers, so the scan above is not vacuous', async () => {
-    const { deriveFallbackPolicy } = await import('./fallback-regex.js');
+  it('has no production site assigning a real allowlist to a TaskAccessPolicy', async () => {
+    const { sites } = await scanProducers();
 
-    const policy = deriveFallbackPolicy(
-      'read the repository and summarise it',
-      'audit',
-      'reachability-hash'
-    );
-
-    expect(policy.allowedTools).toEqual([]);
+    // `unmeasured` is keyed on `allowedTools.length === 0`, which is sound only
+    // while nothing INTENDS a real allowlist — it is fail-open by construction.
+    // Rather than build machinery for a producer that does not exist, this
+    // ratchets the premise: when one lands, this fails and names it, and the
+    // author has to distinguish "no producer attempted" from "a producer
+    // attempted and came back empty".
+    expect(
+      sites.filter((site) => !site.literal).map((site) => `${site.where}: ${site.text}`)
+    ).toEqual([]);
   });
 });

--- a/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.test.ts
@@ -12,7 +12,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { ILogger } from '../../core/index.js';
 import { createAccessPolicyChainMiddleware } from './chain-adapter.js';
-import { withAccessPolicy } from './mcp-guard.js';
+import { withAccessPolicy, withAuditTrail } from './mcp-guard.js';
+import type { AuditEvent, AuditTrail } from '../audit-trail.js';
 import type { TaskAccessPolicy } from './types.js';
 import type { MiddlewareContext } from '../../mcp/middleware/middleware-chain.js';
 import type { RequestContext } from '../../mcp/middleware/request-context.js';
@@ -124,7 +125,7 @@ describe('createAccessPolicyChainMiddleware', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0]?.text).toContain('access denied');
     expect(handler).not.toHaveBeenCalled();
-    expect(ctx.logger.info).toHaveBeenCalledWith(
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
       'access-policy: tool call denied',
       expect.objectContaining({ tool: 'read_file', requestId: 'req-test-1' })
     );
@@ -175,5 +176,120 @@ describe('createAccessPolicyChainMiddleware', () => {
     );
 
     expect(result.content[0]?.text).toBe('handler-ran');
+  });
+
+  it('records an audit-mode violation durably on the log-and-allow branch', async () => {
+    const events: AuditEvent[] = [];
+    const trail = { append: (e: AuditEvent) => void events.push(e) } as unknown as AuditTrail;
+    const mw = createAccessPolicyChainMiddleware('exec_shell');
+
+    await withAccessPolicy(policy({ mode: 'audit', allowedTools: ['read_file'] }), () =>
+      withAuditTrail(trail, () => mw({}, makeCtx(), makeHandler()))
+    );
+
+    expect(events).toHaveLength(1);
+  });
+
+  it('logs a denial at warn, not below the audit-mode observation (#5022)', async () => {
+    const mw = createAccessPolicyChainMiddleware('exec_shell');
+    const ctx = makeCtx();
+
+    await withAccessPolicy(policy({ mode: 'enforce', allowedTools: ['read_file'] }), () =>
+      mw({}, ctx, makeHandler())
+    );
+
+    // A denial previously used logger.info while an audit-mode violation used
+    // logger.warn — the blocking mode logged BELOW the observing one.
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      'access-policy: tool call denied',
+      expect.objectContaining({ tool: 'exec_shell' })
+    );
+    expect(ctx.logger.info).not.toHaveBeenCalled();
+  });
+
+  describe('empty allowedTools is unmeasured, not a blanket deny (#5022)', () => {
+    // Every production producer of allowedTools emits `[]` or `'*'`, never a
+    // tool name. Before #5022 that made `[].includes(name)` false for every
+    // call, so the verdict was a constant function of (mode, isRiskyTool) —
+    // and under `enforce` it would have denied EVERY guarded call the moment
+    // the check became reachable.
+    const empty = { allowedTools: [] as readonly string[] };
+
+    it.each(['enforce', 'confirm_risky', 'audit'] as const)(
+      'runs the handler in %s mode rather than denying on an empty allowlist',
+      async (mode) => {
+        const mw = createAccessPolicyChainMiddleware('exec_shell');
+        const handler = makeHandler();
+
+        const result = await withAccessPolicy(policy({ mode, ...empty }), () =>
+          mw({}, makeCtx(), handler)
+        );
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(result.isError).toBeUndefined();
+      }
+    );
+
+    it('does NOT record a violation for a check that never ran', async () => {
+      const events: AuditEvent[] = [];
+      const trail = { append: (e: AuditEvent) => void events.push(e) } as unknown as AuditTrail;
+      const mw = createAccessPolicyChainMiddleware('exec_shell');
+
+      await withAccessPolicy(policy({ mode: 'audit', ...empty }), () =>
+        withAuditTrail(trail, () => mw({}, makeCtx(), makeHandler()))
+      );
+
+      // Recording this as a violation would give the #2077 enforce-flip
+      // denominator a definitionally 100% violation rate carrying no
+      // information about precision. The sibling test above proves the same
+      // harness DOES capture a real violation, so this is not a dead assertion.
+      expect(events).toEqual([]);
+    });
+
+    it('still denies an unbypassable tool when the allowlist is empty', async () => {
+      const mw = createAccessPolicyChainMiddleware('git_push_force');
+      const handler = makeHandler();
+
+      const result = await withAccessPolicy(policy({ mode: 'audit', ...empty }), () =>
+        mw({}, makeCtx(), handler)
+      );
+
+      // `unmeasured` must not swallow the denylist, which runs first.
+      expect(result.isError).toBe(true);
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#4097 regression: audit mode always ALLOWS', () => {
+    it('returns the handler result when no trail is present', async () => {
+      const mw = createAccessPolicyChainMiddleware('exec_shell');
+      const handler = makeHandler();
+
+      const result = await withAccessPolicy(
+        policy({ mode: 'audit', allowedTools: ['read_file'] }),
+        () => mw({}, makeCtx(), handler)
+      );
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(result.content[0]?.text).toBe('handler-ran');
+    });
+
+    it('returns the handler result and does not throw when the sink throws', async () => {
+      const throwingTrail = {
+        append: () => {
+          throw new Error('sink exploded');
+        },
+      } as unknown as AuditTrail;
+      const mw = createAccessPolicyChainMiddleware('exec_shell');
+      const handler = makeHandler();
+
+      const result = await withAccessPolicy(
+        policy({ mode: 'audit', allowedTools: ['read_file'] }),
+        () => withAuditTrail(throwingTrail, () => mw({}, makeCtx(), handler))
+      );
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(result.content[0]?.text).toBe('handler-ran');
+    });
   });
 });

--- a/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.test.ts
@@ -230,6 +230,23 @@ describe('createAccessPolicyChainMiddleware', () => {
       }
     );
 
+    it('logs the unmeasured verdict — the log IS the disclosure', async () => {
+      const mw = createAccessPolicyChainMiddleware('exec_shell');
+      const ctx = makeCtx();
+
+      await withAccessPolicy(policy({ mode: 'enforce', ...empty }), () =>
+        mw({}, ctx, makeHandler())
+      );
+
+      // The verdict ALLOWS the call and records nothing durable, so this line
+      // is the only trace that a check did not run. Without this assertion,
+      // deleting the log leaves the whole suite green.
+      expect(ctx.logger.info).toHaveBeenCalledWith(
+        'access-policy: allowlist unmeasured',
+        expect.objectContaining({ tool: 'exec_shell' })
+      );
+    });
+
     it('does NOT record a violation for a check that never ran', async () => {
       const events: AuditEvent[] = [];
       const trail = { append: (e: AuditEvent) => void events.push(e) } as unknown as AuditTrail;

--- a/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.ts
@@ -1,14 +1,23 @@
 /**
  * Access Constraint Deriver — MCP middleware-chain adapter (#1977 activation).
  *
- * Bridges `createAccessPolicyMiddleware` (which returns a generic
- * `Promise<unknown>`-shaped middleware) to the strongly-typed `Middleware`
- * contract used by `mcp/middleware/middleware-chain.ts`.
+ * The only `Middleware`-shaped entry point into the ClawGuard enforcer. It is
+ * mounted into the standard stack (`mcp/middleware/middleware-chain.ts`), so
+ * every tool wrapped via `withMiddleware` passes through it.
  *
- * Mounted into the standard middleware stack so every tool call passes
- * through the ClawGuard enforcer. When no orchestrator has wrapped the
- * call with `withAccessPolicy(...)`, this adapter is a no-op pass-through
- * — runtime behavior is unchanged for callers that don't set up a policy.
+ * KNOWN GAP — the policy is not in scope here (#5022). The enforcer reads its
+ * `TaskAccessPolicy` from `AsyncLocalStorage`, and the only two production
+ * callers of `withAccessPolicy` wrap in-process orchestrator/expert execution
+ * (`mcp/tools/orchestrate.ts`, `mcp/tools/execute-expert.ts`). An inbound MCP
+ * request handled by the SDK transport is a SIBLING async context, never a
+ * descendant of one of those `run()` calls, so `getActivePolicy()` returns
+ * undefined and this adapter is a pass-through for every real dispatch.
+ *
+ * That is a boundary question, not a bug to patch here: either the policy is
+ * established at inbound dispatch, or the enforcer belongs at the agent
+ * tool-call seam where its per-objective policy actually has scope. #5022
+ * holds the decision; `access-policy-reachability.test.ts` pins the current
+ * behaviour so it cannot change without that decision being made.
  *
  * @module security/access-constraint-deriver/chain-adapter
  */
@@ -29,7 +38,8 @@ function toGuardArgs(args: unknown): GuardArgs | undefined {
  * Builds a middleware-chain-compatible access-policy middleware for
  * `toolName`. Reads the active `TaskAccessPolicy` from `AsyncLocalStorage`
  * (populated by `withAccessPolicy`). When no policy is active OR the
- * policy is in `off` mode, the middleware is a no-op pass-through.
+ * policy is in `off` mode, the middleware is a no-op pass-through — see the
+ * module note on why that is every inbound dispatch today.
  */
 export function createAccessPolicyChainMiddleware(toolName: string): Middleware {
   return async (args, ctx, next) => {
@@ -41,6 +51,19 @@ export function createAccessPolicyChainMiddleware(toolName: string): Middleware 
     const decision = checkAccess(toolName, policy, toGuardArgs(args));
 
     if (decision.decision === 'allow') {
+      return next(args, ctx);
+    }
+    if (decision.decision === 'unmeasured') {
+      // NOT a violation: the allowlist arm never ran, so there is nothing to
+      // record against the #2077 denominator. Logged so the inertness is
+      // visible, and deliberately NOT sent to recordAuditModeViolation (#5022).
+      ctx.logger.debug('access-policy: allowlist unmeasured', {
+        tool: toolName,
+        reason: decision.reason,
+        policySource: policy.source,
+        mode: policy.mode,
+        requestId: ctx.requestContext.requestId,
+      });
       return next(args, ctx);
     }
     if (decision.decision === 'log-and-allow') {
@@ -59,7 +82,9 @@ export function createAccessPolicyChainMiddleware(toolName: string): Middleware 
       });
       return next(args, ctx);
     }
-    ctx.logger.info('access-policy: tool call denied', {
+    // .warn, not .info: a denial must not be logged BELOW an audit-mode
+    // observation, which uses .warn above (#5022).
+    ctx.logger.warn('access-policy: tool call denied', {
       tool: toolName,
       reason: decision.reason,
       matchedRule: decision.matchedRule,

--- a/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/chain-adapter.ts
@@ -55,9 +55,13 @@ export function createAccessPolicyChainMiddleware(toolName: string): Middleware 
     }
     if (decision.decision === 'unmeasured') {
       // NOT a violation: the allowlist arm never ran, so there is nothing to
-      // record against the #2077 denominator. Logged so the inertness is
-      // visible, and deliberately NOT sent to recordAuditModeViolation (#5022).
-      ctx.logger.debug('access-policy: allowlist unmeasured', {
+      // record against the #2077 denominator, and this is deliberately NOT
+      // sent to recordAuditModeViolation (#5022).
+      //
+      // .info, not .debug: the whole point of an `unmeasured` verdict is that
+      // absence is VISIBLE. At debug level the disclosure exists only in the
+      // source, which is the failure this verdict was introduced to fix.
+      ctx.logger.info('access-policy: allowlist unmeasured', {
         tool: toolName,
         reason: decision.reason,
         policySource: policy.source,

--- a/packages/nexus-agents/src/security/access-constraint-deriver/denylist.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/denylist.ts
@@ -10,6 +10,13 @@
  * that says "I need to view my AWS credentials to debug" would otherwise
  * produce a policy allowing `~/.aws/**`. The denylist refuses regardless.
  *
+ * REACH (#5022): "unbypassable" describes precedence WITHIN `checkAccess`, not
+ * coverage of the process. `isToolDenied` / `isPathDenied` have exactly one
+ * caller each — `checkAccess` — which is only entered when a derived policy is
+ * in AsyncLocalStorage. That is not the case at inbound MCP dispatch, so these
+ * patterns do not currently gate tool calls arriving over the MCP transport.
+ * Which boundary they should gate is the open question in #5022.
+ *
  * @module security/access-constraint-deriver/denylist
  */
 

--- a/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
@@ -24,11 +24,15 @@ import type { AccessDecision, TaskAccessPolicy } from './types.js';
  *    of policy. This is unbypassable even in `off` mode.
  * 2. If a file-path argument is provided and matches an unbypassable path
  *    pattern (e.g. `~/.ssh/**`, `/etc/shadow`) → deny regardless.
- * 3. Otherwise, fall back to the per-task policy (bypass in skeleton).
+ * 3. Otherwise, fall back to the per-task policy. An empty `allowedTools`
+ *    yields `unmeasured` — the allowlist arm did not run — rather than a
+ *    blanket deny (#5022).
  *
  * The denylist check runs before the policy check so a malicious LLM-derived
  * policy cannot grant access to secrets/credentials by listing the tool in
- * `allowedTools`.
+ * `allowedTools`. Both denylist checks are reachable only from here, so they
+ * protect exactly the callers that reach `checkAccess` — see the module note
+ * in `chain-adapter.ts` on which boundary that currently is.
  */
 export function checkAccess(
   toolName: string,
@@ -55,6 +59,29 @@ export function checkAccess(
 
   // 3. Per-task policy check.
   if (policy.allowedTools === '*') return { decision: 'allow' };
+
+  // 3a. An EMPTY allowlist is the absence of a measurement, not a decision to
+  //     deny everything (#5022). No production producer of `allowedTools` ever
+  //     emits a tool name: the LLM deriver is asked for tool_categories /
+  //     file_scope / network_scope and pins `allowedTools: []`
+  //     (llm-deriver.ts), the keyword fallback hardcodes `[]`
+  //     (fallback-regex.ts), and both derivation-failure paths choose between
+  //     `[]` and `'*'`. So `[].includes(name)` is false for every call, and
+  //     without this branch the verdict below is a constant function of
+  //     (mode, isRiskyTool(name)) — independent of the objective, the LLM
+  //     output and the trust tier.
+  //
+  //     Reporting that constant as a deny would be wrong twice over: it would
+  //     block every guarded call the moment the check became reachable, and it
+  //     would record a violation for a check that never actually ran. Say
+  //     `unmeasured` instead, and let the caller allow the call while
+  //     recording that the allowlist arm did not evaluate.
+  if (policy.allowedTools.length === 0) {
+    return {
+      decision: 'unmeasured',
+      reason: `allowlist arm did not run for tool "${toolName}": the derived policy (source "${policy.source}", mode "${policy.mode}") carries an empty allowedTools, and no producer emits tool names (#5022)`,
+    };
+  }
 
   if (policy.allowedTools.includes(toolName)) return { decision: 'allow' };
 

--- a/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/enforcer.ts
@@ -19,9 +19,11 @@ import type { AccessDecision, TaskAccessPolicy } from './types.js';
  * Checks a proposed tool call against the unbypassable denylist AND the
  * task's derived access policy.
  *
- * Order of operations (important — the denylist is FIRST and unbypassable):
- * 1. If the tool is on the hardcoded deny-tool list → deny regardless
- *    of policy. This is unbypassable even in `off` mode.
+ * Order of operations (the denylist is FIRST, and wins over the policy):
+ * 1. If the tool is on the hardcoded deny-tool list → deny regardless of what
+ *    the policy says. Note "regardless of the policy", NOT "in every mode":
+ *    the sole production caller returns before `checkAccess` when the mode is
+ *    `off`, so no code path reaches this line in that mode (#5022).
  * 2. If a file-path argument is provided and matches an unbypassable path
  *    pattern (e.g. `~/.ssh/**`, `/etc/shadow`) → deny regardless.
  * 3. Otherwise, fall back to the per-task policy. An empty `allowedTools`

--- a/packages/nexus-agents/src/security/access-constraint-deriver/index.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/index.ts
@@ -21,9 +21,7 @@ export { checkAccess } from './enforcer.js';
 export {
   withAccessPolicy,
   getActivePolicy,
-  guardMcpToolCall,
   denyToToolResult,
-  createAccessPolicyMiddleware,
   withAuditTrail,
   getActiveAuditTrail,
   recordAuditModeViolation,

--- a/packages/nexus-agents/src/security/access-constraint-deriver/mcp-guard.test.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/mcp-guard.test.ts
@@ -2,22 +2,16 @@
  * Tests for the MCP dispatch guard (#1977 final wiring).
  *
  * Covers:
- * - guardMcpToolCall with / without an active policy
  * - withAccessPolicy ALS propagation across async boundaries
- * - createAccessPolicyMiddleware behavior in all three modes
  * - denyToToolResult format shape
  * - End-to-end smoke: derive policy → run tool call under guard → assert
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
-  checkAccess,
-  createAccessPolicyMiddleware,
   denyToToolResult,
-  deriveAccessPolicy,
   getActivePolicy,
   getActiveAuditTrail,
-  guardMcpToolCall,
   recordAuditModeViolation,
   resetPolicyCache,
   withAccessPolicy,
@@ -88,40 +82,6 @@ describe('getActivePolicy / withAccessPolicy', () => {
   });
 });
 
-describe('guardMcpToolCall', () => {
-  it('allows any tool when no policy is active', () => {
-    expect(guardMcpToolCall('gh_issue_close').decision).toBe('allow');
-  });
-
-  it('delegates to checkAccess when a policy is active', async () => {
-    const policy = policyFactory({
-      allowedTools: ['gh_issue_view'],
-      mode: 'enforce',
-    });
-    await withAccessPolicy(policy, () => {
-      expect(guardMcpToolCall('gh_issue_view').decision).toBe('allow');
-      expect(guardMcpToolCall('gh_issue_close').decision).toBe('deny');
-      return Promise.resolve();
-    });
-  });
-
-  it('applies path denylist even with bypass policy', async () => {
-    await withAccessPolicy(policyFactory(), () => {
-      const result = guardMcpToolCall('read_file', { path: '~/.ssh/id_rsa' });
-      expect(result.decision).toBe('deny');
-      return Promise.resolve();
-    });
-  });
-
-  it('applies tool denylist even with bypass policy', async () => {
-    await withAccessPolicy(policyFactory(), () => {
-      const result = guardMcpToolCall('git_push_force');
-      expect(result.decision).toBe('deny');
-      return Promise.resolve();
-    });
-  });
-});
-
 describe('denyToToolResult', () => {
   it('returns an MCP-compliant isError shape', () => {
     const res = denyToToolResult(
@@ -133,119 +93,6 @@ describe('denyToToolResult', () => {
     expect(res.content[0]?.text).toContain('forbidden tool');
     expect(res.content[0]?.text).toContain('req_abc');
     expect(res.content[0]?.text).toContain('unbypassable:tool');
-  });
-});
-
-describe('createAccessPolicyMiddleware', () => {
-  interface Ctx {
-    readonly requestContext: { readonly requestId: string };
-  }
-
-  function makeCtx(): Ctx {
-    return { requestContext: { requestId: 'req_test' } };
-  }
-
-  interface MockLogger {
-    warn: ReturnType<typeof vi.fn>;
-    info: ReturnType<typeof vi.fn>;
-  }
-
-  function makeLogger(): MockLogger {
-    return {
-      warn: vi.fn(),
-      info: vi.fn(),
-    };
-  }
-
-  it('is a pass-through when no policy is active', async () => {
-    const logger = makeLogger();
-    const mw = createAccessPolicyMiddleware({ toolName: 'gh_issue_view', logger: logger as never });
-    const next = vi.fn(() => Promise.resolve({ ok: true }));
-    const result = await mw({ a: 1 }, makeCtx(), next);
-    expect(next).toHaveBeenCalledOnce();
-    expect(result).toEqual({ ok: true });
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
-
-  it('is a pass-through in off mode', async () => {
-    const logger = makeLogger();
-    const mw = createAccessPolicyMiddleware({ toolName: 'any_tool', logger: logger as never });
-    const next = vi.fn(() => Promise.resolve({ ok: true }));
-    await withAccessPolicy(policyFactory({ mode: 'off' }), () => mw({}, makeCtx(), next as never));
-    expect(next).toHaveBeenCalledOnce();
-  });
-
-  it('allows in audit mode but logs when tool is out of scope', async () => {
-    const logger = makeLogger();
-    const mw = createAccessPolicyMiddleware({
-      toolName: 'gh_issue_close',
-      logger: logger as never,
-    });
-    const next = vi.fn(() => Promise.resolve({ ok: true }));
-    await withAccessPolicy(
-      policyFactory({
-        allowedTools: ['gh_issue_view'],
-        mode: 'audit',
-        source: 'llm',
-      }),
-      () => mw({}, makeCtx(), next as never)
-    );
-    expect(next).toHaveBeenCalledOnce();
-    expect(logger.warn).toHaveBeenCalledWith(
-      'access-policy: audit violation',
-      expect.objectContaining({
-        tool: 'gh_issue_close',
-        policySource: 'llm',
-      })
-    );
-  });
-
-  it('denies in enforce mode when tool is out of scope', async () => {
-    const logger = makeLogger();
-    const mw = createAccessPolicyMiddleware({
-      toolName: 'gh_issue_close',
-      logger: logger as never,
-    });
-    const next = vi.fn(() => Promise.resolve({ ok: true }));
-    const result = (await withAccessPolicy(
-      policyFactory({
-        allowedTools: ['gh_issue_view'],
-        mode: 'enforce',
-        source: 'llm',
-      }),
-      async () => mw({}, makeCtx(), next as never)
-    )) as { isError?: boolean };
-    expect(next).not.toHaveBeenCalled();
-    expect(result.isError).toBe(true);
-    expect(logger.info).toHaveBeenCalledWith(
-      'access-policy: tool call denied',
-      expect.objectContaining({ tool: 'gh_issue_close', mode: 'enforce' })
-    );
-  });
-
-  it('denies unbypassable tools even under audit mode', async () => {
-    const logger = makeLogger();
-    const mw = createAccessPolicyMiddleware({
-      toolName: 'git_push_force',
-      logger: logger as never,
-    });
-    const next = vi.fn(() => Promise.resolve({ ok: true }));
-    const result = (await withAccessPolicy(policyFactory({ mode: 'audit' }), async () =>
-      mw({}, makeCtx(), next as never)
-    )) as { isError?: boolean };
-    expect(next).not.toHaveBeenCalled();
-    expect(result.isError).toBe(true);
-  });
-
-  it('extracts path from args for path denylist check', async () => {
-    const logger = makeLogger();
-    const mw = createAccessPolicyMiddleware({ toolName: 'read_file', logger: logger as never });
-    const next = vi.fn(() => Promise.resolve({ ok: true }));
-    const result = (await withAccessPolicy(policyFactory({ mode: 'enforce' }), async () =>
-      mw({ path: '~/.ssh/id_rsa' }, makeCtx(), next as never)
-    )) as { isError?: boolean };
-    expect(next).not.toHaveBeenCalled();
-    expect(result.isError).toBe(true);
   });
 });
 
@@ -302,84 +149,5 @@ describe('recordAuditModeViolation (#4097)', () => {
       }).not.toThrow();
       return Promise.resolve();
     });
-  });
-});
-
-describe('log-and-allow regression: audit mode always ALLOWS (#4097)', () => {
-  function makeCtx(): { readonly requestContext: { readonly requestId: string } } {
-    return { requestContext: { requestId: 'req_reg' } };
-  }
-  const logger = { warn: vi.fn(), info: vi.fn() };
-  const auditPolicy = policyFactory({
-    allowedTools: ['gh_issue_view'],
-    mode: 'audit',
-    source: 'llm',
-  });
-
-  it('returns next() result with no trail present', async () => {
-    const mw = createAccessPolicyMiddleware({ toolName: 'gh_issue_close', logger });
-    const next = vi.fn(() => Promise.resolve({ ok: true }));
-    const result = await withAccessPolicy(auditPolicy, () => mw({}, makeCtx(), next as never));
-    expect(next).toHaveBeenCalledOnce();
-    expect(result).toEqual({ ok: true });
-  });
-
-  it('returns next() result and does not throw when emit fails', async () => {
-    const throwingTrail = {
-      append: () => {
-        throw new Error('sink exploded');
-      },
-    } as unknown as AuditTrail;
-    const mw = createAccessPolicyMiddleware({ toolName: 'gh_issue_close', logger });
-    const next = vi.fn(() => Promise.resolve({ ok: true }));
-    const result = await withAccessPolicy(auditPolicy, () =>
-      withAuditTrail(throwingTrail, () => mw({}, makeCtx(), next as never))
-    );
-    expect(next).toHaveBeenCalledOnce();
-    expect(result).toEqual({ ok: true });
-  });
-});
-
-describe('end-to-end smoke: derive → withAccessPolicy → guarded dispatch', () => {
-  it('allows a read_file under a read-only LLM-derived policy', async () => {
-    // Tier 3 skips LLM, gets fallback "read-only" from the keyword deriver.
-    const policy = await deriveAccessPolicy('summarize the README', {
-      trustTier: '3',
-      mode: 'enforce',
-    });
-    expect(policy.source).toBe('fallback-keyword');
-
-    let handlerRan = false;
-    await withAccessPolicy(policy, () => {
-      const decision = guardMcpToolCall('memory_query', { path: 'docs/README.md' });
-      if (decision.decision === 'allow') handlerRan = true;
-      return Promise.resolve();
-    });
-    // Fallback policy has allowedTools: [] (not '*'), so by default nothing
-    // is explicitly allowed — but with mode=enforce we get a deny, not an
-    // allow. This test verifies the path ran through the guard; actual
-    // allow semantics are covered by the dedicated unit tests above.
-    expect(handlerRan).toBe(false);
-  });
-
-  it('denies a denylisted tool even when LLM would have granted it', async () => {
-    const policy: TaskAccessPolicy = {
-      allowedTools: ['git_push_force'], // compromised LLM output
-      allowedPathPatterns: [],
-      allowedOperations: '*',
-      objectiveHash: 'bad1234567890abc',
-      derivedAt: '2026-04-19T00:00:00.000Z',
-      source: 'llm',
-      mode: 'enforce',
-    };
-    let result: unknown = null;
-    await withAccessPolicy(policy, () => {
-      result = guardMcpToolCall('git_push_force');
-      return Promise.resolve();
-    });
-    expect((result as { decision: string }).decision).toBe('deny');
-    // Sanity: direct checkAccess agrees
-    const direct = checkAccess('git_push_force', policy);
-    expect(direct.decision).toBe('deny');
   });
 });

--- a/packages/nexus-agents/src/security/access-constraint-deriver/mcp-guard.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/mcp-guard.ts
@@ -1,26 +1,32 @@
 /**
  * Access Constraint Deriver — MCP tool dispatch guard (#1977 final wiring).
  *
- * Per-call helper and middleware factory that plugs the access-constraint
- * enforcer into the MCP tool dispatch path. Runs AFTER policy derivation
- * (deriver.ts owns that) and BEFORE the tool handler executes.
+ * Owns the two AsyncLocalStorage channels the guard reads from — the derived
+ * `TaskAccessPolicy` and the `AuditTrail` — plus the deny-result formatter.
+ * The enforcement middleware itself lives in `chain-adapter.ts`; this module
+ * previously carried a second, parallel copy of it (`createAccessPolicyMiddleware`)
+ * and a per-call helper (`guardMcpToolCall`), both of which had no production
+ * caller and were removed in #5022.
  *
- * Behavior matrix:
- * - mode=off → no-op, allows every call (this is the default; runtime
- *   behavior is unchanged from pre-#1977)
- * - mode=audit → checks against the policy; on violation, logs a warning
- *   and still forwards to the handler
- * - mode=enforce → checks against the policy; on violation, returns an
- *   MCP-format isError result without invoking the handler
+ * Behaviour matrix (as evaluated by `checkAccess`, reached via chain-adapter):
+ * - mode=off → no-op pass-through, allows every call
+ * - mode=audit (the DEFAULT since v2.50, see config.ts) → checks against the
+ *   policy; on violation, logs a warning and still forwards to the handler
+ * - mode=confirm_risky → denies violations on risky tools, log-and-allows on
+ *   read-only ones
+ * - mode=enforce → denies every violation
  *
- * The enforcer's hardcoded denylist (denylist.ts) runs FIRST regardless
- * of mode. Even `off` mode denies destructive tools and secret paths.
+ * SCOPE (#5022): the denylist in `denylist.ts` runs first WITHIN `checkAccess`,
+ * but `checkAccess` is only reached when a policy is in ALS. It is not in scope
+ * at inbound MCP dispatch, and `off` returns before the check regardless — so
+ * the denylist does NOT currently protect `~/.ssh/**`, `~/.aws/**` or
+ * `/etc/shadow` at that boundary in any mode. An earlier version of this header
+ * claimed it did.
  *
  * @module security/access-constraint-deriver/mcp-guard
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { checkAccess } from './enforcer.js';
 import type { AccessDecision, TaskAccessPolicy } from './types.js';
 import { emitClawGuardViolation, type AuditTrail } from '../audit-trail.js';
 
@@ -88,8 +94,11 @@ export function recordAuditModeViolation(input: {
  * Run `fn` with `policy` available to any nested MCP tool dispatch.
  *
  * Orchestrators (orchestrate, execute_expert, etc.) derive a policy at
- * task start and wrap downstream work in this helper. Tool handlers that
- * use `guardMcpToolCall` will read the policy from ALS.
+ * task start and wrap downstream work in this helper.
+ *
+ * NOTE (#5022): only work dispatched INSIDE `fn` sees the policy. An inbound
+ * MCP tool call is a sibling async context, so the middleware mounted on
+ * registered tools does not observe policies established here.
  */
 export function withAccessPolicy<T>(policy: TaskAccessPolicy, fn: () => Promise<T>): Promise<T> {
   return accessPolicyStorage.run(policy, fn);
@@ -97,8 +106,8 @@ export function withAccessPolicy<T>(policy: TaskAccessPolicy, fn: () => Promise<
 
 /**
  * Returns the active access policy, or undefined if no wrapping `withAccessPolicy`
- * is in scope. When undefined, `guardMcpToolCall` treats the request as
- * mode=off (permissive) since no task context has been established.
+ * is in scope. `undefined` is the value observed at every inbound MCP dispatch
+ * today (#5022), and its consumer treats it as permissive pass-through.
  */
 export function getActivePolicy(): TaskAccessPolicy | undefined {
   return accessPolicyStorage.getStore();
@@ -111,33 +120,6 @@ export function getActivePolicy(): TaskAccessPolicy | undefined {
  */
 export interface GuardArgs {
   readonly path?: string;
-}
-
-/**
- * Check a proposed MCP tool call against the active access policy.
- *
- * Pure function — does not mutate the policy or the storage. Returns an
- * AccessDecision the caller interprets:
- *
- * - `allow`: invoke the handler
- * - `deny`: do not invoke; return a RefuseAction / isError result upstream
- * - `log-and-allow`: log a warning, then invoke the handler (audit mode)
- *
- * When no policy is in ALS (no wrapping `withAccessPolicy`), this returns
- * `allow` — the guard is opt-in at the orchestrator layer.
- */
-export function guardMcpToolCall(toolName: string, args?: GuardArgs): AccessDecision {
-  const policy = getActivePolicy();
-  if (policy === undefined) return { decision: 'allow' };
-  return checkAccess(toolName, policy, args);
-}
-
-/**
- * Shape of the logger the middleware uses. Minimal to avoid coupling.
- */
-interface MiddlewareLogger {
-  warn: (message: string, context?: Record<string, unknown>) => void;
-  info: (message: string, context?: Record<string, unknown>) => void;
 }
 
 /**
@@ -158,65 +140,4 @@ export function denyToToolResult(
       },
     ],
   };
-}
-
-/**
- * Create an access-policy middleware that plugs into the MCP middleware
- * chain. Reads the active policy from ALS. When no policy is active OR
- * the policy is in `off` mode, this middleware is a no-op pass-through.
- */
-export function createAccessPolicyMiddleware(config: {
-  readonly toolName: string;
-  readonly logger: MiddlewareLogger;
-}): (
-  args: unknown,
-  ctx: { readonly requestContext: { readonly requestId: string } },
-  next: (args: unknown, ctx: unknown) => Promise<unknown>
-) => Promise<unknown> {
-  return async (args, ctx, next) => {
-    const policy = getActivePolicy();
-    if (policy === undefined || policy.mode === 'off') {
-      return next(args, ctx);
-    }
-
-    const guardArgs = toGuardArgs(args);
-    const decision = checkAccess(config.toolName, policy, guardArgs);
-
-    if (decision.decision === 'allow') {
-      return next(args, ctx);
-    }
-    if (decision.decision === 'log-and-allow') {
-      config.logger.warn('access-policy: audit violation', {
-        tool: config.toolName,
-        warning: decision.warning,
-        policySource: policy.source,
-        requestId: ctx.requestContext.requestId,
-      });
-      recordAuditModeViolation({
-        toolName: config.toolName,
-        warning: decision.warning,
-        policySource: policy.source,
-        mode: policy.mode,
-        requestId: ctx.requestContext.requestId,
-      });
-      return next(args, ctx);
-    }
-    // decision.decision === 'deny'
-    config.logger.info('access-policy: tool call denied', {
-      tool: config.toolName,
-      reason: decision.reason,
-      matchedRule: decision.matchedRule,
-      policySource: policy.source,
-      mode: policy.mode,
-      requestId: ctx.requestContext.requestId,
-    });
-    return denyToToolResult(decision, ctx.requestContext.requestId);
-  };
-}
-
-/** Extract path from a typed tool-arg record, if present and a string. */
-function toGuardArgs(args: unknown): GuardArgs | undefined {
-  if (typeof args !== 'object' || args === null) return undefined;
-  const path = (args as Record<string, unknown>)['path'];
-  return typeof path === 'string' && path.length > 0 ? { path } : undefined;
 }

--- a/packages/nexus-agents/src/security/access-constraint-deriver/types.ts
+++ b/packages/nexus-agents/src/security/access-constraint-deriver/types.ts
@@ -51,8 +51,21 @@ export const TaskAccessPolicySchema = z.object({
 });
 export type TaskAccessPolicy = z.infer<typeof TaskAccessPolicySchema>;
 
-/** Result of checking a proposed tool call against a policy. */
+/**
+ * Result of checking a proposed tool call against a policy.
+ *
+ * `unmeasured` is distinct from `allow` and from `log-and-allow` on purpose
+ * (#5022). It means the allowlist arm of the check could not run at all —
+ * not that the call was examined and passed, and not that it violated a
+ * policy. Collapsing it into either of the others is what produced the
+ * original defect: an empty `allowedTools` was read as "nothing is
+ * permitted", so the verdict became a constant that carried no information
+ * about the call. A consumer MUST NOT record an `unmeasured` outcome as a
+ * violation — doing so gives the #2077 enforce-flip denominator a 100%
+ * violation rate that says nothing about precision.
+ */
 export type AccessDecision =
   | { readonly decision: 'allow' }
   | { readonly decision: 'deny'; readonly reason: string; readonly matchedRule: string }
-  | { readonly decision: 'log-and-allow'; readonly warning: string };
+  | { readonly decision: 'log-and-allow'; readonly warning: string }
+  | { readonly decision: 'unmeasured'; readonly reason: string };


### PR DESCRIPTION
Partially addresses #5022. **Does not answer the boundary question** — see below.

## The vote did not produce a mandate

I put #5022's boundary question to a `higher_order` panel at the supermajority bar with the issue's four options. Result:

| | |
|---|---|
| Approve / reject | **6 / 1** (85.7%) — clears the bar |
| Option split | **B:2, C:2, A:1, D:1** |
| Leading share | **33.3%** — does not clear the bar |
| Verdict | `rejected`, `thresholdMet: false` |

So the panel agrees the defect is real and disagrees on where the guard belongs. I am not breaking a 2-2-1-1 tie on a security boundary. **This PR lands only what all four options require**, and leaves the boundary open.

Worth recording: 4 of the 7 voters — architect, ai_ml, catfish, scope_steward — independently raised the same objection, that inbound MCP dispatch is already owned by `PolicyFirewall` (#4888/#4987) and a second guard there would be a parallel implementation. That coalition is larger than any single option won, and it argues against A and C. It is the strongest signal in the record and belongs in the re-vote framing, not in a unilateral decision here.

## What all four options required

**1. An empty allowlist means `unmeasured`, not deny.**

`checkAccess` decides on one field. No production producer writes a tool name into it — the LLM deriver is asked for `tool_categories` / `file_scope` / `network_scope` and pins `[]`; the keyword fallback hardcodes `[]`; both derivation-failure paths pick between `[]` and `'*'`. So `[].includes(name)` was false for every call and the verdict was a constant function of `(mode, isRiskyTool(name))` — independent of the objective, the LLM output, and the trust tier.

A new `unmeasured` variant on `AccessDecision` says the allowlist arm did not run. That is not "examined and refused", and it is not "examined and passed". The adapter allows the call, logs it, and **deliberately does not record it as a violation** — recording a check that never ran would give the #2077 enforce-flip denominator a definitionally 100% violation rate carrying no information about precision. The unbypassable denylist still runs first and still denies.

This is also the change that makes the boundary question *safe to answer later*. Establishing a policy at dispatch without it would have denied every guarded call under `enforce`, and every non-read-only tool under `confirm_risky`.

**2. Delete the dead parallel adapter.** `guardMcpToolCall` and `createAccessPolicyMiddleware` had no production caller and no entry in `api-surface.txt`, so this is not a public API change. Their unique coverage — the #4097 audit-always-allows regression, including the throwing-sink case — is ported to the adapter that actually runs, not dropped.

**3. Correct the false documentation.** Three module headers described behaviour the code does not have: that `off` is the default (it has been `audit` since v2.50), and that the denylist protects `~/.ssh/**`, `~/.aws/**` and `/etc/shadow` "even in `off` mode". It is reachable only from `checkAccess`, which an absent policy short-circuits before.

**4. A reachability gate.** `access-policy-reachability.test.ts` runs a handler through the real middleware stack instead of establishing the policy itself, and records that no policy is in scope at inbound dispatch.

Also fixed, uncontested: a denial logged at `info` while an audit-mode observation logged at `warn` — the blocking mode logged *below* the observing one.

## Why the existing tests passed

**124 of them, across 9 files, over a subsystem that was a pass-through for every real dispatch.** Every one calls `withAccessPolicy` itself first. That is the one input production never supplies, so the suite could not fail for the reason production was broken. The new test is the inverse: it asserts reachability, not verdicts.

It pins the current *broken* behaviour on purpose, which I would normally not do. The rationale is in the file header: with the boundary question open, the failure mode to prevent is a **silent** change. If these go red, that is the signal to resolve #5022 — not to relax the assertion.

## Deliberately NOT in this PR

**The durability inversion.** `recordAuditModeViolation` is called only on the log-and-allow branch; the deny branch writes an ephemeral `logger.info`. The mode that only observes writes to the hash chain and the modes that block do not. Three of the four options want this fixed, but doing it properly means renaming the sink and extending the `clawguard_violation` event shape — which changes hash-chain *content* and deserves its own review. Filed separately rather than smuggled in here.

## Verification

- **Mutation-tested, each row run separately** (redundant fixes mask each other):
  - remove the `unmeasured` branch → 4 tests fail
  - make `unmeasured` record a violation → the "does NOT record" test fails, alone
  - restore `logger.info` on deny → 2 tests fail
  - unmount the middleware entirely → the contrast assertion fails, alone
- `pnpm typecheck` clean; `eslint` clean.
- `vitest run src/security src/mcp/middleware` — 2184 passed. The single failure is **pre-existing on `main`** (verified by stashing) and unrelated: a cwd-dependent test, now filed as #5099.

## Governance

`src/security/` is neither a governor-owned path nor a CODEOWNERS rule — nothing above or below the sentinel in `CODEOWNERS` matches it — so this is self-mergeable. Flagging that explicitly since it is a p1 security path and the distinction is easy to get wrong. Adversarial review requested on the diff before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
