### PR TITLE
fix(mcp): one request context and one audit pair per tool call

### DIFF
--- a/.changeset/single-request-context.md
+++ b/.changeset/single-request-context.md
@@ -1,0 +1,42 @@
+---
+'nexus-agents': patch
+---
+
+fix(mcp): one request context and one audit pair per tool call
+
+Every MCP tool call ran through two middleware implementations that each minted
+their own `RequestContext`, so one call produced two unlinked `req_*` ids and
+two `Tool invocation started` / `Tool execution completed` pairs. Log-derived
+call counts were 2x, and an id from one layer's log line could not reach the
+other layer's lines for the same call.
+
+They were not merely unlinked but unlinkable: `createRequestContext` accepts
+`traceId` / `parentSpanId`, neither caller passed them, there is no
+`parentRequestId`, and the chain's only AsyncLocalStorage held the AbortSignal.
+
+Argument threading could not fix it. `createSecureHandler` returns a 1-arity
+function, so the chain's arity dispatch drops `ctx` before the inner layer ever
+sees it, and some tools place a 1-arity prerequisite wrapper between the two
+layers. The chain now publishes its context ambiently — mirroring the AbortSignal
+and progress storages it already uses — and the secure handler adopts it instead
+of minting a second one.
+
+The inner start/complete pair is suppressed when a chain context is present. The
+outer pair is the one kept: it is second-outermost in the stack, so its duration
+spans validation, rate limiting, policy and timeout as well as the handler,
+whereas the inner completion timed only the handler body. The inner pair was also
+incomplete — every pre-check rejection returned before it, logging a start with
+no matching completion.
+
+Adoption is gated on the tool name matching, so an in-process nested tool call
+does not inherit its parent's request identity, and on an ambient context
+existing at all, so composing a secure handler without the chain is unchanged.
+
+Audit-logger records now carry the surviving id, which is what makes them
+joinable to the log lines for the same call. Rows written before this change
+correlate to an id that no longer appears in logs; nothing joins across the two,
+so there is no live breakage.
+
+Also corrects a doc comment on `execute_expert`, the one tool of 46 outside the
+standard stack, which claimed it used `createSecureHandler` and carried the #271
+timeout protection. It registers through `registerToolTask` and does neither.

--- a/packages/nexus-agents/src/mcp/middleware/middleware-chain.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/middleware-chain.test.ts
@@ -25,6 +25,9 @@ import {
   type ToolHandler,
   type ToolResult,
 } from './middleware-chain.js';
+import { getCurrentRequestContext } from './request-context.js';
+import type { RequestContext } from './request-context.js';
+import type { MiddlewareContext } from './middleware-chain.js';
 import { createDefaultPolicyFirewall, PolicyFirewall } from './policy.js';
 import { RateLimiter } from './rate-limiter.js';
 
@@ -1383,5 +1386,57 @@ describe('integration tests', () => {
 
     expect(requestIds.length).toBe(3);
     expect(new Set(requestIds).size).toBe(3); // All unique
+  });
+});
+
+describe('ambient request context (#4981)', () => {
+  it('exposes the chain context to a nested layer that never receives ctx', async () => {
+    let seen: RequestContext | undefined;
+    let handlerCtxId: string | undefined;
+
+    // A 1-arity handler is exactly what createSecureHandler returns, so the
+    // chain's arity dispatch drops ctx and this is the only channel left.
+    const wrapped = withMiddleware('probe_tool', (args: unknown) => {
+      void args;
+      seen = getCurrentRequestContext();
+      return Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] });
+    });
+
+    const contextAware = withMiddleware('probe_tool', (_args: unknown, ctx: MiddlewareContext) => {
+      handlerCtxId = ctx.requestContext.requestId;
+      return Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] });
+    });
+
+    await wrapped({});
+    await contextAware({});
+
+    expect(seen).toBeDefined();
+    expect(seen?.toolName).toBe('probe_tool');
+    expect(handlerCtxId).toBeDefined();
+  });
+
+  it('uses the same id the handler sees on its own ctx', async () => {
+    let ambientId: string | undefined;
+    let ctxId: string | undefined;
+
+    const wrapped = withMiddleware('probe_tool', (_args: unknown, ctx: MiddlewareContext) => {
+      ambientId = getCurrentRequestContext()?.requestId;
+      ctxId = ctx.requestContext.requestId;
+      return Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] });
+    });
+
+    await wrapped({});
+
+    expect(ambientId).toBe(ctxId);
+  });
+
+  it('unsets the ambient context after the call resolves', async () => {
+    const wrapped = withMiddleware('probe_tool', () =>
+      Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] })
+    );
+
+    await wrapped({});
+
+    expect(getCurrentRequestContext()).toBeUndefined();
   });
 });

