### PR TITLE
docs(governance): retire the ClawGuard promotion criterion and its registry claim

### DIFF
--- a/docs/adr/0017-authority-ladder.md
+++ b/docs/adr/0017-authority-ladder.md
@@ -278,8 +278,11 @@ Each is an unbundled, per-loop migration governed by this ADR — not new behavi
   per `evaluateEnforceReadiness`.
 - **#3815** — KNN research-maturity weighting (worked example 2). Promotion gated on a
   similarity-controlled, stable, significant success-rate lift; kill-option if none.
-- **#2077** — ClawGuard audit → `enforce` after a bake period. Security-gate loop
-  where the `recall ≥ 0.80` requirement (missed-action cost) is load-bearing.
+- **#2077** — ClawGuard audit → `enforce`. **Retired, not promoted** (#5022, epic
+  #5105): the panel consolidated tool authorization on PolicyFirewall instead. Kept as
+  a worked example of the ladder's failure mode — the bake would have produced zero
+  judged events because the guard's policy was never in scope, so the criterion could
+  never have been evaluated. Successor: **#4988**, for PolicyFirewall.
 - **#3697** — policy-gate escalate → HITL interrupt at the stage boundary. The
   human-ratification machinery the ladder leans on at stage boundaries.
 

--- a/docs/governance/loop-promotion-criteria.md
+++ b/docs/governance/loop-promotion-criteria.md
@@ -192,25 +192,31 @@ lift, controlled for the obvious confounder."
 
 ---
 
-## ClawGuard — audit → `enforce`. Criterion: recall is load-bearing.
+## ClawGuard — RETIRED as a promotion path (#5022, epic #5105).
 
