### PR TITLE
docs(governance): key the canonical-paths table on operations, not symbols

### DIFF
--- a/.changeset/canonical-table-by-operation.md
+++ b/.changeset/canonical-table-by-operation.md
@@ -1,0 +1,24 @@
+---
+'nexus-agents': patch
+---
+
+docs(governance): key the canonical-paths table on operations, not symbols
+
+The table listed important symbols, which let it bless both sides of a
+duplication without anyone noticing. It named `createAllAdapters()` under "CLI
+adapters" AND `UnifiedAdapterRegistry` under "Adapter registry" — two entries
+for one question, 7 call sites on one and 8 on the other — while a separate
+line said adapter access must go through the registry. It named the pipeline
+event bus canonical while `core/event-bus.ts` re-exports the other bus as the
+core surface. It named a pricing source but no canonical cost function, which
+is how eight cost paths accumulated.
+
+Each row now answers "what do I call to do X", with exactly one answer.
+
+`UNRESOLVED` is introduced as a real value. Where two implementations exist and
+choosing between them is a design decision rather than a cleanup, the row says
+so and names the tracking issue. A table that silently blesses both sides is
+worse than one that admits the fork: an author reading it cannot tell they are
+picking a side.
+
+Ratified by the owner. Part of epic #5121.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,19 +204,37 @@ Full tool reference: [docs/ENTRYPOINTS.md](./docs/ENTRYPOINTS.md).
 
 Do not create parallel implementations — modify existing files at these canonical locations. Never create `enhanced_*`, `new_*`, `v2_*`, or `refactor_*` forks; migrate logic to the canonical location and remove the deprecated file.
 