--- a/packages/nexus-agents/src/mcp/middleware/middleware-chain.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/middleware-chain.test.ts
@@ -1410,9 +1410,14 @@ describe('ambient request context (#4981)', () => {
     await wrapped({});
     await contextAware({});
 
+    // `handlerCtxId` alone proves nothing — ctx.requestContext.requestId was
+    // always defined. What is new is that a 1-arity handler, which never
+    // receives ctx at all, can reach the same context.
     expect(seen).toBeDefined();
     expect(seen?.toolName).toBe('probe_tool');
-    expect(handlerCtxId).toBeDefined();
+    expect(seen?.requestId).toMatch(/^req_[a-f0-9]{16}$/);
+    expect(handlerCtxId).toMatch(/^req_[a-f0-9]{16}$/);
+    expect(handlerCtxId).not.toBe(seen?.requestId);
   });
 
   it('uses the same id the handler sees on its own ctx', async () => {

--- a/packages/nexus-agents/src/mcp/middleware/middleware-chain.ts
+++ b/packages/nexus-agents/src/mcp/middleware/middleware-chain.ts
@@ -16,7 +16,12 @@ import { RateLimiter, type RateLimiterConfig } from './rate-limiter.js';
 import { type IPolicyFirewall, type ExecutionMode, createPolicyContext } from './policy.js';
 import { TimeoutGuard, type TimeoutGuardConfig } from './timeout-guard.js';
 import { MCP_TIMEOUTS } from '../../config/timeouts.js';
-import { createRequestContext, contextForLogging, type RequestContext } from './request-context.js';
+import {
+  createRequestContext,
+  contextForLogging,
+  runWithRequestContext,
+  type RequestContext,
+} from './request-context.js';
 import { createMetricsMiddleware } from './tool-metrics.js';
 import { abortSignalStorage } from '../mcp-notifier.js';
 import { createAccessPolicyChainMiddleware } from '../../security/access-constraint-deriver/chain-adapter.js';
@@ -399,7 +404,14 @@ export function createMiddlewareChain(
       const requestContext = createRequestContext({ toolName: config.toolName });
       const requestLogger = logger.child(contextForLogging(requestContext));
       const ctx: MiddlewareContext = { requestContext, logger: requestLogger };
-      return composed(args, ctx, (finalArgs, finalCtx) => handler(finalArgs, finalCtx));
+      // Publish the context ambiently so inner layers adopt it instead of
+      // minting a second one (#4981). Argument threading cannot reach them:
+      // createSecureHandler returns a 1-arity function, so the dispatch in
+      // `withMiddleware` below drops ctx, and some tools put a 1-arity
+      // prerequisite wrapper between the two layers as well.
+      return runWithRequestContext(requestContext, () =>
+        composed(args, ctx, (finalArgs, finalCtx) => handler(finalArgs, finalCtx))
+      );
     };
   };
 }

--- a/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
@@ -429,3 +429,31 @@ describe('ambient request context (#4981)', () => {
     expect(seen?.requestId).not.toBe(outer.requestId);
   });
 });
+
+describe('ambient context liveness (#4981 review)', () => {
+  it('stops being ambient for work that outlives the call', async () => {
+    const ctx = createRequestContext({ toolName: 'outer_tool' });
+    let deferred: RequestContext | undefined;
+    let duringCall: RequestContext | undefined;
+
+    const seen = new Promise<void>((resolve) => {
+      void runWithRequestContext(ctx, () => {
+        duringCall = getCurrentRequestContext();
+        // Detached work scheduled inside the scope but running after it — the
+        // shape runAsJob uses when it fires a job body from the handler.
+        setTimeout(() => {
+          deferred = getCurrentRequestContext();
+          resolve();
+        }, 5);
+        return Promise.resolve();
+      });
+    });
+
+    await seen;
+
+    // Identity is not liveness: the store is still reachable from the timer,
+    // so this only holds because the holder is marked settled.
+    expect(duringCall).toBe(ctx);
+    expect(deferred).toBeUndefined();
+  });
+});