-**Promotion case:** [#2077](https://github.com/nexus-substrate/nexus-agents/issues/2077)
-(absorbed). A **security-gate** loop, so the `recall ≥ 0.80` requirement (missed-action
-cost) is the load-bearing threshold — a missed block is more costly than a false one.
+**There is no ClawGuard `audit → enforce` rung.** A 7-voter panel ratified retiring
+ClawGuard as an enforcement mechanism and consolidating tool authorization on
+PolicyFirewall (option E, 4 of 6 approvers, 66.7%, threshold met). #2077 is closed as
+superseded, and #5106 demoted every `NEXUS_ACCESS_POLICY_MODE` mode to reporting-only.
 
-- **Promotion metric:** the **block-decision precision AND recall** on a judged set of
-  security events over a **bake period**.
-- **Measured where:** the ClawGuard audit log (the `audit`-tier verdicts accumulated
-  during the bake), judged against the ground-truth label of each event.
-- **Threshold (at the advisory → enforce floor, recall load-bearing):**
-  - `evalN ≥ 100` judged security events,
-  - `recall ≥ 0.80` — **the binding constraint** (missed-action cost dominates),
-  - `precision ≥ 0.90` (a false block has cost too, but recall governs),
-  - `soakDuration ≥ P30D` bake in `audit` with no operator intervention,
-  - a recorded ratification vote.
-- **Demotion triggers:** recall drops below `0.80` (a missed block class appears) →
-  automatic, **immediate** demotion to `audit` (a security gate fails safe by ceasing
-  to block, not by blocking wrongly).
+This section previously specified a live ladder — `evalN >= 100`, `recall >= 0.80`,
+`soakDuration >= P30D`, a recorded ratification vote, and an immediate-demotion trigger.
+It is recorded here as retired rather than deleted, because the reason it was
+unreachable is the useful part:
+
+**The denominator was structurally zero.** ClawGuard's policy was never in scope at
+inbound MCP dispatch, so `checkAccess` never ran and **zero `clawguard_violation` events
+were ever written**, in any data dir, across the whole `audit`-default period since
+v2.50. An operator could have completed the full P30D bake, held the ratification vote,
+set `enforce`, and received no blocking at all — believing a security gate had been
+promoted. A promotion criterion whose evidence its own wiring cannot produce is not a
+criterion; it is a gate that cannot fail, one level up.
+
+**The live successor is #4988** — whether MCP policy enforcement should default on after
+a warn-mode soak — for PolicyFirewall, the surviving boundary. It inherits the same
+evidence requirement and the same hazard: its soak needs durable denial records, tracked
+in #5101. Write that criterion against a sink that is verified to produce events before
+setting a threshold on their count.
 
 ---
 

--- a/governance/claims-registry.yaml
+++ b/governance/claims-registry.yaml
@@ -216,12 +216,12 @@ claims:
     lastVerified: '2026-06-16'
 
   - id: clawguard-promotion-criterion
-    claim: 'ClawGuard audit-to-enforce promotion criterion makes recall the load-bearing threshold for missed-action cost.'
+    claim: 'ClawGuard has no audit-to-enforce promotion path: retired as an enforcement mechanism (#5022), with tool authorization consolidated on PolicyFirewall.'
     subject: docs/governance/loop-promotion-criteria.md
-    status: aspirational
+    status: verified
     evidenceType: adr
     verification:
       method: file-exists
       path: docs/governance/loop-promotion-criteria.md
-      subjectContains: 'recall is load-bearing'
-    lastVerified: '2026-06-16'
+      subjectContains: 'RETIRED as a promotion path'
+    lastVerified: '2026-08-27'


### PR DESCRIPTION
**Owner ratification required** — touches `governance/claims-registry.yaml`. I will not self-merge this.

Split out of #5109 deliberately, so a `src/security` change does not ride through the governor gate on the back of a governance edit.

## What happened

#5109 rewrote the ClawGuard section of `docs/governance/loop-promotion-criteria.md` to record the ladder as retired. CI failed: `governance/claims-registry.yaml` carries a claim whose verification matches the string `'recall is load-bearing'`, which the rewrite removes.

**The claims registry did exactly its job** — it caught a doc drifting from a registered claim. Worth saying plainly, given how many gates in this repo have turned out to be unable to fail.

## The fix I did not take

Keeping the phrase `recall is load-bearing` somewhere in the retired section would satisfy `subjectContains` and turn CI green in one line.

That would be gaming the gate. The claim is *"ClawGuard audit-to-enforce promotion criterion makes recall the load-bearing threshold for missed-action cost"* — and after the #5022 decision there is no such criterion, so the claim is **false**, not merely unmatched. Satisfying a string matcher while the proposition behind it is untrue is the precise failure this registry exists to prevent.

Retiring a claim is owner business. Hence this PR.

## What changed

**`docs/governance/loop-promotion-criteria.md`** — the ClawGuard section is rewritten as retired rather than deleted, because the reason it was unreachable is the transferable part:

> The denominator was structurally zero. ClawGuard's policy was never in scope at inbound MCP dispatch, so `checkAccess` never ran and **zero `clawguard_violation` events were ever written**, in any data dir, across the whole `audit`-default period since v2.50. A promotion criterion whose evidence its own wiring cannot produce is not a criterion; it is a gate that cannot fail, one level up.

Concrete harm if left alone: an operator completes the P30D bake, holds the ratification vote, sets `enforce`, and receives no blocking while believing a security gate was promoted.

**`docs/adr/0017-authority-ladder.md`** — #2077 is relisted as retired-not-promoted, kept as a worked example of the ladder's failure mode.

**`governance/claims-registry.yaml`** — the claim is reframed to what the doc now says and re-verified against it.

## One judgement call to check

I set `status: verified`, not `retired`, because **`ClaimStatusSchema` has no `retired` member** (`verified` / `partial` / `aspirational` / `stale`). The reframed claim is genuinely checkable against the file, so `verified` is honest rather than a workaround.

But it is a gap worth your view: a registry that cannot express "this claim is retired, and here is why we kept the row" forces a choice between deleting the record and relabelling it as something it is not. I did not expand the enum in a governor-path PR without asking. Say the word and I will file it.

## Verification

- `claims-registry.test.ts`: **26 passed** — both the schema-validation and the live-verification cases.
- `markdownlint` clean on both docs.
- The claim text is 18 words, under the registry's 25-word cap (which correctly rejected my first, longer draft).

## Predecessor

#5109 now contains only the `src/security` demotion and merges on its own. The docs keep advertising a retired ladder until this lands — worse than fixing it immediately, better than routing a governance change around its gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
