### PR TITLE
docs(rules): trace to the producer, and check what a pass measured

### DIFF
--- a/.changeset/debugging-producer-and-pass-evidence.md
+++ b/.changeset/debugging-producer-and-pass-evidence.md
@@ -1,0 +1,26 @@
+---
+'nexus-agents': patch
+---
+
+docs(rules): trace to the producer, and treat a pass as evidence only once you know what it measured
+
+Two investigation techniques added to `.rules/debugging.md`, ratified 5/6 by a
+`higher_order` panel. Overlap with the existing rules was measured first: most of
+what this session used is already covered by the Triage Sequence and the
+Anti-Rationalization table, so the addition is deliberately two table rows and
+one triage step, not a section.
+
+**Trace to the producer, not the guard.** The word "producer" appeared in no rule
+file, yet the dominant defect class found this session is one shape: the check
+reads correctly and nothing upstream can make it fire. ClawGuard deciding on an
+`allowedTools` no producer populates; `proof_of_learning` reporting weighted
+approval where `updateAgentPerformance` has zero non-test callers;
+`falsePositiveRate` published as measured from a constant verdict; three
+governance gates reading ledgers no producer writes.
+
+**A pass is evidence only once you know what it measured.** Distinct from the
+existing "It works on my machine" row, which is about environment diffs. This is
+the opposite direction from "This is flaky, ignore it": that row says do not
+ignore a failure, this says do not trust a pass. It is the direction that hid
+#5134 — `research_synthesize` erroring on every real call while CI stayed green,
+because CI's registry is empty and the tool returned nothing to validate.

--- a/.rules/debugging.md
+++ b/.rules/debugging.md
@@ -24,19 +24,22 @@ Failures compound. An unresolved bug at step N makes every change N+1…N+k inco
 
 1. **Reproduce** reliably (or document conditions if intermittent)
 2. **Localize** to a layer: UI / service / data / build / external — verify with a log, not a hunch
-3. **Reduce** to minimal failing case
-4. **Fix** at the root. Upstream fix = usually right; downstream dedupe/catch = usually a symptom patch
-5. **Guard** with regression test that fails without the fix
-6. **Verify** end-to-end
+3. **Trace to the producer, not the guard.** When a check, flag, or reported value looks wrong, find every production writer of the value it reads. A guard that reads correctly proves nothing if nothing upstream can make it fire — grep the writers before concluding the logic is fine
+4. **Reduce** to minimal failing case
+5. **Fix** at the root. Upstream fix = usually right; downstream dedupe/catch = usually a symptom patch
+6. **Guard** with regression test that fails without the fix
+7. **Verify** end-to-end
 
 ## Anti-Rationalization
 
-| Excuse                           | Counter                                                                                                                                                  |
-| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| "I know what the bug is"         | Unverified guesses succeed ~70%. Reproduce before fixing — cost of confirming is minutes, cost of a wrong fix is hours + a regression.                   |
-| "The failing test must be wrong" | Sometimes true, but verify against the spec _before_ changing the test. Tests asserting correct-but-inconvenient behavior get "fixed" to assert the bug. |
-| "It works on my machine"         | Diff Node version, env vars, lockfile drift, CI container, clock/timezone, fs case sensitivity. Environment is a variable.                               |
-| "This is flaky, ignore it"       | Flaky = real race / ordering / timing bug being exposed. Fix it or understand why. `.skip` with a TODO is ticking debt.                                  |
+| Excuse                           | Counter                                                                                                                                                                                                                                                                                                                     |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| "I know what the bug is"         | Unverified guesses succeed ~70%. Reproduce before fixing — cost of confirming is minutes, cost of a wrong fix is hours + a regression.                                                                                                                                                                                      |
+| "The failing test must be wrong" | Sometimes true, but verify against the spec _before_ changing the test. Tests asserting correct-but-inconvenient behavior get "fixed" to assert the bug.                                                                                                                                                                    |
+| "It works on my machine"         | Diff Node version, env vars, lockfile drift, CI container, clock/timezone, fs case sensitivity. Environment is a variable.                                                                                                                                                                                                  |
+| "This is flaky, ignore it"       | Flaky = real race / ordering / timing bug being exposed. Fix it or understand why. `.skip` with a TODO is ticking debt.                                                                                                                                                                                                     |
+| "It passed, so it works"         | A pass is evidence only once you know what it measured. Check the subject: right branch (`git rev-parse HEAD` vs the PR head), right run, right input. A test can pass because it never reached the code — a wrong arg name rejected at validation, an empty fixture, a degraded environment returning nothing to validate. |
+| "That failure is pre-existing"   | Pre-existing is not the same as unimportant. Baseline it, then read WHAT is failing. `research_synthesize` had been erroring on every real call; CI was green only because CI's registry was empty, so the tool returned nothing to validate (#5134).                                                                       |
 
 ## Non-Reproducible Bugs
 