-| Concern           | Canonical path                                                                                                 |
-| ----------------- | -------------------------------------------------------------------------------------------------------------- |
-| Task analysis     | `SharedTaskAnalyzer` — `src/core/task-analysis/shared-task-analyzer.ts`                                        |
-| Task routing      | `CompositeRouter` — `src/cli-adapters/composite-router.ts`                                                     |
-| Consensus voting  | `ConsensusEngine` — `src/consensus/engine.ts`                                                                  |
-| CLI adapters      | `createAllAdapters()` — `src/cli-adapters/factory.ts`                                                          |
-| MCP tools         | `registerTools()` — `src/mcp/tools/index.ts`                                                                   |
-| Model registry    | `ModelRegistry` + `getDefaultRegistry()` — `src/config/model-registry.ts` (data: `src/config/in-tree-data.ts`) |
-| Adapter registry  | `UnifiedAdapterRegistry` — `src/adapters/unified-registry.ts`                                                  |
-| Memory registry   | `MemoryRegistry` + `getMemoryRegistry()` — `packages/nexus-memory/src/registry.ts`                             |
-| Graph workflows   | `GraphBuilder` — `src/orchestration/graph/graph-builder.ts`                                                    |
-| Pipeline runner   | `PipelineRunner` — `src/pipeline/pipeline-runner.ts`                                                           |
-| Security pipeline | `src/exports/security.ts`                                                                                      |
+| Operation — what you are trying to do             | Canonical entry point                                                                                          |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Analyse / classify a task                         | `SharedTaskAnalyzer` — `src/core/task-analysis/shared-task-analyzer.ts`                                        |
+| Select a model for a task                         | `CompositeRouter.route(task)` — `src/cli-adapters/composite-router.ts`                                         |
+| Acquire an adapter                                | `getGlobalRegistry()` — `src/adapters/unified-registry.ts`. NOT `createAllAdapters()` in new code.             |
+| Run a consensus vote                              | `ConsensusEngine` — `src/consensus/engine.ts`                                                                  |
+| Register an MCP tool                              | `registerTools()` — `src/mcp/tools/index.ts`                                                                   |
+| Look up model metadata, pricing or context window | `getDefaultRegistry()` — `src/config/model-registry.ts` (data: `src/config/in-tree-data.ts`)                   |
+| Read or write memory                              | `getMemoryRegistry()` — `packages/nexus-memory/src/registry.ts`                                                |
+| Build a graph workflow                            | `GraphBuilder` — `src/orchestration/graph/graph-builder.ts`                                                    |
+| Run a pipeline                                    | `PipelineRunner` — `src/pipeline/pipeline-runner.ts`                                                           |
+| Run the security pipeline                         | `src/exports/security.ts`                                                                                      |
+| Authorize a tool call                             | `PolicyFirewall` — `src/mcp/middleware/policy.ts`. ClawGuard is advisory only (#5022, epic #5105).             |
+| Compute token → USD                               | **UNRESOLVED — eight paths (#5122).** Prefer `computeCostDetail` (`src/learning/usage-log.ts`) until it lands. |
+| Emit a domain event                               | **UNRESOLVED — two buses (#5125).** Do not add a third, and do not add a bridge.                               |
+| Write an audit record                             | **UNRESOLVED — two sinks (#5125).** Use `AuditLogger` (`src/audit/`) when the record must be durable.          |
+
+This table is keyed on the **operation**, not on the symbol. A row answers "what do I call
+to do X", and there is exactly one answer per row. That shape is deliberate: the previous
+version listed important symbols, which let it bless both `createAllAdapters()` and
+`UnifiedAdapterRegistry` as canonical — two entries for one question — and name one event
+bus canonical while `core/event-bus.ts` re-exported the other as the core surface.
+
+**UNRESOLVED is a real value.** Where two implementations exist and choosing between them
+is a design decision rather than a cleanup, the row says so and names the issue. A table
+that silently blesses both sides is worse than one that admits the fork: an author reading
+it cannot tell they are picking a side. Do not resolve an UNRESOLVED row by editing this
+table — take it to a panel, then update the row with the decision.
+
+Adding an implementation of an operation already listed here is the thing this table exists
+to prevent. See #5121 for the ratchet that enforces it and #5125 for the current inventory.
 
 All task routing goes through: `Task → BudgetRouter → ZeroRouter → PreferenceRouter → TopsisRouter → LinUCB → Selected Model`. Do NOT directly instantiate stage routers — use `CompositeRouter.route(task)`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,19 +276,37 @@ Full tool reference: [docs/ENTRYPOINTS.md](./docs/ENTRYPOINTS.md).
 
 Do not create parallel implementations — modify existing files at these canonical locations. Never create `enhanced_*`, `new_*`, `v2_*`, or `refactor_*` forks; migrate logic to the canonical location and remove the deprecated file.
 
-| Concern           | Canonical path                                                                                                 |
-| ----------------- | -------------------------------------------------------------------------------------------------------------- |
-| Task analysis     | `SharedTaskAnalyzer` — `src/core/task-analysis/shared-task-analyzer.ts`                                        |
-| Task routing      | `CompositeRouter` — `src/cli-adapters/composite-router.ts`                                                     |
-| Consensus voting  | `ConsensusEngine` — `src/consensus/engine.ts`                                                                  |
-| CLI adapters      | `createAllAdapters()` — `src/cli-adapters/factory.ts`                                                          |
-| MCP tools         | `registerTools()` — `src/mcp/tools/index.ts`                                                                   |
-| Model registry    | `ModelRegistry` + `getDefaultRegistry()` — `src/config/model-registry.ts` (data: `src/config/in-tree-data.ts`) |
-| Adapter registry  | `UnifiedAdapterRegistry` — `src/adapters/unified-registry.ts`                                                  |
-| Memory registry   | `MemoryRegistry` + `getMemoryRegistry()` — `packages/nexus-memory/src/registry.ts`                             |
-| Graph workflows   | `GraphBuilder` — `src/orchestration/graph/graph-builder.ts`                                                    |
-| Pipeline runner   | `PipelineRunner` — `src/pipeline/pipeline-runner.ts`                                                           |
-| Security pipeline | `src/exports/security.ts`                                                                                      |
+| Operation — what you are trying to do             | Canonical entry point                                                                                          |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Analyse / classify a task                         | `SharedTaskAnalyzer` — `src/core/task-analysis/shared-task-analyzer.ts`                                        |
+| Select a model for a task                         | `CompositeRouter.route(task)` — `src/cli-adapters/composite-router.ts`                                         |
+| Acquire an adapter                                | `getGlobalRegistry()` — `src/adapters/unified-registry.ts`. NOT `createAllAdapters()` in new code.             |
+| Run a consensus vote                              | `ConsensusEngine` — `src/consensus/engine.ts`                                                                  |
+| Register an MCP tool                              | `registerTools()` — `src/mcp/tools/index.ts`                                                                   |
+| Look up model metadata, pricing or context window | `getDefaultRegistry()` — `src/config/model-registry.ts` (data: `src/config/in-tree-data.ts`)                   |
+| Read or write memory                              | `getMemoryRegistry()` — `packages/nexus-memory/src/registry.ts`                                                |
+| Build a graph workflow                            | `GraphBuilder` — `src/orchestration/graph/graph-builder.ts`                                                    |
+| Run a pipeline                                    | `PipelineRunner` — `src/pipeline/pipeline-runner.ts`                                                           |
+| Run the security pipeline                         | `src/exports/security.ts`                                                                                      |
+| Authorize a tool call                             | `PolicyFirewall` — `src/mcp/middleware/policy.ts`. ClawGuard is advisory only (#5022, epic #5105).             |
+| Compute token → USD                               | **UNRESOLVED — eight paths (#5122).** Prefer `computeCostDetail` (`src/learning/usage-log.ts`) until it lands. |
+| Emit a domain event                               | **UNRESOLVED — two buses (#5125).** Do not add a third, and do not add a bridge.                               |
+| Write an audit record                             | **UNRESOLVED — two sinks (#5125).** Use `AuditLogger` (`src/audit/`) when the record must be durable.          |
+
+This table is keyed on the **operation**, not on the symbol. A row answers "what do I call
+to do X", and there is exactly one answer per row. That shape is deliberate: the previous
+version listed important symbols, which let it bless both `createAllAdapters()` and
+`UnifiedAdapterRegistry` as canonical — two entries for one question — and name one event
+bus canonical while `core/event-bus.ts` re-exported the other as the core surface.
+
+**UNRESOLVED is a real value.** Where two implementations exist and choosing between them
+is a design decision rather than a cleanup, the row says so and names the issue. A table
+that silently blesses both sides is worse than one that admits the fork: an author reading
+it cannot tell they are picking a side. Do not resolve an UNRESOLVED row by editing this
+table — take it to a panel, then update the row with the decision.
+
+Adding an implementation of an operation already listed here is the thing this table exists
+to prevent. See #5121 for the ratchet that enforces it and #5125 for the current inventory.
 
 All task routing goes through: `Task → BudgetRouter → ZeroRouter → PreferenceRouter → TopsisRouter → LinUCB → Selected Model`. Do NOT directly instantiate stage routers — use `CompositeRouter.route(task)`.
 


### PR DESCRIPTION
**Owner-ratified in session** — *"I approve correcting the table."* Touches `AGENTS.md` and `CLAUDE.md`, both governor-owned, so the Governor-path ratification gate will show red until an approving review lands on this PR. Flagging that rather than merging past it silently.

Part of epic #5121 (ratified: option D, 5/6 approvers, 83.3%).

## The defect

The canonical-paths table listed **symbols**, not **operations**. That is how it blessed both sides of a duplication without anyone noticing:

- `createAllAdapters()` under "CLI adapters" **and** `UnifiedAdapterRegistry` under "Adapter registry" — two entries for one question, **7 call sites on one, 8 on the other** — while a separate line said adapter access must go through the registry. The document contradicted itself.
- The pipeline event bus named canonical, while `core/event-bus.ts` re-exports the *other* bus as the core surface, with two bridge modules shuttling between them.
- A pricing *source* named, but no canonical cost *function*. That is how eight cost paths accumulated.

Every duplication in #5125 was added in good faith by someone who could point at a blessed name.

## The change

Each row now answers **"what do I call to do X"**, with exactly one answer.

## `UNRESOLVED` is introduced as a real value

Three rows carry it: token→USD (#5122), domain events (#5125), audit records (#5125).

This is the same reasoning that produced `unmeasured` in #5100. Where two implementations exist and choosing between them is a **design decision rather than a cleanup**, the row says so and names the issue. A table that silently blesses both sides is worse than one that admits the fork — an author reading it cannot tell they are picking a side.

Each `UNRESOLVED` row carries interim guidance so the table stays actionable, and the surrounding prose says explicitly that the row is **not** to be resolved by editing the table. Take it to a panel, then record the decision.

## One row changes guidance rather than restating it

**Adapter acquisition** now names `getGlobalRegistry()` alone. The Claude-specific section already said this; the agnostic table contradicted it. This is the only row where the table's meaning changes rather than its shape — worth your eye.

## Mechanical notes

`AGENTS.md` is the source; `CLAUDE.md`'s block is generated. Both are in the diff because `pnpm governance:inject` regenerates the copy.

The governance check initially failed after my edit, and the cause is worth recording: `inject` applies table formatting that `check` does not, so a hand-formatted source table makes regeneration non-idempotent. Running `prettier --write AGENTS.md` **before** injecting fixes it. Anyone editing that table by hand will hit the same thing — the error message ("run `pnpm governance:inject`") does not hint at it, since running inject is exactly what does not help.

## Verification

- `pnpm governance:check` — exit **0** (verified as a real exit code, not a pipe's).
- `markdownlint` — 0 issues.
- Baselined first: `governance:check` passes on clean `main`, so the failure was mine and not pre-existing.

## Not in this PR

The ratchet that would *enforce* this table is #5123. A table is guidance; the enforcement is what changes the outcome. This PR makes the guidance correct so the ratchet has something true to enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