--- a/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.test.ts
@@ -15,7 +15,10 @@ import {
   contextForLogging,
   isRequestContext,
   measuredTrustTier,
+  runWithRequestContext,
+  getCurrentRequestContext,
 } from './request-context.js';
+import type { RequestContext } from './request-context.js';
 
 // ============================================================================
 // generateRequestId
@@ -386,5 +389,43 @@ describe('measuredTrustTier (#4733)', () => {
     const fallback = createRequestContext({ toolName: 'run_pipeline' });
     expect(fallback.trustTier).toBe('3');
     expect(measuredTrustTier(fallback)).toBeUndefined();
+  });
+});
+
+describe('ambient request context (#4981)', () => {
+  it('has no ambient context outside runWithRequestContext', () => {
+    expect(getCurrentRequestContext()).toBeUndefined();
+  });
+
+  it('exposes the context to arbitrarily nested async work', async () => {
+    const ctx = createRequestContext({ toolName: 'outer_tool' });
+
+    const seen = await runWithRequestContext(ctx, async () => {
+      // An intermediary that drops its arguments entirely — the shape that
+      // defeated argument threading (withPrerequisite wrappers are 1-arity).
+      await Promise.resolve();
+      return ((): RequestContext | undefined => getCurrentRequestContext())();
+    });
+
+    expect(seen).toBe(ctx);
+  });
+
+  it('unsets the ambient context once the call resolves', async () => {
+    const ctx = createRequestContext({ toolName: 'outer_tool' });
+    await runWithRequestContext(ctx, () => Promise.resolve());
+
+    expect(getCurrentRequestContext()).toBeUndefined();
+  });
+
+  it('lets an inner run shadow an outer one', async () => {
+    const outer = createRequestContext({ toolName: 'outer_tool' });
+    const inner = createRequestContext({ toolName: 'inner_tool' });
+
+    const seen = await runWithRequestContext(outer, () =>
+      runWithRequestContext(inner, () => Promise.resolve(getCurrentRequestContext()))
+    );
+
+    expect(seen).toBe(inner);
+    expect(seen?.requestId).not.toBe(outer.requestId);
   });
 });

--- a/packages/nexus-agents/src/mcp/middleware/request-context.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.ts
@@ -7,6 +7,7 @@
  * @module mcp/middleware/request-context
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomBytes } from 'node:crypto';
 import { getTimeProvider } from '../../core/index.js';
 import type { TrustTier } from '../../security/trust-types.js';
@@ -170,6 +171,44 @@ export function createRequestContext(options: CreateContextOptions): RequestCont
 
   // Freeze to ensure immutability
   return Object.freeze(context);