### PR DESCRIPTION
**Owner ratification required** — `.rules/` is governor-owned (`CODEOWNERS:23`, above the sentinel). I will not self-merge.

Ratified **5/6, 83.3%, supermajority met** by a `higher_order` panel.

## What this adds — and what it deliberately does not

I measured the overlap before proposing. `.rules/debugging.md` already covers Stop-the-Line, the Triage Sequence, non-reproducible-bug tactics, and an Anti-Rationalization table that includes *"I know what the bug is"*, *"The failing test must be wrong"*, *"It works on my machine"* and *"This is flaky, ignore it"*. `development-disciplines.md` covers "name the empty case".

**Most of what this session used was already written down.** So this is **two table rows and one triage step** — about 12 lines — not a new section. The panel made that a condition: *"the value is salience, not exposition."*

### 1. Trace to the producer, not the guard

The word "producer" appeared in **no rule file**. Yet the dominant defect class found this session is always one shape — the check reads correctly and nothing upstream can make it fire:

- ClawGuard deciding on an `allowedTools` no producer ever populates (#5022)
- `proof_of_learning` reporting weighted approval where `updateAgentPerformance` has zero non-test callers (#5117)
- `falsePositiveRate` published as measured from a constant triage verdict (#5119)
- Three governance gates reading ledgers no producer writes (#5118)

"Name the empty case" is adjacent, but governs *writing* code. This governs *investigating* it.

### 2. A pass is evidence only once you know what it measured

Distinct from "It works on my machine", which is about environment diffs. And directionally **opposite** to the flaky row: that one says don't ignore a failure; this says don't trust a pass.

- A CI gate run locally that passed **because it ran on the wrong branch** — `HEAD` didn't match the PR head
- A poll loop reporting SETTLED from the **previous** run's results
- A seam test passing because the parameter was named `template`, not `workflow`, so validation rejected the call before it reached the code under test
- **#5134** — `research_synthesize` fails `-32602` on every real call, and CI is green *only* because CI's registry is empty, so the tool returns nothing to validate

That last one is the argument. **The test only fails where the tool actually works**, and I nearly dismissed it as pre-existing noise.

## The dissent, recorded rather than dismissed

The contrarian voted reject and called this the *"documentation placebo fallacy"*:

> The ~15 failures cited are infrastructure and tooling failures, not documentation gaps. If a test passes because the tool returns an error envelope and no structured content is validated, the test runner is fundamentally broken. We should be writing strict linters rather than asking agents to second-guess green CI runs. Incremental verifiability: zero.

**That is substantially right, and several approvers conceded it** — rules are not measurable, and the enforcement fix is epic #5121's ratchet, not prose. I have not claimed otherwise: this is the investigation posture, the ratchet is the enforcement, and they are complements.

The specific engineering fix the contrarian points at is already tracked — #5134's acceptance requires the round-trip test to run against a **populated** registry, so it stops certifying tools that only work when they return nothing.

**What decided it against option D** (put these in `skills/bug-fix` instead), raised independently by three voters: **skills are pull-based.** An agent opens the bug-fix playbook once it knows it's debugging. The failure mode here is *not knowing there is a bug*, because the pass looked like evidence. That needs the auto-loaded surface.

## A correction I made mid-flight

I told the owner there was a gap — that `CLAUDE.md` lists `.rules/` as governor-owned while `CODEOWNERS` omits it. **That was wrong.** `.rules/` is at `CODEOWNERS:23`, above the sentinel; the gate does cover it. I'd asserted it from recalling the governor block instead of reading the file, and would have filed a false issue. Caught by measuring before filing — which is item 1 of this very PR.

## Verification

`markdownlint` clean, `governance:check` **exit 0** (verified as a real exit code, not a pipe's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157YynqtwhxypPALSaeZPGk