+}
+
+/**
+ * The request context for the call currently in flight (#4981).
+ *
+ * Exists because a tool call passes through two middleware implementations
+ * that each used to mint their own `RequestContext`, producing two unlinked
+ * `req_*` ids and two `Tool invocation started` pairs per call. Argument
+ * threading cannot fix that: `createSecureHandler` returns a 1-arity function,
+ * so the chain's arity dispatch drops `ctx`, and 1-arity intermediaries such
+ * as the `withPrerequisite` wrappers sit between the layers on some tools.
+ * An ambient channel survives both.
+ *
+ * This mirrors the AbortSignal and progress-context storages the chain already
+ * uses, so it is the established idiom here rather than a new mechanism.
+ */
+const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * Runs `fn` with `context` as the ambient request context, so any nested layer
+ * can adopt it instead of minting a second one.
+ */
+export function runWithRequestContext<T>(
+  context: RequestContext,
+  fn: () => Promise<T>
+): Promise<T> {
+  return requestContextStorage.run(context, fn);
+}
+
+/**
+ * The ambient request context, or `undefined` when nothing established one.
+ *
+ * `undefined` is a real answer, not a failure: a caller that composes a secure
+ * handler without the middleware chain — every direct test of it does — has no
+ * outer context to inherit, and must mint its own.
+ */
+export function getCurrentRequestContext(): RequestContext | undefined {
+  return requestContextStorage.getStore();
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/middleware/request-context.ts
+++ b/packages/nexus-agents/src/mcp/middleware/request-context.ts
@@ -85,6 +85,16 @@ export interface CreateContextOptions {
   traceId?: string;
   /** Optional parent span ID */
   parentSpanId?: string;
+  /**
+   * Reuse this request id instead of minting a new one (#4981).
+   *
+   * Lets a nested layer join an outer layer's request identity while still
+   * deriving its OWN caller, trust tier and timestamp. Adopting the outer
+   * context object wholesale would discard those, which for a handler
+   * configured with `callerInfo` silently downgrades the trust tier and the
+   * audit actor.
+   */
+  inheritRequestId?: string;
 }
 
 /**
@@ -160,7 +170,7 @@ export function deriveTrustTier(caller: CallerInfo): TrustTier {
 export function createRequestContext(options: CreateContextOptions): RequestContext {
   const caller = options.caller ?? {};
   const context: RequestContext = {
-    requestId: generateRequestId(),
+    requestId: options.inheritRequestId ?? generateRequestId(),
     timestamp: formatTimestamp(),
     toolName: options.toolName,
     caller,
@@ -187,7 +197,25 @@ export function createRequestContext(options: CreateContextOptions): RequestCont
  * This mirrors the AbortSignal and progress-context storages the chain already
  * uses, so it is the established idiom here rather than a new mechanism.
  */
-const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+const requestContextStorage = new AsyncLocalStorage<ContextHolder>();
+
+/**
+ * The ambient context plus its liveness.
+ *
+ * AsyncLocalStorage keeps a store reachable from anything spawned inside the
+ * scope, including work that OUTLIVES the call — a `setTimeout`, or the
+ * detached body `runAsJob` fires from inside the secure handler. Without this
+ * flag such work still reads the context of a request that already completed,
+ * and a nested handler for the same tool would adopt a finished identity, then
+ * log neither a start (suppressed) nor a completion (the chain already closed
+ * its own pair).
+ *
+ * Identity is not liveness, so the adoption gate needs both.
+ */
+interface ContextHolder {
+  readonly context: RequestContext;
+  settled: boolean;
+}
 
 /**
  * Runs `fn` with `context` as the ambient request context, so any nested layer
@@ -197,7 +225,12 @@ export function runWithRequestContext<T>(
   context: RequestContext,
   fn: () => Promise<T>
 ): Promise<T> {
-  return requestContextStorage.run(context, fn);
+  const holder: ContextHolder = { context, settled: false };
+  return requestContextStorage.run(holder, () =>
+    fn().finally(() => {
+      holder.settled = true;
+    })
+  );
 }
 
 /**
@@ -208,7 +241,9 @@ export function runWithRequestContext<T>(
  * outer context to inherit, and must mint its own.
  */
 export function getCurrentRequestContext(): RequestContext | undefined {
-  return requestContextStorage.getStore();
+  const holder = requestContextStorage.getStore();
+  if (holder === undefined || holder.settled) return undefined;
+  return holder.context;
 }
 
 /**

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
@@ -20,7 +20,7 @@ import {
 import { type IPolicyFirewall, type PolicyDecision } from './policy-types.js';
 import { withMiddleware } from './middleware-chain.js';
 import { wrapToolWithTimeout } from './tool-wrapper.js';
-import { getCurrentRequestContext } from './request-context.js';
+import { getCurrentRequestContext, measuredTrustTier } from './request-context.js';
 import { createDefaultPolicyFirewall } from './policy.js';
 import { RateLimiter, type RateLimiterState } from './rate-limiter.js';
 import { FAKE_OPENAI_KEY } from '../../testing/test-secrets.js';
@@ -1563,5 +1563,38 @@ describe('single request context per call (#4981)', () => {
     );
     ids.delete(undefined);
     expect(ids.size).toBe(3);
+  });
+});
+
+describe('adoption preserves caller-derived fields (#4981 review)', () => {
+  it('keeps callerInfo, trust tier and audit actor while sharing the chain id', async () => {
+    let seen: HandlerContext['requestContext'] | undefined;
+    const secure = createSecureHandler(
+      (_args: unknown, ctx: HandlerContext) => {
+        seen = ctx.requestContext;
+        return Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] });
+      },
+      {
+        toolName: 'probe_tool',
+        callerInfo: { transport: 'stdio', authenticated: true, clientId: 'claude-cli' },
+      }
+    );
+
+    let ambientId: string | undefined;
+    const wrapped = withMiddleware('probe_tool', (args: unknown) => {
+      ambientId = getCurrentRequestContext()?.requestId;
+      return secure(args);
+    });
+
+    await wrapped({});
+
+    // The chain mints its context from { toolName } alone, with no caller.
+    // Adopting that object wholesale silently dropped configured callerInfo,
+    // downgrading trustTier '1' -> '3' and the audit actor from the client to
+    // "unknown". One ID is the goal; discarding caller identity is not.
+    expect(seen?.requestId).toBe(ambientId);
+    expect(seen?.caller.clientId).toBe('claude-cli');
+    expect(seen?.trustTier).toBe('1');
+    expect(measuredTrustTier(seen as NonNullable<typeof seen>)).toBe('1');
   });
 });

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.test.ts
@@ -18,6 +18,9 @@ import {
   type HandlerContext,
 } from './secure-handler.js';
 import { type IPolicyFirewall, type PolicyDecision } from './policy-types.js';
+import { withMiddleware } from './middleware-chain.js';
+import { wrapToolWithTimeout } from './tool-wrapper.js';
+import { getCurrentRequestContext } from './request-context.js';
 import { createDefaultPolicyFirewall } from './policy.js';
 import { RateLimiter, type RateLimiterState } from './rate-limiter.js';
 import { FAKE_OPENAI_KEY } from '../../testing/test-secrets.js';
@@ -1444,5 +1447,121 @@ describe('SecureHandler', () => {
         })
       );
     });
+  });
+});
+
+describe('single request context per call (#4981)', () => {
+  function countLines(logger: MockLogger, message: string): number {
+    return logger.info.mock.calls.filter((c: unknown[]) => c[0] === message).length;
+  }
+
+  it('adopts the chain context instead of minting a second one', async () => {
+    let handlerCtxId: string | undefined;
+    const secure = createSecureHandler(
+      (_args: unknown, ctx: HandlerContext) => {
+        handlerCtxId = ctx.requestContext.requestId;
+        return Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] });
+      },
+      { toolName: 'probe_tool' }
+    );
+
+    let ambientId: string | undefined;
+    const wrapped = withMiddleware('probe_tool', async (args: unknown) => {
+      ambientId = getCurrentRequestContext()?.requestId;
+      return secure(args);
+    });
+
+    await wrapped({});
+
+    expect(ambientId).toBeDefined();
+    expect(handlerCtxId).toBe(ambientId);
+  });
+
+  it('emits exactly one invocation-started line for a chained call', async () => {
+    const logger = createMockLogger();
+    const secure = createSecureHandler(
+      () => Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+      { toolName: 'probe_tool', logger }
+    );
+    const wrapped = withMiddleware('probe_tool', (args: unknown) => secure(args), {
+      logger,
+    });
+
+    await wrapped({});
+
+    expect(countLines(logger, 'Tool invocation started')).toBe(1);
+    expect(countLines(logger, 'Tool execution completed')).toBe(1);
+  });
+
+  it('still mints and logs its own context when used WITHOUT the chain', async () => {
+    const logger = createMockLogger();
+    let handlerCtxId: string | undefined;
+    const secure = createSecureHandler(
+      (_args: unknown, ctx: HandlerContext) => {
+        handlerCtxId = ctx.requestContext.requestId;
+        return Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] });
+      },
+      { toolName: 'probe_tool', logger }
+    );
+
+    await secure({});
+
+    // Standalone composition has no outer context to inherit. Suppression is
+    // conditional on an ambient context existing, never unconditional.
+    expect(handlerCtxId).toMatch(/^req_/);
+    expect(countLines(logger, 'Tool invocation started')).toBe(1);
+  });
+
+  it('does NOT adopt a parent tool context for a different tool', async () => {
+    let innerCtxId: string | undefined;
+    const inner = createSecureHandler(
+      (_args: unknown, ctx: HandlerContext) => {
+        innerCtxId = ctx.requestContext.requestId;
+        return Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] });
+      },
+      { toolName: 'inner_tool' }
+    );
+
+    let outerId: string | undefined;
+    const outer = withMiddleware('outer_tool', async (args: unknown) => {
+      outerId = getCurrentRequestContext()?.requestId;
+      // An in-process nested tool call: it must NOT inherit the parent's id,
+      // or two different tools share one request identity.
+      return inner(args);
+    });
+
+    await outer({});
+
+    expect(outerId).toBeDefined();
+    expect(innerCtxId).toBeDefined();
+    expect(innerCtxId).not.toBe(outerId);
+  });
+
+  it('emits one pair through the REAL composition tools use (#4981 reproducer)', async () => {
+    const logger = createMockLogger();
+    // This is the exact shape of every registered tool: createSecureHandler
+    // wrapped by wrapToolWithTimeout. The test above uses withMiddleware
+    // directly, which is one layer short of what production composes.
+    const secure = createSecureHandler(
+      () => Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+      { toolName: 'probe_tool', logger }
+    );
+    const wrapped = wrapToolWithTimeout('probe_tool', secure, { logger });
+
+    await wrapped({});
+    await wrapped({});
+    await wrapped({});
+
+    // Before #4981 this was 6 for 3 calls, under 6 distinct ids.
+    expect(countLines(logger, 'Tool invocation started')).toBe(3);
+
+    const ids = new Set(
+      logger.child.mock.calls.map((c: unknown[]) => {
+        const bound = c[0] as { requestId?: string } | undefined;
+        return bound?.requestId;
+      })
+    );
+    ids.delete(undefined);
+    expect(ids.size).toBe(3);
   });
 });

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
@@ -455,7 +455,15 @@ export function createSecureHandler(
     // must keep minting and logging its own.
     const ambient = getCurrentRequestContext();
     const inherited = ambient?.toolName === config.toolName ? ambient : undefined;
-    const requestContext = inherited ?? createRequestContext(ctxOpts);
+    // Join the outer request's IDENTITY, but keep deriving this handler's own
+    // caller and trust tier. The chain mints its context from { toolName }
+    // alone, so adopting that object wholesale would discard a configured
+    // `callerInfo` — downgrading trustTier and the audit actor to "unknown"
+    // on the very path this change is meant to make auditable.
+    const requestContext =
+      inherited === undefined
+        ? createRequestContext(ctxOpts)
+        : createRequestContext({ ...ctxOpts, inheritRequestId: inherited.requestId });
     const requestLogger = logger.child(contextForLogging(requestContext));
     if (inherited === undefined) {
       requestLogger.info('Tool invocation started');

--- a/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
+++ b/packages/nexus-agents/src/mcp/middleware/secure-handler.ts
@@ -18,6 +18,7 @@ import {
   contextForLogging,
   type RequestContext,
   type CallerInfo,
+  getCurrentRequestContext,
 } from './request-context.js';
 import { type IPolicyFirewall, type ExecutionMode, createPolicyContext } from './policy.js';
 import type { RateLimiter } from './rate-limiter.js';
@@ -271,11 +272,17 @@ async function executeHandler(
   handler: ToolHandler | ContextAwareHandler,
   args: unknown,
   ctx: HandlerContext,
-  logger: ILogger
+  logger: ILogger,
+  logLifecycle: boolean
 ): Promise<ToolResult> {
   const startTime = getTimeProvider().now();
   const result =
     handler.length >= 2 ? await handler(args, ctx) : await (handler as ToolHandler)(args);
+
+  // Suppressed when the middleware chain already brackets this call: its own
+  // audit middleware logs a completion spanning the whole stack, where this
+  // one times only the handler body (#4981).
+  if (!logLifecycle) return result;
 
   const durationMs = getTimeProvider().now() - startTime;
   if (result.isError === true) {
@@ -438,9 +445,21 @@ export function createSecureHandler(
       toolName: config.toolName,
       ...(config.callerInfo && { caller: config.callerInfo }),
     };
-    const requestContext = createRequestContext(ctxOpts);
+    // Adopt the middleware chain's context when this handler is nested inside
+    // it, so one call carries one id and one start/complete pair (#4981).
+    //
+    // Gated on the tool NAME matching: an in-process nested tool call would
+    // otherwise inherit its parent's identity, and two different tools would
+    // share one request id. Gated on presence at all because every direct
+    // caller of createSecureHandler — the tests — has no outer context, and
+    // must keep minting and logging its own.
+    const ambient = getCurrentRequestContext();
+    const inherited = ambient?.toolName === config.toolName ? ambient : undefined;
+    const requestContext = inherited ?? createRequestContext(ctxOpts);
     const requestLogger = logger.child(contextForLogging(requestContext));
-    requestLogger.info('Tool invocation started');
+    if (inherited === undefined) {
+      requestLogger.info('Tool invocation started');
+    }
 
     const { error: preCheckError, sanitizedArgs } = runPreChecks(
       config,
@@ -451,7 +470,11 @@ export function createSecureHandler(
     );
     if (preCheckError) return preCheckError;
 
-    return executeAndAudit(handler, sanitizedArgs, requestContext, requestLogger, config);
+    return executeAndAudit(handler, sanitizedArgs, config, {
+      requestContext,
+      requestLogger,
+      logLifecycle: inherited === undefined,
+    });
   };
 }
 
@@ -460,20 +483,29 @@ export function createSecureHandler(
  * exception paths. Extracted from `createSecureHandler` to keep that
  * function within the 50-line budget.
  */
+/** The per-call state `executeAndAudit` needs, bundled to stay under the param cap. */
+interface Invocation {
+  readonly requestContext: RequestContext;
+  readonly requestLogger: ILogger;
+  /** False when the middleware chain already brackets this call (#4981). */
+  readonly logLifecycle: boolean;
+}
+
 async function executeAndAudit(
   handler: ToolHandler | ContextAwareHandler,
   sanitizedArgs: unknown,
-  requestContext: RequestContext,
-  requestLogger: ILogger,
-  config: SecureHandlerConfig
+  config: SecureHandlerConfig,
+  invocation: Invocation
 ): Promise<ToolResult> {
+  const { requestContext, requestLogger } = invocation;
   const execStartTime = getTimeProvider().now();
   try {
     const result = await executeHandler(
       handler,
       sanitizedArgs,
       { requestContext, logger: requestLogger },
-      requestLogger
+      requestLogger,
+      invocation.logLifecycle
     );
     sanitizeToolResult(result, requestLogger);
     if (config.auditLogger) {

--- a/packages/nexus-agents/src/mcp/tools/execute-expert.ts
+++ b/packages/nexus-agents/src/mcp/tools/execute-expert.ts
@@ -906,8 +906,13 @@ async function runBackgroundExpertTask(opts: BackgroundExpertTaskOpts): Promise<
  * Uses MCP Tasks primitive (SEP-1686) via registerToolTask for async execution.
  * taskSupport: 'optional' preserves sync fallback for clients without task support.
  *
- * Uses createSecureHandler for standardized security middleware (Issue #531).
- * Includes timeout protection for CVE-2026-0621 mitigation (Issue #271).
+ * NOT wrapped by createSecureHandler or wrapToolWithTimeout (#4981). Of the 46
+ * tool modules this is the only one outside the standard middleware stack: it
+ * registers through registerToolTask, so it creates no RequestContext, emits
+ * no `Tool invocation started` pair, and no tool-audit record. An earlier
+ * version of this comment claimed it used createSecureHandler (Issue #531)
+ * and that it carried the #271 timeout protection; neither is true as wired.
+ * Whether the tasks primitive can take those wrappers is part of #4978.
  *
  * @category MCP
  * @param server - MCP server instance


### PR DESCRIPTION
Closes #4981 — the scoped first step the issue itself names. **Does not merge the two middleware stacks**; that remains a `consensus_vote` decision, as the issue argues.

## The reproducer, inverted

```
# before — 3 calls
npx vitest run src/mcp/tools/get-job-result-tool.test.ts --silent=false | grep -c "Tool invocation started"
6      (under 6 distinct req_* ids)

# after
3      (under 3 distinct req_* ids)
```

## Why argument threading could not fix this

The issue proposes "thread the outer requestId into the inner secure handler." I went looking for the channel to thread it through and there isn't one:

`createSecureHandler` returns a **1-arity** function (`secure-handler.ts:436`). The chain dispatches on arity and therefore drops `ctx` on the floor:

```ts
// middleware-chain.ts:430-436
const wrappedHandler: ContextAwareToolHandler = (args, ctx) => {
  if (handler.length >= 2) { return handler(args, ctx); }
  return (handler as ToolHandler)(args);   // <- secure handler lands here
};
```

Making the returned function 2-arity is the smallest diff, but it silently misses tools with a 1-arity intermediary between the layers — `withPrerequisite` at `memory-write.ts:356` and `registry-import-tool.ts:88`. Those would keep two contexts, and the bug becomes *non-uniform*, which is worse than uniform. It also doubles down on the `handler.length` idiom that caused the problem.

So the chain publishes its context through an `AsyncLocalStorage` instead. That is not a new mechanism here — it mirrors the AbortSignal and progress-context storages the chain already uses (`tool-wrapper.ts:275-291`, read at `middleware-chain.ts:207`) — it survives arbitrary intermediaries, and it needs **zero edits to any of the 46 tool files**.

Related: the ids were not merely unlinked but *unlinkable*. `createRequestContext` accepts `traceId`/`parentSpanId` (`request-context.ts:170-171`), neither caller passed them, there is no `parentRequestId`, and the chain's only ALS held the AbortSignal.

## Which pair survives, and why the outer

The outer `createAuditMiddleware` is second-outermost in the stack, so its `durationMs` spans rate limiting, validation, policy, ClawGuard, timeout **and** the whole secure handler. The inner completion timed only the handler body.

The inner pair was also **incomplete**: `secure-handler.ts` logs "started", but every pre-check rejection returns before `executeAndAudit`, so a size-cap, tier-reject, rate-limit or policy denial logged a start with no matching completion. Suppressing the inner pair removes an asymmetry as well as a duplicate.

## Two gates on adoption

1. **Tool name must match.** An in-process nested tool call would otherwise inherit its parent's request identity, and two different tools would share one id. Tested.
2. **An ambient context must exist at all.** Every direct caller of `createSecureHandler` — which is to say the tests, since no production caller composes it without the chain — has no outer context and keeps minting and logging its own. Suppression is conditional, never unconditional, so those tests pass untouched. Tested.

## The 46th file

`execute-expert.ts` uses **neither** wrapper. The issue said it "uses one"; it imports nothing from `secure-handler.js` or `tool-wrapper.js` and registers via `registerToolTask`, so it creates zero contexts and emits zero pairs — the opposite tail of the same inconsistency. Its JSDoc claimed it used `createSecureHandler` and carried the #271 timeout protection; both were false. Corrected here. Whether the tasks primitive can take those wrappers belongs to #4978.

## Verification

Mutation matrix, **each row run separately**:

| mutation | result |
|---|---|
| drop the toolName gate | 1 fails, alone — nested calls share an id |
| always mint a fresh context | 2 fail |
| force the inner start line on | 2 fail |
| force the inner start line off | 2 fail, incl. the pre-existing standalone test |
| chain stops publishing the ambient context | 6 fail |
| force the inner completion line on | 1 fails, alone |

`pnpm typecheck` clean, `eslint` clean, and `vitest run src/mcp src/security`: **5788 passed, 0 failed**.

## Note on audit records

Audit-logger rows now carry the surviving id, which is what makes them joinable to the log lines for the same call. Rows written before this change correlate to an id that no longer appears in logs — nothing joins across the two, so there is no live breakage, but it is called out in the changeset.

Error-envelope ids change identity, not shape: every assertion found matches `/req_[a-f0-9]{16}/` rather than a captured value. This is what removes the issue's point 3 — a caller quoting "requestId X" no longer gives an operator an id that lands in one stream and not the other.

## Governance

`src/mcp/` is a CODEOWNERS review-requested path, not a governor-owned one — it is below the ratification sentinel in `CODEOWNERS`, so it is review-requested but not merge-blocked. Flagging the distinction explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
